### PR TITLE
Include deprecated AMIs in cross-account lookups

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -1986,6 +1986,7 @@ func resolveImage(ctx context.Context, ssmClient awsinterfaces.SSMAPI, ec2Client
 
 			request.Owners = []string{owner}
 			request.Filters = append(request.Filters, NewEC2Filter("name", tokens[1]))
+			request.IncludeDeprecated = aws.Bool(true)
 		} else {
 			return nil, fmt.Errorf("image name specification not recognized: %q", name)
 		}


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kops/issues/17440#issuecomment-2986051610

We can debate the pros and cons of this... is it better to allow creation of a cluster with an AMI that the AMI owner doesn't want users to use, or to fail cluster creation?

/hold for discussion