### PR TITLE
Use yum instead of dnf on Amazon Linux 2

### DIFF
--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -91,6 +91,8 @@ func (d *Distribution) HasDNF() bool {
 		return d.version >= 8
 	case "fedora":
 		return d.version >= 22
+	case "amazonlinux2":
+		return false
 	default:
 		klog.Warningf("unknown project for HasDNF (%q), assuming does support dnf", d.project)
 		return true


### PR DESCRIPTION
Amazon Linux 2 only has `yum`, not `dnf` in the official AMIs. Thus, the `kops-configuration` service gets stuck on AL2 trying (and failing) to use `dnf` instead of `yum`.

This PR updates `HasDNF` to always return `false` for AL2 nodes.