### PR TITLE
azure: Fix the setting of creationTimestamp label for tests

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -145,6 +145,8 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 		Tags: []string{
 			"group=sig-cluster-lifecycle",
 			"subproject=kops",
+			// Ensure https://github.com/Azure/rg-cleanup deletes removes resources
+			"creationTimestamp=" + time.Now().Format(time.RFC3339),
 		},
 	}
 	dir, err := defaultArtifactsDir()

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -186,7 +186,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		}
 		args = append(args, createArgs...)
 	}
-	args = append(args, "--cloud-labels", strings.Join(d.Tags, ","))
+	args = appendIfUnset(args, "--cloud-labels", strings.Join(d.Tags, ","))
 	args = appendIfUnset(args, "--admin-access", adminAccess)
 
 	// Dont set --master-count if either --control-plane-count or --master-count
@@ -212,8 +212,6 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 			args = appendIfUnset(args, "--master-size", "c5.large")
 		}
 	case "azure":
-		// Ensure https://github.com/Azure/rg-cleanup deletes removes resources
-		args = appendIfUnset(args, "--cloud-labels", "creationTimestamp="+time.Now().Format(time.RFC3339))
 		// Use SKUs for which there is enough quota
 		args = appendIfUnset(args, "--control-plane-size", "Standard_D4s_v3")
 		args = appendIfUnset(args, "--node-size", "Standard_D2s_v3")


### PR DESCRIPTION
Looks like https://github.com/kubernetes/kops/pull/17682 broke the setting of `creationTimestamp` label for tests.

/cc @ameukam @upodroid 