### PR TITLE
Automated cherry pick of #17640: Update cluster-autoscaler to v1.34.0 releases
#17725: Update cluster-autoscaler to v1.34.1

### DIFF
--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -43,16 +43,20 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 		v, err := util.ParseKubernetesVersion(clusterSpec.KubernetesVersion)
 		if err == nil {
 			switch v.Minor {
-			case 27:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.27.7"
-			case 28:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.28.4"
 			case 29:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.2"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.5"
 			case 30:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.6"
+			case 31:
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.31.4"
+			case 32:
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.3"
+			case 33:
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.1"
+			case 34:
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.0"
 			default:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.0"
 			}
 		}
 		cas.Image = fi.PtrTo(image)

--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -43,6 +43,10 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 		v, err := util.ParseKubernetesVersion(clusterSpec.KubernetesVersion)
 		if err == nil {
 			switch v.Minor {
+			case 27:
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.27.7"
+			case 28:
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.28.4"
 			case 29:
 				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.5"
 			case 30:

--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -46,17 +46,17 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 			case 29:
 				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.5"
 			case 30:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.6"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.7"
 			case 31:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.31.4"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.31.5"
 			case 32:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.3"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4"
 			case 33:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.1"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.2"
 			case 34:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.0"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.1"
 			default:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.0"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.1"
 			}
 		}
 		cas.Image = fi.PtrTo(image)

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: a3dabf22247ebe9511c5714760fffbe206397f265fe710caa73b6162678f3f68
+    manifestHash: 98ea885331dfd0bc57b8c5e149d4886ac238e919002551bede2e253e1737c4f0
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -149,6 +149,7 @@ rules:
   - csinodes
   - csidrivers
   - csistoragecapacities
+  - volumeattachments
   verbs:
   - watch
   - list
@@ -374,7 +375,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -38,7 +38,7 @@ spec:
     enabled: true
     expander: priority
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 29605e5dcd67d0676c67d06dc59a3aaf5e28ecc6a4d8682956b928664b684fd2
+    manifestHash: 3da742fd6d5fc593b32a363cdab310cf50e41a23f4f231bb0eaab64537c9ded1
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -149,6 +149,7 @@ rules:
   - csinodes
   - csidrivers
   - csistoragecapacities
+  - volumeattachments
   verbs:
   - watch
   - list
@@ -374,7 +375,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
     enabled: true
     expander: priority
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -34,7 +34,7 @@ spec:
     enabled: true
     expander: random
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: dbc0df294fcd14e5e160aee8184a0a44f8f19b1405ba6e59df9bc374744cc550
+    manifestHash: 5b15093c718da2166cdebd64b6b5075476cbd045802ad684577b0393095f5c6c
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -149,6 +149,7 @@ rules:
   - csinodes
   - csidrivers
   - csistoragecapacities
+  - volumeattachments
   verbs:
   - watch
   - list
@@ -347,7 +348,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/cluster-autoscaler.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -35,7 +35,7 @@ spec:
     enabled: true
     expander: random
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: d5dcf7453514dd91793ba54ba4e6f1324e6950474124da5cb6b9a5d710770970
+    manifestHash: e3594ec3d49eeb6ce74dee7ad3d5c907fa6fb43a3e5d0cfd3089039efd0aeb58
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -149,6 +149,7 @@ rules:
   - csinodes
   - csidrivers
   - csistoragecapacities
+  - volumeattachments
   verbs:
   - watch
   - list
@@ -349,7 +350,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -35,7 +35,7 @@ spec:
     enabled: true
     expander: random
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 7aaa72ea23224ce59b6009ea711f2cc50f20279aa586e7aa1f75961f990f103b
+    manifestHash: e286ee4f4a2bbbc48594378c6cc996251a6c4819a729bdbf63c5c099c147e431
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -149,6 +149,7 @@ rules:
   - csinodes
   - csidrivers
   - csistoragecapacities
+  - volumeattachments
   verbs:
   - watch
   - list
@@ -345,7 +346,7 @@ spec:
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -35,7 +35,7 @@ spec:
     enabled: true
     expander: random
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     podAnnotations:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: bb64e4cd537511ccc8275e6e20cc77d1410916ac81325ec0e4e2f05462bde200
+    manifestHash: 3e7b7bdf341dc25fdf0aa48182bfb0a05e272443e1685fcd228d16cad8be5503
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -149,6 +149,7 @@ rules:
   - csinodes
   - csidrivers
   - csistoragecapacities
+  - volumeattachments
   verbs:
   - watch
   - list
@@ -350,7 +351,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -142,6 +142,7 @@ rules:
     - csinodes
     - csidrivers
     - csistoragecapacities
+    - volumeattachments
     verbs:
     - watch
     - list


### PR DESCRIPTION
Cherry pick of #17640 #17725 on release-1.33.

#17640: Update cluster-autoscaler to v1.34.0 releases
#17725: Update cluster-autoscaler to v1.34.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```