### PR TITLE
Fix invalid filters for describing security group rules

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -335,14 +335,9 @@ func (e *SecurityGroup) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletio
 	cloud := awsup.GetCloud(c)
 
 	filters := make([]ec2types.Filter, 0)
-	switch {
-	case e.ID != nil:
+	if e.ID != nil {
 		filters = append(filters, awsup.NewEC2Filter("group-id", *e.ID))
-	case e.Name != nil && e.VPC != nil:
-		filters = append(filters, awsup.NewEC2Filter("vpc-id", *e.VPC.ID))
-		filters = append(filters, awsup.NewEC2Filter("group-name", *e.Name))
-		filters = append(filters, awsup.NewEC2Filter("tag:kubernetes.io/cluster/"+c.T.Cluster.Name, "owned"))
-	default:
+	} else {
 		return nil, nil
 	}
 	request := &ec2.DescribeSecurityGroupRulesInput{


### PR DESCRIPTION
The Describe SGR API doesn't support filtering by VPC ID or group name. Therefore if we dont have a SG ID we'll just skip trying to delete SGRs

Followup to https://github.com/kubernetes/kops/pull/17432

Fixes https://github.com/kubernetes/kops/issues/17499