### PR TITLE
GCE: set node labels and taints as autoscaler env vars

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -124,6 +124,21 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 				if strings.HasPrefix(ig.Spec.Image, "cos-cloud/") {
 					autoscalerEnvVars = "os_distribution=cos;arch=amd64;os=linux"
 				}
+
+				if len(ig.Spec.NodeLabels) > 0 {
+					var nodeLabels string
+					for k, v := range ig.Spec.NodeLabels {
+						nodeLabels += k + "=" + v + ","
+					}
+					nodeLabels, _ = strings.CutSuffix(nodeLabels, ",")
+
+					autoscalerEnvVars += ";node_labels=" + nodeLabels
+				}
+
+				if len(ig.Spec.Taints) > 0 {
+					autoscalerEnvVars += ";node_taints=" + strings.Join(ig.Spec.Taints, ",")
+				}
+
 				t.Metadata["kube-env"] = fi.NewStringResource("AUTOSCALER_ENV_VARS: " + autoscalerEnvVars)
 			}
 

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -18,6 +18,7 @@ package gcemodel
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -127,8 +128,17 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 
 				if len(ig.Spec.NodeLabels) > 0 {
 					var nodeLabels string
-					for k, v := range ig.Spec.NodeLabels {
-						nodeLabels += k + "=" + v + ","
+					sortedLabelKeys := make([]string, len(ig.Spec.NodeLabels))
+					i := 0
+					for k := range ig.Spec.NodeLabels {
+						sortedLabelKeys[i] = k
+						i++
+					}
+					slices.SortStableFunc(sortedLabelKeys, func(a, b string) int {
+						return strings.Compare(a, b)
+					})
+					for _, k := range sortedLabelKeys {
+						nodeLabels += k + "=" + ig.Spec.NodeLabels[k] + ","
 					}
 					nodeLabels, _ = strings.CutSuffix(nodeLabels, ",")
 

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-nodes_content
@@ -45,6 +45,7 @@ KubeletConfig:
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   nodeLabels:
+    kops.k8s.io/instancegroup: nodes
     node-role.kubernetes.io/node: ""
   podInfraContainerImage: registry.k8s.io/pause:3.9
   podManifestPath: /etc/kubernetes/manifests
@@ -52,6 +53,8 @@ KubeletConfig:
   registerSchedulable: true
   shutdownGracePeriod: 30s
   shutdownGracePeriodCriticalPods: 10s
+  taints:
+  - a=b:c
 KubernetesVersion: 1.32.0
 Networking:
   nonMasqueradeCIDR: 100.64.0.0/10

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_user-data
@@ -152,7 +152,7 @@ ConfigServer:
   - https://kops-controller.internal.ha-gce.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: yKU09Zx4MJaCy5r784FI8CXqrVXqnDp7nZdOuzohYlU=
+NodeupConfigHash: RTYXnI1xkrWZ/Bnir7cCMFBfUMzhd6uvrj0Zkdg5Z7o=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
@@ -132,9 +132,13 @@ spec:
   machineType: e2-medium
   maxSize: 2
   minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test1
+  taints:
+  - a=b:c
   zones:
   - us-test1-a
   - us-test1-b

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -741,7 +741,7 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
   metadata = {
     "cluster-name"                    = "ha-gce.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
-    "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
+    "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux;node_labels=kops.k8s.io/instancegroup=nodes;node_taints=a=b:c"
     "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_user-data")
   }


### PR DESCRIPTION
This proposed change sets `InstanceGroup` node labels and taints in `kube-env` on GCP, so that autoscaler can make a scale-up decision based on taints and tolerations, and that the resulting node has the labels set.