### PR TITLE
Remove securityGroupOverride validation for NLB

### DIFF
--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -168,9 +168,6 @@ func awsValidateSecurityGroupOverride(fieldPath *field.Path, lbSpec *kops.LoadBa
 	if !strings.HasPrefix(override, "sg-") {
 		allErrs = append(allErrs, field.Invalid(fieldPath, override, "security group override does not match the expected AWS format"))
 	}
-	if lbSpec.Class == kops.LoadBalancerClassNetwork {
-		allErrs = append(allErrs, field.Forbidden(fieldPath, "security group override cannot be specified for a Network Load Balancer"))
-	}
 
 	return allErrs
 }


### PR DESCRIPTION
refs #17207 

NLBs did not support security groups in the past. However, AWS now supports specifying a security group for an NLB. When kops creates a new cluster with an NLB, it also creates a security group for it by default.
Therefore, I believe we can now allow `securityGroupOverride` for NLBs in kops as well.

Please let me know if I'm overlooking anything or if there are any concerns with this approach.