### PR TITLE
Bump skip.regex for failing tests to 1.34

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -79,7 +79,7 @@ func (t *Tester) setSkipRegexFlag() error {
 		// https://github.com/kubernetes/kubernetes/blob/418ae605ec1b788d43bff7ac44af66d8b669b833/test/e2e/network/networking.go#L135
 		skipRegex += "|should.check.kube-proxy.urls"
 
-		if k8sVersion.Minor < 33 {
+		if k8sVersion.Minor < 34 {
 			// This seems to be specific to the kube-proxy replacement
 			// < 33 so we look at this again
 			skipRegex += "|Services.should.support.externalTrafficPolicy.Local.for.type.NodePort"


### PR DESCRIPTION
/cc @rifelpet @ameukam 