### PR TITLE
Remove explicit sysctl fs.inotify.max_user_watches setting

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -111,11 +111,10 @@ func (b *SysctlBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 			"fs.file-max = 2097152",
 			"",
 
-			"# Max number of inotify instances and watches for a user",
+			"# Max number of inotify instances for a user",
 			"# Since dockerd runs as a single user, the default instances value of 128 per user is too low",
 			"# e.g. uses of inotify: nginx ingress controller, kubectl logs -f",
 			"fs.inotify.max_user_instances = 8192",
-			"fs.inotify.max_user_watches = 524288",
 
 			"# Additional sysctl flags that kubelet expects",
 			"vm.overcommit_memory = 1",


### PR DESCRIPTION
Since Linux 5.11-rc1, `fs.inotify.max_user_watches` is dynamically computed up to `1048576` with regards to the addressable physical memory: https://github.com/torvalds/linux/commit/92890123749bafc317bbfacbe0a62ce08d78efb7 .

I suggest removing the current explicit setting to a lower maximum value in favor of using the kernel's default smart way that can provide memory gains on smaller nodes which wouldn't require a high value there.

Tablecloth math from the above-linked commit makes me understand that on a 64bits host with 64GB `fs.inotify.max_user_watches` would be set to the currently hard coded `524288`.

---

Edit: re-running the formula `(totalram_pages << (PAGE_SHIFT - 8)) / sizeof(struct inotify_inode_mark)` for x86_64 (struct size ~128 B), parity with the previous hard-coded `524288` actually lands around 16 GiB; ≥32 GiB hits the `1<<20` cap:

| RAM    | Computed default     |
|--------|----------------------|
|  4 GiB | ~131 072             |
|  8 GiB | ~262 144             |
| 16 GiB | ~524 288 (parity)    |
| ≥32 GiB| 1 048 576 (capped)   |

Users who need a specific value can still override via `cluster.spec.sysctlParameters`.