### PR TITLE
Automated cherry pick of #17485: Use official etcd images from registry.k8s.io

### DIFF
--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -78,7 +78,7 @@ type etcdVersion struct {
 
 var etcdSupportedImages = []etcdVersion{
 	{Version: "3.4.3", SymlinkToVersion: "3.4.13"},
-	{Version: "3.4.13", Image: "registry.k8s.io/etcd:3.4.13-0"},
+	{Version: "3.4.13", Image: "registry.k8s.io/etcd:v3.4.13"},
 	{Version: "3.5.0", SymlinkToVersion: "3.5.21"},
 	{Version: "3.5.1", SymlinkToVersion: "3.5.21"},
 	{Version: "3.5.3", SymlinkToVersion: "3.5.21"},
@@ -88,7 +88,7 @@ var etcdSupportedImages = []etcdVersion{
 	{Version: "3.5.9", SymlinkToVersion: "3.5.21"},
 	{Version: "3.5.13", SymlinkToVersion: "3.5.21"},
 	{Version: "3.5.17", SymlinkToVersion: "3.5.21"},
-	{Version: "3.5.21", Image: "registry.k8s.io/etcd:3.5.21-0"},
+	{Version: "3.5.21", Image: "registry.k8s.io/etcd:v3.5.21"},
 }
 
 func etcdSupportedVersions() []etcdVersion {

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -125,7 +125,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.4.13-0
+      image: registry.k8s.io/etcd:v3.4.13
       name: init-etcd-3-4-13
       resources: {}
       volumeMounts:
@@ -137,7 +137,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.21-0
+      image: registry.k8s.io/etcd:v3.5.21
       name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
@@ -268,7 +268,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.4.13-0
+      image: registry.k8s.io/etcd:v3.4.13
       name: init-etcd-3-4-13
       resources: {}
       volumeMounts:
@@ -280,7 +280,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.21-0
+      image: registry.k8s.io/etcd:v3.5.21
       name: init-etcd-3-5-21
       resources: {}
       volumeMounts:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -124,7 +124,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.4.13-0
+      image: registry.k8s.io/etcd:v3.4.13
       name: init-etcd-3-4-13
       resources: {}
       volumeMounts:
@@ -136,7 +136,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.21-0
+      image: registry.k8s.io/etcd:v3.5.21
       name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
@@ -266,7 +266,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.4.13-0
+      image: registry.k8s.io/etcd:v3.4.13
       name: init-etcd-3-4-13
       resources: {}
       volumeMounts:
@@ -278,7 +278,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.21-0
+      image: registry.k8s.io/etcd:v3.5.21
       name: init-etcd-3-5-21
       resources: {}
       volumeMounts:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -127,7 +127,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.4.13-0
+      image: registry.k8s.io/etcd:v3.4.13
       name: init-etcd-3-4-13
       resources: {}
       volumeMounts:
@@ -139,7 +139,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.21-0
+      image: registry.k8s.io/etcd:v3.5.21
       name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
@@ -272,7 +272,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.4.13-0
+      image: registry.k8s.io/etcd:v3.4.13
       name: init-etcd-3-4-13
       resources: {}
       volumeMounts:
@@ -284,7 +284,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.21-0
+      image: registry.k8s.io/etcd:v3.5.21
       name: init-etcd-3-5-21
       resources: {}
       volumeMounts:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -133,7 +133,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.4.13-0
+      image: registry.k8s.io/etcd:v3.4.13
       name: init-etcd-3-4-13
       resources: {}
       volumeMounts:
@@ -145,7 +145,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.21-0
+      image: registry.k8s.io/etcd:v3.5.21
       name: init-etcd-3-5-21
       resources: {}
       volumeMounts:
@@ -284,7 +284,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.4.13-0
+      image: registry.k8s.io/etcd:v3.4.13
       name: init-etcd-3-4-13
       resources: {}
       volumeMounts:
@@ -296,7 +296,7 @@ Contents: |
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.21-0
+      image: registry.k8s.io/etcd:v3.5.21
       name: init-etcd-3-5-21
       resources: {}
       volumeMounts:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -63,7 +63,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -75,7 +75,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -63,7 +63,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -75,7 +75,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd/assets.yaml
+++ b/tests/integration/update_cluster/containerd/assets.yaml
@@ -88,9 +88,9 @@ images:
   download: registry.k8s.io/kops/kube-apiserver-healthcheck:1.33.0-beta.1
 - canonical: registry.k8s.io/kops/kops-utils-cp:1.33.0-beta.1
   download: registry.k8s.io/kops/kops-utils-cp:1.33.0-beta.1
-- canonical: registry.k8s.io/etcd:3.4.13-0
-  download: registry.k8s.io/etcd:3.4.13-0
-- canonical: registry.k8s.io/etcd:3.5.21-0
-  download: registry.k8s.io/etcd:3.5.21-0
+- canonical: registry.k8s.io/etcd:v3.4.13
+  download: registry.k8s.io/etcd:v3.4.13
+- canonical: registry.k8s.io/etcd:v3.5.21
+  download: registry.k8s.io/etcd:v3.5.21
 - canonical: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704
   download: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20250704

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -63,7 +63,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -75,7 +75,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -62,7 +62,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -74,7 +74,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -62,7 +62,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -74,7 +74,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -64,7 +64,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -76,7 +76,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -64,7 +64,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -76,7 +76,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -73,7 +73,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -60,7 +60,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.4.13-0
+    image: registry.k8s.io/etcd:v3.4.13
     name: init-etcd-3-4-13
     resources: {}
     volumeMounts:
@@ -72,7 +72,7 @@ spec:
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.21-0
+    image: registry.k8s.io/etcd:v3.5.21
     name: init-etcd-3-5-21
     resources: {}
     volumeMounts:


### PR DESCRIPTION
Cherry pick of #17485 on release-1.33.

#17485: Use official etcd images from registry.k8s.io

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```