### PR TITLE
Add HTTP/HTTPS toggle for etcd client connections (needed for k8s scalability tests!)

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1303,6 +1303,13 @@ spec:
                             the specified image.
                           type: string
                       type: object
+                    clientTLSEnabled:
+                      description: |-
+                        ClientTLSEnabled controls whether to use HTTPS (TLS) for client connections to etcd.
+                        When set to false, uses HTTP instead of HTTPS, eliminating TLS overhead.
+                        Defaults to true for security. Setting to false is only recommended for the events etcd cluster.
+                        The main etcd cluster MUST use TLS and will fail validation if this is set to false.
+                      type: boolean
                     cpuRequest:
                       anyOf:
                       - type: integer

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -691,6 +691,11 @@ type EtcdClusterSpec struct {
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
 	// CPURequest specifies the cpu requests of each etcd container in the cluster.
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// ClientTLSEnabled controls whether to use HTTPS (TLS) for client connections to etcd.
+	// When set to false, uses HTTP instead of HTTPS, eliminating TLS overhead.
+	// Defaults to true for security. Setting to false is only recommended for the events etcd cluster.
+	// The main etcd cluster MUST use TLS and will fail validation if this is set to false.
+	ClientTLSEnabled *bool `json:"clientTLSEnabled,omitempty"`
 }
 
 // EtcdBackupSpec describes how we want to do backups of etcd

--- a/pkg/apis/kops/etcdcluster_helpers.go
+++ b/pkg/apis/kops/etcdcluster_helpers.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kops
+
+// IsClientTLSEnabled returns whether client TLS is enabled for this etcd cluster.
+// Defaults to true for security.
+func (e *EtcdClusterSpec) IsClientTLSEnabled() bool {
+	if e.ClientTLSEnabled == nil {
+		return true // Default to HTTPS for security
+	}
+	return *e.ClientTLSEnabled
+}
+
+// GetClientScheme returns the URL scheme (http or https) for client connections to etcd.
+func (e *EtcdClusterSpec) GetClientScheme() string {
+	if e.IsClientTLSEnabled() {
+		return "https"
+	}
+	return "http"
+}

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -677,6 +677,11 @@ type EtcdClusterSpec struct {
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
 	// CPURequest specifies the cpu requests of each etcd container in the cluster.
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// ClientTLSEnabled controls whether to use HTTPS (TLS) for client connections to etcd.
+	// When set to false, uses HTTP instead of HTTPS, eliminating TLS overhead.
+	// Defaults to true for security. Setting to false is only recommended for the events etcd cluster.
+	// The main etcd cluster MUST use TLS and will fail validation if this is set to false.
+	ClientTLSEnabled *bool `json:"clientTLSEnabled,omitempty"`
 }
 
 // EtcdBackupSpec describes how we want to do backups of etcd

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3772,6 +3772,7 @@ func autoConvert_v1alpha2_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdCluste
 	}
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
+	out.ClientTLSEnabled = in.ClientTLSEnabled
 	return nil
 }
 
@@ -3818,6 +3819,7 @@ func autoConvert_kops_EtcdClusterSpec_To_v1alpha2_EtcdClusterSpec(in *kops.EtcdC
 	}
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
+	out.ClientTLSEnabled = in.ClientTLSEnabled
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2034,6 +2034,11 @@ func (in *EtcdClusterSpec) DeepCopyInto(out *EtcdClusterSpec) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.ClientTLSEnabled != nil {
+		in, out := &in.ClientTLSEnabled, &out.ClientTLSEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -642,6 +642,11 @@ type EtcdClusterSpec struct {
 	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
 	// CPURequest specifies the cpu requests of each etcd container in the cluster.
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// ClientTLSEnabled controls whether to use HTTPS (TLS) for client connections to etcd.
+	// When set to false, uses HTTP instead of HTTPS, eliminating TLS overhead.
+	// Defaults to true for security. Setting to false is only recommended for the events etcd cluster.
+	// The main etcd cluster MUST use TLS and will fail validation if this is set to false.
+	ClientTLSEnabled *bool `json:"clientTLSEnabled,omitempty"`
 }
 
 // EtcdBackupSpec describes how we want to do backups of etcd

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -4033,6 +4033,7 @@ func autoConvert_v1alpha3_EtcdClusterSpec_To_kops_EtcdClusterSpec(in *EtcdCluste
 	}
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
+	out.ClientTLSEnabled = in.ClientTLSEnabled
 	return nil
 }
 
