### PR TITLE
calico: Don't install Wireguard if disabled

### DIFF
--- a/nodeup/pkg/model/networking/calico.go
+++ b/nodeup/pkg/model/networking/calico.go
@@ -31,11 +31,12 @@ var _ fi.NodeupModelBuilder = &CalicoBuilder{}
 
 // Build is responsible for performing setup for Calico.
 func (b *CalicoBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	if b.NodeupConfig.Networking.Calico == nil {
+	calico := b.NodeupConfig.Networking.Calico
+	if calico == nil {
 		return nil
 	}
 
-	if b.Distribution.IsUbuntu() {
+	if b.Distribution.IsUbuntu() && !b.IsIPv6Only() && (calico.WireguardEnabled == nil || *calico.WireguardEnabled) {
 		c.AddTask(&nodetasks.Package{Name: "wireguard"})
 	}
 

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -268,7 +268,7 @@ type CalicoNetworkingSpec struct {
 	VXLANMode string `json:"vxlanMode,omitempty"`
 	// WireguardEnabled enables WireGuard encryption for all on-the-wire pod-to-pod traffic
 	// (default: false)
-	WireguardEnabled bool `json:"wireguardEnabled,omitempty"`
+	WireguardEnabled *bool `json:"wireguardEnabled,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -226,7 +226,7 @@ type CalicoNetworkingSpec struct {
 	VXLANMode string `json:"vxlanMode,omitempty"`
 	// WireguardEnabled enables WireGuard encryption for all on-the-wire pod-to-pod traffic
 	// (default: false)
-	WireguardEnabled bool `json:"wireguardEnabled,omitempty"`
+	WireguardEnabled *bool `json:"wireguardEnabled,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -430,6 +430,11 @@ func (in *CalicoNetworkingSpec) DeepCopyInto(out *CalicoNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.WireguardEnabled != nil {
+		in, out := &in.WireguardEnabled, &out.WireguardEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -232,7 +232,7 @@ type CalicoNetworkingSpec struct {
 	VXLANMode string `json:"vxlanMode,omitempty"`
 	// WireguardEnabled enables WireGuard encryption for all on-the-wire pod-to-pod traffic
 	// (default: false)
-	WireguardEnabled bool `json:"wireguardEnabled,omitempty"`
+	WireguardEnabled *bool `json:"wireguardEnabled,omitempty"`
 }
 
 // CanalNetworkingSpec declares that we want Canal networking

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -496,6 +496,11 @@ func (in *CalicoNetworkingSpec) DeepCopyInto(out *CalicoNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.WireguardEnabled != nil {
+		in, out := &in.WireguardEnabled, &out.WireguardEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1602,7 +1602,7 @@ func validateNetworkingCalico(c *kops.ClusterSpec, v *kops.CalicoNetworkingSpec,
 				fmt.Sprintf("Unable to set number of Typha replicas to less than 0, you've specified %d", v.TyphaReplicas)))
 	}
 
-	if v.WireguardEnabled && c.IsIPv6Only() {
+	if fi.ValueOf(v.WireguardEnabled) && c.IsIPv6Only() {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("wireguardEnabled"), `WireGuard is not supported on IPv6 clusters`))
 	}
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -495,6 +495,11 @@ func (in *CalicoNetworkingSpec) DeepCopyInto(out *CalicoNetworkingSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.WireguardEnabled != nil {
+		in, out := &in.WireguardEnabled, &out.WireguardEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -313,7 +313,9 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 	}
 
 	if cluster.Spec.Networking.Calico != nil {
-		config.Networking.Calico = &kops.CalicoNetworkingSpec{}
+		config.Networking.Calico = &kops.CalicoNetworkingSpec{
+			WireguardEnabled: cluster.Spec.Networking.Calico.WireguardEnabled,
+		}
 	}
 
 	if cluster.Spec.Networking.Cilium != nil {

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.25.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.25.yaml.template
@@ -10184,7 +10184,7 @@ spec:
               value: "{{- .Networking.Calico.PrometheusProcessMetricsEnabled }}"
             # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
             - name: FELIX_WIREGUARDENABLED
-              value: "{{ .Networking.Calico.WireguardEnabled }}"
+              value: "{{ WithDefaultBool .Networking.Calico.WireguardEnabled false }}"
             # Enable support for HTTP forward proxy
             {{ range $name, $value := ProxyEnv }}
             - name: {{ $name }}


### PR DESCRIPTION
Some of the presubmits now run with `--set=cluster.spec.networking.calico.wireguardEnabled=false`, which requires changing from `bool` to `*bool`. The change should be transparent for users.
See https://github.com/kubernetes/test-infra/pull/35728.