### PR TITLE
Automated cherry pick of #17229: Make GCE backend service regional for the Terraform target

### DIFF
--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -177,16 +177,6 @@ resource "google_compute_address" "api-us-test1-minimal-gce-example-com" {
   subnetwork   = google_compute_subnetwork.us-test1-minimal-gce-example-com.name
 }
 
-resource "google_compute_backend_service" "api-minimal-gce-example-com" {
-  backend {
-    group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-example-com.instance_group
-  }
-  health_checks         = [google_compute_health_check.api-minimal-gce-example-com.id]
-  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
-  name                  = "api-minimal-gce-example-com"
-  protocol              = "TCP"
-}
-
 resource "google_compute_disk" "a-etcd-events-minimal-gce-example-com" {
   labels = {
     "k8s-io-cluster-name" = "minimal-gce-example-com"
@@ -449,7 +439,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-example-com
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-example-com" {
-  backend_service = google_compute_backend_service.api-minimal-gce-example-com.id
+  backend_service = google_compute_region_backend_service.api-minimal-gce-example-com.id
   ip_address      = google_compute_address.api-us-test1-minimal-gce-example-com.address
   ip_protocol     = "TCP"
   labels = {
@@ -464,7 +454,7 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-example-com"
 }
 
 resource "google_compute_forwarding_rule" "kops-controller-us-test1-minimal-gce-example-com" {
-  backend_service = google_compute_backend_service.api-minimal-gce-example-com.id
+  backend_service = google_compute_region_backend_service.api-minimal-gce-example-com.id
   ip_address      = google_compute_address.api-us-test1-minimal-gce-example-com.address
   ip_protocol     = "TCP"
   labels = {
@@ -476,13 +466,6 @@ resource "google_compute_forwarding_rule" "kops-controller-us-test1-minimal-gce-
   network               = google_compute_network.minimal-gce-example-com.name
   ports                 = ["3988"]
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-example-com.name
-}
-
-resource "google_compute_health_check" "api-minimal-gce-example-com" {
-  name = "api-minimal-gce-example-com"
-  tcp_health_check {
-    port = 443
-  }
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-example-com" {
@@ -610,6 +593,24 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
 resource "google_compute_network" "minimal-gce-example-com" {
   auto_create_subnetworks = false
   name                    = "minimal-gce-example-com"
+}
+
+resource "google_compute_region_backend_service" "api-minimal-gce-example-com" {
+  backend {
+    balancing_mode = "CONNECTION"
+    group          = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-example-com.instance_group
+  }
+  health_checks         = [google_compute_region_health_check.api-minimal-gce-example-com.id]
+  load_balancing_scheme = "INTERNAL"
+  name                  = "api-minimal-gce-example-com"
+  protocol              = "TCP"
+}
+
+resource "google_compute_region_health_check" "api-minimal-gce-example-com" {
+  name = "api-minimal-gce-example-com"
+  tcp_health_check {
+    port = 443
+  }
 }
 
 resource "google_compute_router" "nat-minimal-gce-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -566,8 +566,8 @@ resource "google_compute_network" "minimal-gce-ilb-example-com" {
 
 resource "google_compute_region_backend_service" "api-minimal-gce-ilb-example-com" {
   backend {
-    balancing_group = "CONNECTION"
-    group           = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-ilb-example-com.instance_group
+    balancing_mode = "CONNECTION"
+    group          = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-ilb-example-com.instance_group
   }
   health_checks         = [google_compute_region_health_check.api-minimal-gce-ilb-example-com.id]
   load_balancing_scheme = "INTERNAL"

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -185,16 +185,6 @@ resource "google_compute_address" "api-us-test1-minimal-gce-ilb-example-com" {
   subnetwork   = google_compute_subnetwork.us-test1-minimal-gce-ilb-example-com.name
 }
 
-resource "google_compute_backend_service" "api-minimal-gce-ilb-example-com" {
-  backend {
-    group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-ilb-example-com.instance_group
-  }
-  health_checks         = [google_compute_health_check.api-minimal-gce-ilb-example-com.id]
-  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
-  name                  = "api-minimal-gce-ilb-example-com"
-  protocol              = "TCP"
-}
-
 resource "google_compute_disk" "a-etcd-events-minimal-gce-ilb-example-com" {
   labels = {
     "k8s-io-cluster-name" = "minimal-gce-ilb-example-com"
@@ -433,7 +423,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-ilb-example
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-ilb-example-com" {
-  backend_service = google_compute_backend_service.api-minimal-gce-ilb-example-com.id
+  backend_service = google_compute_region_backend_service.api-minimal-gce-ilb-example-com.id
   ip_address      = google_compute_address.api-us-test1-minimal-gce-ilb-example-com.address
   ip_protocol     = "TCP"
   labels = {
@@ -445,13 +435,6 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-ilb-example-
   network               = google_compute_network.minimal-gce-ilb-example-com.name
   ports                 = ["443"]
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-ilb-example-com.name
-}
-
-resource "google_compute_health_check" "api-minimal-gce-ilb-example-com" {
-  name = "api-minimal-gce-ilb-example-com"
-  tcp_health_check {
-    port = 443
-  }
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-ilb-example-com" {
@@ -579,6 +562,24 @@ resource "google_compute_instance_template" "nodes-minimal-gce-ilb-example-com" 
 resource "google_compute_network" "minimal-gce-ilb-example-com" {
   auto_create_subnetworks = false
   name                    = "minimal-gce-ilb-example-com"
+}
+
+resource "google_compute_region_backend_service" "api-minimal-gce-ilb-example-com" {
+  backend {
+    balancing_group = "CONNECTION"
+    group           = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-ilb-example-com.instance_group
+  }
+  health_checks         = [google_compute_region_health_check.api-minimal-gce-ilb-example-com.id]
+  load_balancing_scheme = "INTERNAL"
+  name                  = "api-minimal-gce-ilb-example-com"
+  protocol              = "TCP"
+}
+
+resource "google_compute_region_health_check" "api-minimal-gce-ilb-example-com" {
+  name = "api-minimal-gce-ilb-example-com"
+  tcp_health_check {
+    port = 443
+  }
 }
 
 resource "google_compute_router" "nat-minimal-gce-ilb-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -185,16 +185,6 @@ resource "google_compute_address" "api-us-test1-minimal-gce-with-a-very-very-ver
   subnetwork   = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
 }
 
-resource "google_compute_backend_service" "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {
-  backend {
-    group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f.instance_group
-  }
-  health_checks         = [google_compute_health_check.api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi.id]
-  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
-  name                  = "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi"
-  protocol              = "TCP"
-}
-
 resource "google_compute_disk" "a-etcd-events-minimal-gce-with-a-very-very-very-very-ver-96dqvi" {
   labels = {
     "k8s-io-cluster-name" = "minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
@@ -433,7 +423,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-with-a-very
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi" {
-  backend_service = google_compute_backend_service.api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi.id
+  backend_service = google_compute_region_backend_service.api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi.id
   ip_address      = google_compute_address.api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi.address
   ip_protocol     = "TCP"
   labels = {
@@ -445,13 +435,6 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-with-a-very-
   network               = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   ports                 = ["443"]
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
-}
-
-resource "google_compute_health_check" "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {
-  name = "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi"
-  tcp_health_check {
-    port = 443
-  }
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f" {
@@ -579,6 +562,24 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
 resource "google_compute_network" "minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi" {
   auto_create_subnetworks = false
   name                    = "minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi"
+}
+
+resource "google_compute_region_backend_service" "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {
+  backend {
+    balancing_mode = "CONNECTION"
+    group          = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f.instance_group
+  }
+  health_checks         = [google_compute_region_health_check.api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi.id]
+  load_balancing_scheme = "INTERNAL"
+  name                  = "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi"
+  protocol              = "TCP"
+}
+
+resource "google_compute_region_health_check" "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {
+  name = "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi"
+  tcp_health_check {
+    port = 443
+  }
 }
 
 resource "google_compute_router" "nat-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -189,16 +189,6 @@ resource "google_compute_address" "api-us-test1-minimal-gce-plb-example-com" {
   subnetwork   = google_compute_subnetwork.us-test1-minimal-gce-plb-example-com.name
 }
 
-resource "google_compute_backend_service" "api-minimal-gce-plb-example-com" {
-  backend {
-    group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-plb-example-com.instance_group
-  }
-  health_checks         = [google_compute_health_check.api-minimal-gce-plb-example-com.id]
-  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
-  name                  = "api-minimal-gce-plb-example-com"
-  protocol              = "TCP"
-}
-
 resource "google_compute_disk" "a-etcd-events-minimal-gce-plb-example-com" {
   labels = {
     "k8s-io-cluster-name" = "minimal-gce-plb-example-com"
@@ -450,7 +440,7 @@ resource "google_compute_forwarding_rule" "api-minimal-gce-plb-example-com" {
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-plb-example-com" {
-  backend_service = google_compute_backend_service.api-minimal-gce-plb-example-com.id
+  backend_service = google_compute_region_backend_service.api-minimal-gce-plb-example-com.id
   ip_address      = google_compute_address.api-us-test1-minimal-gce-plb-example-com.address
   ip_protocol     = "TCP"
   labels = {
@@ -462,13 +452,6 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-plb-example-
   network               = google_compute_network.minimal-gce-plb-example-com.name
   ports                 = ["443"]
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-plb-example-com.name
-}
-
-resource "google_compute_health_check" "api-minimal-gce-plb-example-com" {
-  name = "api-minimal-gce-plb-example-com"
-  tcp_health_check {
-    port = 443
-  }
 }
 
 resource "google_compute_http_health_check" "api-minimal-gce-plb-example-com" {
@@ -603,6 +586,24 @@ resource "google_compute_instance_template" "nodes-minimal-gce-plb-example-com" 
 resource "google_compute_network" "minimal-gce-plb-example-com" {
   auto_create_subnetworks = false
   name                    = "minimal-gce-plb-example-com"
+}
+
+resource "google_compute_region_backend_service" "api-minimal-gce-plb-example-com" {
+  backend {
+    balancing_mode = "CONNECTION"
+    group          = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-plb-example-com.instance_group
+  }
+  health_checks         = [google_compute_region_health_check.api-minimal-gce-plb-example-com.id]
+  load_balancing_scheme = "INTERNAL"
+  name                  = "api-minimal-gce-plb-example-com"
+  protocol              = "TCP"
+}
+
+resource "google_compute_region_health_check" "api-minimal-gce-plb-example-com" {
+  name = "api-minimal-gce-plb-example-com"
+  tcp_health_check {
+    port = 443
+  }
 }
 
 resource "google_compute_router" "nat-minimal-gce-plb-example-com" {

--- a/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
@@ -141,9 +141,9 @@ func (_ *HealthCheck) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 			Port: e.Port,
 		},
 	}
-	return t.RenderResource("google_compute_health_check", *e.Name, tf)
+	return t.RenderResource("google_compute_region_health_check", *e.Name, tf)
 }
 
 func (e *HealthCheck) TerraformAddress() *terraformWriter.Literal {
-	return terraformWriter.LiteralProperty("google_compute_health_check", *e.Name, "id")
+	return terraformWriter.LiteralProperty("google_compute_region_health_check", *e.Name, "id")
 }


### PR DESCRIPTION
Cherry pick of #17229 on release-1.31.

#17229: Make GCE backend service regional for the Terraform target

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```