### PR TITLE
iptables is deprecated and broken on rhel10+ so use nftables by default

### DIFF
--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -48,11 +48,16 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 			c.EnsureTask(&nodetasks.Package{Name: additionalPackage})
 		}
 	} else if b.Distribution.IsRHELFamily() {
-		if b.Distribution == distributions.DistributionAmazonLinux2023 {
+		// RHEL 10+ doesn't support iptables anymore
+		switch b.Distribution {
+		case distributions.DistributionAmazonLinux2023:
 			// install iptables-nft in al2023 (NOT the iptables-legacy!)
 			c.AddTask(&nodetasks.Package{Name: "iptables-nft"})
-		} else {
+		case distributions.DistributionRhel8, distributions.DistributionRhel9,
+			distributions.DistributionRocky8, distributions.DistributionAmazonLinux2:
 			c.AddTask(&nodetasks.Package{Name: "iptables"})
+		default:
+			c.AddTask(&nodetasks.Package{Name: "nftables"})
 		}
 		c.AddTask(&nodetasks.Package{Name: "libseccomp"})
 		if b.NodeupConfig.KubeProxy != nil && fi.ValueOf(b.NodeupConfig.KubeProxy.Enabled) && b.NodeupConfig.KubeProxy.ProxyMode == "nftables" {


### PR DESCRIPTION
iptables is deprecated and broken on rocky linux 10

```
Dec 02 06:18:34.339615 control-plane-us-west2-a-cd4w nodeup[4403]: W1202 06:18:34.339572    4403 executor.go:141] error running task "Package/iptables" (3m19s remaining to succeed): error installing package "iptables": exit status 1: Last metadata expiration check: 0:06:23 ago on Tue 02 Dec 2025 06:12:11 AM UTC.
Dec 02 06:18:34.339615 control-plane-us-west2-a-cd4w nodeup[4403]: Package iptables-nft-1.8.11-9.el10_0.x86_64 is already installed.
Dec 02 06:18:34.339615 control-plane-us-west2-a-cd4w nodeup[4403]: Error:
Dec 02 06:18:34.339615 control-plane-us-west2-a-cd4w nodeup[4403]:  Problem: package iptables-nft-1.8.11-11.el10.x86_64 from appstream requires kernel-modules-extra-matched, but none of the providers can be installed
Dec 02 06:18:34.339615 control-plane-us-west2-a-cd4w nodeup[4403]:   - cannot install the best candidate for the job
Dec 02 06:18:34.339615 control-plane-us-west2-a-cd4w nodeup[4403]:   - package kernel-modules-extra-matched-6.12.0-124.13.1.el10_1.x86_64 from baseos is filtered out by exclude filtering
Dec 02 06:18:34.339615 control-plane-us-west2-a-cd4w nodeup[4403]:   - package kernel-modules-extra-matched-6.12.0-124.8.1.el10_1.x86_64 from baseos is filtered out by exclude filtering
Dec 02 06:18:34.339615 control-plane-us-west2-a-cd4w nodeup[4403]: (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```