@@ -4079,6 +4080,7 @@ func autoConvert_kops_EtcdClusterSpec_To_v1alpha3_EtcdClusterSpec(in *kops.EtcdC
 	}
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
+	out.ClientTLSEnabled = in.ClientTLSEnabled
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -1940,6 +1940,11 @@ func (in *EtcdClusterSpec) DeepCopyInto(out *EtcdClusterSpec) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.ClientTLSEnabled != nil {
+		in, out := &in.ClientTLSEnabled, &out.ClientTLSEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2060,6 +2060,11 @@ func (in *EtcdClusterSpec) DeepCopyInto(out *EtcdClusterSpec) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.ClientTLSEnabled != nil {
+		in, out := &in.ClientTLSEnabled, &out.ClientTLSEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -143,11 +143,16 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(cluster *kops.Cluster) error 
 	c.EtcdServersOverrides = nil
 
 	for _, etcdCluster := range clusterSpec.EtcdClusters {
+		// Use GetClientScheme to determine HTTP or HTTPS
+		scheme := etcdCluster.GetClientScheme()
+
 		switch etcdCluster.Name {
 		case "main":
-			c.EtcdServers = append(c.EtcdServers, "https://127.0.0.1:4001")
+			etcdURL := fmt.Sprintf("%s://127.0.0.1:4001", scheme)
+			c.EtcdServers = append(c.EtcdServers, etcdURL)
 		case "events":
-			c.EtcdServersOverrides = append(c.EtcdServersOverrides, "/events#https://127.0.0.1:4002")
+			etcdURL := fmt.Sprintf("/events#%s://127.0.0.1:4002", scheme)
+			c.EtcdServersOverrides = append(c.EtcdServersOverrides, etcdURL)
 		}
 	}
 

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -453,7 +453,13 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 	}
 
 	{
-		scheme := "https"
+		// Determine scheme based on ClientTLSEnabled setting
+		scheme := etcdCluster.GetClientScheme()
+
+		// Log a warning if TLS is disabled
+		if scheme == "http" {
+			klog.Warningf("etcd cluster %q is configured with client TLS disabled (HTTP). This is NOT recommended for production clusters.", etcdCluster.Name)
+		}
 
 		config.PeerUrls = fmt.Sprintf("%s://__name__:%d", scheme, ports.PeerPort)
 		config.ClientUrls = fmt.Sprintf("%s://%s:%d", scheme, clientHost, ports.ClientPort)


### PR DESCRIPTION
This change allows cluster operators to toggle between HTTP and HTTPS for etcd client connections on a per-cluster basis, matching the pattern used by Kubernetes GCE scale tests where `events` etcd uses HTTP while `main` etcd uses HTTPS.

I'd like to match what is in: https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/configure-kubeapiserver.sh#L35

Changes:
- Add ClientTLSEnabled field to EtcdClusterSpec (defaults to true)
- Add helper methods IsClientTLSEnabled() and GetClientScheme()
- Update etcd-manager model to use configurable scheme
- Update API server to use configurable scheme for etcd URLs
- Add validation to prevent disabling TLS on main etcd cluster
- Generate deepcopy and conversion functions

Benefits:
- Eliminates TLS handshake overhead for events etcd
- Fixes gRPC connection proliferation issues with TLS
- Allows HTTP for events (ephemeral data) while keeping main secure
- Enforces TLS for main etcd (contains cluster state)