### PR TITLE
Automated cherry pick of #17773: aws: Tag Launch Template network interfaces

### DIFF
--- a/tests/integration/update_cluster/additionalobjects/kubernetes.tf
+++ b/tests/integration/update_cluster/additionalobjects/kubernetes.tf
@@ -474,6 +474,22 @@ resource "aws_launch_template" "master-us-test-1a-masters-additionalobjects-exam
       "kubernetes.io/cluster/additionalobjects.example.com"                                                   = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "additionalobjects.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.additionalobjects.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/additionalobjects.example.com"                                                   = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "additionalobjects.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.additionalobjects.example.com"
@@ -542,6 +558,19 @@ resource "aws_launch_template" "nodes-additionalobjects-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "additionalobjects.example.com"
+      "Name"                                                                       = "nodes.additionalobjects.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/additionalobjects.example.com"                        = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "additionalobjects.example.com"
       "Name"                                                                       = "nodes.additionalobjects.example.com"

--- a/tests/integration/update_cluster/apiservernodes/kubernetes.tf
+++ b/tests/integration/update_cluster/apiservernodes/kubernetes.tf
@@ -561,6 +561,18 @@ resource "aws_launch_template" "apiserver-apiservers-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                = "minimal.example.com"
+      "Name"                                                                             = "apiserver.apiservers.minimal.example.com"
+      "aws-node-termination-handler/managed"                                             = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server" = ""
+      "k8s.io/role/apiserver"                                                            = "1"
+      "kops.k8s.io/instancegroup"                                                        = "apiserver"
+      "kubernetes.io/cluster/minimal.example.com"                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                = "minimal.example.com"
     "Name"                                                                             = "apiserver.apiservers.minimal.example.com"
@@ -646,6 +658,22 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server"                      = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -713,6 +741,18 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -623,6 +623,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -689,6 +704,18 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -598,6 +598,17 @@ resource "aws_launch_template" "bastion-bastionuserdata-example-com" {
       "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                 = "bastionuserdata.example.com"
+      "Name"                                              = "bastion.bastionuserdata.example.com"
+      "aws-node-termination-handler/managed"              = ""
+      "k8s.io/role/bastion"                               = "1"
+      "kops.k8s.io/instancegroup"                         = "bastion"
+      "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                 = "bastionuserdata.example.com"
     "Name"                                              = "bastion.bastionuserdata.example.com"
@@ -680,6 +691,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-exampl
       "kubernetes.io/cluster/bastionuserdata.example.com"                                                     = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "bastionuserdata.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.bastionuserdata.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/bastionuserdata.example.com"                                                     = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "bastionuserdata.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.bastionuserdata.example.com"
@@ -746,6 +772,18 @@ resource "aws_launch_template" "nodes-bastionuserdata-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "bastionuserdata.example.com"
+      "Name"                                                                       = "nodes.bastionuserdata.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/bastionuserdata.example.com"                          = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "bastionuserdata.example.com"
       "Name"                                                                       = "nodes.bastionuserdata.example.com"

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/kubernetes.tf
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/kubernetes.tf
@@ -578,6 +578,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-cas-priority-expander-
       "kubernetes.io/cluster/cas-priority-expander-custom.example.com"                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "cas-priority-expander-custom.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.cas-priority-expander-custom.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/cas-priority-expander-custom.example.com"                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "cas-priority-expander-custom.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.cas-priority-expander-custom.example.com"
@@ -644,6 +659,18 @@ resource "aws_launch_template" "nodes-cas-priority-expander-custom-example-com" 
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "cas-priority-expander-custom.example.com"
+      "Name"                                                                       = "nodes.cas-priority-expander-custom.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/cas-priority-expander-custom.example.com"             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "cas-priority-expander-custom.example.com"
       "Name"                                                                       = "nodes.cas-priority-expander-custom.example.com"
@@ -727,6 +754,18 @@ resource "aws_launch_template" "nodes-high-priority-cas-priority-expander-custom
       "kubernetes.io/cluster/cas-priority-expander-custom.example.com"             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                          = "cas-priority-expander-custom.example.com"
+      "Name"                                                                       = "nodes-high-priority.cas-priority-expander-custom.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes-high-priority"
+      "kubernetes.io/cluster/cas-priority-expander-custom.example.com"             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                          = "cas-priority-expander-custom.example.com"
     "Name"                                                                       = "nodes-high-priority.cas-priority-expander-custom.example.com"
@@ -790,6 +829,18 @@ resource "aws_launch_template" "nodes-low-priority-cas-priority-expander-custom-
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "cas-priority-expander-custom.example.com"
+      "Name"                                                                       = "nodes-low-priority.cas-priority-expander-custom.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes-low-priority"
+      "kubernetes.io/cluster/cas-priority-expander-custom.example.com"             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "cas-priority-expander-custom.example.com"
       "Name"                                                                       = "nodes-low-priority.cas-priority-expander-custom.example.com"

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/kubernetes.tf
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/kubernetes.tf
@@ -578,6 +578,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-cas-priority-expander-
       "kubernetes.io/cluster/cas-priority-expander.example.com"                                               = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "cas-priority-expander.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.cas-priority-expander.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/cas-priority-expander.example.com"                                               = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "cas-priority-expander.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.cas-priority-expander.example.com"
@@ -644,6 +659,18 @@ resource "aws_launch_template" "nodes-cas-priority-expander-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "cas-priority-expander.example.com"
+      "Name"                                                                       = "nodes.cas-priority-expander.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/cas-priority-expander.example.com"                    = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "cas-priority-expander.example.com"
       "Name"                                                                       = "nodes.cas-priority-expander.example.com"
