### PR TITLE
Set MACAddressPolicy=none for Ubuntu 24.04

### DIFF
--- a/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
+++ b/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
@@ -65,10 +65,11 @@ ManageForeignRoutingPolicyRules=no
 		})
 	}
 
-	// Running Amazon VPC CNI on Ubuntu 22.04 or any version of al2023 requires
+	// Running Amazon VPC CNI on Ubuntu 22.04+ or any version of al2023 requires
 	// setting MACAddressPolicy to `none` (ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/2103
+	// & https://github.com/aws/amazon-vpc-cni-k8s/issues/2839
 	// & https://github.com/kubernetes/kops/issues/16255)
-	if (b.Distribution.IsUbuntu() && b.Distribution.Version() == 22.04) ||
+	if (b.Distribution.IsUbuntu() && b.Distribution.Version() >= 22.04) ||
 		b.Distribution == distributions.DistributionAmazonLinux2023 {
 		contents := `
 [Match]


### PR DESCRIPTION
[known issues](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/troubleshooting.md#known-issues) in the  vpc cni project mention:

> The workaround for this issue is to set MACAddressPolicy=none, as shown https://github.com/aws/amazon-vpc-cni-k8s/issues/2103#issuecomment-1321698870. This issue is known to affect Ubuntu 22.04+, and long-term solutions are being evaluated.

Kops was only setting this on 22.04, and we've seen similar pod connectivity issues with 24.04. So we'll try setting the same workaround for 24.04.