### PR TITLE
fix: fix node-local-dns on cilium 1.16.5+ 

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3635,6 +3635,12 @@ spec:
                           config for node local dns by the user - it will include
                           the original CoreFile made by kOps.
                         type: string
+                      ciliumBPFCompatibility:
+                        description: CiliumBPFCompatibility allows user to enable
+                          cilium bpf host routing compatibility mode, which is required
+                          for cilium 1.16.5+ and above, when the user is using cilium
+                          as an externally managed daemonset.
+                        type: boolean
                       cpuRequest:
                         anyOf:
                         - type: integer

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -625,6 +625,8 @@ type NodeLocalDNSConfig struct {
 	// PodAnnotations makes possible to add additional annotations to node-local-dns.
 	// Default: none
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+	// CiliumBPFCompatibility allows user to enable cilium bpf host routing compatibility mode, which is required for cilium 1.16.5+ and above, when the user is using cilium as an externally managed daemonset.
+	CiliumBPFCompatibility *bool `json:"ciliumBPFCompatibility,omitempty"`
 }
 
 type ExternalDNSProvider string

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -604,6 +604,8 @@ type NodeLocalDNSConfig struct {
 	// PodAnnotations makes possible to add additional annotations to node-local-dns.
 	// Default: none
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+	// CiliumBPFCompatibility allows user to enable cilium bpf host routing compatibility mode, which is required for cilium 1.16.5+ and above, when the user is using cilium as an externally managed daemonset.
+	CiliumBPFCompatibility *bool `json:"ciliumBPFCompatibility,omitempty"`
 }
 
 type ExternalDNSProvider string

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -6662,6 +6662,7 @@ func autoConvert_v1alpha2_NodeLocalDNSConfig_To_kops_NodeLocalDNSConfig(in *Node
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.PodAnnotations = in.PodAnnotations
+	out.CiliumBPFCompatibility = in.CiliumBPFCompatibility
 	return nil
 }
 
