### PR TITLE
Automated cherry pick of #17459: Create flag api-server which allows for custom DNS setups

### DIFF
--- a/cmd/kops/export_kubeconfig.go
+++ b/cmd/kops/export_kubeconfig.go
@@ -94,8 +94,11 @@ func NewCmdExportKubeconfig(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().Lookup("admin").NoOptDefVal = kubeconfig.DefaultKubecfgAdminLifetime.String()
 	cmd.Flags().StringVar(&options.User, "user", options.User, "Existing user in kubeconfig file to use")
 	cmd.RegisterFlagCompletionFunc("user", completeKubecfgUser)
+
 	cmd.Flags().BoolVar(&options.Internal, "internal", options.Internal, "Use the cluster's internal DNS name")
 	cmd.Flags().BoolVar(&options.UseKopsAuthenticationPlugin, "auth-plugin", options.UseKopsAuthenticationPlugin, "Use the kOps authentication plugin")
+
+	options.CreateKubecfgOptions.AddCommonFlags(cmd.Flags())
 
 	return cmd
 }

--- a/cmd/kops/toolbox_enroll.go
+++ b/cmd/kops/toolbox_enroll.go
@@ -50,5 +50,7 @@ func NewCmdToolboxEnroll(f commandutils.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.SSHUser, "ssh-user", options.SSHUser, "user for ssh")
 	cmd.Flags().IntVar(&options.SSHPort, "ssh-port", options.SSHPort, "port for ssh")
 
+	options.CreateKubecfgOptions.AddCommonFlags(cmd.Flags())
+
 	return cmd
 }

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -170,7 +170,10 @@ func NewCmdUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().Lookup("admin").NoOptDefVal = kubeconfig.DefaultKubecfgAdminLifetime.String()
 	cmd.Flags().StringVar(&options.User, "user", options.User, "Existing user in kubeconfig file to use.  Implies --create-kube-config")
 	cmd.RegisterFlagCompletionFunc("user", completeKubecfgUser)
+
 	cmd.Flags().BoolVar(&options.Internal, "internal", options.Internal, "Use the cluster's internal DNS name. Implies --create-kube-config")
+	options.CreateKubecfgOptions.AddCommonFlags(cmd.Flags())
+
 	cmd.Flags().BoolVar(&options.AllowKopsDowngrade, "allow-kops-downgrade", options.AllowKopsDowngrade, "Allow an older version of kOps to update the cluster than last used")
 	cmd.Flags().StringSliceVar(&options.InstanceGroups, "instance-group", options.InstanceGroups, "Instance groups to update (defaults to all if not specified)")
 	cmd.RegisterFlagCompletionFunc("instance-group", completeInstanceGroup(f, &options.InstanceGroups, &options.InstanceGroupRoles))

