### PR TITLE
Automated cherry pick of #17438: add systemd network config for Cilium and Amazon VPC CNI on Ubuntu 22.04+ and AL2023 to prevent route removal

### DIFF
--- a/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
+++ b/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
@@ -48,7 +48,10 @@ func (b *AmazonVPCRoutedENIBuilder) Build(c *fi.NodeupModelBuilderContext) error
 				{"udevadm", "trigger"},
 			},
 		})
+	}
 
+	if (b.Distribution.IsUbuntu() && b.Distribution.Version() >= 22.04) ||
+		b.Distribution == distributions.DistributionAmazonLinux2023 {
 		// Make systemd-networkd ignore foreign settings, else it may
 		// unexpectedly delete IP rules and routes added by CNI
 		contents := `


### PR DESCRIPTION
Cherry pick of #17438 on release-1.31.

#17438: add systemd network config for Cilium and Amazon VPC CNI on Ubuntu 22.04+ and AL2023 to prevent route removal

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```