### PR TITLE
clean up the skip regex files

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -168,15 +168,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		"--kubernetes-version", d.KubernetesVersion,
 		"--ssh-public-key", d.SSHPublicKeyPath,
 		"--set", "cluster.spec.nodePortAccess=0.0.0.0/0",
-	}
-
-	version, err := kops.GetVersion(d.KopsBinaryPath)
-	if err != nil {
-		return err
-	}
-	if version > "1.29" {
-		// Requires https://github.com/kubernetes/kops/pull/16128
-		args = append(args, "--set", `spec.containerd.configAdditions=plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.runtime_type=io.containerd.runc.v2`)
+		"--set", `spec.containerd.configAdditions=plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.runtime_type=io.containerd.runc.v2`,
 	}
 
 	if yes {
@@ -265,12 +257,12 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 	cmd.SetEnv(d.env()...)
 
 	exec.InheritOutput(cmd)
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
 		return err
 	}
 
-	if d.setInstanceGroupOverrides(); err != nil {
+	if err = d.setInstanceGroupOverrides(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
1. K8s 1.31 is no longer supported
2. NPD is behind a featuregate
3. Firewall|kube-dns tests have been removed from the kubernetes code
4. The cilium bug has been fixed
5. in-tree cloud providers were removed in 1.31
6. We set the custom runtimeclass that e2e test needs.


I also need to introduce some new skips to fix permafails

https://storage.googleapis.com/k8s-triage/index.html?job=kops*
