### PR TITLE
fix(kubelet): parse image GC args failed

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -248,6 +248,12 @@ func buildKubeletComponentConfig(kubeletConfig *kops.KubeletConfigSpec, provider
 	if kubeletConfig.ShutdownGracePeriodCriticalPods != nil {
 		componentConfig.ShutdownGracePeriodCriticalPods = *kubeletConfig.ShutdownGracePeriodCriticalPods
 	}
+	if kubeletConfig.ImageMaximumGCAge != nil {
+		componentConfig.ImageMaximumGCAge = *kubeletConfig.ImageMaximumGCAge
+	}
+	if kubeletConfig.ImageMinimumGCAge != nil {
+		componentConfig.ImageMinimumGCAge = *kubeletConfig.ImageMinimumGCAge
+	}
 	componentConfig.MemorySwap.SwapBehavior = kubeletConfig.MemorySwapBehavior
 
 	s := runtime.NewScheme()

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -132,11 +132,11 @@ type KubeletConfigSpec struct {
 	// computed (such as IPSEC).
 	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
 	// imageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: "2m"
-	ImageMinimumGCAge *string `json:"imageMinimumGCAge,omitempty" flag:"image-minimum-gc-age"`
+	ImageMinimumGCAge *metav1.Duration `json:"imageMinimumGCAge,omitempty"`
 	// imageMaximumGCAge is the maximum age an image can be unused before it is garbage collected.
 	// The default of this field is "0s", which disables this field--meaning images won't be garbage
 	// collected based on being unused for too long. Default: "0s" (disabled)
-	ImageMaximumGCAge *string `json:"imageMaximumGCAge,omitempty" flag:"image-maximum-gc-age"`
+	ImageMaximumGCAge *metav1.Duration `json:"imageMaximumGCAge,omitempty"`
 	// ImageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.
 	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"image-gc-high-threshold"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -132,11 +132,11 @@ type KubeletConfigSpec struct {
 	// computed (such as IPSEC).
 	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
 	// imageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: "2m"
-	ImageMinimumGCAge *string `json:"imageMinimumGCAge,omitempty" flag:"image-minimum-gc-age"`
+	ImageMinimumGCAge *metav1.Duration `json:"imageMinimumGCAge,omitempty"`
 	// imageMaximumGCAge is the maximum age an image can be unused before it is garbage collected.
 	// The default of this field is "0s", which disables this field--meaning images won't be garbage
 	// collected based on being unused for too long. Default: "0s" (disabled)
-	ImageMaximumGCAge *string `json:"imageMaximumGCAge,omitempty" flag:"image-maximum-gc-age"`
+	ImageMaximumGCAge *metav1.Duration `json:"imageMaximumGCAge,omitempty"`
 	// ImageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.
 	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"image-gc-high-threshold"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -4197,12 +4197,12 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 	}
 	if in.ImageMinimumGCAge != nil {
 		in, out := &in.ImageMinimumGCAge, &out.ImageMinimumGCAge
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.ImageMaximumGCAge != nil {
 		in, out := &in.ImageMaximumGCAge, &out.ImageMaximumGCAge
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.ImageGCHighThresholdPercent != nil {

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -131,11 +131,11 @@ type KubeletConfigSpec struct {
 	// computed (such as IPSEC).
 	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
 	// imageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: "2m"
-	ImageMinimumGCAge *string `json:"imageMinimumGCAge,omitempty" flag:"image-minimum-gc-age"`
+	ImageMinimumGCAge *metav1.Duration `json:"imageMinimumGCAge,omitempty"`
 	// imageMaximumGCAge is the maximum age an image can be unused before it is garbage collected.
 	// The default of this field is "0s", which disables this field--meaning images won't be garbage
 	// collected based on being unused for too long. Default: "0s" (disabled)
-	ImageMaximumGCAge *string `json:"imageMaximumGCAge,omitempty" flag:"image-maximum-gc-age"`
+	ImageMaximumGCAge *metav1.Duration `json:"imageMaximumGCAge,omitempty"`
 	// ImageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.
 	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"image-gc-high-threshold"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -4176,12 +4176,12 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 	}
 	if in.ImageMinimumGCAge != nil {
 		in, out := &in.ImageMinimumGCAge, &out.ImageMinimumGCAge
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.ImageMaximumGCAge != nil {
 		in, out := &in.ImageMaximumGCAge, &out.ImageMaximumGCAge
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.ImageGCHighThresholdPercent != nil {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4279,12 +4279,12 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 	}
 	if in.ImageMinimumGCAge != nil {
 		in, out := &in.ImageMinimumGCAge, &out.ImageMinimumGCAge
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.ImageMaximumGCAge != nil {
 		in, out := &in.ImageMaximumGCAge, &out.ImageMaximumGCAge
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.ImageGCHighThresholdPercent != nil {


### PR DESCRIPTION
Fixes #17463

This PR fixes the imageMinimumGCAge and imageMaximumGCAge parsing failure issue. This is because these two parameters are specified using the kubelet command line, and the kubelet command line itself does not provide these two parameters, so we need to write these two parameters into the kubelet file

Changes:
1. Change the type of imageMaximumGCAge and imageMinimumGCAge to metav1.Duration
3. Returns useful error messages when parsing fails
4. Added unit tests to cover valid and invalid cases