### PR TITLE
Skip package updates at boot time

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
-	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/local"
 	"k8s.io/kops/util/pkg/distributions"
@@ -198,7 +197,7 @@ func (e *Package) findDpkg(c *fi.NodeupContext) (*Package, error) {
 		}
 	}
 
-	if c.T.NodeupConfig.UpdatePolicy != kops.UpdatePolicyExternal || !installed {
+	if !installed {
 		return nil, nil
 	}
 
@@ -246,7 +245,7 @@ func (e *Package) findYum(c *fi.NodeupContext) (*Package, error) {
 		healthy = fi.PtrTo(true)
 	}
 
-	if c.T.NodeupConfig.UpdatePolicy != kops.UpdatePolicyExternal || !installed {
+	if !installed {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Should reduce bootstrap time by about 1 min.
Historically, this was added because images had old/broken packages and newer versions were needed by Kubernetes components. It's not the case these days. 

Alternative to https://github.com/kubernetes/kops/pull/17686. More or less reverting my own change from long ago https://github.com/kubernetes/kops/pull/8635. 😁 
PS: I still think that unattended upgrades are a ticking time bomb.