### PR TITLE
Update requiredVersion for 1.31 and 1.32 in alpha

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -121,10 +121,10 @@ spec:
   kubernetesVersions:
   - range: ">=1.32.0"
     recommendedVersion: 1.32.4
-    requiredVersion: 1.30.0
+    requiredVersion: 1.32.0
   - range: ">=1.31.0"
     recommendedVersion: 1.31.8
-    requiredVersion: 1.30.0
+    requiredVersion: 1.31.0
   - range: ">=1.30.0"
     recommendedVersion: 1.30.12
     requiredVersion: 1.30.0


### PR DESCRIPTION
There are reports of `kops upgrade cluster` on a k8s 1.31 cluster not suggesting an upgrade to k8s 1.32. 

While troubleshooting I noticed these values are inconsistent compared to older k8s minor versions. I'll update the stable channel with the same change in a few days