@@ -727,6 +754,18 @@ resource "aws_launch_template" "nodes-high-priority-cas-priority-expander-exampl
       "kubernetes.io/cluster/cas-priority-expander.example.com"                    = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                          = "cas-priority-expander.example.com"
+      "Name"                                                                       = "nodes-high-priority.cas-priority-expander.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes-high-priority"
+      "kubernetes.io/cluster/cas-priority-expander.example.com"                    = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                          = "cas-priority-expander.example.com"
     "Name"                                                                       = "nodes-high-priority.cas-priority-expander.example.com"
@@ -790,6 +829,18 @@ resource "aws_launch_template" "nodes-low-priority-cas-priority-expander-example
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "cas-priority-expander.example.com"
+      "Name"                                                                       = "nodes-low-priority.cas-priority-expander.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes-low-priority"
+      "kubernetes.io/cluster/cas-priority-expander.example.com"                    = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "cas-priority-expander.example.com"
       "Name"                                                                       = "nodes-low-priority.cas-priority-expander.example.com"

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -509,6 +509,22 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
       "kubernetes.io/cluster/complex.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "complex.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.complex.example.com"
+      "Owner"                                                                                                 = "John Doe"
+      "foo/bar"                                                                                               = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/complex.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "complex.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.complex.example.com"
@@ -589,6 +605,19 @@ resource "aws_launch_template" "nodes-complex-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "complex.example.com"
+      "Name"                                                                       = "nodes.complex.example.com"
+      "Owner"                                                                      = "John Doe"
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/complex.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "complex.example.com"
       "Name"                                                                       = "nodes.complex.example.com"

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -451,6 +451,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-compress-example-com" 
       "kubernetes.io/cluster/compress.example.com"                                                            = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "compress.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.compress.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/compress.example.com"                                                            = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "compress.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.compress.example.com"
@@ -516,6 +531,18 @@ resource "aws_launch_template" "nodes-compress-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "compress.example.com"
+      "Name"                                                                       = "nodes.compress.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/compress.example.com"                                 = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "compress.example.com"
       "Name"                                                                       = "nodes.compress.example.com"

--- a/tests/integration/update_cluster/containerd-custom/kubernetes.tf
+++ b/tests/integration/update_cluster/containerd-custom/kubernetes.tf
@@ -462,6 +462,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-containerd-example-com
       "kubernetes.io/cluster/containerd.example.com"                                                          = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "containerd.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.containerd.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/containerd.example.com"                                                          = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "containerd.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.containerd.example.com"
@@ -528,6 +543,18 @@ resource "aws_launch_template" "nodes-containerd-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "containerd.example.com"
+      "Name"                                                                       = "nodes.containerd.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/containerd.example.com"                               = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "containerd.example.com"
       "Name"                                                                       = "nodes.containerd.example.com"

--- a/tests/integration/update_cluster/containerd/kubernetes.tf
+++ b/tests/integration/update_cluster/containerd/kubernetes.tf
@@ -462,6 +462,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-containerd-example-com
       "kubernetes.io/cluster/containerd.example.com"                                                          = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "containerd.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.containerd.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/containerd.example.com"                                                          = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "containerd.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.containerd.example.com"
@@ -528,6 +543,18 @@ resource "aws_launch_template" "nodes-containerd-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "containerd.example.com"
+      "Name"                                                                       = "nodes.containerd.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/containerd.example.com"                               = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "containerd.example.com"
       "Name"                                                                       = "nodes.containerd.example.com"

--- a/tests/integration/update_cluster/digit/kubernetes.tf
+++ b/tests/integration/update_cluster/digit/kubernetes.tf
@@ -538,6 +538,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-123-example-com" {
       "kubernetes.io/cluster/123.example.com"                                                                 = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "123.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.123.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/123.example.com"                                                                 = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "123.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.123.example.com"
@@ -604,6 +619,18 @@ resource "aws_launch_template" "nodes-123-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "123.example.com"
+      "Name"                                                                       = "nodes.123.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/123.example.com"                                      = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "123.example.com"
       "Name"                                                                       = "nodes.123.example.com"

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -614,6 +614,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-c
       "kubernetes.io/cluster/existing-iam.example.com"                                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "existing-iam.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.existing-iam.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/existing-iam.example.com"                                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "existing-iam.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.existing-iam.example.com"
@@ -687,6 +702,21 @@ resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-c
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                                                     = "existing-iam.example.com"
+      "Name"                                                                                                  = "master-us-test-1b.masters.existing-iam.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1b"
+      "kubernetes.io/cluster/existing-iam.example.com"                                                        = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                                                     = "existing-iam.example.com"
       "Name"                                                                                                  = "master-us-test-1b.masters.existing-iam.example.com"
@@ -786,6 +816,21 @@ resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-c
       "kubernetes.io/cluster/existing-iam.example.com"                                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "existing-iam.example.com"
+      "Name"                                                                                                  = "master-us-test-1c.masters.existing-iam.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1c"
+      "kubernetes.io/cluster/existing-iam.example.com"                                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "existing-iam.example.com"
     "Name"                                                                                                  = "master-us-test-1c.masters.existing-iam.example.com"
@@ -852,6 +897,18 @@ resource "aws_launch_template" "nodes-existing-iam-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "existing-iam.example.com"
+      "Name"                                                                       = "nodes.existing-iam.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/existing-iam.example.com"                             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "existing-iam.example.com"
       "Name"                                                                       = "nodes.existing-iam.example.com"

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -717,6 +717,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com
       "kubernetes.io/cluster/existingsg.example.com"                                                          = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "existingsg.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.existingsg.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/existingsg.example.com"                                                          = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "existingsg.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.existingsg.example.com"
