### PR TITLE
Add support for `cilium-etcd` with `dns=none`

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -478,6 +478,9 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.CloudupMo
 				t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("tcp"))
 				if b.Cluster.UsesNoneDNS() && ig.IsControlPlane() {
 					t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("kops-controller"))
+					if b.Cluster.Spec.Networking.Cilium != nil && b.Cluster.Spec.Networking.Cilium.EtcdManaged {
+						t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("etcd-cilium"))
+					}
 				}
 				if b.Cluster.Spec.API.LoadBalancer.SSLCertificate != "" {
 					t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("tls"))

--- a/pkg/wellknownservices/wellknownservices.go
+++ b/pkg/wellknownservices/wellknownservices.go
@@ -24,4 +24,7 @@ const (
 
 	// KopsController is the service where kops-controller listens.
 	KopsController WellKnownService = "kops-controller"
+
+	// EtcdCilium is the service where Cilium etcd listens.
+	EtcdCilium WellKnownService = "etcd-cilium"
 )


### PR DESCRIPTION
In newer versions of cilium, all agents require access to the dedicated etcd cluster.

/cc @ameukam @rifelpet 