### PR TITLE
Automated cherry pick of #17398: Set MACAddressPolicy=none for Ubuntu 24.04

### DIFF
--- a/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
+++ b/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
@@ -65,10 +65,11 @@ ManageForeignRoutingPolicyRules=no
 		})
 	}
 
-	// Running Amazon VPC CNI on Ubuntu 22.04 or any version of al2023 requires
+	// Running Amazon VPC CNI on Ubuntu 22.04+ or any version of al2023 requires
 	// setting MACAddressPolicy to `none` (ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/2103
+	// & https://github.com/aws/amazon-vpc-cni-k8s/issues/2839
 	// & https://github.com/kubernetes/kops/issues/16255)
-	if (b.Distribution.IsUbuntu() && b.Distribution.Version() == 22.04) ||
+	if (b.Distribution.IsUbuntu() && b.Distribution.Version() >= 22.04) ||
 		b.Distribution == distributions.DistributionAmazonLinux2023 {
 		contents := `
 [Match]


### PR DESCRIPTION
Cherry pick of #17398 on release-1.31.

#17398: Set MACAddressPolicy=none for Ubuntu 24.04

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```