### PR TITLE
Automated cherry pick of #17745: Skip Pod Level Resources tests
#17747: Skip Pod InPlace Resize Container tests

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -44,7 +44,14 @@ func (t *Tester) setSkipRegexFlag() error {
 
 	skipRegex := skipRegexBase
 
-	//.Skip.broken.test,.see.https://github.com/kubernetes/kubernetes/pull/133262
+	if k8sVersion.Minor < 35 {
+		// cpu.weight value changed in runc 1.3.2
+		// https://github.com/kubernetes/kubernetes/issues/135214
+		// https://github.com/opencontainers/runc/issues/4896
+		skipRegex += "|[Burstable|Guaranteed].QoS.pod"
+	}
+
+	// Skip broken test, see https://github.com/kubernetes/kubernetes/pull/133262
 	skipRegex += "|blackbox.*should.not.be.able.to.pull.image.from.invalid.registry"
 	skipRegex += "|blackbox.*should.be.able.to.pull.from.private.registry.with.secret"
 

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -49,6 +49,7 @@ func (t *Tester) setSkipRegexFlag() error {
 		// https://github.com/kubernetes/kubernetes/issues/135214
 		// https://github.com/opencontainers/runc/issues/4896
 		skipRegex += "|[Burstable|Guaranteed].QoS.pod"
+		skipRegex += "|Pod.InPlace.Resize.Container"
 	}
 
 	// Skip broken test, see https://github.com/kubernetes/kubernetes/pull/133262


### PR DESCRIPTION
Cherry pick of #17745 #17747 on release-1.34.

#17745: Skip Pod Level Resources tests
#17747: Skip Pod InPlace Resize Container tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```