### PR TITLE
Continue to skip failing e2e tests in k8s CI versions

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -83,7 +83,7 @@ func (t *Tester) setSkipRegexFlag() error {
 		// https://github.com/kubernetes/kubernetes/blob/418ae605ec1b788d43bff7ac44af66d8b669b833/test/e2e/network/networking.go#L135
 		skipRegex += "|should.check.kube-proxy.urls"
 
-		if k8sVersion.Minor < 36 {
+		if k8sVersion.Minor < 37 {
 			// This seems to be specific to the kube-proxy replacement
 			// < 36 so we look at this again
 			skipRegex += "|Services.should.support.externalTrafficPolicy.Local.for.type.NodePort"
@@ -113,8 +113,8 @@ func (t *Tester) setSkipRegexFlag() error {
 	// ref: https://github.com/kubernetes/kubernetes/issues/123255
 	// ref: https://github.com/kubernetes/kubernetes/issues/121018
 	// ref: https://github.com/kubernetes/kubernetes/pull/126896
-	// < 36 so we look at this again
-	if k8sVersion.Minor < 36 {
+	// < 37 so we look at this again
+	if k8sVersion.Minor < 37 {
 		skipRegex += "|Services.should.function.for.service.endpoints.using.hostNetwork"
 		skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
 	}


### PR DESCRIPTION
These tests are still failing in k8s 1.36 (CI) builds:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-cni-cilium-k8s-ci/2010729797163945984

```
Kubernetes e2e suite: [It] [sig-network] Services should support externalTrafficPolicy=Local for type=NodePort
{ failed [FAILED] Source IP 100.96.1.243 is not the client IP
In [It] at: k8s.io/kubernetes/test/e2e/network/service.go:2819 @ 01/12/26 15:20:54.452
}
```

```
Kubernetes e2e suite: [It] [sig-network] Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy
{ failed [FAILED] expected client IP to be preserved
Expected
    <string>: 100.96.1.243
to equal
    <string>: 172.20.78.102
In [It] at: k8s.io/kubernetes/test/e2e/network/service.go:3944 @ 01/12/26 15:31:12.075
}
```

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-upgrade-k134-kolatest-to-klatest-kolatest/2010805547284041728

```
Summarizing 1 Failure:
  [FAIL] [sig-network] Networking Granular Checks: Services [It] should function for service endpoints using hostNetwork [sig-network]
  k8s.io/kubernetes/test/e2e/network/networking.go:479
```
