### PR TITLE
Automated cherry pick of #17500: Fix invalid filters for describing security group rules

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -335,14 +335,9 @@ func (e *SecurityGroup) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletio
 	cloud := awsup.GetCloud(c)
 
 	filters := make([]ec2types.Filter, 0)
-	switch {
-	case e.ID != nil:
+	if e.ID != nil {
 		filters = append(filters, awsup.NewEC2Filter("group-id", *e.ID))
-	case e.Name != nil && e.VPC != nil:
-		filters = append(filters, awsup.NewEC2Filter("vpc-id", *e.VPC.ID))
-		filters = append(filters, awsup.NewEC2Filter("group-name", *e.Name))
-		filters = append(filters, awsup.NewEC2Filter("tag:kubernetes.io/cluster/"+c.T.Cluster.Name, "owned"))
-	default:
+	} else {
 		return nil, nil
 	}
 	request := &ec2.DescribeSecurityGroupRulesInput{


### PR DESCRIPTION
Cherry pick of #17500 on release-1.33.

#17500: Fix invalid filters for describing security group rules

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```