### PR TITLE
Automated cherry pick of #17663: aws: Add the option to set Karpenter feature gates

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1661,6 +1661,8 @@ spec:
                     x-kubernetes-int-or-string: true
                   enabled:
                     type: boolean
+                  featureGates:
+                    type: string
                   image:
                     type: string
                   logEncoding:

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -270,6 +270,7 @@ type KarpenterConfig struct {
 	LogEncoding   string             `json:"logFormat,omitempty"`
 	LogLevel      string             `json:"logLevel,omitempty"`
 	Image         string             `json:"image,omitempty"`
+	FeatureGates  string             `json:"featureGates,omitempty"`
 	MemoryLimit   *resource.Quantity `json:"memoryLimit,omitempty"`
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
 	CPURequest    *resource.Quantity `json:"cpuRequest,omitempty"`

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -267,6 +267,7 @@ type KarpenterConfig struct {
 	LogEncoding   string             `json:"logEncoding,omitempty"`
 	LogLevel      string             `json:"logLevel,omitempty"`
 	Image         string             `json:"image,omitempty"`
+	FeatureGates  string             `json:"featureGates,omitempty"`
 	MemoryLimit   *resource.Quantity `json:"memoryLimit,omitempty"`
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
 	CPURequest    *resource.Quantity `json:"cpuRequest,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4859,6 +4859,7 @@ func autoConvert_v1alpha2_KarpenterConfig_To_kops_KarpenterConfig(in *KarpenterC
 	out.LogEncoding = in.LogEncoding
 	out.LogLevel = in.LogLevel
 	out.Image = in.Image
+	out.FeatureGates = in.FeatureGates
 	out.MemoryLimit = in.MemoryLimit
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
@@ -4875,6 +4876,7 @@ func autoConvert_kops_KarpenterConfig_To_v1alpha2_KarpenterConfig(in *kops.Karpe
 	out.LogEncoding = in.LogEncoding
 	out.LogLevel = in.LogLevel
 	out.Image = in.Image
+	out.FeatureGates = in.FeatureGates
 	out.MemoryLimit = in.MemoryLimit
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -261,6 +261,7 @@ type KarpenterConfig struct {
 	LogEncoding   string             `json:"logEncoding,omitempty"`
 	LogLevel      string             `json:"logLevel,omitempty"`
 	Image         string             `json:"image,omitempty"`
+	FeatureGates  string             `json:"featureGates,omitempty"`
 	MemoryLimit   *resource.Quantity `json:"memoryLimit,omitempty"`
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
 	CPURequest    *resource.Quantity `json:"cpuRequest,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5256,6 +5256,7 @@ func autoConvert_v1alpha3_KarpenterConfig_To_kops_KarpenterConfig(in *KarpenterC
 	out.LogEncoding = in.LogEncoding
 	out.LogLevel = in.LogLevel
 	out.Image = in.Image
+	out.FeatureGates = in.FeatureGates
 	out.MemoryLimit = in.MemoryLimit
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
@@ -5272,6 +5273,7 @@ func autoConvert_kops_KarpenterConfig_To_v1alpha3_KarpenterConfig(in *kops.Karpe
 	out.LogEncoding = in.LogEncoding
 	out.LogLevel = in.LogLevel
 	out.Image = in.Image
+	out.FeatureGates = in.FeatureGates
 	out.MemoryLimit = in.MemoryLimit
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest

--- a/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
@@ -38,6 +38,7 @@ spec:
     useServiceAccountExternalPermissions: true
   karpenter:
     enabled: true
+    featureGates: StaticCapacity=true
   kubelet:
     anonymousAuth: false
   kubernetesApiAccess:

--- a/tests/integration/create_cluster/karpenter/options.yaml
+++ b/tests/integration/create_cluster/karpenter/options.yaml
@@ -8,3 +8,5 @@ Networking: calico
 KubernetesVersion: v1.23.0
 InstanceManager: karpenter
 DiscoveryStore: memfs://kops-state-store
+Sets:
+- cluster.spec.karpenter.featureGates=StaticCapacity=true

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -57,6 +57,7 @@ spec:
   karpenter:
     cpuRequest: 100m
     enabled: true
+    featureGates: StaticCapacity=true
     image: public.ecr.aws/karpenter/controller:1.8.1
     logEncoding: console
     logLevel: debug

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: abf06eb5b8f5c5545d374c34a5ef6c1d835aeddbee5b058d2fdff82850fc2e80
+    manifestHash: 59095ecba37bcee840f11306998b495fea5da1c3b5bf4ef95b9bbae0ff5c9bf0
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -2769,7 +2769,7 @@ spec:
               divisor: "0"
               resource: limits.memory
         - name: FEATURE_GATES
-          value: ReservedCapacity=true,SpotToSpotConsolidation=false,NodeRepair=false,NodeOverlay=false,StaticCapacity=false
+          value: StaticCapacity=true
         - name: BATCH_MAX_DURATION
           value: 10s
         - name: BATCH_IDLE_DURATION

--- a/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
@@ -23,6 +23,7 @@ spec:
   karpenter:
     cpuRequest: 100m
     enabled: true
+    featureGates: StaticCapacity=true
     memoryRequest: 500Mi
     memoryLimit: 2Gi
   kubelet:

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -2413,7 +2413,7 @@ spec:
                   divisor: "0"
                   resource: limits.memory
             - name: FEATURE_GATES
-              value: "ReservedCapacity=true,SpotToSpotConsolidation=false,NodeRepair=false,NodeOverlay=false,StaticCapacity=false"
+              value: '{{ or .Karpenter.FeatureGates "ReservedCapacity=true,SpotToSpotConsolidation=false,NodeRepair=false,NodeOverlay=false,StaticCapacity=true" }}'
             - name: BATCH_MAX_DURATION
               value: "10s"
             - name: BATCH_IDLE_DURATION


### PR DESCRIPTION
Cherry pick of #17663 on release-1.34.

#17663: aws: Add the option to set Karpenter feature gates

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```