### PR TITLE
scaleway: Fix failing terraform test

### DIFF
--- a/tests/integration/update_cluster/minimal_scaleway/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_scaleway/kubernetes.tf
@@ -240,7 +240,7 @@ resource "scaleway_lb_backend" "lb-backend-https" {
   lb_id            = scaleway_lb.api-scw-minimal-k8s-local.id
   name             = "lb-backend-https"
   proxy_protocol   = "none"
-  server_ips       = [scaleway_instance_server.control-plane-fr-par-1-0.private_ip]
+  server_ips       = [scaleway_instance_server.control-plane-fr-par-1-0.private_ips[0].address]
 }
 
 resource "scaleway_lb_backend" "lb-backend-kops-controller" {
@@ -249,7 +249,7 @@ resource "scaleway_lb_backend" "lb-backend-kops-controller" {
   lb_id            = scaleway_lb.api-scw-minimal-k8s-local.id
   name             = "lb-backend-kops-controller"
   proxy_protocol   = "none"
-  server_ips       = [scaleway_instance_server.control-plane-fr-par-1-0.private_ip]
+  server_ips       = [scaleway_instance_server.control-plane-fr-par-1-0.private_ips[0].address]
 }
 
 resource "scaleway_lb_frontend" "lb-frontend-https" {

--- a/upup/pkg/fi/cloudup/scalewaytasks/lb_backend.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/lb_backend.go
@@ -221,7 +221,7 @@ func (l *LBBackend) RenderTerraform(t *terraform.TerraformTarget, actual, expect
 	for _, server := range servers {
 		tfInstance := server.(terraformInstance)
 		if role := scaleway.InstanceRoleFromTags(tfInstance.Tags); role == scaleway.TagRoleControlPlane {
-			serverIPs = append(serverIPs, terraformWriter.LiteralProperty("scaleway_instance_server", fi.ValueOf(tfInstance.Name), "private_ip"))
+			serverIPs = append(serverIPs, terraformWriter.LiteralProperty("scaleway_instance_server", fi.ValueOf(tfInstance.Name), "private_ips[0].address"))
 		}
 	}
 


### PR DESCRIPTION
```
/home/prow/go/src/k8s.io/kops/tests/integration/update_cluster/minimal_scaleway
 [31m╷
[31m│ [31mError: Unsupported attribute
[31m│ 
[31m│   on kubernetes.tf line 243, in resource "scaleway_lb_backend" "lb-backend-https":
[31m│  243:   server_ips       = [scaleway_instance_server.control-plane-fr-par-1-0.private_ip]
[31m│ 
[31m│ This object has no argument, nested block, or exported attribute named
[31m│ "private_ip". Did you mean "private_ips"?
[31m╵
[31m╷
[31m│ [31mError: Unsupported attribute
[31m│ 
[31m│   on kubernetes.tf line 252, in resource "scaleway_lb_backend" "lb-backend-kops-controller":
[31m│  252:   server_ips       = [scaleway_instance_server.control-plane-fr-par-1-0.private_ip]
[31m│ 
[31m│ This object has no argument, nested block, or exported attribute named
[31m│ "private_ip". Did you mean "private_ips"?
[31m╵
```