### PR TITLE
Automated cherry pick of #17776: aws: Enable CloudWatch metrics for the warm pool of an ASG

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -110,6 +110,16 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 				if warmPool.MaxSize != nil {
 					warmPoolTask.MaxSize = fi.PtrTo(int32(aws.ToInt64(warmPool.MaxSize)))
 				}
+				asg.Metrics = append(asg.Metrics,
+					"WarmPoolMinSize",
+					"WarmPoolDesiredCapacity",
+					"WarmPoolPendingCapacity",
+					"WarmPoolTerminatingCapacity",
+					"WarmPoolWarmedCapacity",
+					"WarmPoolTotalCapacity",
+					"GroupAndWarmPoolDesiredCapacity",
+					"GroupAndWarmPoolTotalCapacity",
+				)
 				asg.WarmPool = warmPoolTask
 			} else {
 				asg.WarmPool = nil

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -161,7 +161,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-warmpool-exa
 }
 
 resource "aws_autoscaling_group" "nodes-minimal-warmpool-example-com" {
-  enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
+  enabled_metrics = ["GroupAndWarmPoolDesiredCapacity", "GroupAndWarmPoolTotalCapacity", "GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances", "WarmPoolDesiredCapacity", "WarmPoolMinSize", "WarmPoolPendingCapacity", "WarmPoolTerminatingCapacity", "WarmPoolTotalCapacity", "WarmPoolWarmedCapacity"]
   launch_template {
     id      = aws_launch_template.nodes-minimal-warmpool-example-com.id
     version = aws_launch_template.nodes-minimal-warmpool-example-com.latest_version


### PR DESCRIPTION
Cherry pick of #17776 on release-1.34.

#17776: aws: Enable CloudWatch metrics for the warm pool of an ASG

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```