### PR TITLE
Use public dns for apiserver-nodes e2e

### DIFF
--- a/tests/e2e/templates/apiserver.yaml.tmpl
+++ b/tests/e2e/templates/apiserver.yaml.tmpl
@@ -39,7 +39,7 @@ spec:
     - {{.publicIP}}
   topology:
     dns:
-      type: None
+      type: Public
   subnets:
   - cidr: 172.20.32.0/19
     name: {{$zone}}


### PR DESCRIPTION
followup to https://github.com/kubernetes/kops/pull/17851

dns=none is not supported on apiserver nodes


https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-apiserver-nodes/2009993625936596992

```
 Error: spec.role: Forbidden: APIServer cannot be used with topology.dns.type=None 
```