### PR TITLE
Update openstack csi images

### DIFF
--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -282,7 +282,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
         {{ if HasSnapshotController }}
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"


### PR DESCRIPTION
Update openstack csi images to latest minor version.

The latest versions of csi-provisioner and csi-resizer require Kubernetes 1.34. We don't want to update these yet.