### PR TITLE
gce: use set type where order does not matter

### DIFF
--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/pkg/wellknownservices"
@@ -101,9 +102,9 @@ func (b *APILoadBalancerBuilder) addFirewallRules(c *fi.CloudupModelBuilderConte
 		b.AddFirewallRulesTasks(c, "https-api", &gcetasks.FirewallRule{
 			Lifecycle:    b.Lifecycle,
 			Network:      network,
-			SourceRanges: b.Cluster.Spec.API.Access,
+			SourceRanges: sets.New(b.Cluster.Spec.API.Access...),
 			TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleControlPlane)},
-			Allowed:      []string{"tcp:" + strconv.Itoa(wellknownports.KubeAPIServer)},
+			Allowed:      sets.New("tcp:" + strconv.Itoa(wellknownports.KubeAPIServer)),
 		})
 
 		if b.NetworkingIsIPAlias() {
@@ -112,9 +113,9 @@ func (b *APILoadBalancerBuilder) addFirewallRules(c *fi.CloudupModelBuilderConte
 				Lifecycle:    b.Lifecycle,
 				Network:      network,
 				Family:       gcetasks.AddressFamilyIPv4, // ip alias is always ipv4
-				SourceRanges: []string{b.Cluster.Spec.Networking.PodCIDR},
+				SourceRanges: sets.New(b.Cluster.Spec.Networking.PodCIDR),
 				TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleControlPlane)},
-				Allowed:      []string{"tcp:" + strconv.Itoa(wellknownports.KubeAPIServer)},
+				Allowed:      sets.New("tcp:" + strconv.Itoa(wellknownports.KubeAPIServer)),
 			})
 		}
 
@@ -122,9 +123,9 @@ func (b *APILoadBalancerBuilder) addFirewallRules(c *fi.CloudupModelBuilderConte
 			b.AddFirewallRulesTasks(c, "kops-controller", &gcetasks.FirewallRule{
 				Lifecycle:    b.Lifecycle,
 				Network:      network,
-				SourceRanges: b.Cluster.Spec.API.Access,
+				SourceRanges: sets.New(b.Cluster.Spec.API.Access...),
 				TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleControlPlane)},
-				Allowed:      []string{"tcp:" + strconv.Itoa(wellknownports.KopsControllerPort)},
+				Allowed:      sets.New("tcp:" + strconv.Itoa(wellknownports.KopsControllerPort)),
 			})
 		}
 	}

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -316,22 +316,22 @@ resource "google_compute_firewall" "kubernetes-master-https-ipv6-ha-gce-example-
 
 resource "google_compute_firewall" "master-to-master-ha-gce-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-master-ha-gce-example-com"
