### PR TITLE
Enable RBAC in E2E templates

### DIFF
--- a/tests/e2e/templates/apiserver.yaml.tmpl
+++ b/tests/e2e/templates/apiserver.yaml.tmpl
@@ -10,6 +10,8 @@ spec:
     loadBalancer:
       type: Public
       class: Network
+  authorization:
+    rbac: {}
   channel: stable
   cloudProvider: {{.cloudProvider}}
   configBase: "{{.stateStore}}/{{.clusterName}}"

--- a/tests/e2e/templates/many-addons.yaml.tmpl
+++ b/tests/e2e/templates/many-addons.yaml.tmpl
@@ -7,6 +7,8 @@ spec:
     loadBalancer:
       class: Network
       type: Public
+  authorization:
+    rbac: {}
   awsLoadBalancerController:
     enabled: true
   kubernetesApiAccess:

--- a/tests/e2e/templates/simple.yaml.tmpl
+++ b/tests/e2e/templates/simple.yaml.tmpl
@@ -4,6 +4,8 @@ kind: Cluster
 metadata:
   name: {{.clusterName}}
 spec:
+  authorization:
+    rbac: {}
   kubernetesApiAccess:
   - {{.publicIP}}
   channel: stable

--- a/tests/e2e/templates/staticcpumanagerpolicy.tmpl
+++ b/tests/e2e/templates/staticcpumanagerpolicy.tmpl
@@ -4,6 +4,8 @@ kind: Cluster
 metadata:
   name: {{.clusterName}}
 spec:
+  authorization:
+    rbac: {}
   kubernetesApiAccess:
   - {{.publicIP}}
   channel: stable


### PR DESCRIPTION
Kops only defaults to RBAC in `kops create cluster`:

https://github.com/kubernetes/kops/blob/05e2a3718926dae8836d518720edc8eee921f5ed/upup/pkg/fi/cloudup/new_cluster.go#L183-L185

A cluster applied via manifest will default to AlwaysAllow:

https://github.com/kubernetes/kops/blob/05e2a3718926dae8836d518720edc8eee921f5ed/pkg/apis/kops/v1alpha2/defaults.go#L57-L60


Certain E2E tests expect RBAC to be enabled, and theres little value in testing these configurations with AlwaysAllow, so set RBAC in these templates.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-apiserver-nodes/2010839104693997568

```
Kubernetes e2e suite: [It] [sig-node] [FeatureGate:KubeletFineGrainedAuthz] [Beta] when calling kubelet API check /healthz enpoint is not accessible via nodes/configz
    <string>: 200
to equal
    <string>: 403
In [It] at: k8s.io/kubernetes/test/e2e/node/kubelet_authz.go:54 @ 01/12/26 22:39:03.443
}
```

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-aws-apiserver-nodes/2010839104693997568/artifacts/cluster.yaml

```yaml
  authorization:
    alwaysAllow: {}
```