### PR TITLE
Automated cherry pick of #17557: Use yum instead of dnf on Amazon Linux 2

### DIFF
--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -91,6 +91,8 @@ func (d *Distribution) HasDNF() bool {
 		return d.version >= 8
 	case "fedora":
 		return d.version >= 22
+	case "amazonlinux2":
+		return false
 	default:
 		klog.Warningf("unknown project for HasDNF (%q), assuming does support dnf", d.project)
 		return true


### PR DESCRIPTION
Cherry pick of #17557 on release-1.33.

#17557: Use yum instead of dnf on Amazon Linux 2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```