### PR TITLE
Makefile: correct .PHONY casing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,11 +103,11 @@ endif
 kops-install: kops
 	cp ${DIST}/$(shell go env GOOS)/$(shell go env GOARCH)/kops* ${GOBIN}
 
-.phony: channels-install # install channels to local $gopath/bin
+.PHONY: channels-install # install channels to local $gopath/bin
 channels-install: channels
 	cp ${DIST}/${OSARCH}/channels ${GOPATH_1ST}/bin
 
-.phony: nodeup-install # install channels to local $gopath/bin
+.PHONY: nodeup-install # install channels to local $gopath/bin
 nodeup-install: nodeup
 	cp ${DIST}/${OSARCH}/channels ${GOPATH_1ST}/bin
 


### PR DESCRIPTION
The `channels-install` and `nodeup-install` rules were mistakenly declared with a lowercase `.phony` directive.  
Only the uppercase special target `.PHONY` tells GNU make to run the rule unconditionally; with the typo, the targets could be skipped if files named `channels-install` or `nodeup-install` existed, breaking local builds or CI.

This patch capitalises the directive:

* `.PHONY: channels-install`
* `.PHONY: nodeup-install`

Restores proper phony-target behaviour and guarantees reliable installation of the `channels` and `nodeup` binaries.