### PR TITLE
Fix HasHighlyAvailableControlPlane to use AllInstanceGroups

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -499,7 +499,7 @@ func (tf *TemplateFunctions) APIServerNodeRole() string {
 // HasHighlyAvailableControlPlane returns true of the cluster has more than one control plane node. False otherwise.
 func (tf *TemplateFunctions) HasHighlyAvailableControlPlane() bool {
 	cp := 0
-	for _, ig := range tf.InstanceGroups {
+	for _, ig := range tf.AllInstanceGroups {
 		if ig.Spec.Role == kops.InstanceGroupRoleControlPlane {
 			cp++
 			if cp > 1 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug where `HasHighlyAvailableControlPlane()` incorrectly uses the filtered `InstanceGroups` list instead of `AllInstanceGroups`. This causes cluster-wide controllers (aws-load-balancer-controller, node-termination-handler, etc.) to incorrectly downscale from 2 to 1 replica when running `kops update cluster` with `--instance-group` or `--instance-group-roles` filters on HA clusters.

The fix changes the function to use `AllInstanceGroups` since HA status is a cluster-wide property that should not depend on instance group filtering.

**Which issue(s) this PR fixes**:
Fixes #17739

**Special notes for your reviewer**:

- Added unit tests including a regression test for the filtered instance groups scenario
- The bug only manifests when using `--instance-group` or `--instance-group-roles` flags
- Change is minimal: single line change in `template_functions.go:502`