### PR TITLE
testing: Fix e2e test job name

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -342,7 +342,7 @@ func defaultClusterName(cloudProvider string) (string, error) {
 	}
 
 	if suffix != "" {
-		jobName = jobType + "." + suffix
+		jobName = jobName + "." + suffix
 	}
 
 	return jobName, nil

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -50,6 +50,10 @@ func (t *Tester) setSkipRegexFlag() error {
 
 	skipRegex := skipRegexBase
 
+	//.Skip.broken.test,.see.https://github.com/kubernetes/kubernetes/pull/133262
+	skipRegex += "|blackbox.*should.not.be.able.to.pull.image.from.invalid.registry"
+	skipRegex += "|blackbox.*should.be.able.to.pull.from.private.registry.with.secret"
+
 	if !isPre28 {
 		// K8s 1.28 promoted ProxyTerminatingEndpoints to GA, but it has limited CNI support
 		// https://github.com/kubernetes/kubernetes/pull/117718


### PR DESCRIPTION
Broken in https://github.com/kubernetes/kops/commit/553509bd46c4525f187cdc8e75891e2b7f761885
```diff
-       return fmt.Sprintf("%v.%v", jobName, suffix), nil
+
+       if suffix != "" {
+               jobName = jobType + "." + suffix
+       }
+
+       return jobName, nil
```