### PR TITLE
azure: Fix rolling-update error

### DIFF
--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -162,7 +162,7 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 			}
 
 			subscriptionID := cluster.Spec.CloudProvider.Azure.SubscriptionID
-			resourceGroupName := cluster.Spec.CloudProvider.Azure.ResourceGroupName
+			resourceGroupName := cluster.AzureResourceGroupName()
 			azureCloud, err := azure.NewAzureCloud(subscriptionID, resourceGroupName, region, cloudTags)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
```
% kops --state azureblob://kopstest --name my-k8s rolling-update cluster --yes --cloudonly --force
I0803 13:44:41.916588   21940 featureflag.go:168] FeatureFlag "Azure"=true
NAME				STATUS	NEEDUPDATE	READY	MIN	TARGET	MAX
control-plane-northeurope-1	Ready	0		1	1	0	1
nodes-northeurope-1		Ready	0		1	1	0	1
W0803 13:44:44.489931   21940 instancegroups.go:506] Not validating cluster as cloudonly flag is set.
W0803 13:44:44.490063   21940 instancegroups.go:428] Not draining cluster nodes as 'cloudonly' flag is set.
I0803 13:44:44.490111   21940 instancegroups.go:634] Stopping instance "control-plane-northeurope-1.masters.my-k8s_1", in group "control-plane-northeurope-1.masters.my-k8s" (this may take a while).
E0803 13:44:44.490225   21940 instancegroups.go:459] error deleting instance "control-plane-northeurope-1.masters.my-k8s_1", node "": error deleting instance "control-plane-northeurope-1.masters.my-k8s_1":
deleting VMSS VM: parameter resourceGroupName cannot be empty
Error: control-plane node not healthy after update, stopping rolling-update: "error deleting instance \"control-plane-northeurope-1.masters.my-k8s_1\":
deleting VMSS VM: parameter resourceGroupName cannot be empty
```

/cc @ameukam @rifelpet 