### PR TITLE
Automated cherry pick of #17581: Install cgroupfs-mount for distros lower than Debian

### DIFF
--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -40,7 +40,9 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.Distribution.IsDebianFamily() {
 		// From containerd: https://github.com/containerd/cri/blob/master/contrib/ansible/tasks/bootstrap_ubuntu.yaml
 		c.AddTask(&nodetasks.Package{Name: "bridge-utils"})
-		c.AddTask(&nodetasks.Package{Name: "cgroupfs-mount"})
+		if (b.Distribution.IsDebian() && b.Distribution.Version() < 13) || (b.Distribution.IsUbuntu() && b.Distribution.Version() < 25.10) {
+			c.AddTask(&nodetasks.Package{Name: "cgroupfs-mount"})
+		}
 		c.AddTask(&nodetasks.Package{Name: "conntrack"})
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})

--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -68,6 +68,11 @@ func (d *Distribution) IsDebianFamily() bool {
 	return d.packageFormat == "deb"
 }
 
+// IsDebian returns true if this distribution is Debian
+func (d *Distribution) IsDebian() bool {
+	return d.project == "debian"
+}
+
 // IsUbuntu returns true if this distribution is Ubuntu (but not debian)
 func (d *Distribution) IsUbuntu() bool {
 	return d.project == "ubuntu"


### PR DESCRIPTION
Cherry pick of #17581 on release-1.32.

#17581: Install cgroupfs-mount for distros lower than Debian

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```