### PR TITLE
kube-scheduler: Wait for the auth conf from the API server

### DIFF
--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -191,6 +191,9 @@ func (b *KubeSchedulerBuilder) buildPod(kubeScheduler *kops.KubeSchedulerConfig)
 
 	flags = append(flags, "--config="+"/var/lib/kube-scheduler/config.yaml")
 
+	// Make sure the scheduler always looks up its authentication configuration from the API server.
+	flags = append(flags, "--authentication-tolerate-lookup-failure=false")
+	flags = append(flags, "--authentication-skip-lookup=false")
 	// Add kubeconfig flags
 	for _, flag := range []string{"authentication-", "authorization-"} {
 		flags = append(flags, "--"+flag+"kubeconfig="+kubescheduler.KubeConfigPath)

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
@@ -13,6 +13,8 @@ contents: |
       - --also-stdout
       - /usr/local/bin/kube-scheduler
       - --authentication-kubeconfig=/var/lib/kube-scheduler/kubeconfig
+      - --authentication-skip-lookup=false
+      - --authentication-tolerate-lookup-failure=false
       - --authorization-kubeconfig=/var/lib/kube-scheduler/kubeconfig
       - --config=/var/lib/kube-scheduler/config.yaml
       - --leader-elect=true

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-amd64.yaml
@@ -13,6 +13,8 @@ contents: |
       - --also-stdout
       - /usr/local/bin/kube-scheduler
       - --authentication-kubeconfig=/var/lib/kube-scheduler/kubeconfig
+      - --authentication-skip-lookup=false
+      - --authentication-tolerate-lookup-failure=false
       - --authorization-kubeconfig=/var/lib/kube-scheduler/kubeconfig
       - --config=/var/lib/kube-scheduler/config.yaml
       - --feature-gates=InTreePluginAWSUnregister=true

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-arm64.yaml
@@ -13,6 +13,8 @@ contents: |
       - --also-stdout
       - /usr/local/bin/kube-scheduler
       - --authentication-kubeconfig=/var/lib/kube-scheduler/kubeconfig
+      - --authentication-skip-lookup=false
+      - --authentication-tolerate-lookup-failure=false
       - --authorization-kubeconfig=/var/lib/kube-scheduler/kubeconfig
       - --config=/var/lib/kube-scheduler/config.yaml
       - --feature-gates=InTreePluginAWSUnregister=true


### PR DESCRIPTION
From logs:
https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-aws-upgrade-kstable-kolatest-to-klatest-kolatest-many-addons/2012345928245055488/artifacts/i-060794809b3b301c7/kube-scheduler.log
```
I0117 02:14:17.049026      11 dynamic_serving_content.go:116] "Loaded a new cert/key pair" name="serving-cert::/srv/kubernetes/kube-scheduler/server.crt::/srv/kubernetes/kube-scheduler/server.key"
W0117 02:14:17.050325      11 authentication.go:397] Error looking up in-cluster authentication configuration: Get "https://127.0.0.1/api/v1/namespaces/kube-system/configmaps/extension-apiserver-authentication": dial tcp 127.0.0.1:443: connect: connection refused
W0117 02:14:17.050346      11 authentication.go:398] Continuing without authentication configuration. This may treat all requests as anonymous.
W0117 02:14:17.050355      11 authentication.go:399] To require authentication configuration lookup to succeed, set --authentication-tolerate-lookup-failure=false
```

/cc @rifelpet 