### PR TITLE
Add iam:ListInstanceProfiles permission to Karpenter

### DIFF
--- a/pkg/model/components/addonmanifests/karpenter/iam.go
+++ b/pkg/model/components/addonmanifests/karpenter/iam.go
@@ -87,5 +87,6 @@ func addKarpenterPermissions(p *iam.Policy) {
 	// AllowInstanceProfileReadActions
 	p.AddUnconditionalActions(
 		"iam:GetInstanceProfile",
+		"iam:ListInstanceProfiles",
 	)
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
@@ -19,6 +19,7 @@
         "iam:AddRoleToInstanceProfile",
         "iam:DeleteInstanceProfile",
         "iam:GetInstanceProfile",
+        "iam:ListInstanceProfiles",
         "iam:PassRole",
         "iam:RemoveRoleFromInstanceProfile",
         "iam:TagInstanceProfile",


### PR DESCRIPTION
The karpenter jobs are failing with this iam permission error: 

https://testgrid.k8s.io/kops-misc#kops-aws-karpenter

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-aws-karpenter/2010022566961352704/artifacts/cluster-info/kube-system/karpenter-849c87cc57-qzjgr/controller.log

`{"level":"ERROR","time":"2026-01-10T16:26:41.804Z","logger":"controller","caller":"controller/controller.go:474","message":"Reconciler error","commit":"1ad0d78","controller":"instanceprofile.garbagecollection","namespace":"","name":"","reconcileID":"c21b77ab-9df2-4d77-9afd-208c51bc1d23","aws-error-code":"AccessDenied","aws-operation-name":"ListInstanceProfiles","aws-request-id":"9feb3d6b-17de-47b9-94c1-fe1312ebc017","aws-service-name":"IAM","aws-status-code":403,"error":"listing instance profiles, listing instance profiles, operation error IAM: ListInstanceProfiles, https response error StatusCode: 403, RequestID: 9feb3d6b-17de-47b9-94c1-fe1312ebc017, api error AccessDenied: User: arn:aws:sts::808842816990:assumed-role/karpenter.kube-system.sa.e2e-e2e-kops-aws-karpenter.tests-qd5hli/1768062234299783051 is not authorized to perform: iam:ListInstanceProfiles on resource: arn:aws:iam::808842816990:instance-profile/karpenter/eu-west-1/e2e-e2e-kops-aws-karpenter.tests-kops-aws.k8s.io/ because no identity-based policy allows the iam:ListInstanceProfiles action (aws-error-code=AccessDenied, aws-operation-name=ListInstanceProfiles, aws-request-id=9feb3d6b-17de-47b9-94c1-fe1312ebc017, aws-service-name=IAM, aws-status-code=403)"}`
