### PR TITLE
azure: Fix periodic tests

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -537,12 +537,8 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 	}
 
 	if featureflag.Azure.Enabled() {
-		if c.AzureSubscriptionID == "" {
-			if id, ok := os.LookupEnv("AZURE_SUBSCRIPTION_ID"); ok {
-				c.AzureSubscriptionID = id
-			} else {
-				return fmt.Errorf("--azure-subscription-id is required")
-			}
+		if c.CloudProvider == "azure" && c.AzureSubscriptionID == "" {
+			return fmt.Errorf("--azure-subscription-id is required")
 		}
 	}
 

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -319,6 +319,9 @@ func defaultClusterName(cloudProvider string) (string, error) {
 	switch cloudProvider {
 	case "aws":
 		suffix = dnsDomain
+	case "azure":
+		// Azure uses --dns=none and the domain is not needed
+		suffix = ""
 	default:
 		suffix = "k8s.local"
 	}
@@ -337,7 +340,12 @@ func defaultClusterName(cloudProvider string) (string, error) {
 	if len(jobName) > gcpLimit && cloudProvider == "gce" {
 		jobName = jobName[:gcpLimit]
 	}
-	return fmt.Sprintf("%v.%v", jobName, suffix), nil
+
+	if suffix != "" {
+		jobName = jobType + "." + suffix
+	}
+
+	return jobName, nil
 }
 
 // stateStore returns the kops state store to use

--- a/upup/pkg/fi/cloudup/azure/verifier.go
+++ b/upup/pkg/fi/cloudup/azure/verifier.go
@@ -91,7 +91,7 @@ func (a azureVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request
 	}
 	nodeName := strings.ToLower(*vm.Properties.OSProfile.ComputerName)
 
-	ni, err := a.client.nisClient.GetVirtualMachineScaleSetNetworkInterface(ctx, a.client.resourceGroup, vmssName, vmssIndex, vmssName+"-netconfig", nil)
+	ni, err := a.client.nisClient.GetVirtualMachineScaleSetNetworkInterface(ctx, a.client.resourceGroup, vmssName, vmssIndex, vmssName, nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting info for VMSS network interface %q #%s: %w", vmssName, vmssIndex, err)
 	}

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
@@ -334,7 +334,7 @@ func (s *VMScaleSet) RenderAzure(t *azure.AzureAPITarget, a, e, changes *VMScale
 			EnableIPForwarding: to.Ptr(true),
 			IPConfigurations: []*compute.VirtualMachineScaleSetIPConfiguration{
 				{
-					Name:       to.Ptr(name + "-ipconfig"),
+					Name:       to.Ptr(name),
 					Properties: ipConfigProperties,
 				},
 			},

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
@@ -308,7 +308,7 @@ func (s *VMScaleSet) RenderAzure(t *azure.AzureAPITarget, a, e, changes *VMScale
 	}
 	if *e.RequirePublicIP {
 		ipConfigProperties.PublicIPAddressConfiguration = &compute.VirtualMachineScaleSetPublicIPAddressConfiguration{
-			Name: to.Ptr(name + "-publicipconfig"),
+			Name: to.Ptr(name),
 			Properties: &compute.VirtualMachineScaleSetPublicIPAddressConfigurationProperties{
 				PublicIPAddressVersion: to.Ptr(compute.IPVersionIPv4),
 			},

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
@@ -328,7 +328,7 @@ func (s *VMScaleSet) RenderAzure(t *azure.AzureAPITarget, a, e, changes *VMScale
 	}
 
 	networkConfig := &compute.VirtualMachineScaleSetNetworkConfiguration{
-		Name: to.Ptr(name + "-netconfig"),
+		Name: to.Ptr(name),
 		Properties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 			Primary:            to.Ptr(true),
 			EnableIPForwarding: to.Ptr(true),

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
@@ -229,7 +229,7 @@ func TestVMScaleSetFind(t *testing.T) {
 			EnableIPForwarding: to.Ptr(true),
 			IPConfigurations: []*compute.VirtualMachineScaleSetIPConfiguration{
 				{
-					Name:       to.Ptr("vmss-ipconfig"),
+					Name:       to.Ptr("vmss"),
 					Properties: ipConfigProperties,
 				},
 			},

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
@@ -212,7 +212,7 @@ func TestVMScaleSetFind(t *testing.T) {
 		PrivateIPAddressVersion: to.Ptr(compute.IPVersionIPv4),
 	}
 	ipConfigProperties.PublicIPAddressConfiguration = &compute.VirtualMachineScaleSetPublicIPAddressConfiguration{
-		Name: to.Ptr("vmss-publicipconfig"),
+		Name: to.Ptr("vmss"),
 		Properties: &compute.VirtualMachineScaleSetPublicIPAddressConfigurationProperties{
 			PublicIPAddressVersion: to.Ptr(compute.IPVersionIPv4),
 		},

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
@@ -223,7 +223,7 @@ func TestVMScaleSetFind(t *testing.T) {
 		},
 	}
 	networkConfig := &compute.VirtualMachineScaleSetNetworkConfiguration{
-		Name: to.Ptr("vmss-netconfig"),
+		Name: to.Ptr("vmss"),
 		Properties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 			Primary:            to.Ptr(true),
 			EnableIPForwarding: to.Ptr(true),

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -19,6 +19,7 @@ package cloudup
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -179,6 +180,7 @@ func (o *NewClusterOptions) InitDefaults() {
 
 	// Azure-specific
 	o.AzureAdminUser = "kops"
+	o.AzureSubscriptionID = os.Getenv("AZURE_SUBSCRIPTION_ID")
 }
 
 type NewClusterResult struct {


### PR DESCRIPTION
Ref: https://testgrid.k8s.io/kops-network-plugins#kops-azure-cni-cilium
> Resource name control-plane-uksouth-1.masters.e2e-e2e-kops-azure-cni-cilium.k8s.local-netconfig is invalid. The name can be up to 80 characters long. It must begin with a word character, and it must end with a word character or with '_'. The name may contain word characters or '.', '-', '_'.

/cc @ameukam @rifelpet 