### PR TITLE
Automated cherry pick of #17160: Update etcd to v3.5.17
#17367: Update etcd to v3.5.21

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -29,7 +29,7 @@ type EtcdOptionsBuilder struct {
 var _ loader.ClusterOptionsBuilder = &EtcdOptionsBuilder{}
 
 const (
-	DefaultEtcd3Version_1_22 = "3.5.17"
+	DefaultEtcd3Version_1_22 = "3.5.21"
 )
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -29,7 +29,7 @@ type EtcdOptionsBuilder struct {
 var _ loader.ClusterOptionsBuilder = &EtcdOptionsBuilder{}
 
 const (
-	DefaultEtcd3Version_1_22 = "3.5.13"
+	DefaultEtcd3Version_1_22 = "3.5.17"
 )
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -79,14 +79,15 @@ type etcdVersion struct {
 var etcdSupportedImages = []etcdVersion{
 	{Version: "3.4.3", SymlinkToVersion: "3.4.13"},
 	{Version: "3.4.13", Image: "registry.k8s.io/etcd:3.4.13-0"},
-	{Version: "3.5.0", SymlinkToVersion: "3.5.13"},
-	{Version: "3.5.1", SymlinkToVersion: "3.5.13"},
-	{Version: "3.5.3", SymlinkToVersion: "3.5.13"},
-	{Version: "3.5.4", SymlinkToVersion: "3.5.13"},
-	{Version: "3.5.6", SymlinkToVersion: "3.5.13"},
-	{Version: "3.5.7", SymlinkToVersion: "3.5.13"},
-	{Version: "3.5.9", SymlinkToVersion: "3.5.13"},
-	{Version: "3.5.13", Image: "registry.k8s.io/etcd:3.5.13-0"},
+	{Version: "3.5.0", SymlinkToVersion: "3.5.17"},
+	{Version: "3.5.1", SymlinkToVersion: "3.5.17"},
+	{Version: "3.5.3", SymlinkToVersion: "3.5.17"},
+	{Version: "3.5.4", SymlinkToVersion: "3.5.17"},
+	{Version: "3.5.6", SymlinkToVersion: "3.5.17"},
+	{Version: "3.5.7", SymlinkToVersion: "3.5.17"},
+	{Version: "3.5.9", SymlinkToVersion: "3.5.17"},
+	{Version: "3.5.13", SymlinkToVersion: "3.5.17"},
+	{Version: "3.5.17", Image: "registry.k8s.io/etcd:3.5.17-0"},
 }
 
 func etcdSupportedVersions() []etcdVersion {

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -79,15 +79,16 @@ type etcdVersion struct {
 var etcdSupportedImages = []etcdVersion{
 	{Version: "3.4.3", SymlinkToVersion: "3.4.13"},
 	{Version: "3.4.13", Image: "registry.k8s.io/etcd:3.4.13-0"},
-	{Version: "3.5.0", SymlinkToVersion: "3.5.17"},
-	{Version: "3.5.1", SymlinkToVersion: "3.5.17"},
-	{Version: "3.5.3", SymlinkToVersion: "3.5.17"},
-	{Version: "3.5.4", SymlinkToVersion: "3.5.17"},
-	{Version: "3.5.6", SymlinkToVersion: "3.5.17"},
-	{Version: "3.5.7", SymlinkToVersion: "3.5.17"},
-	{Version: "3.5.9", SymlinkToVersion: "3.5.17"},
-	{Version: "3.5.13", SymlinkToVersion: "3.5.17"},
-	{Version: "3.5.17", Image: "registry.k8s.io/etcd:3.5.17-0"},
+	{Version: "3.5.0", SymlinkToVersion: "3.5.21"},
+	{Version: "3.5.1", SymlinkToVersion: "3.5.21"},
+	{Version: "3.5.3", SymlinkToVersion: "3.5.21"},
+	{Version: "3.5.4", SymlinkToVersion: "3.5.21"},
+	{Version: "3.5.6", SymlinkToVersion: "3.5.21"},
+	{Version: "3.5.7", SymlinkToVersion: "3.5.21"},
+	{Version: "3.5.9", SymlinkToVersion: "3.5.21"},
+	{Version: "3.5.13", SymlinkToVersion: "3.5.21"},
+	{Version: "3.5.17", SymlinkToVersion: "3.5.21"},
+	{Version: "3.5.21", Image: "registry.k8s.io/etcd:3.5.21-0"},
 }
 
 func etcdSupportedVersions() []etcdVersion {

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -132,13 +132,13 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.21
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.13-0
-      name: init-etcd-3-5-13
+      image: registry.k8s.io/etcd:3.5.21-0
+      name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -160,17 +160,19 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.17
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.13/etcd
-      - --src=/opt/etcd-v3.5.13/etcdctl
+      - --src=/opt/etcd-v3.5.21/etcd
+      - --src=/opt/etcd-v3.5.21/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-      name: init-etcd-symlinks-3-5-13
+      name: init-etcd-symlinks-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -273,13 +275,13 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.21
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.13-0
-      name: init-etcd-3-5-13
+      image: registry.k8s.io/etcd:3.5.21-0
+      name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -301,17 +303,19 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.17
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.13/etcd
-      - --src=/opt/etcd-v3.5.13/etcdctl
+      - --src=/opt/etcd-v3.5.21/etcd
+      - --src=/opt/etcd-v3.5.21/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-      name: init-etcd-symlinks-3-5-13
+      name: init-etcd-symlinks-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -131,13 +131,13 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.21
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.13-0
-      name: init-etcd-3-5-13
+      image: registry.k8s.io/etcd:3.5.21-0
+      name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -159,17 +159,19 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.17
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.13/etcd
-      - --src=/opt/etcd-v3.5.13/etcdctl
+      - --src=/opt/etcd-v3.5.21/etcd
+      - --src=/opt/etcd-v3.5.21/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-      name: init-etcd-symlinks-3-5-13
+      name: init-etcd-symlinks-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -271,13 +273,13 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.21
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.13-0
-      name: init-etcd-3-5-13
+      image: registry.k8s.io/etcd:3.5.21-0
+      name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -299,17 +301,19 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.17
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.13/etcd
-      - --src=/opt/etcd-v3.5.13/etcdctl
+      - --src=/opt/etcd-v3.5.21/etcd
+      - --src=/opt/etcd-v3.5.21/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-      name: init-etcd-symlinks-3-5-13
+      name: init-etcd-symlinks-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -134,13 +134,13 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.21
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.13-0
-      name: init-etcd-3-5-13
+      image: registry.k8s.io/etcd:3.5.21-0
+      name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -162,17 +162,19 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.17
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.13/etcd
-      - --src=/opt/etcd-v3.5.13/etcdctl
+      - --src=/opt/etcd-v3.5.21/etcd
+      - --src=/opt/etcd-v3.5.21/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-      name: init-etcd-symlinks-3-5-13
+      name: init-etcd-symlinks-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -277,13 +279,13 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.21
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.13-0
-      name: init-etcd-3-5-13
+      image: registry.k8s.io/etcd:3.5.21-0
+      name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -305,17 +307,19 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.17
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.13/etcd
-      - --src=/opt/etcd-v3.5.13/etcdctl
+      - --src=/opt/etcd-v3.5.21/etcd
+      - --src=/opt/etcd-v3.5.21/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-      name: init-etcd-symlinks-3-5-13
+      name: init-etcd-symlinks-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -140,13 +140,13 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.21
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.13-0
-      name: init-etcd-3-5-13
+      image: registry.k8s.io/etcd:3.5.21-0
+      name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -168,17 +168,19 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.17
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.13/etcd
-      - --src=/opt/etcd-v3.5.13/etcdctl
+      - --src=/opt/etcd-v3.5.21/etcd
+      - --src=/opt/etcd-v3.5.21/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-      name: init-etcd-symlinks-3-5-13
+      name: init-etcd-symlinks-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -289,13 +291,13 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.21
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.13-0
-      name: init-etcd-3-5-13
+      image: registry.k8s.io/etcd:3.5.21-0
+      name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -317,17 +319,19 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.17
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.13/etcd
-      - --src=/opt/etcd-v3.5.13/etcdctl
+      - --src=/opt/etcd-v3.5.21/etcd
+      - --src=/opt/etcd-v3.5.21/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-      name: init-etcd-symlinks-3-5-13
+      name: init-etcd-symlinks-3-5-21
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/additionalobjects.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/additionalobjects.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,13 +70,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -98,17 +98,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,13 +70,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -98,17 +98,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/bastionuserdata.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/bastionuserdata.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -65,7 +65,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/cas-priority-expander-custom.example.com/backups/etcd/events
     etcdMembers:
@@ -74,7 +74,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/cas-priority-expander-custom.example.com/pki

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -65,7 +65,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/cas-priority-expander-custom.example.com/backups/etcd/events
     etcdMembers:
@@ -74,7 +74,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/cas-priority-expander-custom.example.com/pki

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
@@ -58,7 +58,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/cas-priority-expander.example.com/backups/etcd/events
     etcdMembers:
@@ -67,7 +67,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/cas-priority-expander.example.com/pki

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
@@ -58,7 +58,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/cas-priority-expander.example.com/backups/etcd/events
     etcdMembers:
@@ -67,7 +67,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/cas-priority-expander.example.com/pki

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -61,7 +61,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/complex.example.com/backups/etcd/events
     etcdMembers:
@@ -70,7 +70,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -61,7 +61,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/complex.example.com/backups/etcd/events
     etcdMembers:
@@ -70,7 +70,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/compress.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/compress.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/containerd.example.com/backups/etcd/events
     etcdMembers:
@@ -57,7 +57,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/containerd.example.com/backups/etcd/events
     etcdMembers:
@@ -57,7 +57,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/containerd.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/containerd.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/123.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/123.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/existing-iam.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/existing-iam.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
@@ -46,7 +46,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
     etcdMembers:
@@ -59,7 +59,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
@@ -46,7 +46,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
     etcdMembers:
@@ -59,7 +59,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: external-dns
   iam:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: external-dns
   iam:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: external-dns
   iam:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: external-dns
   iam:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/externallb.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/externallb.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
@@ -47,7 +47,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/externalpolicies.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   externalPolicies:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
@@ -47,7 +47,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/externalpolicies.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   externalPolicies:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/ha.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/ha.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/ha-gce.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -65,7 +65,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/ha-gce.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -65,7 +65,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -61,7 +61,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -70,7 +70,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -61,7 +61,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -70,7 +70,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
@@ -61,7 +61,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -70,7 +70,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
@@ -61,7 +61,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -70,7 +70,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
@@ -61,7 +61,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -70,7 +70,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
@@ -61,7 +61,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -70,7 +70,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -62,7 +62,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -71,7 +71,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -62,7 +62,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -71,7 +71,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -64,7 +64,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -75,7 +75,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -64,7 +64,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -75,7 +75,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -64,7 +64,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/many-addons.example.com/backups/etcd/events
     etcdMembers:
@@ -73,7 +73,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -64,7 +64,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/many-addons.example.com/backups/etcd/events
     etcdMembers:
@@ -73,7 +73,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -54,7 +54,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal-aws.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/minimal-aws.example.com/pki

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal-aws.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/minimal-aws.example.com/pki

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   iam:
     allowContainerRegistry: true
     legacy: false

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   iam:
     allowContainerRegistry: true
     legacy: false

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc
       logLevel: 10
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal-etcd.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
         value: 1d
       image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc
       logLevel: 10
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal-etcd.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
         value: 1d
       image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,13 +70,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -98,17 +98,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -54,7 +54,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -54,7 +54,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com/pki

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com/pki

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal-warmpool.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal-warmpool.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -46,7 +46,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal-gce.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -57,7 +57,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -46,7 +46,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal-gce.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -57,7 +57,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -48,7 +48,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal-gce.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -59,7 +59,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   iam:
     legacy: false
   keyStore: memfs://tests/minimal-gce.example.com/pki

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -48,7 +48,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal-gce.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -59,7 +59,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   iam:
     legacy: false
   keyStore: memfs://tests/minimal-gce.example.com/pki

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal-gce-ilb.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -61,7 +61,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal-gce-ilb.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -61,7 +61,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -61,7 +61,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -61,7 +61,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -47,7 +47,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -58,7 +58,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -47,7 +47,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -58,7 +58,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal-gce-plb.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -61,7 +61,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal-gce-plb.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -61,7 +61,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
@@ -46,7 +46,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal-gce-private.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -57,7 +57,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
@@ -46,7 +46,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal-gce-private.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -57,7 +57,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
@@ -38,7 +38,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
     etcdMembers:
@@ -47,7 +47,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
@@ -38,7 +38,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
     etcdMembers:
@@ -47,7 +47,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -38,7 +38,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
     etcdMembers:
@@ -47,7 +47,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -38,7 +38,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
     etcdMembers:
@@ -47,7 +47,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -51,7 +51,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   iam:
     allowContainerRegistry: true
     legacy: false

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -51,7 +51,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   iam:
     allowContainerRegistry: true
     legacy: false

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -69,13 +69,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -97,17 +97,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -69,13 +69,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -97,17 +97,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://tests/scw-minimal.k8s.local/backups/etcd/events
     cpuRequest: 100m
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://tests/scw-minimal.k8s.local/backups/etcd/events
     cpuRequest: 100m
@@ -42,7 +42,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -71,13 +71,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -99,17 +99,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -71,13 +71,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -99,17 +99,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
     etcdMembers:
@@ -56,7 +56,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-ip.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-ip.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-subnet.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-subnet.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privatecalico.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privatecalico.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privatecanal.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privatecanal.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium
     etcdMembers:
@@ -59,7 +59,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: cilium
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium
     etcdMembers:
@@ -59,7 +59,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: cilium
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-cilium_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-cilium_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-cilium_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-cilium_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privatedns1.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privatedns1.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privatedns2.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privatedns2.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privateflannel.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privateflannel.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/privatekopeio.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/privatekopeio.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/sharedsubnet.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/sharedsubnet.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/sharedvpc.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/sharedvpc.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -52,7 +52,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -68,13 +68,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -96,17 +96,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/unmanaged.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/unmanaged.example.com/backups/etcd/events
     etcdMembers:
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.17
+    version: 3.5.21
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.17
+    version: 3.5.21
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.13
+    version: 3.5.17
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.13
+    version: 3.5.17
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.17"
+  "etcdVersion": "3.5.21"
 }

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.13"
+  "etcdVersion": "3.5.17"
 }

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -67,13 +67,13 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.21
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.13-0
-    name: init-etcd-3-5-13
+    image: registry.k8s.io/etcd:3.5.21-0
+    name: init-etcd-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -95,17 +95,19 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.17
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.13/etcd
-    - --src=/opt/etcd-v3.5.13/etcdctl
+    - --src=/opt/etcd-v3.5.21/etcd
+    - --src=/opt/etcd-v3.5.21/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.31.0
-    name: init-etcd-symlinks-3-5-13
+    name: init-etcd-symlinks-3-5-21
     resources: {}
     volumeMounts:
     - mountPath: /opt


### PR DESCRIPTION
Cherry pick of #17160 #17367 on release-1.31.

#17160: Update etcd to v3.5.17
#17367: Update etcd to v3.5.21

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```