### PR TITLE
add KOPS_CL2_TEST_CONFIG to scalibility/run-test.sh

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -203,7 +203,7 @@ kubetest2 kops "${KUBETEST2_ARGS[@]}" \
   -- \
   --provider="${CLOUD_PROVIDER}" \
   --repo-root="${GOPATH}"/src/k8s.io/perf-tests \
-  --test-configs="${GOPATH}"/src/k8s.io/perf-tests/clusterloader2/testing/load/config.yaml \
+  --test-configs="${TEST_CONFIG}" \
   --test-overrides="${GOPATH}"/src/k8s.io/perf-tests/clusterloader2/testing/load/overrides.yaml \
   --extra-args="--experimental-prometheus-snapshot-to-report-dir=true" \
   --kube-config="${HOME}/.kube/config"


### PR DESCRIPTION
This PR allows configuring custom test config file for invoking  ClusterLoader2 scale tests.

It will be used here: https://github.com/kubernetes/test-infra/pull/35699