### PR TITLE
aws: Bypass the graceful OS shutdown process on cluster deletion

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -336,7 +336,8 @@ func DeleteInstances(cloud fi.Cloud, t []*resources.Resource) error {
 
 		klog.Infof("Terminating %d EC2 instances", len(ids))
 		request := &ec2.TerminateInstancesInput{
-			InstanceIds: ids,
+			InstanceIds:    ids,
+			SkipOsShutdown: aws.Bool(true),
 		}
 		ids = []string{}
 		_, err := c.EC2().TerminateInstances(ctx, request)


### PR DESCRIPTION
Should be a good optimisation for scalability tests.

/cc @rifelpet @ameukam @upodroid @hakuna-matatah 