### PR TITLE
Automated cherry pick of #17550: Recognize Debian 13

### DIFF
--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -58,6 +58,8 @@ func FindDistribution(rootfs string) (Distribution, error) {
 		return DistributionDebian11, nil
 	case "debian-12":
 		return DistributionDebian12, nil
+	case "debian-13":
+		return DistributionDebian13, nil
 	case "fedora-41":
 		return DistributionFedora41, nil
 	case "ubuntu-20.04":

--- a/util/pkg/distributions/identify_test.go
+++ b/util/pkg/distributions/identify_test.go
@@ -85,6 +85,10 @@ func TestFindDistribution(t *testing.T) {
 			expected: DistributionDebian12,
 		},
 		{
+			rootfs:   "debian13",
+			err:      nil,
+			expected: DistributionDebian13,
+		}, {
 			rootfs:   "flatcar",
 			err:      nil,
 			expected: DistributionFlatcar,

--- a/util/pkg/distributions/tests/debian13/etc/os-release
+++ b/util/pkg/distributions/tests/debian13/etc/os-release
@@ -1,0 +1,10 @@
+PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
+NAME="Debian GNU/Linux"
+VERSION_ID="13"
+VERSION="13 (trixie)"
+VERSION_CODENAME=trixie
+DEBIAN_VERSION_FULL=13.0
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"


### PR DESCRIPTION
Cherry pick of #17550 on release-1.33.

#17550: Recognize Debian 13

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```