### PR TITLE
Allow release of the discovery service

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,6 +20,7 @@ steps:
       - kops-controller-push
       - dns-controller-push
       - kube-apiserver-healthcheck-push
+      - discovery-server-push
   # Push the artifacts
   - name: "mirror.gcr.io/library/golang:1.25.5-trixie"
     id: artifacts


### PR DESCRIPTION
Ensure the discovery server is released along side the other kOps components

Done with the help of Gemini CLI.