### PR TITLE
Automated cherry pick of #17734: azure: Avoid spurious changes in NetworkSecurityGroup

### DIFF
--- a/upup/pkg/fi/cloudup/azure/azure_utils.go
+++ b/upup/pkg/fi/cloudup/azure/azure_utils.go
@@ -115,19 +115,6 @@ func (s *ApplicationSecurityGroupID) String() string {
 		s.ApplicationSecurityGroupName)
 }
 
-// ParseApplicationSecurityGroupID parses a given ApplicationSecurityGroup ID string and returns a ApplicationSecurityGroup ID.
-func ParseApplicationSecurityGroupID(s string) (*ApplicationSecurityGroupID, error) {
-	l := strings.Split(s, "/")
-	if len(l) != 9 {
-		return nil, fmt.Errorf("malformed format of ApplicationSecurityGroup ID: %s, %d", s, len(l))
-	}
-	return &ApplicationSecurityGroupID{
-		SubscriptionID:               l[2],
-		ResourceGroupName:            l[4],
-		ApplicationSecurityGroupName: l[8],
-	}, nil
-}
-
 // LoadBalancerID contains the resource ID/names required to construct a load balancer ID.
 type LoadBalancerID struct {
 	SubscriptionID    string

--- a/upup/pkg/fi/cloudup/azuretasks/networksecuritygroup.go
+++ b/upup/pkg/fi/cloudup/azuretasks/networksecuritygroup.go
@@ -18,7 +18,9 @@ package azuretasks
 
 import (
 	"context"
+	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"k8s.io/klog/v2"
@@ -95,13 +97,11 @@ func (nsg *NetworkSecurityGroup) Find(c *fi.CloudupContext) (*NetworkSecurityGro
 		if len(rule.Properties.SourceApplicationSecurityGroups) > 0 {
 			var sasgs []*string
 			for _, sasg := range rule.Properties.SourceApplicationSecurityGroups {
-				asg, err := azure.ParseApplicationSecurityGroupID(*sasg.ID)
+				asg, err := arm.ParseResourceID(*sasg.ID)
 				if err != nil {
-					if err != nil {
-						return nil, err
-					}
+					return nil, err
 				}
-				sasgs = append(sasgs, &asg.ApplicationSecurityGroupName)
+				sasgs = append(sasgs, to.Ptr(strings.ToLower(asg.Name)))
 			}
 			nsr.SourceApplicationSecurityGroupNames = sasgs
 		}
@@ -111,13 +111,11 @@ func (nsg *NetworkSecurityGroup) Find(c *fi.CloudupContext) (*NetworkSecurityGro
 		if len(rule.Properties.DestinationApplicationSecurityGroups) > 0 {
 			var dasgs []*string
 			for _, dasg := range rule.Properties.DestinationApplicationSecurityGroups {
-				asg, err := azure.ParseApplicationSecurityGroupID(*dasg.ID)
+				asg, err := arm.ParseResourceID(*dasg.ID)
 				if err != nil {
-					if err != nil {
-						return nil, err
-					}
+					return nil, err
 				}
-				dasgs = append(dasgs, &asg.ApplicationSecurityGroupName)
+				dasgs = append(dasgs, to.Ptr(strings.ToLower(asg.Name)))
 			}
 			nsr.DestinationApplicationSecurityGroupNames = dasgs
 		}


### PR DESCRIPTION
Cherry pick of #17734 on release-1.34.

#17734: azure: Avoid spurious changes in NetworkSecurityGroup

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```