### PR TITLE
GCE: do not reset MIG target size on cluster updates

### DIFF
--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -493,7 +493,10 @@ resource "google_compute_firewall" "ssh-external-to-node-ipv6-ha-gce-example-com
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-ha-gce-example-com" {
-  base_instance_name             = "master-us-test1-a"
+  base_instance_name = "master-us-test1-a"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-master-us-test1-a-ha-gce-example-com"
   target_size                    = 1
@@ -508,7 +511,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-ha-gce-exa
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-ha-gce-example-com" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-nodes-ha-gce-example-com"
   target_size                    = 1
@@ -523,7 +529,10 @@ resource "google_compute_instance_group_manager" "a-nodes-ha-gce-example-com" {
 }
 
 resource "google_compute_instance_group_manager" "b-master-us-test1-b-ha-gce-example-com" {
-  base_instance_name             = "master-us-test1-b"
+  base_instance_name = "master-us-test1-b"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "b-master-us-test1-b-ha-gce-example-com"
   target_size                    = 1
@@ -538,7 +547,10 @@ resource "google_compute_instance_group_manager" "b-master-us-test1-b-ha-gce-exa
 }
 
 resource "google_compute_instance_group_manager" "b-nodes-ha-gce-example-com" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "b-nodes-ha-gce-example-com"
   target_size                    = 1
@@ -553,7 +565,10 @@ resource "google_compute_instance_group_manager" "b-nodes-ha-gce-example-com" {
 }
 
 resource "google_compute_instance_group_manager" "c-master-us-test1-c-ha-gce-example-com" {
-  base_instance_name             = "master-us-test1-c"
+  base_instance_name = "master-us-test1-c"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "c-master-us-test1-c-ha-gce-example-com"
   target_size                    = 1
@@ -568,7 +583,10 @@ resource "google_compute_instance_group_manager" "c-master-us-test1-c-ha-gce-exa
 }
 
 resource "google_compute_instance_group_manager" "c-nodes-ha-gce-example-com" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "c-nodes-ha-gce-example-com"
   target_size                    = 0

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -421,7 +421,10 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-example-com" {
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-example-com" {
-  base_instance_name             = "master-us-test1-a"
+  base_instance_name = "master-us-test1-a"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-master-us-test1-a-minimal-example-com"
   target_size                    = 1
@@ -436,7 +439,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-ex
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-example-com" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-nodes-minimal-example-com"
   target_size                    = 1

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -397,7 +397,10 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-example-com
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-example-com" {
-  base_instance_name             = "master-us-test1-a"
+  base_instance_name = "master-us-test1-a"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-master-us-test1-a-minimal-gce-example-com"
   target_size                    = 1
@@ -412,7 +415,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-example-com" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-nodes-minimal-gce-example-com"
   target_size                    = 2

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -461,7 +461,10 @@ resource "google_compute_forwarding_rule" "kops-controller-us-test1-minimal-gce-
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-example-com" {
-  base_instance_name             = "master-us-test1-a"
+  base_instance_name = "master-us-test1-a"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-master-us-test1-a-minimal-gce-example-com"
   target_size                    = 1
@@ -476,7 +479,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-example-com" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-nodes-minimal-gce-example-com"
   target_size                    = 2

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -430,7 +430,10 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-ilb-example-
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-ilb-example-com" {
-  base_instance_name             = "master-us-test1-a"
+  base_instance_name = "master-us-test1-a"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-master-us-test1-a-minimal-gce-ilb-example-com"
   target_size                    = 1
@@ -445,7 +448,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-ilb-example-com" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-nodes-minimal-gce-ilb-example-com"
   target_size                    = 2

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -430,7 +430,10 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-with-a-very-
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f" {
-  base_instance_name             = "master-us-test1-a"
+  base_instance_name = "master-us-test1-a"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f"
   target_size                    = 1
