### PR TITLE
test: Skip Pod Level Resources tests

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -43,7 +43,14 @@ func (t *Tester) setSkipRegexFlag() error {
 
 	skipRegex := skipRegexBase
 
-	//.Skip.broken.test,.see.https://github.com/kubernetes/kubernetes/pull/133262
+	if k8sVersion.Minor < 35 {
+		// cpu.weight value changed in runc 1.3.2
+		// https://github.com/kubernetes/kubernetes/issues/135214
+		// https://github.com/opencontainers/runc/issues/4896
+		skipRegex += "|[Burstable|Guaranteed].QoS.pod"
+	}
+
+	// Skip broken test, see https://github.com/kubernetes/kubernetes/pull/133262
 	skipRegex += "|blackbox.*should.not.be.able.to.pull.image.from.invalid.registry"
 	skipRegex += "|blackbox.*should.be.able.to.pull.from.private.registry.with.secret"
 


### PR DESCRIPTION
The cpu.weight value changed in runc 1.3.2. Until tests are updated, they need to be skipped.
https://github.com/kubernetes/kubernetes/issues/135214
https://github.com/opencontainers/runc/issues/4896
