### PR TITLE
Fix upgrades to CI k8s versions

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -237,7 +237,11 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 	}
 
 	assetBuilder := assets.NewAssetBuilder(c.Clientset.VFSContext(), c.Cluster.Spec.Assets, c.GetAssets)
-	if len(c.ControlPlaneRunningVersion) > 0 && c.ControlPlaneRunningVersion != c.Cluster.Spec.KubernetesVersion {
+	// Use HasSuffix for CI builds where the cluster spec contains a GCS url like
+	// https://storage.googleapis.com/k8s-release-dev/ci/v1.36.0-alpha.0.615+cc55e3447816e4
+	// and ControlPlaneRunningVersion is a build like v1.36.0-alpha.0.615+cc55e3447816e4
+	// Release versions will be an exact match
+	if len(c.ControlPlaneRunningVersion) > 0 && !strings.HasSuffix(c.Cluster.Spec.KubernetesVersion, c.ControlPlaneRunningVersion) {
 		assetBuilder.KubeletSupportedVersion = c.ControlPlaneRunningVersion
 	}
 	err = c.upgradeSpecs(ctx, assetBuilder)


### PR DESCRIPTION
Attempting to fix this failure:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-upgrade-kstable-kolatest-to-kci-kolatest/2011919362616725504

The job successfully upgrades the control plane, but fails to run the `update cluster` logic for nodes:

`W0115 22:21:19.370332   13770 executor.go:141] error running task "BootstrapScript/nodes-us-west-2a" (8s remaining to succeed): cannot determine hash for "https://dl.k8s.io/release/v1.36.0-alpha.0.664+fd41228d1ad1ce/bin/linux/amd64/kubelet" (have you specified a valid file location?)`

The [cluster spec](https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-aws-upgrade-kstable-kolatest-to-kci-kolatest/2011919362616725504/artifacts/cluster.yaml) has:

```yaml
kubernetesVersion: https://storage.googleapis.com/k8s-release-dev/ci/v1.36.0-alpha.0.664+fd41228d1ad1ce
```

and [the control plane Node statuses](https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-aws-upgrade-kstable-kolatest-to-kci-kolatest/2011919362616725504/artifacts/cluster-info/nodes.yaml) have:

```yaml
kubeletVersion: v1.36.0-alpha.0.664+fd41228d1ad1ce
```

Kops was incorrectly overwriting the kubernetes version to use for assets, causing it to try to build a release dl.k8s.io URLs when it should be re-using the CI build URLs.