### PR TITLE
Use GCP CCM release image

### DIFF
--- a/pkg/model/components/gcpcloudcontrollermanager.go
+++ b/pkg/model/components/gcpcloudcontrollermanager.go
@@ -74,7 +74,7 @@ func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(cluster *kops.Clu
 		// TODO: Implement CCM image publishing
 		switch b.ControlPlaneKubernetesVersion().Minor() {
 		default:
-			ccmConfig.Image = "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4"
+			ccmConfig.Image = "registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1"
 		}
 	}
 

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -23,7 +23,7 @@ spec:
     clusterName: ha-gce-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+    image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 8848daa01a1eba5593954e6deed7fa332bd06580f2aeed6299e5a6a164a171da
+    manifestHash: 97f2f5e46381a092c0f0d4e0b24eccc214753d29c2764958a8982058b9004ef2
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+        image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterName: minimal-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+    image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -126,7 +126,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: dc8bbce922afb0a0b8ddf5046b0a437855e3ab3da201767529325b7306a0bfac
+    manifestHash: 106b5c019555542afd148fe44e402956c0f07c2fe966c5559f2f62d3d57f18c8
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+        image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -23,7 +23,7 @@ spec:
     clusterName: minimal-gce-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+    image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 2dbb043fedf395b9030d1dc48cd89326cf96de37aebe9019201ace2d3ee9115d
+    manifestHash: 1b0bc4e4d5008c650edab50f62fd6411d63601bd918a5d4bf3e3ae73a5994d02
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+        image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -26,7 +26,7 @@ spec:
     clusterName: minimal-gce-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+    image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 2dbb043fedf395b9030d1dc48cd89326cf96de37aebe9019201ace2d3ee9115d
+    manifestHash: 1b0bc4e4d5008c650edab50f62fd6411d63601bd918a5d4bf3e3ae73a5994d02
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+        image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
@@ -27,7 +27,7 @@ spec:
     clusterName: minimal-gce-ilb-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+    image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 125eca8c38d2f8ce90015ba6d3b6390f7b9e74488ce5d9c73cebcfbd79da0d94
+    manifestHash: 33b533a103b6a7b7c44736418febe0b638bdf6ff69b5372c6b8684789a9f88eb
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+        image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -27,7 +27,7 @@ spec:
     clusterName: minimal-gce-with-a-very-very-very-very-very-long-name-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+    image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: d14749a8f8a5984e3c8657d10b8bef7f768ba302012fb2f4f384539ed3f44e30
+    manifestHash: cf4cf06b42b81d0b775276418b79cd67e9fc843e114e569401e4e7d8cabaf669
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+        image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterName: minimal-gce-with-a-very-very-very-very-very-long-name-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+    image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: d14749a8f8a5984e3c8657d10b8bef7f768ba302012fb2f4f384539ed3f44e30
+    manifestHash: cf4cf06b42b81d0b775276418b79cd67e9fc843e114e569401e4e7d8cabaf669
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+        image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
@@ -27,7 +27,7 @@ spec:
     clusterName: minimal-gce-plb-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+    image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: dd4fb1d11df2ddeae3417f179827020f4cb1019247ff2f00c798d938f6350652
+    manifestHash: 0acede94b4f0c013705e9554e1c22def7ae9b4adb2be9ffc53dca3cb2adedde2
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+        image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
@@ -23,7 +23,7 @@ spec:
     clusterName: minimal-gce-private-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+    image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: cb05a2e357db1f88553f876cde27710ad9034c7371cd9279337a8b0770fa9456
+    manifestHash: bbbddf15133e712ebccf5f94e86b69dcad611044d19de203d4c1fe2032218610
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
+        image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v33.1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
The GCP CCM release process was fixed, we should be able to update to the latest release tag now.

https://github.com/kubernetes/cloud-provider-gcp/releases/tag/ccm%2Fv33.1.1