### PR TITLE
Update etcd-manager to v3.0.20250704

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -171,7 +171,7 @@ metadata:
 spec:
   containers:
   - name: etcd-manager
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     resources:
       requests:
         cpu: 100m
@@ -183,10 +183,6 @@ spec:
     # TODO: Would be nice to scope this more tightly, but needed for volume mounting
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -200,14 +196,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -86,7 +86,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
       name: etcd-manager
       resources:
         requests:
@@ -97,10 +97,6 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
-      - mountPath: /etc/ssl
-        name: ca-certificates
-      - mountPath: /etc/pki
-        name: ca-bundle
       - mountPath: /run
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -190,14 +186,6 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
-    - hostPath:
-        path: /etc/ssl
-        type: DirectoryOrCreate
-      name: ca-certificates
-    - hostPath:
-        path: /etc/pki
-        type: DirectoryOrCreate
-      name: ca-bundle
     - hostPath:
         path: /run
         type: DirectoryOrCreate
@@ -241,7 +229,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
       name: etcd-manager
       resources:
         requests:
@@ -252,10 +240,6 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
-      - mountPath: /etc/ssl
-        name: ca-certificates
-      - mountPath: /etc/pki
-        name: ca-bundle
       - mountPath: /run
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -345,14 +329,6 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
-    - hostPath:
-        path: /etc/ssl
-        type: DirectoryOrCreate
-      name: ca-certificates
-    - hostPath:
-        path: /etc/pki
-        type: DirectoryOrCreate
-      name: ca-bundle
     - hostPath:
         path: /run
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -85,7 +85,7 @@ Contents: |
         --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
         --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
       name: etcd-manager
       resources:
         requests:
@@ -96,10 +96,6 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
-      - mountPath: /etc/ssl
-        name: ca-certificates
-      - mountPath: /etc/pki
-        name: ca-bundle
       - mountPath: /run
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -189,14 +185,6 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
-    - hostPath:
-        path: /etc/ssl
-        type: DirectoryOrCreate
-      name: ca-certificates
-    - hostPath:
-        path: /etc/pki
-        type: DirectoryOrCreate
-      name: ca-bundle
     - hostPath:
         path: /run
         type: DirectoryOrCreate
@@ -239,7 +227,7 @@ Contents: |
         --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
         --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
       name: etcd-manager
       resources:
         requests:
@@ -250,10 +238,6 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
-      - mountPath: /etc/ssl
-        name: ca-certificates
-      - mountPath: /etc/pki
-        name: ca-bundle
       - mountPath: /run
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -343,14 +327,6 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
-    - hostPath:
-        path: /etc/ssl
-        type: DirectoryOrCreate
-      name: ca-certificates
-    - hostPath:
-        path: /etc/pki
-        type: DirectoryOrCreate
-      name: ca-bundle
     - hostPath:
         path: /run
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -88,7 +88,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
       name: etcd-manager
       resources:
         requests:
@@ -99,10 +99,6 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
-      - mountPath: /etc/ssl
-        name: ca-certificates
-      - mountPath: /etc/pki
-        name: ca-bundle
       - mountPath: /run
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -192,14 +188,6 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
-    - hostPath:
-        path: /etc/ssl
-        type: DirectoryOrCreate
-      name: ca-certificates
-    - hostPath:
-        path: /etc/pki
-        type: DirectoryOrCreate
-      name: ca-bundle
     - hostPath:
         path: /run
         type: DirectoryOrCreate
@@ -245,7 +233,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
       name: etcd-manager
       resources:
         requests:
@@ -256,10 +244,6 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
-      - mountPath: /etc/ssl
-        name: ca-certificates
-      - mountPath: /etc/pki
-        name: ca-bundle
       - mountPath: /run
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -349,14 +333,6 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
-    - hostPath:
-        path: /etc/ssl
-        type: DirectoryOrCreate
-      name: ca-certificates
-    - hostPath:
-        path: /etc/pki
-        type: DirectoryOrCreate
-      name: ca-bundle
     - hostPath:
         path: /run
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -94,7 +94,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
       name: etcd-manager
       resources:
         requests:
@@ -105,10 +105,6 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
-      - mountPath: /etc/ssl
-        name: ca-certificates
-      - mountPath: /etc/pki
-        name: ca-bundle
       - mountPath: /run
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -198,14 +194,6 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
-    - hostPath:
-        path: /etc/ssl
-        type: DirectoryOrCreate
-      name: ca-certificates
-    - hostPath:
-        path: /etc/pki
-        type: DirectoryOrCreate
-      name: ca-bundle
     - hostPath:
         path: /run
         type: DirectoryOrCreate
@@ -257,7 +245,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
       name: etcd-manager
       resources:
         requests:
@@ -268,10 +256,6 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
-      - mountPath: /etc/ssl
-        name: ca-certificates
-      - mountPath: /etc/pki
-        name: ca-bundle
       - mountPath: /run
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -361,14 +345,6 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
-    - hostPath:
-        path: /etc/ssl
-        type: DirectoryOrCreate
-      name: ca-certificates
-    - hostPath:
-        path: /etc/pki
-        type: DirectoryOrCreate
-      name: ca-bundle
     - hostPath:
         path: /run
         type: DirectoryOrCreate

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -24,7 +24,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -35,10 +35,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -128,14 +124,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -24,7 +24,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -35,10 +35,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -128,14 +124,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/containerd/assets.yaml
+++ b/tests/integration/update_cluster/containerd/assets.yaml
@@ -92,5 +92,5 @@ images:
   download: registry.k8s.io/etcd:3.4.13-0
 - canonical: registry.k8s.io/etcd:3.5.21-0
   download: registry.k8s.io/etcd:3.5.21-0
-- canonical: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
-  download: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+- canonical: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
+  download: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -35,10 +35,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -128,14 +124,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -23,7 +23,7 @@ spec:
       value: REDACTED
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -34,10 +34,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -127,14 +123,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -23,7 +23,7 @@ spec:
       value: REDACTED
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -34,10 +34,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -127,14 +123,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -25,7 +25,7 @@ spec:
     - name: SCW_SECRET_KEY
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -36,10 +36,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -129,14 +125,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -25,7 +25,7 @@ spec:
     - name: SCW_SECRET_KEY
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -36,10 +36,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -129,14 +125,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -22,7 +22,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -33,10 +33,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -126,14 +122,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250629
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
     name: etcd-manager
     resources:
       requests:
@@ -32,10 +32,6 @@ spec:
     volumeMounts:
     - mountPath: /rootfs
       name: rootfs
-    - mountPath: /etc/ssl
-      name: ca-certificates
-    - mountPath: /etc/pki
-      name: ca-bundle
     - mountPath: /run
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
@@ -125,14 +121,6 @@ spec:
       path: /
       type: Directory
     name: rootfs
-  - hostPath:
-      path: /etc/ssl
-      type: DirectoryOrCreate
-    name: ca-certificates
-  - hostPath:
-      path: /etc/pki
-      type: DirectoryOrCreate
-    name: ca-bundle
   - hostPath:
       path: /run
       type: DirectoryOrCreate


### PR DESCRIPTION
`debian-base` is built by sig-release and contains ca-certificates, so it can be used without additional mounts.
See: https://github.com/kubernetes/release/pull/4052

/cc @justinsb @rifelpet @ameukam 