### PR TITLE
gce: Support cloudLabels for InstanceGroup

### DIFF
--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -780,9 +780,10 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
     type                   = "PERSISTENT"
   }
   labels = {
-    "k8s-io-cluster-name"   = "ha-gce-example-com"
-    "k8s-io-instance-group" = "nodes"
-    "k8s-io-role-node"      = "node"
+    "k8s-io-cluster-name"                             = "ha-gce-example-com"
+    "k8s-io-instance-group"                           = "nodes"
+    "k8s-io-role-node"                                = "node"
+    "k8s.io/cluster-autoscaler/node-template/taint/a" = "b:c"
   }
   lifecycle {
     create_before_destroy = true

--- a/tests/integration/update_cluster/minimal_gce/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal_gce/in-v1alpha2.yaml
@@ -62,6 +62,8 @@ metadata:
   name: master-us-test1-a
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20221018
+  cloudLabels:
+    testCloudLabel: foobar
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -446,6 +446,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-examp
     "k8s-io-instance-group"     = "master-us-test1-a"
     "k8s-io-role-control-plane" = "control-plane"
     "k8s-io-role-master"        = "master"
+    "testCloudLabel"            = "foobar"
   }
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Moved existing default label application logic for GCE IG to central CloudTagsForInstanceGroup. We then call this function when generating the IG template which also gives us the user supplied cloudLabels from both the Cluster and InstanceGroup resource. I have explicitly not plumbed through support for node labels and have left it for a TODO. There was an issue with GCE label length limits that I ran into in the e2e test.

Note that a simple refactor would be to move the shared CloudTagsForInstanceGroup function to respective context.go files in each cloud provider directory. I think this is better served in a follow up PR to ensure consistency at this very moment in case we don't get to the refactor.

In terms of testing, I have added a single integration test which verifies that a `cloudLabel` added to the InstanceGroup is reflected properly in the output Terraform. This doesn't necessarily cover all cases (e.g what happens when cluster.cloudLabel and instanceGroup.cloudLabel) are specified. I think these would be better served as unit tests which should be added when the aformentioned refactor is complete.

Ref: #17638