### PR TITLE
Automated cherry pick of #17559: Bump ko-build

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,12 +27,17 @@ jobs:
         with:
           go-version-file: '${{ env.GOPATH }}/src/k8s.io/kops/go.mod'
 
+      - name: dev/tasks/free-disk-space-on-github-actions-runner
+        working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
+        run: |
+          dev/tasks/free-disk-space-on-github-actions-runner
+
       - name: tests/e2e/scenarios/bare-metal/run-test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
         run: |
           CHANGED_VERSION=$(git diff --name-only HEAD~2 | grep -E '^kops-version\.go$' || true)
           if [ -z "${CHANGED_VERSION}" ]
-          then 
+          then
             timeout 60m tests/e2e/scenarios/bare-metal/run-test
           else
             echo "kops-version.go has been modified, skipping test"

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 # CODEGEN_VERSION is the version of k8s.io/code-generator to use
 CODEGEN_VERSION=v0.29.0
 
-KO=go run github.com/google/ko@v0.14.1
+KO=go run github.com/google/ko@v0.18.0
 
 UPLOAD_CMD=$(KOPS_ROOT)/hack/upload ${UPLOAD_ARGS}
 

--- a/dev/tasks/free-disk-space-on-github-actions-runner
+++ b/dev/tasks/free-disk-space-on-github-actions-runner
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+
+# Free up disk space on GitHub Actions runners
+# Based on https://github.com/apache/flink/blob/02d30ace69dc18555a5085eccf70ee884e73a16e/tools/azure-pipelines/free_disk_space.sh
+
+if [[ -z "${GITHUB_ACTIONS:-}" ]]; then
+  echo "Not running on GitHub Actions; skipping disk space cleanup (for safety)"
+  exit 1
+fi
+
+echo "=============================================================================="
+echo "Freeing up disk space on CI system"
+echo "=============================================================================="
+
+echo "Before cleanup:"
+echo "** 100 largest packages:"
+dpkg-query -Wf '${Installed-Size}\t${Status;1}\t${Package}\n' | sort -n | tail -n 100
+echo "** Disk usage:"
+df -h
+
+echo "Removing man-db (to speed up further removals)"
+sudo apt-get remove -y man-db || true
+
+echo "Removing large packages"
+sudo apt-get remove -y '^mysql-server-.*' || true
+sudo apt-get remove -y '^dotnet-.*' || true
+sudo apt-get remove -y '^llvm-.*' '^libllvm.*' '^libclang.*' || true
+# Hard to remove gcc because it is a dependency for many things
+#sudo apt-get remove -y '^gcc-.*' '^g\+\+.*' '^gfortran-.*' '^cpp-.*' || true
+sudo apt-get remove -y '^openjdk.*' '^temurin-.*' ca-certificates-java || true
+sudo apt-get remove -y 'php.*' || true
+sudo apt-get remove -y '^ruby.*' || true
+sudo apt-get remove -y microsoft-edge-stable google-chrome-stable firefox powershell mercurial-common
+sudo apt-get autoremove -y
+sudo apt-get clean
+
+echo "Removing large directories"
+# deleting 15GB
+rm -rf /usr/share/dotnet/
+
+
+echo "After cleanup:"
+echo "** 100 largest packages:"
+dpkg-query -Wf '${Installed-Size}\t${Status;1}\t${Package}\n' | sort -n | tail -n 100
+echo "** Disk usage:"
+df -h


### PR DESCRIPTION
Cherry pick of #17559 on release-1.33.

#17559: Bump ko-build

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```