### PR TITLE
Introduce flag use-kubeconfig which allows loading from the local kubeconfig

### DIFF
--- a/cmd/kops/export_kubeconfig.go
+++ b/cmd/kops/export_kubeconfig.go
@@ -98,7 +98,7 @@ func NewCmdExportKubeconfig(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.Internal, "internal", options.Internal, "Use the cluster's internal DNS name")
 	cmd.Flags().BoolVar(&options.UseKopsAuthenticationPlugin, "auth-plugin", options.UseKopsAuthenticationPlugin, "Use the kOps authentication plugin")
 
-	options.CreateKubecfgOptions.AddCommonFlags(cmd.Flags())
+	options.CreateKubecfgOptions.AddFlagsForExport(cmd.Flags())
 
 	return cmd
 }

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -412,6 +412,10 @@ func RunUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Up
 		}
 		firstRun = !hasKubeconfig
 
+		if c.CreateKubecfgOptions.UseKubeconfig {
+			klog.Infof("hint: passing --create-kube-config=true causes the kubeconfig to be overwritten, you may not want to use this flag with --use-kubeconfig=false")
+		}
+
 		klog.Infof("Exporting kubeconfig for cluster")
 
 		conf, err := kubeconfig.BuildKubecfg(

--- a/docs/cli/kops_delete_instance.md
+++ b/docs/cli/kops_delete_instance.md
@@ -37,6 +37,7 @@ kops delete instance INSTANCE|NODE [flags]
   -h, --help                          help for instance
       --post-drain-delay duration     Time to wait after draining each node (default 5s)
       --surge                         Surge by detaching the node from the ASG before deletion (default true)
+      --use-kubeconfig                Use the server endpoint from the local kubeconfig instead of inferring from cluster name
       --validate-count int32          Number of times that a cluster needs to be validated after single node update (default 2)
       --validation-timeout duration   Maximum time to wait for a cluster to validate (default 15m0s)
   -y, --yes                           Specify --yes to immediately delete the instance

--- a/docs/cli/kops_get_instances.md
+++ b/docs/cli/kops_get_instances.md
@@ -21,6 +21,7 @@ kops get instances [CLUSTER] [flags]
 ```
       --api-server string   Override the API server used when communicating with the cluster kube-apiserver
   -h, --help                help for instances
+      --use-kubeconfig      Use the server endpoint from the local kubeconfig instead of inferring from cluster name
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -74,6 +74,7 @@ kops rolling-update cluster [CLUSTER] [flags]
   -i, --interactive                       Prompt to continue after each instance is updated
       --node-interval duration            Time to wait between restarting worker nodes (default 15s)
       --post-drain-delay duration         Time to wait after draining each node (default 5s)
+      --use-kubeconfig                    Use the server endpoint from the local kubeconfig instead of inferring from cluster name
       --validate-count int32              Number of times that a cluster needs to be validated after single node update (default 2)
       --validation-timeout duration       Maximum time to wait for a cluster to validate (default 15m0s)
   -y, --yes                               Perform rolling update immediately; without --yes rolling-update executes a dry-run

--- a/docs/cli/kops_toolbox_enroll.md
+++ b/docs/cli/kops_toolbox_enroll.md
@@ -29,6 +29,7 @@ kops toolbox enroll [CLUSTER] [flags]
       --instance-group string   Name of instance-group to join
       --ssh-port int            port for ssh (default 22)
       --ssh-user string         user for ssh (default "root")
+      --use-kubeconfig          Use the server endpoint from the local kubeconfig instead of inferring from cluster name
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -40,6 +40,7 @@ kops update cluster [CLUSTER] [flags]
       --prune                          Delete old revisions of cloud resources that were needed during an upgrade
       --ssh-public-key string          SSH public key to use (deprecated: use kops create secret instead)
       --target target                  Target - "direct", "terraform" (default direct)
+      --use-kubeconfig                 Use the server endpoint from the local kubeconfig instead of inferring from cluster name
       --user string                    Existing user in kubeconfig file to use.  Implies --create-kube-config
   -y, --yes                            Create cloud resources, without --yes update is in dry run mode
 ```

--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -35,6 +35,7 @@ kops validate cluster [CLUSTER] [flags]
       --interval duration   Time in duration to wait between validation attempts (default 10s)
       --kubeconfig string   Path to the kubeconfig file
   -o, --output string       Output format. One of json|yaml|table. (default "table")
+      --use-kubeconfig      Use the server endpoint from the local kubeconfig instead of inferring from cluster name
       --wait duration       Amount of time to wait for the cluster to become ready
 ```
 


### PR DESCRIPTION
This supports workflows that modify the local kubeconfig for advanced configurations,
which were accidentally broken by trying to always generate the config.

Issue #17262
