### PR TITLE
Pull cluster name from context in `kops version --server`

### DIFF
--- a/cmd/kops/version.go
+++ b/cmd/kops/version.go
@@ -107,7 +107,7 @@ func RunVersion(f *util.Factory, out io.Writer, options *VersionOptions) error {
 
 func serverVersion(f *util.Factory, options *VersionOptions) string {
 	if options.ClusterName == "" {
-		return "No cluster selected"
+		options.ClusterName = rootCommand.ClusterName(true)
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Output from local run:

```
Client version: 1.35.0-alpha.1 (git-v1.35.0-alpha.1-138-g076ce00ce8)
Using cluster from kubectl context: alias.k8s.local

Last applied server version: 1.34.1
```

Ref: #16586 