### PR TITLE
Extend openstack mock by misc. resources

### DIFF
--- a/cloudmock/openstack/mockcompute/api.go
+++ b/cloudmock/openstack/mockcompute/api.go
@@ -20,6 +20,8 @@ import (
 	"net/http/httptest"
 	"sync"
 
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/instanceactions"
+
 	"github.com/gophercloud/gophercloud/v2"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
@@ -35,12 +37,13 @@ type MockClient struct {
 	openstack.MockOpenstackServer
 	mutex sync.Mutex
 
-	serverGroups  map[string]servergroups.ServerGroup
-	servers       map[string]servers.Server
-	keyPairs      map[string]keypairs.KeyPair
-	images        map[string]images.Image
-	flavors       map[string]flavors.Flavor
-	networkClient *gophercloud.ServiceClient
+	serverGroups    map[string]servergroups.ServerGroup
+	servers         map[string]servers.Server
+	keyPairs        map[string]keypairs.KeyPair
+	images          map[string]images.Image
+	flavors         map[string]flavors.Flavor
+	instanceActions map[string]instanceactions.InstanceAction
+	networkClient   *gophercloud.ServiceClient
 }
 
 // CreateClient will create a new mock networking client
@@ -52,6 +55,7 @@ func CreateClient(networkClient *gophercloud.ServiceClient) *MockClient {
 	m.mockServers()
 	m.mockKeyPairs()
 	m.mockFlavors()
+	m.mockInstanceActions()
 	m.Server = httptest.NewServer(m.Mux)
 	m.networkClient = networkClient
 	return m

--- a/cloudmock/openstack/mockcompute/instanceactions.go
+++ b/cloudmock/openstack/mockcompute/instanceactions.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockcompute
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type instanceActionsResponse struct {
+	InstanceActions []interface{} `json:"instanceActions"`
+}
+
+func (m *MockClient) mockInstanceActions() {
+	//re := regexp.MustCompile(`/servers/(.*?)/os-instance-actions/?`)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
+
+		w.Header().Add("Content-Type", "application/json")
+
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		resp := instanceActionsResponse{
+			InstanceActions: make([]interface{}, 0),
+		}
+		respB, err := json.Marshal(resp)
+		if err != nil {
+			panic("failed to marshal response")
+		}
+		_, err = w.Write(respB)
+		if err != nil {
+			panic("failed to write body")
+		}
+	}
+	m.Mux.HandleFunc("/servers/{server_id}/os-instance-actions/", handler)
+}

--- a/cloudmock/openstack/mockcompute/servers.go
+++ b/cloudmock/openstack/mockcompute/servers.go
@@ -212,11 +212,21 @@ func (m *MockClient) createServer(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusAccepted)
 
+	flavorId := create.Server.FlavorRef
+	flavor := m.flavors[flavorId]
+
 	server := servers.Server{
 		ID:       uuid.New().String(),
 		Name:     create.Server.Name,
 		Metadata: create.Server.Metadata,
 		Status:   "ACTIVE",
+		Flavor: map[string]any{
+			"id":    flavor.ID,
+			"name":  flavor.Name,
+			"ram":   flavor.RAM,
+			"vcpus": flavor.VCPUs,
+			"disk":  flavor.Disk,
+		},
 	}
 	securityGroups := make([]map[string]interface{}, len(create.Server.SecurityGroups))
 	for i, groupName := range create.Server.SecurityGroups {

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/google/go-tpm v0.9.3
 	github.com/google/go-tpm-tools v0.4.5
 	github.com/google/uuid v1.6.0
-	github.com/gophercloud/gophercloud/v2 v2.6.0
+	github.com/gophercloud/gophercloud/v2 v2.7.0
 	github.com/hetznercloud/hcloud-go v1.59.2
 	github.com/jacksontj/memberlistmesh v0.0.0-20190905163944-93462b9d2bb7
 	github.com/pelletier/go-toml v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,8 @@ github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrk
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
 github.com/gophercloud/gophercloud/v2 v2.6.0 h1:XJKQ0in3iHOZHVAFMXq/OhjCuvvG+BKR0unOqRfG1EI=
 github.com/gophercloud/gophercloud/v2 v2.6.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
+github.com/gophercloud/gophercloud/v2 v2.7.0 h1:o0m4kgVcPgHlcXiWAjoVxGd8QCmvM5VU+YM71pFbn0E=
+github.com/gophercloud/gophercloud/v2 v2.7.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.6 h1:GW/XbdyBFQ8Qe+YAmFU
 github.com/googleapis/enterprise-certificate-proxy v0.3.6/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrkurSS/Q=
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
-github.com/gophercloud/gophercloud/v2 v2.6.0 h1:XJKQ0in3iHOZHVAFMXq/OhjCuvvG+BKR0unOqRfG1EI=
-github.com/gophercloud/gophercloud/v2 v2.6.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
 github.com/gophercloud/gophercloud/v2 v2.7.0 h1:o0m4kgVcPgHlcXiWAjoVxGd8QCmvM5VU+YM71pFbn0E=
 github.com/gophercloud/gophercloud/v2 v2.7.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -172,7 +172,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
-	github.com/gophercloud/gophercloud/v2 v2.6.0 // indirect
+	github.com/gophercloud/gophercloud/v2 v2.7.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -620,8 +620,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrkurSS/Q=
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
-github.com/gophercloud/gophercloud/v2 v2.6.0 h1:XJKQ0in3iHOZHVAFMXq/OhjCuvvG+BKR0unOqRfG1EI=
-github.com/gophercloud/gophercloud/v2 v2.6.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
+github.com/gophercloud/gophercloud/v2 v2.7.0 h1:o0m4kgVcPgHlcXiWAjoVxGd8QCmvM5VU+YM71pFbn0E=
+github.com/gophercloud/gophercloud/v2 v2.7.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/vendor/github.com/gophercloud/gophercloud/v2/CHANGELOG.md
+++ b/vendor/github.com/gophercloud/gophercloud/v2/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v2.7.0 (2025-04-03)
+
+* [GH-3306](https://github.com/gophercloud/gophercloud/pull/3306) [v2] identity: Add Get endpoint by ID
+* [GH-3325](https://github.com/gophercloud/gophercloud/pull/3325) [v2] Switch to a version of gocovmerge compatible with go 1.22
+* [GH-3327](https://github.com/gophercloud/gophercloud/pull/3327) Merge pull request #3209 from shiftstack/proper-service-discovery
+* [GH-3328](https://github.com/gophercloud/gophercloud/pull/3328) [v2] Improve support for `network standard-attr-*` extensions
+* [GH-3330](https://github.com/gophercloud/gophercloud/pull/3330) [v2] Enhance Snapshot struct and add ListDetail function in V3 blockstorage
+* [GH-3333](https://github.com/gophercloud/gophercloud/pull/3333) [v2] vpnaas: add support for more ciphers (auth, encryption, pfs modes)
+* [GH-3334](https://github.com/gophercloud/gophercloud/pull/3334) [v2] Added support for VIF's in Baremetal
+* [GH-3335](https://github.com/gophercloud/gophercloud/pull/3335) [v2] Baremetal virtual media Get API
+
 ## v2.6.0 (2025-03-03)
 
 * [GH-3309](https://github.com/gophercloud/gophercloud/pull/3309) Backport: Added support for hypervisor_hostname to v2

--- a/vendor/github.com/gophercloud/gophercloud/v2/endpoint_search.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/endpoint_search.go
@@ -1,5 +1,7 @@
 package gophercloud
 
+import "slices"
+
 // Availability indicates to whom a specific service endpoint is accessible:
 // the internet at large, internal networks only, or only to administrators.
 // Different identity services use different terminology for these. Identity v2
@@ -22,6 +24,31 @@ const (
 	AvailabilityInternal Availability = "internal"
 )
 
+// ServiceTypeAliases contains a mapping of service types to any aliases, as
+// defined by the OpenStack Service Types Authority. Only service types that
+// we support are included.
+var ServiceTypeAliases = map[string][]string{
+	"application-container":               {"container"},
+	"baremetal":                           {"bare-metal"},
+	"baremetal-introspection":             {},
+	"block-storage":                       {"block-store", "volume", "volumev2", "volumev3"},
+	"compute":                             {},
+	"container-infrastructure-management": {"container-infrastructure", "container-infra"},
+	"database":                            {},
+	"dns":                                 {},
+	"identity":                            {},
+	"image":                               {},
+	"key-manager":                         {},
+	"load-balancer":                       {},
+	"message":                             {"messaging"},
+	"networking":                          {},
+	"object-store":                        {},
+	"orchestration":                       {},
+	"placement":                           {},
+	"shared-file-system":                  {"sharev2", "share"},
+	"workflow":                            {"workflowv2"},
+}
+
 // EndpointOpts specifies search criteria used by queries against an
 // OpenStack service catalog. The options must contain enough information to
 // unambiguously identify one, and only one, endpoint within the catalog.
@@ -30,14 +57,22 @@ const (
 // package, like "openstack.NewComputeV2()".
 type EndpointOpts struct {
 	// Type [required] is the service type for the client (e.g., "compute",
-	// "object-store"). Generally, this will be supplied by the service client
-	// function, but a user-given value will be honored if provided.
+	// "object-store"), as defined by the OpenStack Service Types Authority.
+	// This will generally be supplied by the service client function, but a
+	// user-given value will be honored if provided.
 	Type string
 
 	// Name [optional] is the service name for the client (e.g., "nova") as it
 	// appears in the service catalog. Services can have the same Type but a
 	// different Name, which is why both Type and Name are sometimes needed.
 	Name string
+
+	// Aliases [optional] is the set of aliases of the service type (e.g.
+	// "volumev2"/"volumev3", "volume" and "block-store" for the
+	// "block-storage" service type), as defined by the OpenStack Service Types
+	// Authority. As with Type, this will generally be supplied by the service
+	// client function, but a user-given value will be honored if provided.
+	Aliases []string
 
 	// Region [required] is the geographic region in which the endpoint resides,
 	// generally specifying which datacenter should house your resources.
@@ -73,4 +108,26 @@ func (eo *EndpointOpts) ApplyDefaults(t string) {
 	if eo.Availability == "" {
 		eo.Availability = AvailabilityPublic
 	}
+	if len(eo.Aliases) == 0 {
+		if aliases, ok := ServiceTypeAliases[eo.Type]; ok {
+			// happy path: user requested a service type by its official name
+			eo.Aliases = aliases
+		} else {
+			// unhappy path: user requested a service type by its alias or an
+			// invalid/unsupported service type
+			// TODO(stephenfin): This should probably be an error in v3
+			for t, aliases := range ServiceTypeAliases {
+				if slices.Contains(aliases, eo.Type) {
+					// we intentionally override the service type, even if it
+					// was explicitly requested by the user
+					eo.Type = t
+					eo.Aliases = aliases
+				}
+			}
+		}
+	}
+}
+
+func (eo *EndpointOpts) Types() []string {
+	return append([]string{eo.Type}, eo.Aliases...)
 }

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/client.go
@@ -344,6 +344,7 @@ func NewIdentityV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOp
 	}, nil
 }
 
+// TODO(stephenfin): Allow passing aliases to all New${SERVICE}V${VERSION} methods in v3
 func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clientType string) (*gophercloud.ServiceClient, error) {
 	sc := new(gophercloud.ServiceClient)
 	eo.ApplyDefaults(clientType)
@@ -393,6 +394,7 @@ func NewNetworkV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpt
 	return sc, err
 }
 
+// TODO(stephenfin): Remove this in v3. We no longer support the V1 Block Storage service.
 // NewBlockStorageV1 creates a ServiceClient that may be used to access the v1
 // block storage service.
 func NewBlockStorageV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
@@ -402,17 +404,17 @@ func NewBlockStorageV1(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 // NewBlockStorageV2 creates a ServiceClient that may be used to access the v2
 // block storage service.
 func NewBlockStorageV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "volumev2")
+	return initClientOpts(client, eo, "block-storage")
 }
 
 // NewBlockStorageV3 creates a ServiceClient that may be used to access the v3 block storage service.
 func NewBlockStorageV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "volumev3")
+	return initClientOpts(client, eo, "block-storage")
 }
 
 // NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
 func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "sharev2")
+	return initClientOpts(client, eo, "shared-file-system")
 }
 
 // NewOrchestrationV1 creates a ServiceClient that may be used to access the v1
@@ -457,14 +459,14 @@ func NewLoadBalancerV2(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 // NewMessagingV2 creates a ServiceClient that may be used with the v2 messaging
 // service.
 func NewMessagingV2(client *gophercloud.ProviderClient, clientID string, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "messaging")
+	sc, err := initClientOpts(client, eo, "message")
 	sc.MoreHeaders = map[string]string{"Client-ID": clientID}
 	return sc, err
 }
 
 // NewContainerV1 creates a ServiceClient that may be used with v1 container package
 func NewContainerV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "container")
+	return initClientOpts(client, eo, "application-container")
 }
 
 // NewKeyManagerV1 creates a ServiceClient that may be used with the v1 key
@@ -478,12 +480,12 @@ func NewKeyManagerV1(client *gophercloud.ProviderClient, eo gophercloud.Endpoint
 // NewContainerInfraV1 creates a ServiceClient that may be used with the v1 container infra management
 // package.
 func NewContainerInfraV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "container-infra")
+	return initClientOpts(client, eo, "container-infrastructure-management")
 }
 
 // NewWorkflowV2 creates a ServiceClient that may be used with the v2 workflow management package.
 func NewWorkflowV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "workflowv2")
+	return initClientOpts(client, eo, "workflow")
 }
 
 // NewPlacementV1 creates a ServiceClient that may be used with the placement package.

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/compute/v2/instanceactions/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/compute/v2/instanceactions/doc.go
@@ -1,0 +1,26 @@
+package instanceactions
+
+/*
+Package instanceactions provides the ability to list or get a server instance-action.
+
+Example to List and Get actions:
+
+	pages, err := instanceactions.List(client, "server-id", nil).AllPages(context.TODO())
+	if err != nil {
+		panic("fail to get actions pages")
+	}
+
+	actions, err := instanceactions.ExtractInstanceActions(pages)
+	if err != nil {
+		panic("fail to list instance actions")
+	}
+
+	for _, action := range actions {
+		action, err = instanceactions.Get(context.TODO(), client, "server-id", action.RequestID).Extract()
+		if err != nil {
+			panic("fail to get instance action")
+		}
+
+		fmt.Println(action)
+	}
+*/

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/compute/v2/instanceactions/request.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/compute/v2/instanceactions/request.go
@@ -1,0 +1,81 @@
+package instanceactions
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToInstanceActionsListQuery() (string, error)
+}
+
+// ListOpts represents options used to filter instance action results
+// in a List request.
+type ListOpts struct {
+	// Limit is an integer value to limit the results to return.
+	// This requires microversion 2.58 or later.
+	Limit int `q:"limit"`
+
+	// Marker is the request ID of the last-seen instance action.
+	// This requires microversion 2.58 or later.
+	Marker string `q:"marker"`
+
+	// ChangesSince filters the response by actions after the given time.
+	// This requires microversion 2.58 or later.
+	ChangesSince *time.Time `q:"changes-since"`
+
+	// ChangesBefore filters the response by actions before the given time.
+	// This requires microversion 2.66 or later.
+	ChangesBefore *time.Time `q:"changes-before"`
+}
+
+// ToInstanceActionsListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToInstanceActionsListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+
+	params := q.Query()
+
+	if opts.ChangesSince != nil {
+		params.Add("changes-since", opts.ChangesSince.Format(time.RFC3339))
+	}
+
+	if opts.ChangesBefore != nil {
+		params.Add("changes-before", opts.ChangesBefore.Format(time.RFC3339))
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+	return q.String(), nil
+}
+
+// List makes a request against the API to list the servers actions.
+func List(client *gophercloud.ServiceClient, id string, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client, id)
+	if opts != nil {
+		query, err := opts.ToInstanceActionsListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return InstanceActionPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get makes a request against the API to get a server action.
+func Get(ctx context.Context, client *gophercloud.ServiceClient, serverID, requestID string) (r InstanceActionResult) {
+	resp, err := client.Get(ctx, instanceActionsURL(client, serverID, requestID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/compute/v2/instanceactions/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/compute/v2/instanceactions/results.go
@@ -1,0 +1,194 @@
+package instanceactions
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// InstanceAction represents an instance action.
+type InstanceAction struct {
+	// Action is the name of the action.
+	Action string `json:"action"`
+
+	// InstanceUUID is the UUID of the instance.
+	InstanceUUID string `json:"instance_uuid"`
+
+	// Message is the related error message for when an action fails.
+	Message string `json:"message"`
+
+	// Project ID is the ID of the project which initiated the action.
+	ProjectID string `json:"project_id"`
+
+	// RequestID is the ID generated when performing the action.
+	RequestID string `json:"request_id"`
+
+	// StartTime is the time the action started.
+	StartTime time.Time `json:"-"`
+
+	// UserID is the ID of the user which initiated the action.
+	UserID string `json:"user_id"`
+}
+
+// UnmarshalJSON converts our JSON API response into our instance action struct
+func (i *InstanceAction) UnmarshalJSON(b []byte) error {
+	type tmp InstanceAction
+	var s struct {
+		tmp
+		StartTime gophercloud.JSONRFC3339MilliNoZ `json:"start_time"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*i = InstanceAction(s.tmp)
+
+	i.StartTime = time.Time(s.StartTime)
+
+	return err
+}
+
+// InstanceActionPage abstracts the raw results of making a List() request
+// against the API. As OpenStack extensions may freely alter the response bodies
+// of structures returned to the client, you may only safely access the data
+// provided through the ExtractInstanceActions call.
+type InstanceActionPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if an InstanceActionPage contains no instance actions.
+func (r InstanceActionPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	instanceactions, err := ExtractInstanceActions(r)
+	return len(instanceactions) == 0, err
+}
+
+// ExtractInstanceActions interprets a page of results as a slice
+// of InstanceAction.
+func ExtractInstanceActions(r pagination.Page) ([]InstanceAction, error) {
+	var resp []InstanceAction
+	err := ExtractInstanceActionsInto(r, &resp)
+	return resp, err
+}
+
+// Event represents an event of instance action.
+type Event struct {
+	// Event is the name of the event.
+	Event string `json:"event"`
+
+	// Host is the host of the event.
+	// This requires microversion 2.62 or later.
+	Host *string `json:"host"`
+
+	// HostID is the host id of the event.
+	// This requires microversion 2.62 or later.
+	HostID *string `json:"hostId"`
+
+	// Result is the result of the event.
+	Result string `json:"result"`
+
+	// Traceback is the traceback stack if an error occurred.
+	Traceback string `json:"traceback"`
+
+	// StartTime is the time the action started.
+	StartTime time.Time `json:"-"`
+
+	// FinishTime is the time the event finished.
+	FinishTime time.Time `json:"-"`
+}
+
+// UnmarshalJSON converts our JSON API response into our instance action struct.
+func (e *Event) UnmarshalJSON(b []byte) error {
+	type tmp Event
+	var s struct {
+		tmp
+		StartTime  gophercloud.JSONRFC3339MilliNoZ `json:"start_time"`
+		FinishTime gophercloud.JSONRFC3339MilliNoZ `json:"finish_time"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*e = Event(s.tmp)
+
+	e.StartTime = time.Time(s.StartTime)
+	e.FinishTime = time.Time(s.FinishTime)
+
+	return err
+}
+
+// InstanceActionDetail represents the details of an Action.
+type InstanceActionDetail struct {
+	// Action is the name of the Action.
+	Action string `json:"action"`
+
+	// InstanceUUID is the UUID of the instance.
+	InstanceUUID string `json:"instance_uuid"`
+
+	// Message is the related error message for when an action fails.
+	Message string `json:"message"`
+
+	// Project ID is the ID of the project which initiated the action.
+	ProjectID string `json:"project_id"`
+
+	// RequestID is the ID generated when performing the action.
+	RequestID string `json:"request_id"`
+
+	// UserID is the ID of the user which initiated the action.
+	UserID string `json:"user_id"`
+
+	// Events is the list of events of the action.
+	// This requires microversion 2.50 or later.
+	Events *[]Event `json:"events"`
+
+	// UpdatedAt last update date of the action.
+	// This requires microversion 2.58 or later.
+	UpdatedAt *time.Time `json:"-"`
+
+	// StartTime is the time the action started.
+	StartTime time.Time `json:"-"`
+}
+
+// UnmarshalJSON converts our JSON API response into our instance action struct
+func (i *InstanceActionDetail) UnmarshalJSON(b []byte) error {
+	type tmp InstanceActionDetail
+	var s struct {
+		tmp
+		UpdatedAt *gophercloud.JSONRFC3339MilliNoZ `json:"updated_at"`
+		StartTime gophercloud.JSONRFC3339MilliNoZ  `json:"start_time"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*i = InstanceActionDetail(s.tmp)
+
+	i.UpdatedAt = (*time.Time)(s.UpdatedAt)
+	i.StartTime = time.Time(s.StartTime)
+	return err
+}
+
+// InstanceActionResult is the result handler of Get.
+type InstanceActionResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a result as an InstanceActionDetail.
+func (r InstanceActionResult) Extract() (InstanceActionDetail, error) {
+	var s InstanceActionDetail
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+func (r InstanceActionResult) ExtractInto(v any) error {
+	return r.Result.ExtractIntoStructPtr(v, "instanceAction")
+}
+
+func ExtractInstanceActionsInto(r pagination.Page, v any) error {
+	return r.(InstanceActionPage).Result.ExtractIntoSlicePtr(v, "instanceActions")
+}

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/compute/v2/instanceactions/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/compute/v2/instanceactions/urls.go
@@ -1,0 +1,11 @@
+package instanceactions
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func listURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "os-instance-actions")
+}
+
+func instanceActionsURL(client *gophercloud.ServiceClient, serverID, requestID string) string {
+	return client.ServiceURL("servers", serverID, "os-instance-actions", requestID)
+}

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/endpoint_location.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/endpoint_location.go
@@ -1,6 +1,8 @@
 package openstack
 
 import (
+	"slices"
+
 	"github.com/gophercloud/gophercloud/v2"
 	tokens2 "github.com/gophercloud/gophercloud/v2/openstack/identity/v2/tokens"
 	tokens3 "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
@@ -20,7 +22,7 @@ func V2EndpointURL(catalog *tokens2.ServiceCatalog, opts gophercloud.EndpointOpt
 	// Extract Endpoints from the catalog entries that match the requested Type, Name if provided, and Region if provided.
 	var endpoints = make([]tokens2.Endpoint, 0, 1)
 	for _, entry := range catalog.Entries {
-		if (entry.Type == opts.Type) && (opts.Name == "" || entry.Name == opts.Name) {
+		if (slices.Contains(opts.Types(), entry.Type)) && (opts.Name == "" || entry.Name == opts.Name) {
 			for _, endpoint := range entry.Endpoints {
 				if opts.Region == "" || endpoint.Region == opts.Region {
 					endpoints = append(endpoints, endpoint)
@@ -74,7 +76,7 @@ func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts gophercloud.EndpointOpt
 	// Name if provided, and Region if provided.
 	var endpoints = make([]tokens3.Endpoint, 0, 1)
 	for _, entry := range catalog.Entries {
-		if (entry.Type == opts.Type) && (opts.Name == "" || entry.Name == opts.Name) {
+		if (slices.Contains(opts.Types(), entry.Type)) && (opts.Name == "" || entry.Name == opts.Name) {
 			for _, endpoint := range entry.Endpoints {
 				if opts.Availability != gophercloud.AvailabilityAdmin &&
 					opts.Availability != gophercloud.AvailabilityPublic &&

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -2,6 +2,7 @@ package floatingips
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -37,6 +38,7 @@ type ListOpts struct {
 	TagsAny           string `q:"tags-any"`
 	NotTags           string `q:"not-tags"`
 	NotTagsAny        string `q:"not-tags-any"`
+	RevisionNumber    *int   `q:"revision_number"`
 }
 
 // ToNetworkListQuery formats a ListOpts into a query string.
@@ -144,6 +146,11 @@ type UpdateOpts struct {
 	Description *string `json:"description,omitempty"`
 	PortID      *string `json:"port_id,omitempty"`
 	FixedIP     string  `json:"fixed_ip_address,omitempty"`
+
+	// RevisionNumber implements extension:standard-attr-revisions. If != "" it
+	// will set revision_number=%s. If the revision number does not match, the
+	// update will fail.
+	RevisionNumber *int `json:"-" h:"If-Match"`
 }
 
 // ToFloatingIPUpdateMap allows UpdateOpts to satisfy the UpdateOptsBuilder
@@ -171,8 +178,19 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 		r.Err = err
 		return
 	}
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	for k := range h {
+		if k == "If-Match" {
+			h[k] = fmt.Sprintf("revision_number=%s", h[k])
+		}
+	}
 	resp, err := c.Put(ctx, resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
+		MoreHeaders: h,
+		OkCodes:     []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips/results.go
@@ -56,6 +56,9 @@ type FloatingIP struct {
 
 	// Tags optionally set via extensions/attributestags
 	Tags []string `json:"tags"`
+
+	// RevisionNumber optionally set via extensions/standard-attr-revisions
+	RevisionNumber int `json:"revision_number"`
 }
 
 func (r *FloatingIP) UnmarshalJSON(b []byte) error {

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -13,22 +14,23 @@ import (
 // sort by a particular network attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID           string `q:"id"`
-	Name         string `q:"name"`
-	Description  string `q:"description"`
-	AdminStateUp *bool  `q:"admin_state_up"`
-	Distributed  *bool  `q:"distributed"`
-	Status       string `q:"status"`
-	TenantID     string `q:"tenant_id"`
-	ProjectID    string `q:"project_id"`
-	Limit        int    `q:"limit"`
-	Marker       string `q:"marker"`
-	SortKey      string `q:"sort_key"`
-	SortDir      string `q:"sort_dir"`
-	Tags         string `q:"tags"`
-	TagsAny      string `q:"tags-any"`
-	NotTags      string `q:"not-tags"`
-	NotTagsAny   string `q:"not-tags-any"`
+	ID             string `q:"id"`
+	Name           string `q:"name"`
+	Description    string `q:"description"`
+	AdminStateUp   *bool  `q:"admin_state_up"`
+	Distributed    *bool  `q:"distributed"`
+	Status         string `q:"status"`
+	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+	Tags           string `q:"tags"`
+	TagsAny        string `q:"tags-any"`
+	NotTags        string `q:"not-tags"`
+	NotTagsAny     string `q:"not-tags-any"`
+	RevisionNumber *int   `q:"revision_number"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -112,6 +114,11 @@ type UpdateOpts struct {
 	Distributed  *bool        `json:"distributed,omitempty"`
 	GatewayInfo  *GatewayInfo `json:"external_gateway_info,omitempty"`
 	Routes       *[]Route     `json:"routes,omitempty"`
+
+	// RevisionNumber implements extension:standard-attr-revisions. If != "" it
+	// will set revision_number=%s. If the revision number does not match, the
+	// update will fail.
+	RevisionNumber *int `json:"-" h:"If-Match"`
 }
 
 // ToRouterUpdateMap builds an update body based on UpdateOpts.
@@ -130,8 +137,19 @@ func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts U
 		r.Err = err
 		return
 	}
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	for k := range h {
+		if k == "If-Match" {
+			h[k] = fmt.Sprintf("revision_number=%s", h[k])
+		}
+	}
 	resp, err := c.Put(ctx, resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
+		MoreHeaders: h,
+		OkCodes:     []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -77,6 +77,15 @@ type Router struct {
 
 	// Tags optionally set via extensions/attributestags
 	Tags []string `json:"tags"`
+
+	// RevisionNumber optionally set via extensions/standard-attr-revisions
+	RevisionNumber int `json:"revision_number"`
+
+	// Timestamp when the router was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Timestamp when the router was last updated
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // RouterPage is the page returned by a pager when traversing over a

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups/results.go
@@ -41,6 +41,9 @@ type SecGroup struct {
 
 	// Tags optionally set via extensions/attributestags
 	Tags []string `json:"tags"`
+
+	// RevisionNumber optionally set via extensions/standard-attr-revisions
+	RevisionNumber int `json:"revision_number"`
 }
 
 func (r *SecGroup) UnmarshalJSON(b []byte) error {

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules/requests.go
@@ -29,6 +29,7 @@ type ListOpts struct {
 	Marker         string `q:"marker"`
 	SortKey        string `q:"sort_key"`
 	SortDir        string `q:"sort_dir"`
+	RevisionNumber *int   `q:"revision_number"`
 }
 
 // List returns a Pager which allows you to iterate over a collection of

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules/results.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"time"
+
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
@@ -56,6 +58,15 @@ type SecGroupRule struct {
 
 	// ProjectID is the project owner of this security group rule.
 	ProjectID string `json:"project_id"`
+
+	// RevisionNumber optionally set via extensions/standard-attr-revisions
+	RevisionNumber int `json:"revision_number"`
+
+	// Timestamp when the rule was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Timestamp when the rule was last updated
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // SecGroupRulePage is the page returned by a pager when traversing over a

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks/requests.go
@@ -20,22 +20,23 @@ type ListOptsBuilder interface {
 // by a particular network attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Status       string `q:"status"`
-	Name         string `q:"name"`
-	Description  string `q:"description"`
-	AdminStateUp *bool  `q:"admin_state_up"`
-	TenantID     string `q:"tenant_id"`
-	ProjectID    string `q:"project_id"`
-	Shared       *bool  `q:"shared"`
-	ID           string `q:"id"`
-	Marker       string `q:"marker"`
-	Limit        int    `q:"limit"`
-	SortKey      string `q:"sort_key"`
-	SortDir      string `q:"sort_dir"`
-	Tags         string `q:"tags"`
-	TagsAny      string `q:"tags-any"`
-	NotTags      string `q:"not-tags"`
-	NotTagsAny   string `q:"not-tags-any"`
+	Status         string `q:"status"`
+	Name           string `q:"name"`
+	Description    string `q:"description"`
+	AdminStateUp   *bool  `q:"admin_state_up"`
+	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
+	Shared         *bool  `q:"shared"`
+	ID             string `q:"id"`
+	Marker         string `q:"marker"`
+	Limit          int    `q:"limit"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+	Tags           string `q:"tags"`
+	TagsAny        string `q:"tags-any"`
+	NotTags        string `q:"not-tags"`
+	NotTagsAny     string `q:"not-tags-any"`
+	RevisionNumber *int   `q:"revision_number"`
 }
 
 // ToNetworkListQuery formats a ListOpts into a query string.

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports/requests.go
@@ -41,6 +41,7 @@ type ListOpts struct {
 	TagsAny        string   `q:"tags-any"`
 	NotTags        string   `q:"not-tags"`
 	NotTagsAny     string   `q:"not-tags-any"`
+	RevisionNumber *int     `q:"revision_number"`
 	SecurityGroups []string `q:"security_groups"`
 	FixedIPs       []FixedIPOpts
 }

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets/requests.go
@@ -42,6 +42,7 @@ type ListOpts struct {
 	TagsAny           string `q:"tags-any"`
 	NotTags           string `q:"not-tags"`
 	NotTagsAny        string `q:"not-tags-any"`
+	RevisionNumber    *int   `q:"revision_number"`
 }
 
 // ToSubnetListQuery formats a ListOpts into a query string.

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets/results.go
@@ -1,6 +1,8 @@
 package subnets
 
 import (
+	"time"
+
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
@@ -121,6 +123,12 @@ type Subnet struct {
 
 	// RevisionNumber optionally set via extensions/standard-attr-revisions
 	RevisionNumber int `json:"revision_number"`
+
+	// Timestamp when the subnet was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Timestamp when the subnet was last updated
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // SubnetPage is the page returned by a pager when traversing over a collection

--- a/vendor/github.com/gophercloud/gophercloud/v2/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/provider_client.go
@@ -13,7 +13,7 @@ import (
 
 // DefaultUserAgent is the default User-Agent string set in the request header.
 const (
-	DefaultUserAgent         = "gophercloud/v2.6.0"
+	DefaultUserAgent         = "gophercloud/v2.7.0"
 	DefaultMaxBackoffRetries = 60
 )
 

--- a/vendor/github.com/gophercloud/gophercloud/v2/service_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/service_client.go
@@ -115,13 +115,17 @@ func (client *ServiceClient) Head(ctx context.Context, url string, opts *Request
 }
 
 func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
+	serviceType := client.Type
+
 	switch client.Type {
 	case "compute":
 		opts.MoreHeaders["X-OpenStack-Nova-API-Version"] = client.Microversion
-	case "sharev2":
+	case "shared-file-system", "sharev2", "share":
 		opts.MoreHeaders["X-OpenStack-Manila-API-Version"] = client.Microversion
-	case "volume":
+	case "block-storage", "block-store", "volume", "volumev3":
 		opts.MoreHeaders["X-OpenStack-Volume-API-Version"] = client.Microversion
+		// cinder should accept block-storage but (as of Dalmatian) does not
+		serviceType = "volume"
 	case "baremetal":
 		opts.MoreHeaders["X-OpenStack-Ironic-API-Version"] = client.Microversion
 	case "baremetal-introspection":
@@ -129,7 +133,7 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 	}
 
 	if client.Type != "" {
-		opts.MoreHeaders["OpenStack-API-Version"] = client.Type + " " + client.Microversion
+		opts.MoreHeaders["OpenStack-API-Version"] = serviceType + " " + client.Microversion
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -738,7 +738,7 @@ github.com/googleapis/gax-go/v2/callctx
 github.com/googleapis/gax-go/v2/internal
 github.com/googleapis/gax-go/v2/internallog
 github.com/googleapis/gax-go/v2/internallog/internal
-# github.com/gophercloud/gophercloud/v2 v2.6.0
+# github.com/gophercloud/gophercloud/v2 v2.7.0
 ## explicit; go 1.22
 github.com/gophercloud/gophercloud/v2
 github.com/gophercloud/gophercloud/v2/openstack
@@ -746,6 +746,7 @@ github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes
 github.com/gophercloud/gophercloud/v2/openstack/compute/v2/attachinterfaces
 github.com/gophercloud/gophercloud/v2/openstack/compute/v2/availabilityzones
 github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors
+github.com/gophercloud/gophercloud/v2/openstack/compute/v2/instanceactions
 github.com/gophercloud/gophercloud/v2/openstack/compute/v2/keypairs
 github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups
 github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers


### PR DESCRIPTION
* Bump gophercloud and gopherclient both to v2.7.0
* Add a referenced Flavor to a Server object
* Enable to read Server Instance-Actions (just an empty list)
* Enable to create FloatinIPs