### PR TITLE
Automated cherry pick of #17559: Bump ko-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 # CODEGEN_VERSION is the version of k8s.io/code-generator to use
 CODEGEN_VERSION=v0.29.0
 
-KO=go run github.com/google/ko@v0.14.1
+KO=go run github.com/google/ko@v0.18.0
 
 UPLOAD_CMD=$(KOPS_ROOT)/hack/upload ${UPLOAD_ARGS}
 


### PR DESCRIPTION
Cherry pick of #17559 on release-1.32.

#17559: Bump ko-build

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```