### PR TITLE
azure: Use VXLAN encapsulation for pod traffic with Calico

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1569,6 +1569,11 @@ func validateNetworkingCalico(c *kops.ClusterSpec, v *kops.CalicoNetworkingSpec,
 			// backend in order to allow use of BGP to distribute routes for pod traffic.
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("encapsulationMode"), "encapsulationMode \"none\" is only supported for IPv6 clusters"))
 		}
+
+		if v.EncapsulationMode != "vxlan" && c.CloudProvider.Azure != nil {
+			// IPIP packets are blocked by the Azure network fabric. This requires the use of VXLAN encapsulation for pod traffic.
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("encapsulationMode"), "Azure requires an encapsulationMode of \"vxlan\""))
+		}
 	}
 
 	if v.IPIPMode != "" {

--- a/pkg/model/components/calico.go
+++ b/pkg/model/components/calico.go
@@ -40,5 +40,10 @@ func (b *CalicoOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 		c.EncapsulationMode = "none"
 	}
 
+	if o.GetCloudProvider() == kops.CloudProviderAzure {
+		c.EncapsulationMode = "vxlan"
+		c.VXLANMode = "Always"
+	}
+
 	return nil
 }


### PR DESCRIPTION
IPIP packets are blocked by the Azure network fabric. This requires the use of VXLAN encapsulation for pod traffic.
https://docs.tigera.io/calico/latest/reference/public-cloud/azure

/cc @upodroid 