### PR TITLE
Automated cherry pick of #17315: Allow to setup CoreDNS pod annotations#17472: Enforce topologySpreadConstraints for CoreDNS

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3690,6 +3690,13 @@ spec:
                           Default: none
                         type: object
                     type: object
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      PodAnnotations makes possible to add additional annotations to CoreDNS Pods.
+                      Default: none
+                    type: object
                   provider:
                     description: Provider indicates whether CoreDNS or kube-dns will
                       be the default service discovery.

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -599,6 +599,9 @@ type KubeDNSConfig struct {
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// NodeLocalDNS specifies the configuration for the node-local-dns addon
 	NodeLocalDNS *NodeLocalDNSConfig `json:"nodeLocalDNS,omitempty"`
+	// PodAnnotations makes possible to add additional annotations to CoreDNS Pods.
+	// Default: none
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // NodeLocalDNSConfig are options of the node-local-dns

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -578,6 +578,9 @@ type KubeDNSConfig struct {
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// NodeLocalDNS specifies the configuration for the node-local-dns addon
 	NodeLocalDNS *NodeLocalDNSConfig `json:"nodeLocalDNS,omitempty"`
+	// PodAnnotations makes possible to add additional annotations to CoreDNS Pods.
+	// Default: none
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // NodeLocalDNSConfig are options of the node-local-dns

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5436,6 +5436,7 @@ func autoConvert_v1alpha2_KubeDNSConfig_To_kops_KubeDNSConfig(in *KubeDNSConfig,
 	} else {
 		out.NodeLocalDNS = nil
 	}
+	out.PodAnnotations = in.PodAnnotations
 	return nil
 }
 
@@ -5469,6 +5470,7 @@ func autoConvert_kops_KubeDNSConfig_To_v1alpha2_KubeDNSConfig(in *kops.KubeDNSCo
 	} else {
 		out.NodeLocalDNS = nil
 	}
+	out.PodAnnotations = in.PodAnnotations
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3881,6 +3881,13 @@ func (in *KubeDNSConfig) DeepCopyInto(out *KubeDNSConfig) {
 		*out = new(NodeLocalDNSConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -564,6 +564,9 @@ type KubeDNSConfig struct {
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// NodeLocalDNS specifies the configuration for the node-local-dns addon
 	NodeLocalDNS *NodeLocalDNSConfig `json:"nodeLocalDNS,omitempty"`
+	// PodAnnotations makes possible to add additional annotations to CoreDNS Pods.
+	// Default: none
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // NodeLocalDNSConfig are options of the node-local-dns

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5830,6 +5830,7 @@ func autoConvert_v1alpha3_KubeDNSConfig_To_kops_KubeDNSConfig(in *KubeDNSConfig,
 	} else {
 		out.NodeLocalDNS = nil
 	}
+	out.PodAnnotations = in.PodAnnotations
 	return nil
 }
 
@@ -5863,6 +5864,7 @@ func autoConvert_kops_KubeDNSConfig_To_v1alpha3_KubeDNSConfig(in *kops.KubeDNSCo
 	} else {
 		out.NodeLocalDNS = nil
 	}
+	out.PodAnnotations = in.PodAnnotations
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3855,6 +3855,13 @@ func (in *KubeDNSConfig) DeepCopyInto(out *KubeDNSConfig) {
 		*out = new(NodeLocalDNSConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3958,6 +3958,13 @@ func (in *KubeDNSConfig) DeepCopyInto(out *KubeDNSConfig) {
 		*out = new(NodeLocalDNSConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/containerd/assets.yaml
+++ b/tests/integration/update_cluster/containerd/assets.yaml
@@ -60,10 +60,10 @@ images:
   download: registry.k8s.io/kube-proxy:v1.32.0
 - canonical: registry.k8s.io/kops/kops-controller:1.32.0
   download: registry.k8s.io/kops/kops-controller:1.32.0
-- canonical: registry.k8s.io/coredns/coredns:v1.11.3
-  download: registry.k8s.io/coredns/coredns:v1.11.3
-- canonical: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
-  download: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+- canonical: registry.k8s.io/coredns/coredns:v1.11.4
+  download: registry.k8s.io/coredns/coredns:v1.11.4
+- canonical: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
+  download: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
 - canonical: registry.k8s.io/kops/dns-controller:1.32.0
   download: registry.k8s.io/kops/dns-controller:1.32.0
 - canonical: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.22.0

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 083087378418c789f6d147109acd8d4af45735fce6651bc6ef7797370ff267d9
+    manifestHash: e20290a5b4c7a1dd1596b4a9adb1e7ecbf9efbe0aa0a51b8e09334c97e1ec9cb
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -198,13 +198,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -372,7 +372,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e3edf4d59baa037a5b2ffd48548c83d426a7e62380f4efc037402ebfb4b7c3c3
+    manifestHash: 11ec00571b2d2df9712a64ae6bd860ce342029576346d0da022206239d5fa34c
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -139,7 +139,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -201,13 +201,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -379,7 +379,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4866e83e02b7f63ed0f85012e2dcd375d859653f4a3cd11d0d9d0bf87cf27f8c
+    manifestHash: 7c2d784b23e7d10f8ed8890de5707a383c662d3ca4e654f2b7e58ad6f185f59e
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -136,7 +136,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -195,13 +195,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -369,7 +369,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4866e83e02b7f63ed0f85012e2dcd375d859653f4a3cd11d0d9d0bf87cf27f8c
+    manifestHash: 7c2d784b23e7d10f8ed8890de5707a383c662d3ca4e654f2b7e58ad6f185f59e
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -136,7 +136,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -195,13 +195,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -369,7 +369,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4866e83e02b7f63ed0f85012e2dcd375d859653f4a3cd11d0d9d0bf87cf27f8c
+    manifestHash: 7c2d784b23e7d10f8ed8890de5707a383c662d3ca4e654f2b7e58ad6f185f59e
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -136,7 +136,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -195,13 +195,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -369,7 +369,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4866e83e02b7f63ed0f85012e2dcd375d859653f4a3cd11d0d9d0bf87cf27f8c
+    manifestHash: 7c2d784b23e7d10f8ed8890de5707a383c662d3ca4e654f2b7e58ad6f185f59e
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -136,7 +136,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -195,13 +195,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -369,7 +369,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4866e83e02b7f63ed0f85012e2dcd375d859653f4a3cd11d0d9d0bf87cf27f8c
+    manifestHash: 7c2d784b23e7d10f8ed8890de5707a383c662d3ca4e654f2b7e58ad6f185f59e
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -136,7 +136,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -195,13 +195,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -369,7 +369,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 633cf31037f483c3b5b81ba45c06867c2441f8f488cac3443ecebf441f6d3baf
+    manifestHash: c4c73074a0432684e90c906aa3382db944babc08374c20f916b81964420edeef
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -139,7 +139,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -201,13 +201,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -379,7 +379,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 937be8b865e64561798d83473754678866c56416052ca5847a2c1f7fd89422d2
+    manifestHash: 785cdeaa1efecf85f28144da9d69337cc07bc6a3cb38377ca4f04a92520dabda
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -139,7 +139,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -201,13 +201,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -379,7 +379,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 937be8b865e64561798d83473754678866c56416052ca5847a2c1f7fd89422d2
+    manifestHash: 785cdeaa1efecf85f28144da9d69337cc07bc6a3cb38377ca4f04a92520dabda
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -139,7 +139,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -201,13 +201,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -379,7 +379,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e3edf4d59baa037a5b2ffd48548c83d426a7e62380f4efc037402ebfb4b7c3c3
+    manifestHash: 11ec00571b2d2df9712a64ae6bd860ce342029576346d0da022206239d5fa34c
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -139,7 +139,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -201,13 +201,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -379,7 +379,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 937be8b865e64561798d83473754678866c56416052ca5847a2c1f7fd89422d2
+    manifestHash: 785cdeaa1efecf85f28144da9d69337cc07bc6a3cb38377ca4f04a92520dabda
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -139,7 +139,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -201,13 +201,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -379,7 +379,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4866e83e02b7f63ed0f85012e2dcd375d859653f4a3cd11d0d9d0bf87cf27f8c
+    manifestHash: 7c2d784b23e7d10f8ed8890de5707a383c662d3ca4e654f2b7e58ad6f185f59e
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -136,7 +136,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -195,13 +195,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -369,7 +369,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -135,7 +135,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -194,13 +194,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -368,7 +368,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -153,14 +153,13 @@ spec:
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: "topology.kubernetes.io/zone"
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
         labelSelector:
           matchLabels:
             k8s-app: kube-dns
       - maxSkew: 1
         topologyKey: "kubernetes.io/hostname"
-        # Normally we use DoNotSchedule here, but because CoreDNS autoscales, we cannot guarantee this constraint can be satisfied
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
         labelSelector:
           matchLabels:
             k8s-app: kube-dns

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -165,7 +165,7 @@ spec:
             k8s-app: kube-dns
       containers:
       - name: coredns
-        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}registry.k8s.io/coredns/coredns:v1.11.3{{ end }}
+        image: {{ if KubeDNS.CoreDNSImage }}{{ KubeDNS.CoreDNSImage }}{{ else }}registry.k8s.io/coredns/coredns:v1.11.4{{ end }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -343,7 +343,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: {{ if KubeDNS.CPAImage }}{{ KubeDNS.CPAImage }}{{ else }}registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9{{ end }}
+        image: {{ if KubeDNS.CPAImage }}{{ KubeDNS.CPAImage }}{{ else }}registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0{{ end }}
         resources:
             requests:
                 cpu: "20m"

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -122,6 +122,12 @@ spec:
     metadata:
       labels:
         k8s-app: kube-dns
+      {{- if KubeDNS.PodAnnotations }}
+      annotations:
+        {{- range $key, $value := KubeDNS.PodAnnotations }}
+        {{ $key }}: "{{ $value }}"
+        {{- end }}
+      {{- end }}
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/values.yaml
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/values.yaml
@@ -5,14 +5,14 @@ topologySpreadConstraints:
         app.kubernetes.io/instance: '{{ .Release.Name }}'
     topologyKey: topology.kubernetes.io/zone
     maxSkew: 1
-    whenUnsatisfiable: ScheduleAnyway
+    whenUnsatisfiable: DoNotSchedule
   - labelSelector:
       matchLabels:
         app.kubernetes.io/name: '{{ template "coredns.name" . }}'
         app.kubernetes.io/instance: '{{ .Release.Name }}'
     topologyKey: kubernetes.io/hostname
     maxSkew: 1
-    whenUnsatisfiable: ScheduleAnyway
+    whenUnsatisfiable: DoNotSchedule
 
 autoscaler:
   enabled: true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/coredns.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/coredns.addons.k8s.io-k8s-1.12.yaml
@@ -156,7 +156,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.11.3
+        image: registry.k8s.io/coredns/coredns:v1.11.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -215,13 +215,13 @@ spec:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       - labelSelector:
           matchLabels:
             k8s-app: kube-dns
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
           name: coredns
@@ -410,7 +410,7 @@ spec:
         - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
         - --logtostderr=true
         - --v=2
-        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+        image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
         name: autoscaler
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f4c5ca9c72e8d40c9a35ea566fdaddd18c2fe5181b307436c6553e8b686de9c9
+    manifestHash: 739bdc11764e34fafc3ccf61b4f297f03faf52f3ab0ad5ba5aa9ff7ff3e5bd2e
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 591e3b40d00949575616698ce1c9230db8cb00bdab4f8a0d5ef14080a1d7a93c
+    manifestHash: 5cf27d74240a028d347903ee2a81d068e221660f19a9c71b4e8438b8f3c8de81
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #17315 #17472 on release-1.32.

#17315: feat: allow to setup CoreDNS pod annotations
#17472: Enforce topologySpreadConstraints for CoreDNS

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```