@@ -790,6 +805,21 @@ resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                                                     = "existingsg.example.com"
+      "Name"                                                                                                  = "master-us-test-1b.masters.existingsg.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1b"
+      "kubernetes.io/cluster/existingsg.example.com"                                                          = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                                                     = "existingsg.example.com"
       "Name"                                                                                                  = "master-us-test-1b.masters.existingsg.example.com"
@@ -889,6 +919,21 @@ resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com
       "kubernetes.io/cluster/existingsg.example.com"                                                          = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "existingsg.example.com"
+      "Name"                                                                                                  = "master-us-test-1c.masters.existingsg.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1c"
+      "kubernetes.io/cluster/existingsg.example.com"                                                          = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "existingsg.example.com"
     "Name"                                                                                                  = "master-us-test-1c.masters.existingsg.example.com"
@@ -955,6 +1000,18 @@ resource "aws_launch_template" "nodes-existingsg-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "existingsg.example.com"
+      "Name"                                                                       = "nodes.existingsg.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/existingsg.example.com"                               = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "existingsg.example.com"
       "Name"                                                                       = "nodes.existingsg.example.com"

--- a/tests/integration/update_cluster/external_dns/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns/kubernetes.tf
@@ -462,6 +462,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -528,6 +543,18 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
@@ -595,6 +595,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -661,6 +676,18 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -466,6 +466,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com
       "kubernetes.io/cluster/externallb.example.com"                                                          = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "externallb.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.externallb.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/externallb.example.com"                                                          = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "externallb.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.externallb.example.com"
@@ -532,6 +547,18 @@ resource "aws_launch_template" "nodes-externallb-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "externallb.example.com"
+      "Name"                                                                       = "nodes.externallb.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/externallb.example.com"                               = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "externallb.example.com"
       "Name"                                                                       = "nodes.externallb.example.com"

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -552,6 +552,23 @@ resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-examp
       "kubernetes.io/cluster/externalpolicies.example.com"                                                    = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "externalpolicies.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.externalpolicies.example.com"
