### PR TITLE
Add nftables package

### DIFF
--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -50,6 +50,9 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		c.AddTask(&nodetasks.Package{Name: "libapparmor1"})
 		c.AddTask(&nodetasks.Package{Name: "libseccomp2"})
 		c.AddTask(&nodetasks.Package{Name: "libltdl7"})
+		if b.NodeupConfig.KubeProxy != nil && fi.ValueOf(b.NodeupConfig.KubeProxy.Enabled) && b.NodeupConfig.KubeProxy.ProxyMode == "nftables" {
+			c.AddTask(&nodetasks.Package{Name: "nftables"})
+		}
 		c.AddTask(&nodetasks.Package{Name: "pigz"})
 		c.AddTask(&nodetasks.Package{Name: "socat"})
 		c.AddTask(&nodetasks.Package{Name: "util-linux"})
@@ -70,6 +73,9 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		}
 		c.AddTask(&nodetasks.Package{Name: "libseccomp"})
 		c.AddTask(&nodetasks.Package{Name: "libtool-ltdl"})
+		if b.NodeupConfig.KubeProxy != nil && fi.ValueOf(b.NodeupConfig.KubeProxy.Enabled) && b.NodeupConfig.KubeProxy.ProxyMode == "nftables" {
+			c.AddTask(&nodetasks.Package{Name: "nftables"})
+		}
 		c.AddTask(&nodetasks.Package{Name: "socat"})
 		c.AddTask(&nodetasks.Package{Name: "util-linux"})
 		// Handle some packages differently for each distro


### PR DESCRIPTION
NFtables proxy mode is GA in Kubernetes 1.33. See: https://kubernetes.io/blog/2025/02/28/nftables-kube-proxy/