### PR TITLE
Automated cherry pick of #17531: metal: Update Debian image

### DIFF
--- a/docs/metal.md
+++ b/docs/metal.md
@@ -80,7 +80,7 @@ bare-metal machine.
 ```
 mkdir vm1
 cd vm1
-wget -O debian11.qcow2 https://cloud.debian.org/images/cloud/bookworm/20250703-2162/debian-12-generic-amd64-20250703-2162.qcow2
+wget -O debian12.qcow2 https://cloud.debian.org/images/cloud/bookworm/20250703-2162/debian-12-generic-amd64-20250703-2162.qcow2
 
 qemu-img create -o backing_file=debian11.qcow2,backing_fmt=qcow2 -f qcow2 vm1-root.qcow2 10G
 

--- a/docs/metal.md
+++ b/docs/metal.md
@@ -80,7 +80,7 @@ bare-metal machine.
 ```
 mkdir vm1
 cd vm1
-wget -O debian11.qcow2 https://cloud.debian.org/images/cloud/bullseye/20231013-1532/debian-11-nocloud-amd64-20231013-1532.qcow2
+wget -O debian11.qcow2 https://cloud.debian.org/images/cloud/bookworm/20250703-2162/debian-12-generic-amd64-20250703-2162.qcow2
 
 qemu-img create -o backing_file=debian11.qcow2,backing_fmt=qcow2 -f qcow2 vm1-root.qcow2 10G
 

--- a/tests/e2e/scenarios/bare-metal/start-vms
+++ b/tests/e2e/scenarios/bare-metal/start-vms
@@ -76,9 +76,9 @@ fi
 
 # Download boot disk
 cd ${WORKDIR}
-if [[ ! -f debian-12-generic-amd64-20240702-1796.qcow2 ]]; then
-  echo "Downloading debian-12-generic-amd64-20240702-1796.qcow2"
-  wget --no-verbose -N https://cloud.debian.org/images/cloud/bookworm/20240702-1796/debian-12-generic-amd64-20240702-1796.qcow2
+if [[ ! -f debian-12-generic-amd64-20250703-2162.qcow2 ]]; then
+  echo "Downloading debian-12-generic-amd64-20250703-2162.qcow2"
+  wget --no-verbose -N https://cloud.debian.org/images/cloud/bookworm/20250703-2162/debian-12-generic-amd64-20250703-2162.qcow2
 fi
 
 # Create bridge
@@ -183,7 +183,7 @@ EOF
 
   genisoimage  -output seed.iso -volid cidata -joliet -rock user-data meta-data
 
-  qemu-img create -b ../debian-12-generic-amd64-20240702-1796.qcow2 -F qcow2 -f qcow2 root.qcow2 20G
+  qemu-img create -b ../debian-12-generic-amd64-20250703-2162.qcow2 -F qcow2 -f qcow2 root.qcow2 20G
 
   # TODO: Create tuntap with user $(whoami) - might need less sudo?
   sudo ip tuntap add dev tap-${vm_name} mode tap


### PR DESCRIPTION
Cherry pick of #17531 on release-1.32.

#17531: metal: Update Debian image

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```