### PR TITLE
Automated cherry pick of #17512: Wait for the GCE disk creation operation to finish

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/disk.go
+++ b/upup/pkg/fi/cloudup/gcetasks/disk.go
@@ -119,8 +119,13 @@ func (_ *Disk) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Disk) error {
 	}
 
 	if a == nil {
-		if _, err := cloud.Compute().Disks().Insert(t.Cloud.Project(), *e.Zone, disk); err != nil {
+		op, err := cloud.Compute().Disks().Insert(t.Cloud.Project(), *e.Zone, disk)
+		if err != nil {
 			return fmt.Errorf("error creating Disk: %v", err)
+		}
+		err = cloud.WaitForOp(op)
+		if err != nil {
+			return fmt.Errorf("error during Disk creation: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #17512 on release-1.33.

#17512: Wait for the GCE disk creation operation to finish

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```