### PR TITLE
allow specific GCE IGs to have public IP addresses

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -84,6 +84,15 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 			if err != nil {
 				return nil, err
 			}
+
+			HasExternalIP := fi.PtrTo(false)
+			if subnet.Type == kops.SubnetTypePublic || subnet.Type == kops.SubnetTypeUtility || ig.IsBastion() {
+				HasExternalIP = fi.PtrTo(true)
+			}
+			if ig.Spec.AssociatePublicIP != nil {
+				HasExternalIP = ig.Spec.AssociatePublicIP
+			}
+
 			t := &gcetasks.InstanceTemplate{
 				Name:           s(name),
 				NamePrefix:     s(namePrefix),
@@ -97,7 +106,7 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 				Preemptible:          fi.PtrTo(fi.ValueOf(ig.Spec.GCPProvisioningModel) == "SPOT"),
 				GCPProvisioningModel: ig.Spec.GCPProvisioningModel,
 
-				HasExternalIP: fi.PtrTo(subnet.Type == kops.SubnetTypePublic || subnet.Type == kops.SubnetTypeUtility || ig.IsBastion()),
+				HasExternalIP: HasExternalIP,
 
 				Scopes: []string{
 					"compute-rw",


### PR DESCRIPTION
clusterloader2 has to SSH into the master instance to pull metrics for perf-dash but its unable to do so because we don't have a public IP on the instance.

After https://github.com/kubernetes/kops/blob/master/tests/e2e/scenarios/scalability/run-test.sh#L153 this line, we'll insert a new one with the following values:

`KUBETEST2_ARGS+=("--control-plane-instance-group-overrides=spec.associatePublicIP=true")`
