### PR TITLE
Fix panic when security group ID is not known

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -334,10 +334,18 @@ func (e *SecurityGroup) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletio
 
 	cloud := awsup.GetCloud(c)
 
+	filters := make([]ec2types.Filter, 0)
+	switch {
+	case e.ID != nil:
+		filters = append(filters, awsup.NewEC2Filter("group-id", *e.ID))
+	case e.Name != nil && e.VPC != nil:
+		filters = append(filters, awsup.NewEC2Filter("vpc-id", *e.VPC.ID))
+		filters = append(filters, awsup.NewEC2Filter("group-name", *e.Name))
+	default:
+		return nil, nil
+	}
 	request := &ec2.DescribeSecurityGroupRulesInput{
-		Filters: []ec2types.Filter{
-			awsup.NewEC2Filter("group-id", *e.ID),
-		},
+		Filters: filters,
 	}
 
 	response, err := cloud.EC2().DescribeSecurityGroupRules(ctx, request)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/17421