### PR TITLE
Reduce verbosity of k8s version warning

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -359,9 +359,9 @@ func RunUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Up
 	if !c.IgnoreKubeletVersionSkew {
 		minControlPlaneRunningVersion, err = checkControlPlaneRunningVersion(ctx, cluster.ObjectMeta.Name, minControlPlaneRunningVersion)
 		if err != nil {
-			klog.Warningf("error checking control plane running version, assuming no k8s upgrade in progress: %v", err)
+			klog.V(2).Infof("error checking control plane running version, assuming no k8s upgrade in progress: %v", err)
 		} else {
-			klog.V(2).Infof("successfully checked control plane running version: %v", minControlPlaneRunningVersion)
+			klog.V(2).Infof("found control plane running version: %v", minControlPlaneRunningVersion)
 		}
 	}
 	applyCmd := &cloudup.ApplyClusterCmd{


### PR DESCRIPTION
This warning isnt particularly actionable - it is expected behavior for `kops create cluster` and any `kops update cluster` that experiences this (due to a broken cluster) will proceed as normal. The user's subsequent `kops validate cluster` would surface any such errors


ref: https://github.com/kubernetes/kops/issues/17146#issuecomment-3076579856