### PR TITLE
Fix toolbox addons apply command

### DIFF
--- a/cmd/kops/toolbox_addons.go
+++ b/cmd/kops/toolbox_addons.go
@@ -35,15 +35,19 @@ func NewCmdToolboxAddons(out io.Writer) *cobra.Command {
 	f := channelscmd.NewChannelsFactory()
 
 	// create subcommands
-	cmd.AddCommand(&cobra.Command{
+	var applyOptions channelscmd.ApplyChannelOptions
+	applyCmd := &cobra.Command{
 		Use:     "apply CHANNEL",
 		Short:   "Applies updates from the given channel",
 		Example: "kops toolbox addons apply s3://<state_store>/<cluster_name>/addons/bootstrap-channel.yaml",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			return channelscmd.RunApplyChannel(ctx, f, out, &channelscmd.ApplyChannelOptions{}, args)
+			return channelscmd.RunApplyChannel(ctx, f, out, &applyOptions, args)
 		},
-	})
+	}
+	applyCmd.Flags().BoolVar(&applyOptions.Yes, "yes", false, "Apply update")
+
+	cmd.AddCommand(applyCmd)
 	cmd.AddCommand(&cobra.Command{
 		Use:   "list",
 		Short: "Lists installed addons",

--- a/docs/cli/kops_toolbox_addons_apply.md
+++ b/docs/cli/kops_toolbox_addons_apply.md
@@ -19,6 +19,7 @@ kops toolbox addons apply s3://<state_store>/<cluster_name>/addons/bootstrap-cha
 
 ```
   -h, --help   help for apply
+      --yes    Apply update
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Currently, when running `kops toolbox addons apply <some-channel>` user is instructed to supply non-supported flag `Must specify --yes to update`.

This change will allow to use the command the same way as in `channels/pkg/cmd/apply_channel.go`.