### PR TITLE
Automated cherry pick of #17523: testing: Fix e2e test job name

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -50,6 +50,10 @@ func (t *Tester) setSkipRegexFlag() error {
 
 	skipRegex := skipRegexBase
 
+	//.Skip.broken.test,.see.https://github.com/kubernetes/kubernetes/pull/133262
+	skipRegex += "|blackbox.*should.not.be.able.to.pull.image.from.invalid.registry"
+	skipRegex += "|blackbox.*should.be.able.to.pull.from.private.registry.with.secret"
+
 	if !isPre28 {
 		// K8s 1.28 promoted ProxyTerminatingEndpoints to GA, but it has limited CNI support
 		// https://github.com/kubernetes/kubernetes/pull/117718


### PR DESCRIPTION
Cherry pick of #17523 on release-1.33.

#17523: testing: Fix e2e test job name

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```