### PR TITLE
GCE: avoid duplicate bucket IAM tasks for a single service account

### DIFF
--- a/pkg/model/gcemodel/storageacl.go
+++ b/pkg/model/gcemodel/storageacl.go
@@ -38,7 +38,7 @@ type StorageAclBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.CloudupModelBuilder = &NetworkModelBuilder{}
+var _ fi.CloudupModelBuilder = &StorageAclBuilder{}
 
 // Build creates the tasks that set up storage acls
 

--- a/pkg/model/gcemodel/storageacl.go
+++ b/pkg/model/gcemodel/storageacl.go
@@ -125,6 +125,7 @@ func (b *StorageAclBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		Role           kops.InstanceGroupRole
 	}
 	serviceAccountRoles := make(map[serviceAccountRole]bool)
+	serviceAccountEmails := sets.NewString()
 
 	for _, ig := range b.InstanceGroups {
 		serviceAccount := b.LinkToServiceAccount(ig)
@@ -133,6 +134,12 @@ func (b *StorageAclBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 
 	for serviceAccountRole := range serviceAccountRoles {
 		role := serviceAccountRole.Role
+		email := *serviceAccountRole.ServiceAccount.Email
+
+		if serviceAccountEmails.Has(email) {
+			continue
+		}
+		serviceAccountEmails.Insert(email)
 
 		nodeRole, err := iam.BuildNodeRoleSubject(role, false)
 		if err != nil {


### PR DESCRIPTION
Keep track of already visited service accounts, using the email as the index, in order to avoid creating duplicate bucket IAM tasks.

This fixes a regression introduced in 65aba4e, where switching from email to the entire ServiceAccount object as index subkey would cause set `serviceAccountRoles` to have as many items as the amount of `InstanceGroups`, some of them referencing the same service account if they belong to the same role.
This in turn causes kops to attempt to build duplicate `StorageBucketIAM` tasks, such as object admin permission for control planes/etcd.

This was not an issue before due to implicitly avoiding duplicates by using the email as index subkey. The proposed fix is to reinstate this check, in a separate set.