### PR TITLE
fix: add kops details to Hetzner Cloud client user agent

### DIFF
--- a/pkg/nodeidentity/hetzner/identify.go
+++ b/pkg/nodeidentity/hetzner/identify.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	expirationcache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	version "k8s.io/kops"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/nodeidentity"
 	"k8s.io/kops/pkg/nodelabels"
@@ -53,6 +54,7 @@ func New(cacheNodeidentityInfo bool) (nodeidentity.Identifier, error) {
 	}
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(hcloudToken),
+		hcloud.WithApplication("kops", version.Version),
 	}
 	hcloudClient := hcloud.NewClient(opts...)
 

--- a/protokube/pkg/protokube/hetzner_volume.go
+++ b/protokube/pkg/protokube/hetzner_volume.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/metadata"
 	"k8s.io/klog/v2"
+	version "k8s.io/kops"
 	"k8s.io/kops/protokube/pkg/gossip"
 	gossiphetzner "k8s.io/kops/protokube/pkg/gossip/hetzner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
@@ -51,6 +52,7 @@ func NewHetznerCloudProvider() (*HetznerCloudProvider, error) {
 	}
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(hcloudToken),
+		hcloud.WithApplication("kops", version.Version),
 	}
 	hcloudClient := hcloud.NewClient(opts...)
 

--- a/upup/pkg/fi/cloudup/hetzner/cloud.go
+++ b/upup/pkg/fi/cloudup/hetzner/cloud.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	version "k8s.io/kops"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/cloudinstances"
@@ -83,6 +84,7 @@ func NewHetznerCloud(region string) (HetznerCloud, error) {
 
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(accessToken),
+		hcloud.WithApplication("kops", version.Version),
 	}
 	client := hcloud.NewClient(opts...)
 

--- a/upup/pkg/fi/cloudup/hetzner/verifier.go
+++ b/upup/pkg/fi/cloudup/hetzner/verifier.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	version "k8s.io/kops"
 	"k8s.io/kops/pkg/bootstrap"
 	"k8s.io/kops/pkg/wellknownports"
 )
@@ -48,6 +49,7 @@ func NewHetznerVerifier(opt *HetznerVerifierOptions) (bootstrap.Verifier, error)
 
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(hcloudToken),
+		hcloud.WithApplication("kops", version.Version),
 	}
 	hcloudClient := hcloud.NewClient(opts...)
 


### PR DESCRIPTION
Add kops details to the Hetzner Cloud client user-agent.

Helps us identify and troubleshoot issues with users running kOps on Hetzner Cloud.

EDIT: Please ignore this PR.