### PR TITLE
Automated cherry pick of #17482: Fix cloud-provider flag for K8s 1.31+

### DIFF
--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -98,28 +98,32 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(cluster *kops.Cluster) error 
 	c.Image = image
 
 	if b.controlPlaneKubernetesVersion.IsLT("1.33") {
-		switch cluster.GetCloudProvider() {
-		case kops.CloudProviderAWS:
-			c.CloudProvider = "aws"
-		case kops.CloudProviderGCE:
-			c.CloudProvider = "gce"
-		case kops.CloudProviderDO:
-			c.CloudProvider = "external"
-		case kops.CloudProviderHetzner:
-			c.CloudProvider = "external"
-		case kops.CloudProviderOpenstack:
-			c.CloudProvider = "openstack"
-		case kops.CloudProviderAzure:
-			c.CloudProvider = "azure"
-		case kops.CloudProviderScaleway:
-			c.CloudProvider = "external"
-		case kops.CloudProviderMetal:
-			c.CloudProvider = "external"
-		default:
-			return fmt.Errorf("unknown cloudprovider %q", cluster.GetCloudProvider())
-		}
+		if b.controlPlaneKubernetesVersion.IsLT("1.31") {
+			switch cluster.GetCloudProvider() {
+			case kops.CloudProviderAWS:
+				c.CloudProvider = "aws"
+			case kops.CloudProviderGCE:
+				c.CloudProvider = "gce"
+			case kops.CloudProviderDO:
+				c.CloudProvider = "external"
+			case kops.CloudProviderHetzner:
+				c.CloudProvider = "external"
+			case kops.CloudProviderOpenstack:
+				c.CloudProvider = "openstack"
+			case kops.CloudProviderAzure:
+				c.CloudProvider = "azure"
+			case kops.CloudProviderScaleway:
+				c.CloudProvider = "external"
+			case kops.CloudProviderMetal:
+				c.CloudProvider = "external"
+			default:
+				return fmt.Errorf("unknown cloudprovider %q", cluster.GetCloudProvider())
+			}
 
-		if clusterSpec.ExternalCloudControllerManager != nil {
+			if clusterSpec.ExternalCloudControllerManager != nil {
+				c.CloudProvider = "external"
+			}
+		} else {
 			c.CloudProvider = "external"
 		}
 	}

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -120,21 +120,40 @@ func (b *KubeletOptionsBuilder) configureKubelet(cluster *kops.Cluster, kubelet 
 	const kubeconfigPath = "/var/lib/kubelet/kubeconfig"
 	kubelet.KubeconfigPath = kubeconfigPath
 
-	cloudProvider := cluster.GetCloudProvider()
-
 	kubelet.CgroupRoot = "/"
 
+	cloudProvider := cluster.GetCloudProvider()
 	klog.V(1).Infof("Cloud Provider: %s", cloudProvider)
-	if cloudProvider == kops.CloudProviderAWS {
-		kubelet.CloudProvider = "aws"
-	}
+	if cloudProvider != kops.CloudProviderMetal {
+		if b.controlPlaneKubernetesVersion.IsLT("1.31") {
+			switch cloudProvider {
+			case kops.CloudProviderAWS:
+				kubelet.CloudProvider = "aws"
+			case kops.CloudProviderGCE:
+				kubelet.CloudProvider = "gce"
+			case kops.CloudProviderDO:
+				kubelet.CloudProvider = "external"
+			case kops.CloudProviderHetzner:
+				kubelet.CloudProvider = "external"
+			case kops.CloudProviderOpenstack:
+				kubelet.CloudProvider = "openstack"
+			case kops.CloudProviderAzure:
+				kubelet.CloudProvider = "azure"
+			case kops.CloudProviderScaleway:
+				kubelet.CloudProvider = "external"
+			default:
+				kubelet.CloudProvider = "external"
+			}
 
-	if cloudProvider == kops.CloudProviderDO {
-		kubelet.CloudProvider = "external"
+			if cluster.Spec.ExternalCloudControllerManager != nil {
+				kubelet.CloudProvider = "external"
+			}
+		} else {
+			kubelet.CloudProvider = "external"
+		}
 	}
 
 	if cloudProvider == kops.CloudProviderGCE {
-		kubelet.CloudProvider = "gce"
 		kubelet.HairpinMode = "promiscuous-bridge"
 
 		if cluster.Spec.CloudConfig == nil {
@@ -142,26 +161,6 @@ func (b *KubeletOptionsBuilder) configureKubelet(cluster *kops.Cluster, kubelet 
 		}
 		cluster.Spec.CloudProvider.GCE.Multizone = fi.PtrTo(true)
 		cluster.Spec.CloudProvider.GCE.NodeTags = fi.PtrTo(gce.TagForRole(b.ClusterName, kops.InstanceGroupRoleNode))
-	}
-
-	if cloudProvider == kops.CloudProviderHetzner {
-		kubelet.CloudProvider = "external"
-	}
-
-	if cloudProvider == kops.CloudProviderOpenstack {
-		kubelet.CloudProvider = "openstack"
-	}
-
-	if cloudProvider == kops.CloudProviderAzure {
-		kubelet.CloudProvider = "azure"
-	}
-
-	if cloudProvider == kops.CloudProviderScaleway {
-		kubelet.CloudProvider = "external"
-	}
-
-	if cluster.Spec.ExternalCloudControllerManager != nil {
-		kubelet.CloudProvider = "external"
 	}
 
 	// Prevent image GC from pruning the pause image


### PR DESCRIPTION
Cherry pick of #17482 on release-1.33.

#17482: Fix cloud-provider flag for K8s 1.31+

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```