### PR TITLE
azure: Use internal K8s API endpoint for cloud-node-manager

### DIFF
--- a/upup/models/cloudup/resources/addons/azure-cloud-node.addons.k8s.io/k8s-1.31.yaml.template
+++ b/upup/models/cloudup/resources/addons/azure-cloud-node.addons.k8s.io/k8s-1.31.yaml.template
@@ -82,6 +82,8 @@ spec:
         - --node-name=$(NODE_NAME)
         - --v=4
         env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{ APIInternalName }}"
         - name: NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
**cloud-node-manager** needs to be able to remove the `node.cloudprovider.kubernetes.io/uninitialized` taint, before the CNI can run (e.g. `cilium-operator`).

/cc @ameukam 