@@ -6680,6 +6681,7 @@ func autoConvert_kops_NodeLocalDNSConfig_To_v1alpha2_NodeLocalDNSConfig(in *kops
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.PodAnnotations = in.PodAnnotations
+	out.CiliumBPFCompatibility = in.CiliumBPFCompatibility
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -5018,6 +5018,11 @@ func (in *NodeLocalDNSConfig) DeepCopyInto(out *NodeLocalDNSConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.CiliumBPFCompatibility != nil {
+		in, out := &in.CiliumBPFCompatibility, &out.CiliumBPFCompatibility
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -590,6 +590,8 @@ type NodeLocalDNSConfig struct {
 	// PodAnnotations makes possible to add additional annotations to node-local-dns.
 	// Default: none
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+	// CiliumBPFCompatibility allows user to enable cilium bpf host routing compatibility mode, which is required for cilium 1.16.5+ and above, when the user is using cilium as an externally managed daemonset.
+	CiliumBPFCompatibility *bool `json:"ciliumBPFCompatibility,omitempty"`
 }
 
 type ExternalDNSProvider string

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6919,6 +6919,7 @@ func autoConvert_v1alpha3_NodeLocalDNSConfig_To_kops_NodeLocalDNSConfig(in *Node
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.PodAnnotations = in.PodAnnotations
+	out.CiliumBPFCompatibility = in.CiliumBPFCompatibility
 	return nil
 }
 
@@ -6937,6 +6938,7 @@ func autoConvert_kops_NodeLocalDNSConfig_To_v1alpha3_NodeLocalDNSConfig(in *kops
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.PodAnnotations = in.PodAnnotations
+	out.CiliumBPFCompatibility = in.CiliumBPFCompatibility
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -4917,6 +4917,11 @@ func (in *NodeLocalDNSConfig) DeepCopyInto(out *NodeLocalDNSConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.CiliumBPFCompatibility != nil {
+		in, out := &in.CiliumBPFCompatibility, &out.CiliumBPFCompatibility
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -1456,12 +1456,13 @@ func Test_Validate_NodeLocalDNS(t *testing.T) {
 		{
 			Input: kops.ClusterSpec{
 				Kubelet: &kops.KubeletConfigSpec{
-					ClusterDNS: "169.254.20.10",
+					ClusterDNS: "100.64.0.10",
 				},
 				KubeProxy: &kops.KubeProxyConfig{
 					ProxyMode: "iptables",
 				},
 				KubeDNS: &kops.KubeDNSConfig{
+					ServerIP: "100.64.0.10",
 					Provider: "CoreDNS",
 					NodeLocalDNS: &kops.NodeLocalDNSConfig{
 						Enabled: fi.PtrTo(true),
@@ -1470,6 +1471,26 @@ func Test_Validate_NodeLocalDNS(t *testing.T) {
 				},
 				Networking: kops.NetworkingSpec{
 					Cilium: &kops.CiliumNetworkingSpec{},
+				},
+			},
+			ExpectedErrors: []string{},
+		},
+		{
+			Input: kops.ClusterSpec{
+				Kubelet: &kops.KubeletConfigSpec{
+					ClusterDNS: "100.64.0.10",
+				},
+				KubeProxy: &kops.KubeProxyConfig{
+					ProxyMode: "iptables",
+				},
+				KubeDNS: &kops.KubeDNSConfig{
+					ServerIP: "100.64.0.10",
+					Provider: "CoreDNS",
+					NodeLocalDNS: &kops.NodeLocalDNSConfig{
+						Enabled:                fi.PtrTo(true),
+						LocalIP:                "169.254.20.10",
+						CiliumBPFCompatibility: fi.PtrTo(true),
+					},
 				},
 			},
 			ExpectedErrors: []string{},

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -5116,6 +5116,11 @@ func (in *NodeLocalDNSConfig) DeepCopyInto(out *NodeLocalDNSConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.CiliumBPFCompatibility != nil {
+		in, out := &in.CiliumBPFCompatibility, &out.CiliumBPFCompatibility
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -87,7 +87,7 @@ func (b *KubeletOptionsBuilder) configureKubelet(cluster *kops.Cluster, kubelet 
 	}
 
 	if kubelet.ClusterDNS == "" {
-		if cluster.Spec.KubeDNS != nil && cluster.Spec.KubeDNS.NodeLocalDNS != nil && fi.ValueOf(cluster.Spec.KubeDNS.NodeLocalDNS.Enabled) {
+		if cluster.Spec.KubeDNS != nil && cluster.Spec.KubeDNS.NodeLocalDNS != nil && fi.ValueOf(cluster.Spec.KubeDNS.NodeLocalDNS.Enabled) && !fi.ValueOf(cluster.Spec.KubeDNS.NodeLocalDNS.CiliumBPFCompatibility) && cluster.Spec.Networking.Cilium == nil {
 			kubelet.ClusterDNS = cluster.Spec.KubeDNS.NodeLocalDNS.LocalIP
 		} else {
 			ip, err := WellKnownServiceIP(&cluster.Spec.Networking, 10)

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -52,12 +52,12 @@ data:
         }
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
+        bind 0.0.0.0
         forward . {{ NodeLocalDNSClusterIP }} {
           force_tcp
         }
         prometheus :9253
-        health {{ joinHostPort KubeDNS.NodeLocalDNS.LocalIP NodeLocalDNSHealthCheck }}
+        health :{{ NodeLocalDNSHealthCheck }}
     }
     {{- if WithDefaultBool KubeDNS.NodeLocalDNS.ForwardToKubeDNS false }}
     .:53 {
@@ -65,7 +65,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
+        bind 0.0.0.0
         forward . {{ NodeLocalDNSClusterIP }} {
           force_tcp
         }
@@ -77,7 +77,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
+        bind 0.0.0.0
         forward . {{ NodeLocalDNSClusterIP }} {
           force_tcp
         }
@@ -88,7 +88,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
+        bind 0.0.0.0
         forward . {{ NodeLocalDNSClusterIP }} {
           force_tcp
         }
@@ -99,7 +99,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
+        bind 0.0.0.0
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
         {{- if IsIPv6Only }}
@@ -130,6 +130,7 @@ spec:
       labels:
         k8s-app: node-local-dns
       annotations:
+        policy.cilium.io/no-track-port: "53"
         prometheus.io/port: "9253"
         prometheus.io/scrape: "true"
         {{- range $key, $value := KubeDNS.NodeLocalDNS.PodAnnotations }}
@@ -138,7 +139,11 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: node-local-dns
+      {{- if or (.Networking.Cilium) ( .KubeDNS.NodeLocalDNS.CiliumBPFCompatibility) }}
+      hostNetwork: false
+      {{- else }}
       hostNetwork: true
+      {{- end }}
       dnsPolicy: Default  # Don't use cluster DNS.
       tolerations:
       - key: "CriticalAddonsOnly"
@@ -155,7 +160,13 @@ spec:
             cpu: {{ KubeDNS.NodeLocalDNS.CPURequest }}
             memory: {{ KubeDNS.NodeLocalDNS.MemoryRequest }}
         args:
+          {{- if or (.Networking.Cilium) ( .KubeDNS.NodeLocalDNS.CiliumBPFCompatibility) }}
+          - -localip={{ .KubeDNS.NodeLocalDNS.LocalIP }},{{ .KubeDNS.ServerIP }}
+          - -skipteardown=true
+          - -setupinterface=false
+          {{- else }}
           - -localip={{ .KubeDNS.NodeLocalDNS.LocalIP }}
+          {{- end }}
           - -conf=/etc/Corefile
           - -upstreamsvc=kube-dns-upstream
           - -setupiptables=false
@@ -208,3 +219,27 @@ spec:
           items:
             - key: Corefile
               path: Corefile.base
+{{- if or (.Networking.Cilium) ( .KubeDNS.NodeLocalDNS.CiliumBPFCompatibility) }}
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "nodelocaldns"
+  namespace: kube-system
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: kube-dns
+      namespace: kube-system
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        k8s-app: node-local-dns
+    toPorts:
+      - port: "53"
+        name: dns
+        protocol: UDP
+      - port: "53"
+        name: dns-tcp
+        protocol: TCP
+{{- end }}


### PR DESCRIPTION
fixes node-local-dns when BPF host networking is enabled on cilium 1.16.5+

The config change should automatically enable when `cluster.spec.networking.cilium` is specified
The config change should also enable when `cluster.Spec.KubeDNS.NodeLocalDNS.CiliumBPFCompatibility` is explicitly set to true, which is needed when users are managing cilium on their on via `cluster.spec.networking.cni: {}`

When applying onto an existing cluster, the nodes will need to be rolled out to recreate the node-local-dns pod, as well as update the dns resolver address that is being passed explicitly to kubelet. Once rollout of existing nodes is finished, it should be safe to upgrade cilium with BPF host networking enabled

fixes: https://github.com/kubernetes/kops/issues/16597