### PR TITLE
tests: allow env vars to be exported from kubetest2-kops

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -86,6 +86,9 @@ type deployer struct {
 
 	BuildOptions *builder.BuildOptions
 
+	// EnvFile is the path to a file that will be written containing the env vars, in particular KOPS_STATE_STORE
+	EnvFile string `flag:"env-file" desc:"The path to a file that will be written containing the env vars, in particular KOPS_STATE_STORE"`
+
 	// manifestPath is the location of the rendered manifest based on TemplatePath
 	manifestPath string
 	terraform    *target.Terraform

--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -142,11 +142,20 @@ function kops-up() {
       KOPS_CONTROL_PLANE_COUNT=${KOPS_CONTROL_PLANE_SIZE}
     fi
 
+    if [[ -z "${ENV_FILE-}" ]]; then
+        ENV_FILE="${WORKSPACE}/env"
+    fi
+
     ${KUBETEST2} \
         --up \
+        --env-file="${ENV_FILE}" \
         --kops-binary-path="${KOPS}" \
         --kubernetes-version="${K8S_VERSION}" \
         --create-args="${create_args}" \
         --control-plane-count="${KOPS_CONTROL_PLANE_COUNT:-1}" \
         --template-path="${KOPS_TEMPLATE-}"
+
+    # Source the env file to get exported variables, in particular KOPS_STATE_STORE
+    . "${ENV_FILE}"
+    export KOPS_STATE_STORE
 }


### PR DESCRIPTION
This allows us to get the dynamically created KOPS_STATE_STORE,
and then make calls to kops that need KOPS_STATE_STORE.
