### PR TITLE
Disable cloud-init network hotplug on Ubuntu 24.04 for Cilium and Ama…

### DIFF
--- a/nodeup/pkg/model/networking/cilium.go
+++ b/nodeup/pkg/model/networking/cilium.go
@@ -76,6 +76,20 @@ ManageForeignRoutingPolicyRules=no
 		})
 	}
 
+	if b.Distribution.IsUbuntu() && b.Distribution.Version() >= 24.04 {
+		contents := `# Disable cloud-init network hotplug to prevent interference with Cilium ENI management.
+# See: https://github.com/kubernetes/kops/issues/17881
+updates:
+  network:
+    when: [boot-new-instance]
+`
+		c.AddTask(&nodetasks.File{
+			Path:     "/etc/cloud/cloud.cfg.d/99-disable-network-hotplug.cfg",
+			Contents: fi.NewStringResource(contents),
+			Type:     nodetasks.FileType_File,
+		})
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
…zon VPC CNI

On Ubuntu 24.04+, cloud-init network hotplug is enabled by default (https://github.com/canonical/cloud-init/pull/4799). This causes cloud-init to reconfigure netplan when CNIs dynamically attach secondary ENIs, breaking BPF masquerade and network routing functionality.

This fix disables cloud-init network hotplug by creating a configuration file at /etc/cloud/cloud.cfg.d/99-disable-network-hotplug.cfg that sets updates.network.when to an empty list, preventing cloud-init from handling any network update events including hotplug.

Fixes #17881