### PR TITLE
[docs] fixed cilium cni exclusive topic placement

### DIFF
--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -168,7 +168,7 @@ Cilium can make use of the [wireguard protocol for transparent encryption](https
       encryptionType: wireguard
 ```
 
-#### Resources in Cilium
+### Resources in Cilium
 {{ kops_feature_table(kops_added_default='1.21', k8s_min='1.20') }}
 
 As of kOps 1.20, it is possible to choose your own values for Cilium Agents + Operator. Example:

--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -168,17 +168,6 @@ Cilium can make use of the [wireguard protocol for transparent encryption](https
       encryptionType: wireguard
 ```
 
-#### CNI Exclusive
-{{ kops_feature_table(kops_added_default='1.32') }}
-
-If you want to use additional CNI plugins, for example when using service meshes like Istio or Linkerd, It is required to disable the `cni-exclusive` option so that Cilium does not remove the other CNI configuration files.
-
-```yaml
-  networking:
-    cilium:
-      cniExclusive: false
-```
-
 #### Resources in Cilium
 {{ kops_feature_table(kops_added_default='1.21', k8s_min='1.20') }}
 
@@ -188,6 +177,17 @@ As of kOps 1.20, it is possible to choose your own values for Cilium Agents + Op
     cilium:
       cpuRequest: "25m"
       memoryRequest: "128Mi"
+```
+
+### CNI Exclusive
+{{ kops_feature_table(kops_added_default='1.32') }}
+
+If you want to use additional CNI plugins, for example when using service meshes like Istio or Linkerd, It is required to disable the `cni-exclusive` option so that Cilium does not remove the other CNI configuration files.
+
+```yaml
+  networking:
+    cilium:
+      cniExclusive: false
 ```
 
 ## Hubble


### PR DESCRIPTION
The "CNI Exclusive" topic should come under "Configuring Cilium" instead of "Enabling Cilium ENI IPAM (IPv4 only)". Adjusted the placement of the topic.