### PR TITLE
Support API field mapping for bastion.loadBalancer.type

### DIFF
--- a/pkg/apis/kops/fieldmap.go
+++ b/pkg/apis/kops/fieldmap.go
@@ -81,5 +81,6 @@ var clusterFieldMappings = []struct {
 }{
 	{V1Alpha2: "spec.masterPublicName", V1Alpha3: "spec.api.publicName"},
 	{V1Alpha2: "spec.topology.dns.type", V1Alpha3: "spec.networking.topology.dns"},
+	{V1Alpha2: "spec.topology.bastion.loadBalancer.type", V1Alpha3: "spec.networking.topology.bastion.loadBalancer.type"},
 	{V1Alpha2: "spec.externalDns.provider", V1Alpha3: "spec.externalDNS.provider"},
 }


### PR DESCRIPTION
Note that this only fixes the exact bug in the linked issue. We ideally need to add all other fields in the `bastion` struct to this as well but it's not clear to me if the best way to do that is list all fields in the tree one by one or if there is a simpler way.

Ref: #17623

/assign @hakman 
