### PR TITLE
truncate very long sqs queue names

### DIFF
--- a/pkg/model/names.go
+++ b/pkg/model/names.go
@@ -236,6 +236,7 @@ func (b *KopsModelContext) InstanceName(ig *kops.InstanceGroup, suffix string) s
 }
 
 func QueueNamePrefix(clusterName string) string {
-	// periods aren't allowed in queue name
-	return strings.ReplaceAll(clusterName, ".", "-")
+	// periods aren't allowed in queue name and queue name can't exceed 80 characters
+	safeClusterName := strings.ReplaceAll(clusterName, ".", "-")
+	return truncate.TruncateString(safeClusterName, truncate.TruncateStringOptions{MaxLength: 75, AlwaysAddHash: false})
 }


### PR DESCRIPTION
Some jobs are failing to create SQS queues for node termination handler because the cluster name is too long, this should fix it

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-ci-kubernetes-kops-al2023-aws-conformance-canary/2014385191694372864