### PR TITLE
Use ssm parameter for AMI ID in LBC scenario

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -26,7 +26,7 @@ NETWORKING="amazonvpc"
 OVERRIDES="${OVERRIDES-} --set=cluster.spec.cloudProvider.aws.loadBalancerController.enabled=true"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.certManager.enabled=true"
 OVERRIDES="${OVERRIDES} --master-size=t3.medium --node-size=t3.medium" # Use amd64 because LBC's E2E suite uses single-arch amd64 test images
-OVERRIDES="${OVERRIDES} --image=${INSTANCE_IMAGE:-099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20240906}"
+OVERRIDES="${OVERRIDES} --image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id}"
 
 # shellcheck disable=SC2034
 ZONES="eu-west-1a,eu-west-1b,eu-west-1c"


### PR DESCRIPTION
This was failing because the AMI is no longer discoverable:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-aws-load-balancer-controller/1950309628495532032

Since we dont update these jobs regularly, we can just use the SSM parameter already used by other e2e jobs: https://github.com/search?q=repo%3Akubernetes%2Fkops+%2Faws%2Fservice%2Fcanonical%2Fubuntu%2Fserver&type=code