### PR TITLE
Remove cloud-config and cloud-provider from 1.33 kubelet

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -327,7 +327,9 @@ func (b *KubeletBuilder) buildSystemdEnvironmentFile(ctx context.Context, kubele
 	// We build this flag differently because it depends on CloudConfig, and to expose it directly
 	// would be a degree of freedom we don't have (we'd have to write the config to different files)
 	// We can always add this later if it is needed.
-	flags += " --cloud-config=" + InTreeCloudConfigFilePath
+	if b.IsKubernetesLT("1.33") {
+		flags += " --cloud-config=" + InTreeCloudConfigFilePath
+	}
 
 	if b.UsesSecondaryIP() {
 		localIP, err := b.GetMetadataLocalIP(ctx)


### PR DESCRIPTION
Several periodic tests are failing due to the removal of the --cloud-provider flag
https://github.com/kubernetes/kubernetes/pull/130161

Failing tests:
https://github.com/kubernetes/kubernetes/issues/130849

Code change modeled after the removal of the flag from the api-server
https://github.com/kubernetes/kops/commit/1f6ea4fc7519a3d9567e14cb96a5c3e7003b1912#diff-f81768b75ea2816be1479eac878f905b34b772f08c233164966f7fbe237d91b1