### PR TITLE
Ensure only owned security groups are deleted

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -341,6 +341,7 @@ func (e *SecurityGroup) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletio
 	case e.Name != nil && e.VPC != nil:
 		filters = append(filters, awsup.NewEC2Filter("vpc-id", *e.VPC.ID))
 		filters = append(filters, awsup.NewEC2Filter("group-name", *e.Name))
+		filters = append(filters, awsup.NewEC2Filter("tag:kubernetes.io/cluster/"+c.T.Cluster.Name, "owned"))
 	default:
 		return nil, nil
 	}


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kops/pull/17432. I added logic to discover SGs to delete when we only know the SG name, but we should make sure these aren't shared SGs too. 