@@ -342,22 +342,22 @@ resource "google_compute_firewall" "master-to-master-ha-gce-example-com" {
 
 resource "google_compute_firewall" "master-to-node-ha-gce-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-node-ha-gce-example-com"
@@ -368,15 +368,15 @@ resource "google_compute_firewall" "master-to-node-ha-gce-example-com" {
 
 resource "google_compute_firewall" "node-to-master-ha-gce-example-com" {
   allow {
-    ports    = ["443"]
-    protocol = "tcp"
-  }
-  allow {
     ports    = ["10250"]
     protocol = "tcp"
   }
   allow {
     ports    = ["3988"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["443"]
     protocol = "tcp"
   }
   disabled    = false
@@ -388,22 +388,22 @@ resource "google_compute_firewall" "node-to-master-ha-gce-example-com" {
 
 resource "google_compute_firewall" "node-to-node-ha-gce-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "node-to-node-ha-gce-example-com"

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -244,22 +244,22 @@ resource "google_compute_firewall" "kubernetes-master-https-minimal-example-com"
 
 resource "google_compute_firewall" "master-to-master-minimal-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-master-minimal-example-com"
@@ -270,22 +270,22 @@ resource "google_compute_firewall" "master-to-master-minimal-example-com" {
 
 resource "google_compute_firewall" "master-to-node-minimal-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-node-minimal-example-com"
@@ -296,15 +296,15 @@ resource "google_compute_firewall" "master-to-node-minimal-example-com" {
 
 resource "google_compute_firewall" "node-to-master-minimal-example-com" {
   allow {
-    ports    = ["443"]
-    protocol = "tcp"
-  }
-  allow {
     ports    = ["10250"]
     protocol = "tcp"
   }
   allow {
     ports    = ["3988"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["443"]
     protocol = "tcp"
   }
   disabled    = false
@@ -316,22 +316,22 @@ resource "google_compute_firewall" "node-to-master-minimal-example-com" {
 
 resource "google_compute_firewall" "node-to-node-minimal-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "node-to-node-minimal-example-com"

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -220,22 +220,22 @@ resource "google_compute_firewall" "kubernetes-master-https-minimal-gce-example-
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-master-minimal-gce-example-com"
@@ -246,22 +246,22 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-example-com" {
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-node-minimal-gce-example-com"
@@ -272,15 +272,15 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-example-com" {
 
 resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
   allow {
-    ports    = ["443"]
-    protocol = "tcp"
-  }
-  allow {
     ports    = ["10250"]
     protocol = "tcp"
   }
   allow {
     ports    = ["3988"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["443"]
     protocol = "tcp"
   }
   disabled    = false
@@ -292,22 +292,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
 
 resource "google_compute_firewall" "node-to-node-minimal-gce-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "node-to-node-minimal-gce-example-com"

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -248,28 +248,28 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-example-com" {
   disabled      = false
   name          = "lb-health-checks-minimal-gce-example-com"
   network       = google_compute_network.minimal-gce-example-com.name
-  source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
+  source_ranges = ["130.211.0.0/22", "209.85.152.0/22", "209.85.204.0/22", "35.191.0.0/16"]
   target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane"]
 }
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-master-minimal-gce-example-com"
@@ -280,22 +280,22 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-example-com" {
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-node-minimal-gce-example-com"
@@ -306,15 +306,15 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-example-com" {
 
 resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
   allow {
-    ports    = ["443"]
-    protocol = "tcp"
-  }
-  allow {
     ports    = ["10250"]
     protocol = "tcp"
   }
   allow {
     ports    = ["3988"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["443"]
     protocol = "tcp"
   }
   disabled    = false
@@ -326,22 +326,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
 
 resource "google_compute_firewall" "node-to-node-minimal-gce-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "node-to-node-minimal-gce-example-com"

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -232,28 +232,28 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-ilb-example-com
   disabled      = false
   name          = "lb-health-checks-minimal-gce-ilb-example-com"
   network       = google_compute_network.minimal-gce-ilb-example-com.name
-  source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
+  source_ranges = ["130.211.0.0/22", "209.85.152.0/22", "209.85.204.0/22", "35.191.0.0/16"]
   target_tags   = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane"]
 }
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-ilb-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-master-minimal-gce-ilb-example-com"
@@ -264,22 +264,22 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-ilb-example-com
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-ilb-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-node-minimal-gce-ilb-example-com"
@@ -290,15 +290,15 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-ilb-example-com" 
 
 resource "google_compute_firewall" "node-to-master-minimal-gce-ilb-example-com" {
   allow {
-    ports    = ["443"]
-    protocol = "tcp"
-  }
-  allow {
     ports    = ["10250"]
     protocol = "tcp"
   }
   allow {
     ports    = ["3988"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["443"]
     protocol = "tcp"
   }
   disabled    = false
@@ -310,22 +310,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-ilb-example-com" 
 
 resource "google_compute_firewall" "node-to-node-minimal-gce-ilb-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "node-to-node-minimal-gce-ilb-example-com"

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -232,28 +232,28 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-with-a-very-ver
   disabled      = false
   name          = "lb-health-checks-minimal-gce-with-a-very-very-very-very--96dqvi"
   network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
-  source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
+  source_ranges = ["130.211.0.0/22", "209.85.152.0/22", "209.85.204.0/22", "35.191.0.0/16"]
   target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane"]
 }
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-with-a-very-very-very-very--96dqvi" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-master-minimal-gce-with-a-very-very-very-very--96dqvi"
@@ -264,22 +264,22 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-with-a-very-ver
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-with-a-very-very-very-very-ve-96dqvi" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-node-minimal-gce-with-a-very-very-very-very-ve-96dqvi"
@@ -290,15 +290,15 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-with-a-very-very-
 
 resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-very-very-ve-96dqvi" {
   allow {
-    ports    = ["443"]
-    protocol = "tcp"
-  }
-  allow {
     ports    = ["10250"]
     protocol = "tcp"
   }
   allow {
     ports    = ["3988"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["443"]
     protocol = "tcp"
   }
   disabled    = false
@@ -310,22 +310,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-
 
 resource "google_compute_firewall" "node-to-node-minimal-gce-with-a-very-very-very-very-very-96dqvi" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "node-to-node-minimal-gce-with-a-very-very-very-very-very-96dqvi"

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -220,22 +220,22 @@ resource "google_compute_firewall" "kubernetes-master-https-minimal-gce-with-a-v
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-with-a-very-very-very-very--96dqvi" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-master-minimal-gce-with-a-very-very-very-very--96dqvi"
@@ -246,22 +246,22 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-with-a-very-ver
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-with-a-very-very-very-very-ve-96dqvi" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-node-minimal-gce-with-a-very-very-very-very-ve-96dqvi"
@@ -272,15 +272,15 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-with-a-very-very-
 
 resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-very-very-ve-96dqvi" {
   allow {
-    ports    = ["443"]
-    protocol = "tcp"
-  }
-  allow {
     ports    = ["10250"]
     protocol = "tcp"
   }
   allow {
     ports    = ["3988"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["443"]
     protocol = "tcp"
   }
   disabled    = false
@@ -292,22 +292,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-
 
 resource "google_compute_firewall" "node-to-node-minimal-gce-with-a-very-very-very-very-very-96dqvi" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "node-to-node-minimal-gce-with-a-very-very-very-very-very-96dqvi"

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -236,28 +236,28 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-plb-example-com
   disabled      = false
   name          = "lb-health-checks-minimal-gce-plb-example-com"
   network       = google_compute_network.minimal-gce-plb-example-com.name
-  source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
+  source_ranges = ["130.211.0.0/22", "209.85.152.0/22", "209.85.204.0/22", "35.191.0.0/16"]
   target_tags   = ["minimal-gce-plb-example-com-k8s-io-role-control-plane"]
 }
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-plb-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-master-minimal-gce-plb-example-com"
@@ -268,22 +268,22 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-plb-example-com
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-plb-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-node-minimal-gce-plb-example-com"
@@ -294,15 +294,15 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-plb-example-com" 
 
 resource "google_compute_firewall" "node-to-master-minimal-gce-plb-example-com" {
   allow {
-    ports    = ["443"]
-    protocol = "tcp"
-  }
-  allow {
     ports    = ["10250"]
     protocol = "tcp"
   }
   allow {
     ports    = ["3988"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["443"]
     protocol = "tcp"
   }
   disabled    = false
@@ -314,22 +314,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-plb-example-com" 
 
 resource "google_compute_firewall" "node-to-node-minimal-gce-plb-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "node-to-node-minimal-gce-plb-example-com"

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -220,22 +220,22 @@ resource "google_compute_firewall" "kubernetes-master-https-minimal-gce-private-
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-private-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-master-minimal-gce-private-example-com"
@@ -246,22 +246,22 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-private-example
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-private-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "master-to-node-minimal-gce-private-example-com"
@@ -272,15 +272,15 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-private-example-c
 
 resource "google_compute_firewall" "node-to-master-minimal-gce-private-example-com" {
   allow {
-    ports    = ["443"]
-    protocol = "tcp"
-  }
-  allow {
     ports    = ["10250"]
     protocol = "tcp"
   }
   allow {
     ports    = ["3988"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["443"]
     protocol = "tcp"
   }
   disabled    = false
@@ -292,22 +292,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-private-example-c
 
 resource "google_compute_firewall" "node-to-node-minimal-gce-private-example-com" {
   allow {
-    protocol = "tcp"
-  }
-  allow {
-    protocol = "udp"
-  }
-  allow {
-    protocol = "icmp"
+    protocol = "ah"
   }
   allow {
     protocol = "esp"
   }
   allow {
-    protocol = "ah"
+    protocol = "icmp"
   }
   allow {
     protocol = "sctp"
+  }
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
   }
   disabled    = false
   name        = "node-to-node-minimal-gce-private-example-com"

--- a/upup/pkg/fi/changes.go
+++ b/upup/pkg/fi/changes.go
@@ -138,11 +138,10 @@ func equalFieldValues(a, e reflect.Value) bool {
 
 // equalMapValues performs a deep-equality check on a map, but using our custom comparison logic (equalFieldValues)
 func equalMapValues(a, e reflect.Value) bool {
-	if a.IsNil() != e.IsNil() {
+	aIsEmpty := a.IsNil() || a.Len() == 0
+	eIsEmpty := e.IsNil() || e.Len() == 0
+	if aIsEmpty != eIsEmpty {
 		return false
-	}
-	if a.IsNil() && e.IsNil() {
-		return true
 	}
 	if a.Len() != e.Len() {
 		return false


### PR DESCRIPTION
Starting small with FirewallRule Allowed and SourceRanges fields,
but this should be easier than explicitly handling values
where order does not matter.