+      "Owner"                                                                                                 = "John Doe"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "foo/bar"                                                                                               = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/externalpolicies.example.com"                                                    = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "externalpolicies.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.externalpolicies.example.com"
@@ -622,6 +639,20 @@ resource "aws_launch_template" "nodes-externalpolicies-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "externalpolicies.example.com"
+      "Name"                                                                       = "nodes.externalpolicies.example.com"
+      "Owner"                                                                      = "John Doe"
+      "aws-node-termination-handler/managed"                                       = ""
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/externalpolicies.example.com"                         = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "externalpolicies.example.com"
       "Name"                                                                       = "nodes.externalpolicies.example.com"

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -686,6 +686,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {
       "kubernetes.io/cluster/ha.example.com"                                                                  = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "ha.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.ha.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/ha.example.com"                                                                  = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "ha.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.ha.example.com"
@@ -759,6 +774,21 @@ resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                                                     = "ha.example.com"
+      "Name"                                                                                                  = "master-us-test-1b.masters.ha.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1b"
+      "kubernetes.io/cluster/ha.example.com"                                                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                                                     = "ha.example.com"
       "Name"                                                                                                  = "master-us-test-1b.masters.ha.example.com"
@@ -858,6 +888,21 @@ resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
       "kubernetes.io/cluster/ha.example.com"                                                                  = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "ha.example.com"
+      "Name"                                                                                                  = "master-us-test-1c.masters.ha.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1c"
+      "kubernetes.io/cluster/ha.example.com"                                                                  = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "ha.example.com"
     "Name"                                                                                                  = "master-us-test-1c.masters.ha.example.com"
@@ -924,6 +969,18 @@ resource "aws_launch_template" "nodes-ha-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "ha.example.com"
+      "Name"                                                                       = "nodes.ha.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/ha.example.com"                                       = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "ha.example.com"
       "Name"                                                                       = "nodes.ha.example.com"

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -565,6 +565,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -631,6 +646,18 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/karpenter/kubernetes.tf
+++ b/tests/integration/update_cluster/karpenter/kubernetes.tf
@@ -507,6 +507,20 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -571,6 +585,17 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
@@ -651,6 +651,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -717,6 +732,18 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
@@ -477,6 +477,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -543,6 +558,18 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/many-addons/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons/kubernetes.tf
@@ -462,6 +462,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-many-addons-example-co
       "kubernetes.io/cluster/many-addons.example.com"                                                         = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "many-addons.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.many-addons.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/many-addons.example.com"                                                         = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "many-addons.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.many-addons.example.com"
@@ -528,6 +543,18 @@ resource "aws_launch_template" "nodes-many-addons-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "many-addons.example.com"
+      "Name"                                                                       = "nodes.many-addons.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/many-addons.example.com"                              = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "many-addons.example.com"
       "Name"                                                                       = "nodes.many-addons.example.com"

--- a/tests/integration/update_cluster/minimal-1.29/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.29/kubernetes.tf
@@ -474,6 +474,22 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -542,6 +558,19 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/minimal-1.30/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.30/kubernetes.tf
@@ -474,6 +474,22 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -542,6 +558,19 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/minimal-1.31/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.31/kubernetes.tf
@@ -474,6 +474,22 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -542,6 +558,19 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/minimal-1.32/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.32/kubernetes.tf
@@ -474,6 +474,22 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -542,6 +558,19 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/minimal-1.33/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.33/kubernetes.tf
@@ -474,6 +474,22 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -542,6 +558,19 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/minimal-1.34/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.34/kubernetes.tf
@@ -474,6 +474,22 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -542,6 +558,19 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/minimal-aws/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-aws/kubernetes.tf
@@ -462,6 +462,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-aws-example-co
       "kubernetes.io/cluster/minimal-aws.example.com"                                                         = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal-aws.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal-aws.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-aws.example.com"                                                         = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal-aws.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal-aws.example.com"
@@ -528,6 +543,18 @@ resource "aws_launch_template" "nodes-minimal-aws-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal-aws.example.com"
+      "Name"                                                                       = "nodes.minimal-aws.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-aws.example.com"                              = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal-aws.example.com"
       "Name"                                                                       = "nodes.minimal-aws.example.com"

--- a/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
@@ -475,6 +475,22 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -543,6 +559,19 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/minimal-etcd/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-etcd/kubernetes.tf
@@ -462,6 +462,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-etcd-example-c
       "kubernetes.io/cluster/minimal-etcd.example.com"                                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal-etcd.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal-etcd.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-etcd.example.com"                                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal-etcd.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal-etcd.example.com"
@@ -528,6 +543,18 @@ resource "aws_launch_template" "nodes-minimal-etcd-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal-etcd.example.com"
+      "Name"                                                                       = "nodes.minimal-etcd.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-etcd.example.com"                             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal-etcd.example.com"
       "Name"                                                                       = "nodes.minimal-etcd.example.com"

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -458,6 +458,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -524,6 +539,18 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
@@ -525,6 +525,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
       "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
@@ -591,6 +606,18 @@ resource "aws_launch_template" "nodes-minimal-ipv6-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
+      "Name"                                                                       = "nodes.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
       "Name"                                                                       = "nodes.minimal-ipv6.example.com"

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
@@ -525,6 +525,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
       "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
@@ -591,6 +606,18 @@ resource "aws_launch_template" "nodes-minimal-ipv6-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
+      "Name"                                                                       = "nodes.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
       "Name"                                                                       = "nodes.minimal-ipv6.example.com"

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/kubernetes.tf
@@ -525,6 +525,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
       "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
@@ -591,6 +606,18 @@ resource "aws_launch_template" "nodes-minimal-ipv6-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
+      "Name"                                                                       = "nodes.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
       "Name"                                                                       = "nodes.minimal-ipv6.example.com"

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
@@ -525,6 +525,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
       "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
@@ -591,6 +606,18 @@ resource "aws_launch_template" "nodes-minimal-ipv6-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
+      "Name"                                                                       = "nodes.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
       "Name"                                                                       = "nodes.minimal-ipv6.example.com"

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -525,6 +525,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
       "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
@@ -591,6 +606,18 @@ resource "aws_launch_template" "nodes-minimal-ipv6-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
+      "Name"                                                                       = "nodes.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
       "Name"                                                                       = "nodes.minimal-ipv6.example.com"

--- a/tests/integration/update_cluster/minimal-longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-longclustername/kubernetes.tf
@@ -462,6 +462,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-this-is-truly-a-really
       "kubernetes.io/cluster/this.is.truly.a.really.really.long.cluster-name.minimal.example.com"             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "this.is.truly.a.really.really.long.cluster-name.minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.this.is.truly.a.really.really.long.cluster-name.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/this.is.truly.a.really.really.long.cluster-name.minimal.example.com"             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "this.is.truly.a.really.really.long.cluster-name.minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.this.is.truly.a.really.really.long.cluster-name.minimal.example.com"
@@ -528,6 +543,18 @@ resource "aws_launch_template" "nodes-this-is-truly-a-really-really-long-cluster
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                                         = "this.is.truly.a.really.really.long.cluster-name.minimal.example.com"
+      "Name"                                                                                      = "nodes.this.is.truly.a.really.really.long.cluster-name.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                      = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"                = ""
+      "k8s.io/role/node"                                                                          = "1"
+      "kops.k8s.io/instancegroup"                                                                 = "nodes"
+      "kubernetes.io/cluster/this.is.truly.a.really.really.long.cluster-name.minimal.example.com" = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                                         = "this.is.truly.a.really.really.long.cluster-name.minimal.example.com"
       "Name"                                                                                      = "nodes.this.is.truly.a.really.really.long.cluster-name.minimal.example.com"

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -474,6 +474,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-warmpool-examp
       "kubernetes.io/cluster/minimal-warmpool.example.com"                                                    = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal-warmpool.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal-warmpool.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-warmpool.example.com"                                                    = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal-warmpool.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal-warmpool.example.com"
@@ -540,6 +555,18 @@ resource "aws_launch_template" "nodes-minimal-warmpool-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal-warmpool.example.com"
+      "Name"                                                                       = "nodes.minimal-warmpool.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-warmpool.example.com"                         = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal-warmpool.example.com"
       "Name"                                                                       = "nodes.minimal-warmpool.example.com"

--- a/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
@@ -462,6 +462,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-k8s-local" {
       "kubernetes.io/cluster/minimal.k8s.local"                                                               = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.k8s.local"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.k8s.local"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.k8s.local"                                                               = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.k8s.local"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.k8s.local"
@@ -528,6 +543,18 @@ resource "aws_launch_template" "nodes-minimal-k8s-local" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.k8s.local"
+      "Name"                                                                       = "nodes.minimal.k8s.local"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.k8s.local"                                    = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.k8s.local"
       "Name"                                                                       = "nodes.minimal.k8s.local"

--- a/tests/integration/update_cluster/minimal_gossip_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/kubernetes.tf
@@ -567,6 +567,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-k8s-local" {
       "kubernetes.io/cluster/minimal.k8s.local"                                                               = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.k8s.local"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.k8s.local"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.k8s.local"                                                               = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.k8s.local"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.k8s.local"
@@ -633,6 +648,18 @@ resource "aws_launch_template" "nodes-minimal-k8s-local" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.k8s.local"
+      "Name"                                                                       = "nodes.minimal.k8s.local"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.k8s.local"                                    = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.k8s.local"
       "Name"                                                                       = "nodes.minimal.k8s.local"

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -704,6 +704,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
       "kubernetes.io/cluster/mixedinstances.example.com"                                                      = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.mixedinstances.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/mixedinstances.example.com"                                                      = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.mixedinstances.example.com"
@@ -777,6 +792,21 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
+      "Name"                                                                                                  = "master-us-test-1b.masters.mixedinstances.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1b"
+      "kubernetes.io/cluster/mixedinstances.example.com"                                                      = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
       "Name"                                                                                                  = "master-us-test-1b.masters.mixedinstances.example.com"
@@ -876,6 +906,21 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
       "kubernetes.io/cluster/mixedinstances.example.com"                                                      = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
+      "Name"                                                                                                  = "master-us-test-1c.masters.mixedinstances.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1c"
+      "kubernetes.io/cluster/mixedinstances.example.com"                                                      = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
     "Name"                                                                                                  = "master-us-test-1c.masters.mixedinstances.example.com"
@@ -942,6 +987,18 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "mixedinstances.example.com"
+      "Name"                                                                       = "nodes.mixedinstances.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/mixedinstances.example.com"                           = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "mixedinstances.example.com"
       "Name"                                                                       = "nodes.mixedinstances.example.com"

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -704,6 +704,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
       "kubernetes.io/cluster/mixedinstances.example.com"                                                      = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.mixedinstances.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/mixedinstances.example.com"                                                      = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.mixedinstances.example.com"
@@ -777,6 +792,21 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
+      "Name"                                                                                                  = "master-us-test-1b.masters.mixedinstances.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1b"
+      "kubernetes.io/cluster/mixedinstances.example.com"                                                      = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
       "Name"                                                                                                  = "master-us-test-1b.masters.mixedinstances.example.com"
@@ -876,6 +906,21 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
       "kubernetes.io/cluster/mixedinstances.example.com"                                                      = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
+      "Name"                                                                                                  = "master-us-test-1c.masters.mixedinstances.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1c"
+      "kubernetes.io/cluster/mixedinstances.example.com"                                                      = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "mixedinstances.example.com"
     "Name"                                                                                                  = "master-us-test-1c.masters.mixedinstances.example.com"
@@ -942,6 +987,18 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "mixedinstances.example.com"
+      "Name"                                                                       = "nodes.mixedinstances.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/mixedinstances.example.com"                           = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "mixedinstances.example.com"
       "Name"                                                                       = "nodes.mixedinstances.example.com"

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/kubernetes.tf
@@ -507,6 +507,20 @@ resource "aws_launch_template" "master-us-test-1a-masters-nthimdsprocessor-longc
       "kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com"                                    = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "nthimdsprocessor.longclustername.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com"                                    = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "nthimdsprocessor.longclustername.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com"
@@ -571,6 +585,17 @@ resource "aws_launch_template" "nodes-nthimdsprocessor-longclustername-example-c
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "nthimdsprocessor.longclustername.example.com"
+      "Name"                                                                       = "nodes.nthimdsprocessor.longclustername.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com"         = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "nthimdsprocessor.longclustername.example.com"
       "Name"                                                                       = "nodes.nthimdsprocessor.longclustername.example.com"

--- a/tests/integration/update_cluster/nth-imds-processor/kubernetes.tf
+++ b/tests/integration/update_cluster/nth-imds-processor/kubernetes.tf
@@ -374,6 +374,20 @@ resource "aws_launch_template" "master-us-test-1a-masters-nthimdsprocessor-longc
       "kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com"                                    = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "nthimdsprocessor.longclustername.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com"                                    = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "nthimdsprocessor.longclustername.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com"
@@ -438,6 +452,17 @@ resource "aws_launch_template" "nodes-nthimdsprocessor-longclustername-example-c
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "nthimdsprocessor.longclustername.example.com"
+      "Name"                                                                       = "nodes.nthimdsprocessor.longclustername.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com"         = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "nthimdsprocessor.longclustername.example.com"
       "Name"                                                                       = "nodes.nthimdsprocessor.longclustername.example.com"

--- a/tests/integration/update_cluster/nvidia/kubernetes.tf
+++ b/tests/integration/update_cluster/nvidia/kubernetes.tf
@@ -467,6 +467,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -534,6 +549,19 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/gpu"              = "1"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -580,6 +580,17 @@ resource "aws_launch_template" "bastion-private-shared-ip-example-com" {
       "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                   = "private-shared-ip.example.com"
+      "Name"                                                = "bastion.private-shared-ip.example.com"
+      "aws-node-termination-handler/managed"                = ""
+      "k8s.io/role/bastion"                                 = "1"
+      "kops.k8s.io/instancegroup"                           = "bastion"
+      "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                   = "private-shared-ip.example.com"
     "Name"                                                = "bastion.private-shared-ip.example.com"
@@ -661,6 +672,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-ip-exam
       "kubernetes.io/cluster/private-shared-ip.example.com"                                                   = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "private-shared-ip.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.private-shared-ip.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/private-shared-ip.example.com"                                                   = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "private-shared-ip.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.private-shared-ip.example.com"
@@ -727,6 +753,18 @@ resource "aws_launch_template" "nodes-private-shared-ip-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "private-shared-ip.example.com"
+      "Name"                                                                       = "nodes.private-shared-ip.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/private-shared-ip.example.com"                        = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "private-shared-ip.example.com"
       "Name"                                                                       = "nodes.private-shared-ip.example.com"

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -575,6 +575,17 @@ resource "aws_launch_template" "bastion-private-shared-subnet-example-com" {
       "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+      "Name"                                                    = "bastion.private-shared-subnet.example.com"
+      "aws-node-termination-handler/managed"                    = ""
+      "k8s.io/role/bastion"                                     = "1"
+      "kops.k8s.io/instancegroup"                               = "bastion"
+      "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                       = "private-shared-subnet.example.com"
     "Name"                                                    = "bastion.private-shared-subnet.example.com"
@@ -656,6 +667,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-
       "kubernetes.io/cluster/private-shared-subnet.example.com"                                               = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "private-shared-subnet.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.private-shared-subnet.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/private-shared-subnet.example.com"                                               = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "private-shared-subnet.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.private-shared-subnet.example.com"
@@ -722,6 +748,18 @@ resource "aws_launch_template" "nodes-private-shared-subnet-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "private-shared-subnet.example.com"
+      "Name"                                                                       = "nodes.private-shared-subnet.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/private-shared-subnet.example.com"                    = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "private-shared-subnet.example.com"
       "Name"                                                                       = "nodes.private-shared-subnet.example.com"

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -598,6 +598,17 @@ resource "aws_launch_template" "bastion-privatecalico-example-com" {
       "kubernetes.io/cluster/privatecalico.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                               = "privatecalico.example.com"
+      "Name"                                            = "bastion.privatecalico.example.com"
+      "aws-node-termination-handler/managed"            = ""
+      "k8s.io/role/bastion"                             = "1"
+      "kops.k8s.io/instancegroup"                       = "bastion"
+      "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                               = "privatecalico.example.com"
     "Name"                                            = "bastion.privatecalico.example.com"
@@ -662,6 +673,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecalico-example-
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                                                     = "privatecalico.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.privatecalico.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecalico.example.com"                                                       = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                                                     = "privatecalico.example.com"
       "Name"                                                                                                  = "master-us-test-1a.masters.privatecalico.example.com"
@@ -741,6 +767,18 @@ resource "aws_launch_template" "nodes-privatecalico-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "privatecalico.example.com"
+      "Name"                                                                       = "nodes.privatecalico.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecalico.example.com"                            = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "privatecalico.example.com"
       "Name"                                                                       = "nodes.privatecalico.example.com"

--- a/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
@@ -598,6 +598,17 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
       "kubernetes.io/cluster/privatecilium.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                               = "privatecilium.example.com"
+      "Name"                                            = "bastion.privatecilium.example.com"
+      "aws-node-termination-handler/managed"            = ""
+      "k8s.io/role/bastion"                             = "1"
+      "kops.k8s.io/instancegroup"                       = "bastion"
+      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "bastion.privatecilium.example.com"
@@ -679,6 +690,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
       "kubernetes.io/cluster/privatecilium.example.com"                                                       = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "privatecilium.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.privatecilium.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecilium.example.com"                                                       = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "privatecilium.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.privatecilium.example.com"
@@ -745,6 +771,18 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "nodes.privatecilium.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "privatecilium.example.com"
       "Name"                                                                       = "nodes.privatecilium.example.com"

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -598,6 +598,17 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
       "kubernetes.io/cluster/privatecilium.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                               = "privatecilium.example.com"
+      "Name"                                            = "bastion.privatecilium.example.com"
+      "aws-node-termination-handler/managed"            = ""
+      "k8s.io/role/bastion"                             = "1"
+      "kops.k8s.io/instancegroup"                       = "bastion"
+      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "bastion.privatecilium.example.com"
@@ -679,6 +690,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
       "kubernetes.io/cluster/privatecilium.example.com"                                                       = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "privatecilium.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.privatecilium.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecilium.example.com"                                                       = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "privatecilium.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.privatecilium.example.com"
@@ -745,6 +771,18 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "nodes.privatecilium.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "privatecilium.example.com"
       "Name"                                                                       = "nodes.privatecilium.example.com"

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -598,6 +598,17 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
       "kubernetes.io/cluster/privatecilium.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                               = "privatecilium.example.com"
+      "Name"                                            = "bastion.privatecilium.example.com"
+      "aws-node-termination-handler/managed"            = ""
+      "k8s.io/role/bastion"                             = "1"
+      "kops.k8s.io/instancegroup"                       = "bastion"
+      "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "bastion.privatecilium.example.com"
@@ -679,6 +690,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
       "kubernetes.io/cluster/privatecilium.example.com"                                                       = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "privatecilium.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.privatecilium.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/privatecilium.example.com"                                                       = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "privatecilium.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.privatecilium.example.com"
@@ -745,6 +771,18 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "privatecilium.example.com"
+      "Name"                                                                       = "nodes.privatecilium.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatecilium.example.com"                            = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "privatecilium.example.com"
       "Name"                                                                       = "nodes.privatecilium.example.com"

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -615,6 +615,17 @@ resource "aws_launch_template" "bastion-privateciliumadvanced-example-com" {
       "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+      "Name"                                                    = "bastion.privateciliumadvanced.example.com"
+      "aws-node-termination-handler/managed"                    = ""
+      "k8s.io/role/bastion"                                     = "1"
+      "kops.k8s.io/instancegroup"                               = "bastion"
+      "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
     "Name"                                                    = "bastion.privateciliumadvanced.example.com"
@@ -696,6 +707,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-
       "kubernetes.io/cluster/privateciliumadvanced.example.com"                                               = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "privateciliumadvanced.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.privateciliumadvanced.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/privateciliumadvanced.example.com"                                               = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "privateciliumadvanced.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.privateciliumadvanced.example.com"
@@ -762,6 +788,18 @@ resource "aws_launch_template" "nodes-privateciliumadvanced-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "privateciliumadvanced.example.com"
+      "Name"                                                                       = "nodes.privateciliumadvanced.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privateciliumadvanced.example.com"                    = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "privateciliumadvanced.example.com"
       "Name"                                                                       = "nodes.privateciliumadvanced.example.com"

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -664,6 +664,19 @@ resource "aws_launch_template" "bastion-privatedns1-example-com" {
       "kubernetes.io/cluster/privatedns1.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                             = "privatedns1.example.com"
+      "Name"                                          = "bastion.privatedns1.example.com"
+      "Owner"                                         = "John Doe"
+      "aws-node-termination-handler/managed"          = ""
+      "foo/bar"                                       = "fib+baz"
+      "k8s.io/role/bastion"                           = "1"
+      "kops.k8s.io/instancegroup"                     = "bastion"
+      "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "bastion.privatedns1.example.com"
@@ -751,6 +764,23 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-co
       "kubernetes.io/cluster/privatedns1.example.com"                                                         = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "privatedns1.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.privatedns1.example.com"
+      "Owner"                                                                                                 = "John Doe"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "foo/bar"                                                                                               = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/privatedns1.example.com"                                                         = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "privatedns1.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.privatedns1.example.com"
@@ -821,6 +851,20 @@ resource "aws_launch_template" "nodes-privatedns1-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "privatedns1.example.com"
+      "Name"                                                                       = "nodes.privatedns1.example.com"
+      "Owner"                                                                      = "John Doe"
+      "aws-node-termination-handler/managed"                                       = ""
+      "foo/bar"                                                                    = "fib+baz"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatedns1.example.com"                              = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "privatedns1.example.com"
       "Name"                                                                       = "nodes.privatedns1.example.com"

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -589,6 +589,17 @@ resource "aws_launch_template" "bastion-privatedns2-example-com" {
       "kubernetes.io/cluster/privatedns2.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                             = "privatedns2.example.com"
+      "Name"                                          = "bastion.privatedns2.example.com"
+      "aws-node-termination-handler/managed"          = ""
+      "k8s.io/role/bastion"                           = "1"
+      "kops.k8s.io/instancegroup"                     = "bastion"
+      "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                             = "privatedns2.example.com"
     "Name"                                          = "bastion.privatedns2.example.com"
@@ -670,6 +681,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-co
       "kubernetes.io/cluster/privatedns2.example.com"                                                         = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "privatedns2.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.privatedns2.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/privatedns2.example.com"                                                         = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "privatedns2.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.privatedns2.example.com"
@@ -736,6 +762,18 @@ resource "aws_launch_template" "nodes-privatedns2-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "privatedns2.example.com"
+      "Name"                                                                       = "nodes.privatedns2.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatedns2.example.com"                              = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "privatedns2.example.com"
       "Name"                                                                       = "nodes.privatedns2.example.com"

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -598,6 +598,17 @@ resource "aws_launch_template" "bastion-privateflannel-example-com" {
       "kubernetes.io/cluster/privateflannel.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                = "privateflannel.example.com"
+      "Name"                                             = "bastion.privateflannel.example.com"
+      "aws-node-termination-handler/managed"             = ""
+      "k8s.io/role/bastion"                              = "1"
+      "kops.k8s.io/instancegroup"                        = "bastion"
+      "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                = "privateflannel.example.com"
     "Name"                                             = "bastion.privateflannel.example.com"
@@ -679,6 +690,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example
       "kubernetes.io/cluster/privateflannel.example.com"                                                      = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "privateflannel.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.privateflannel.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/privateflannel.example.com"                                                      = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "privateflannel.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.privateflannel.example.com"
@@ -745,6 +771,18 @@ resource "aws_launch_template" "nodes-privateflannel-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "privateflannel.example.com"
+      "Name"                                                                       = "nodes.privateflannel.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privateflannel.example.com"                           = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "privateflannel.example.com"
       "Name"                                                                       = "nodes.privateflannel.example.com"

--- a/tests/integration/update_cluster/privatekindnet/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekindnet/kubernetes.tf
@@ -598,6 +598,17 @@ resource "aws_launch_template" "bastion-privatekindnet-example-com" {
       "kubernetes.io/cluster/privatekindnet.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                = "privatekindnet.example.com"
+      "Name"                                             = "bastion.privatekindnet.example.com"
+      "aws-node-termination-handler/managed"             = ""
+      "k8s.io/role/bastion"                              = "1"
+      "kops.k8s.io/instancegroup"                        = "bastion"
+      "kubernetes.io/cluster/privatekindnet.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                = "privatekindnet.example.com"
     "Name"                                             = "bastion.privatekindnet.example.com"
@@ -679,6 +690,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekindnet-example
       "kubernetes.io/cluster/privatekindnet.example.com"                                                      = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "privatekindnet.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.privatekindnet.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/privatekindnet.example.com"                                                      = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "privatekindnet.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.privatekindnet.example.com"
@@ -745,6 +771,18 @@ resource "aws_launch_template" "nodes-privatekindnet-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "privatekindnet.example.com"
+      "Name"                                                                       = "nodes.privatekindnet.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatekindnet.example.com"                           = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "privatekindnet.example.com"
       "Name"                                                                       = "nodes.privatekindnet.example.com"

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -604,6 +604,17 @@ resource "aws_launch_template" "bastion-privatekopeio-example-com" {
       "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                               = "privatekopeio.example.com"
+      "Name"                                            = "bastion.privatekopeio.example.com"
+      "aws-node-termination-handler/managed"            = ""
+      "k8s.io/role/bastion"                             = "1"
+      "kops.k8s.io/instancegroup"                       = "bastion"
+      "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                               = "privatekopeio.example.com"
     "Name"                                            = "bastion.privatekopeio.example.com"
@@ -685,6 +696,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-
       "kubernetes.io/cluster/privatekopeio.example.com"                                                       = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "privatekopeio.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.privatekopeio.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/privatekopeio.example.com"                                                       = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "privatekopeio.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.privatekopeio.example.com"
@@ -751,6 +777,18 @@ resource "aws_launch_template" "nodes-privatekopeio-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "privatekopeio.example.com"
+      "Name"                                                                       = "nodes.privatekopeio.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/privatekopeio.example.com"                            = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "privatekopeio.example.com"
       "Name"                                                                       = "nodes.privatekopeio.example.com"

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -595,6 +595,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -661,6 +676,18 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -453,6 +453,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-c
       "kubernetes.io/cluster/sharedsubnet.example.com"                                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "sharedsubnet.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.sharedsubnet.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/sharedsubnet.example.com"                                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "sharedsubnet.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.sharedsubnet.example.com"
@@ -519,6 +534,18 @@ resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "sharedsubnet.example.com"
+      "Name"                                                                       = "nodes.sharedsubnet.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/sharedsubnet.example.com"                             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "sharedsubnet.example.com"
       "Name"                                                                       = "nodes.sharedsubnet.example.com"

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -453,6 +453,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com"
       "kubernetes.io/cluster/sharedvpc.example.com"                                                           = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "sharedvpc.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.sharedvpc.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/sharedvpc.example.com"                                                           = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "sharedvpc.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.sharedvpc.example.com"
@@ -519,6 +534,18 @@ resource "aws_launch_template" "nodes-sharedvpc-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "sharedvpc.example.com"
+      "Name"                                                                       = "nodes.sharedvpc.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/sharedvpc.example.com"                                = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "sharedvpc.example.com"
       "Name"                                                                       = "nodes.sharedvpc.example.com"

--- a/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
@@ -507,6 +507,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
       "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                                                        = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal-ipv6.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal-ipv6.example.com"
@@ -573,6 +588,18 @@ resource "aws_launch_template" "nodes-minimal-ipv6-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
+      "Name"                                                                       = "nodes.minimal-ipv6.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal-ipv6.example.com"                             = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal-ipv6.example.com"
       "Name"                                                                       = "nodes.minimal-ipv6.example.com"

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -580,6 +580,17 @@ resource "aws_launch_template" "bastion-unmanaged-example-com" {
       "kubernetes.io/cluster/unmanaged.example.com" = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                           = "unmanaged.example.com"
+      "Name"                                        = "bastion.unmanaged.example.com"
+      "aws-node-termination-handler/managed"        = ""
+      "k8s.io/role/bastion"                         = "1"
+      "kops.k8s.io/instancegroup"                   = "bastion"
+      "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                           = "unmanaged.example.com"
     "Name"                                        = "bastion.unmanaged.example.com"
@@ -661,6 +672,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com"
       "kubernetes.io/cluster/unmanaged.example.com"                                                           = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "unmanaged.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.unmanaged.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/unmanaged.example.com"                                                           = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "unmanaged.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.unmanaged.example.com"
@@ -727,6 +753,18 @@ resource "aws_launch_template" "nodes-unmanaged-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "unmanaged.example.com"
+      "Name"                                                                       = "nodes.unmanaged.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/unmanaged.example.com"                                = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "unmanaged.example.com"
       "Name"                                                                       = "nodes.unmanaged.example.com"

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -483,6 +483,21 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
     }
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      "KubernetesCluster"                                                                                     = "minimal.example.com"
+      "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
+      "aws-node-termination-handler/managed"                                                                  = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
+      "k8s.io/role/control-plane"                                                                             = "1"
+      "k8s.io/role/master"                                                                                    = "1"
+      "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
+      "kubernetes.io/cluster/minimal.example.com"                                                             = "owned"
+    }
+  }
   tags = {
     "KubernetesCluster"                                                                                     = "minimal.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
@@ -549,6 +564,18 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   tag_specifications {
     resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                          = "minimal.example.com"
+      "Name"                                                                       = "nodes.minimal.example.com"
+      "aws-node-termination-handler/managed"                                       = ""
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
+      "k8s.io/role/node"                                                           = "1"
+      "kops.k8s.io/instancegroup"                                                  = "nodes"
+      "kubernetes.io/cluster/minimal.example.com"                                  = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags = {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -121,6 +121,10 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchT
 			ResourceType: ec2types.ResourceTypeVolume,
 			Tags:         tags,
 		})
+		data.TagSpecifications = append(data.TagSpecifications, ec2types.LaunchTemplateTagSpecificationRequest{
+			ResourceType: ec2types.ResourceTypeNetworkInterface,
+			Tags:         tags,
+		})
 	}
 	// @step: add the userdata
 	if t.UserData != nil {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -308,6 +308,10 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 			ResourceType: fi.PtrTo("volume"),
 			Tags:         e.Tags,
 		})
+		tf.TagSpecifications = append(tf.TagSpecifications, &terraformLaunchTemplateTagSpecification{
+			ResourceType: fi.PtrTo("network-interface"),
+			Tags:         e.Tags,
+		})
 		tf.Tags = e.Tags
 	}
 


### PR DESCRIPTION
Cherry pick of #17773 on release-1.34.

#17773: aws: Tag Launch Template network interfaces

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```