### PR TITLE
Automated cherry pick of #17500: Fix invalid filters for describing security group rules

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -334,10 +334,14 @@ func (e *SecurityGroup) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletio
 
 	cloud := awsup.GetCloud(c)
 
+	filters := make([]ec2types.Filter, 0)
+	if e.ID != nil {
+		filters = append(filters, awsup.NewEC2Filter("group-id", *e.ID))
+	} else {
+		return nil, nil
+	}
 	request := &ec2.DescribeSecurityGroupRulesInput{
-		Filters: []ec2types.Filter{
-			awsup.NewEC2Filter("group-id", *e.ID),
-		},
+		Filters: filters,
 	}
 
 	response, err := cloud.EC2().DescribeSecurityGroupRules(ctx, request)


### PR DESCRIPTION
Cherry pick of #17500 on release-1.32.

#17500: Fix invalid filters for describing security group rules

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```