@@ -445,7 +448,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-with-a-very-very-very-very-very-long-qk78uj" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-nodes-minimal-gce-with-a-very-very-very-very-very-long-qk78uj"
   target_size                    = 2

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -397,7 +397,10 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-with-a-very
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f" {
-  base_instance_name             = "master-us-test1-a"
+  base_instance_name = "master-us-test1-a"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f"
   target_size                    = 1
@@ -412,7 +415,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-with-a-very-very-very-very-very-long-qk78uj" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-nodes-minimal-gce-with-a-very-very-very-very-very-long-qk78uj"
   target_size                    = 2

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -453,7 +453,10 @@ resource "google_compute_http_health_check" "api-minimal-gce-plb-example-com" {
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-plb-example-com" {
-  base_instance_name             = "master-us-test1-a"
+  base_instance_name = "master-us-test1-a"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-master-us-test1-a-minimal-gce-plb-example-com"
   target_pools                   = [google_compute_target_pool.api-minimal-gce-plb-example-com.self_link]
@@ -469,7 +472,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-plb-example-com" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-nodes-minimal-gce-plb-example-com"
   target_size                    = 2

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -397,7 +397,10 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-private-exa
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-private-example-com" {
-  base_instance_name             = "master-us-test1-a"
+  base_instance_name = "master-us-test1-a"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-master-us-test1-a-minimal-gce-private-example-com"
   target_size                    = 1
@@ -412,7 +415,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-private-example-com" {
-  base_instance_name             = "nodes"
+  base_instance_name = "nodes"
+  lifecycle {
+    ignore_changes = [target_size]
+  }
   list_managed_instances_results = "PAGINATED"
   name                           = "a-nodes-minimal-gce-private-example-com"
   target_size                    = 2

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
@@ -63,7 +63,7 @@ func (e *InstanceGroupManager) Find(c *fi.CloudupContext) (*InstanceGroupManager
 	actual.Name = &r.Name
 	actual.Zone = fi.PtrTo(lastComponent(r.Zone))
 	actual.BaseInstanceName = &r.BaseInstanceName
-	actual.TargetSize = &r.TargetSize
+	actual.TargetSize = e.TargetSize
 	actual.InstanceTemplate = &InstanceTemplate{ID: fi.PtrTo(lastComponent(r.InstanceTemplate))}
 	actual.ListManagedInstancesResults = r.ListManagedInstancesResults
 
@@ -187,6 +187,7 @@ func (_ *InstanceGroupManager) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Ins
 }
 
 type terraformInstanceGroupManager struct {
+	Lifecycle                   *terraform.Lifecycle       `cty:"lifecycle"`
 	Name                        *string                    `cty:"name"`
 	Zone                        *string                    `cty:"zone"`
 	BaseInstanceName            *string                    `cty:"base_instance_name"`
@@ -213,6 +214,9 @@ func (_ *InstanceGroupManager) RenderTerraform(t *terraform.TerraformTarget, a, 
 		BaseInstanceName:            e.BaseInstanceName,
 		TargetSize:                  e.TargetSize,
 		ListManagedInstancesResults: e.ListManagedInstancesResults,
+	}
+	tf.Lifecycle = &terraform.Lifecycle{
+		IgnoreChanges: []*terraformWriter.Literal{{String: "target_size"}},
 	}
 	if policy := e.UpdatePolicy; policy != nil {
 		tf.UpdatePolicy = &terraformUpdatePolicy{


### PR DESCRIPTION
This change makes it so that kops doesn't reset existing GCE managed instance groups `target_size` field on cluster updates, making it a "set once at creation" parameter.

The reason for this proposal is the following:

It is more consistent with the AWS model, where autoscaling groups do not have a `desired_capacity` value set, and instead set the initial ASG size at creation time based on `min_size` value. GCE's API does not support min and max sizes for MIGs, so `target_size` has to be set at least once.

The respective implementations on direct cloud and Terraform targets make `target_size` behave like AWS' `min_size`. This way, kops does not interfere with any external MIG size changes (e.g. from `cluster-autoscaler`).