--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -75,6 +75,8 @@ type ValidateClusterOptions struct {
 
 	// filterPodsForValidation is a function that returns true if the pod should be validated
 	filterPodsForValidation func(pod *v1.Pod) bool
+
+	ExportKubeconfigOptions
 }
 
 func (o *ValidateClusterOptions) InitDefaults() {
@@ -117,6 +119,8 @@ func NewCmdValidateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().DurationVar(&options.interval, "interval", options.interval, "Time in duration to wait between validation attempts")
 	cmd.Flags().StringVar(&options.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
 
+	options.CreateKubecfgOptions.AddCommonFlags(cmd.Flags())
+
 	return cmd
 }
 
@@ -155,12 +159,12 @@ func RunValidateCluster(ctx context.Context, f *util.Factory, out io.Writer, opt
 		return nil, fmt.Errorf("no InstanceGroup objects found")
 	}
 
-	restConfig, err := f.RESTConfig(cluster)
+	restConfig, err := f.RESTConfig(ctx, cluster, options.CreateKubecfgOptions)
 	if err != nil {
 		return nil, fmt.Errorf("getting rest config: %w", err)
 	}
 
-	httpClient, err := f.HTTPClient(cluster)
+	httpClient, err := f.HTTPClient(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("getting http client: %w", err)
 	}

--- a/docs/cli/kops_delete_instance.md
+++ b/docs/cli/kops_delete_instance.md
@@ -30,6 +30,7 @@ kops delete instance INSTANCE|NODE [flags]
 ### Options
 
 ```
+      --api-server string             Override the API server used when communicating with the cluster kube-apiserver
       --cloudonly                     Perform deletion update without confirming progress with Kubernetes
       --fail-on-drain-error           Fail if draining a node fails (default true)
       --fail-on-validate-error        Fail if the cluster fails to validate (default true)

--- a/docs/cli/kops_export_kubeconfig.md
+++ b/docs/cli/kops_export_kubeconfig.md
@@ -31,6 +31,7 @@ kops export kubeconfig [CLUSTER | --all] [flags]
 ```
       --admin duration[=18h0m0s]   Also export a cluster admin user credential with the specified lifetime and add it to the cluster context
       --all                        Export all clusters from the kOps state store
+      --api-server string          Override the API server used when communicating with the cluster kube-apiserver
       --auth-plugin                Use the kOps authentication plugin
   -h, --help                       help for kubeconfig
       --internal                   Use the cluster's internal DNS name

--- a/docs/cli/kops_get_instances.md
+++ b/docs/cli/kops_get_instances.md
@@ -19,7 +19,8 @@ kops get instances [CLUSTER] [flags]
 ### Options
 
 ```
-  -h, --help   help for instances
+      --api-server string   Override the API server used when communicating with the cluster kube-apiserver
+  -h, --help                help for instances
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -60,6 +60,7 @@ kops rolling-update cluster [CLUSTER] [flags]
 
 ```
       --admin duration                    a cluster admin user credential with the specified lifetime (default 18h0m0s)
+      --api-server string                 Override the API server used when communicating with the cluster kube-apiserver
       --bastion-interval duration         Time to wait between restarting bastions (default 15s)
       --cloudonly                         Perform rolling update without validating cluster status (will cause downtime)
       --control-plane-interval duration   Time to wait between restarting control plane nodes (default 15s)

--- a/docs/cli/kops_toolbox_enroll.md
+++ b/docs/cli/kops_toolbox_enroll.md
@@ -22,6 +22,7 @@ kops toolbox enroll [CLUSTER] [flags]
 ### Options
 
 ```
+      --api-server string       Override the API server used when communicating with the cluster kube-apiserver
       --cluster string          Name of cluster to join
   -h, --help                    help for enroll
       --host string             IP/hostname for machine to add

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -27,6 +27,7 @@ kops update cluster [CLUSTER] [flags]
 ```
       --admin duration[=18h0m0s]       Also export a cluster admin user credential with the specified lifetime and add it to the cluster context
       --allow-kops-downgrade           Allow an older version of kOps to update the cluster than last used
+      --api-server string              Override the API server used when communicating with the cluster kube-apiserver
       --create-kube-config             Will control automatically creating the kube config file on your local filesystem (default true)
   -h, --help                           help for cluster
       --ignore-kubelet-version-skew    Setting this to true will force updating the kubernetes version on all instance groups, regardles of which control plane version is running

--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -29,6 +29,7 @@ kops validate cluster [CLUSTER] [flags]
 ### Options
 
 ```
+      --api-server string   Override the API server used when communicating with the cluster kube-apiserver
       --count int           Number of consecutive successful validations required
   -h, --help                help for cluster
       --interval duration   Time in duration to wait between validation attempts (default 10s)

--- a/pkg/commands/commandutils/factory.go
+++ b/pkg/commands/commandutils/factory.go
@@ -17,15 +17,18 @@ limitations under the License.
 package commandutils
 
 import (
+	"context"
+
 	"k8s.io/client-go/rest"
 
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/client/simple"
+	"k8s.io/kops/pkg/kubeconfig"
 	"k8s.io/kops/util/pkg/vfs"
 )
 
 type Factory interface {
 	KopsClient() (simple.Clientset, error)
 	VFSContext() *vfs.VFSContext
-	RESTConfig(cluster *kops.Cluster) (*rest.Config, error)
+	RESTConfig(ctx context.Context, cluster *kops.Cluster, options kubeconfig.CreateKubecfgOptions) (*rest.Config, error)
 }

--- a/pkg/commands/toolbox_enroll.go
+++ b/pkg/commands/toolbox_enroll.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/kops/pkg/client/simple"
 	"k8s.io/kops/pkg/commands/commandutils"
 	"k8s.io/kops/pkg/featureflag"
+	"k8s.io/kops/pkg/kubeconfig"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/resources"
 	"k8s.io/kops/pkg/nodemodel"
@@ -66,6 +67,8 @@ type ToolboxEnrollOptions struct {
 
 	SSHUser string
 	SSHPort int
+
+	kubeconfig.CreateKubecfgOptions
 }
 
 func (o *ToolboxEnrollOptions) InitDefaults() {
@@ -109,7 +112,7 @@ func RunToolboxEnroll(ctx context.Context, f commandutils.Factory, out io.Writer
 
 	// Enroll the node over SSH.
 	if options.Host != "" {
-		restConfig, err := f.RESTConfig(fullCluster)
+		restConfig, err := f.RESTConfig(ctx, fullCluster, options.CreateKubecfgOptions)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubeconfig/create_kubecfg_test.go
+++ b/pkg/kubeconfig/create_kubecfg_test.go
@@ -405,6 +405,26 @@ func TestBuildKubecfg(t *testing.T) {
 			},
 			wantClientCert: false,
 		},
+		{
+			name: "Test Kube Config Data with APIEndpoint set",
+			args: args{
+				cluster: publicCluster,
+				status:  fakeStatus,
+				CreateKubecfgOptions: CreateKubecfgOptions{
+					Admin:             DefaultKubecfgAdminLifetime,
+					Internal:          true,
+					OverrideAPIServer: "https://api.testcluster.example.com",
+				},
+			},
+			want: &KubeconfigBuilder{
+				Context:       "testcluster",
+				Server:        "https://api.testcluster.example.com",
+				TLSServerName: "api.internal.testcluster",
+				CACerts:       []byte(nextCertificate + certData),
+				User:          "testcluster",
+			},
+			wantClientCert: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #17459 on release-1.32.

#17459: Create flag api-server which allows for custom DNS setups

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```