### PR TITLE
Add more context to terraform fatal log

### DIFF
--- a/upup/pkg/fi/cloudup/terraformWriter/writer.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/writer.go
@@ -115,7 +115,7 @@ func (t *TerraformWriter) EnsureTerraformProvider(name string, arguments map[str
 			// already exists and matches
 			return existing
 		}
-		klog.Fatalf("attempt to add different tfProvider with key %q", key)
+		klog.Fatalf("attempt to add different tfProvider with key %q, arguments: %q vs %q", key, tfProvider.Arguments, existing.Arguments)
 	}
 	t.Providers[key] = tfProvider
 	return tfProvider


### PR DESCRIPTION
The terraform e2e tests are failing at this log line:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-scenario-ipv6-terraform/1949972594287448064#1:build-log.txt%3A357

This function can only be called in 3 places: s3fs, memfs, and gsfs

https://github.com/search?q=repo%3Akubernetes%2Fkops%20EnsureTerraformProvider&type=code

The gsfs and s3fs arguments should always be identical, leading me to believe we're somehow referencing a memfs:// file in the e2e test.

I'm hoping this additional logging helps troubleshoot.