### PR TITLE
Continue skipping hostPort protocol test with Cilium

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -72,13 +72,8 @@ func (t *Tester) setSkipRegexFlag() error {
 		// https://github.com/cilium/cilium/issues/15361
 		skipRegex += "|external.IP.is.not.assigned.to.a.node"
 
-		if networking.Cilium.Version < "v1.17" {
-			// https://github.com/cilium/cilium/issues/14287
-			skipRegex += "|same.port.number.but.different.protocols"
-			skipRegex += "|same.hostPort.but.different.hostIP.and.protocol"
-			// https://github.com/cilium/cilium/issues/9207
-			skipRegex += "|serve.endpoints.on.same.port.and.different.protocols"
-		}
+		// https://github.com/cilium/cilium/issues/14287
+		skipRegex += "|same.hostPort.but.different.hostIP.and.protocol"
 
 		// https://github.com/kubernetes/kubernetes/blob/418ae605ec1b788d43bff7ac44af66d8b669b833/test/e2e/network/networking.go#L135
 		skipRegex += "|should.check.kube-proxy.urls"


### PR DESCRIPTION
We only support Cilium 1.18:

https://github.com/kubernetes/kops/blob/1ef558bd574600150dee95111e1598e906ecba0b/pkg/apis/kops/validation/validation.go#L1234-L1236

but one of the tests continues to fail because the linked issue is still not completely resolved:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-distro-amzn2/2012236706614349824

`Kubernetes e2e suite: [It] [sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]`