### PR TITLE
Add constructor for kopscontrollerclient so that internal http client can be cleanly initialized

### DIFF
--- a/nodeup/pkg/model/bootstrap_client.go
+++ b/nodeup/pkg/model/bootstrap_client.go
@@ -111,12 +111,7 @@ func (b BootstrapClientBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		Path:   "/",
 	}
 
-	bootstrapClient := &kopscontrollerclient.Client{
-		Authenticator: authenticator,
-		CAs:           []byte(b.NodeupConfig.CAs[fi.CertificateIDCA]),
-		BaseURL:       baseURL,
-	}
-
+	bootstrapClient := kopscontrollerclient.New(authenticator, []byte(b.NodeupConfig.CAs[fi.CertificateIDCA]), baseURL)
 	bootstrapClientTask := &nodetasks.BootstrapClientTask{
 		Client:     bootstrapClient,
 		Certs:      b.bootstrapCerts,

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -677,7 +677,6 @@ func getNodeConfigFromServers(ctx context.Context, bootConfig *nodeup.BootConfig
 	}
 
 	var challengeListener *bootstrap.ChallengeListener
-
 	if kopsmodel.UseChallengeCallback(bootConfig.CloudProvider) {
 		challengeServer, err := bootstrap.NewChallengeServer(bootConfig.ClusterName, []byte(bootConfig.ConfigServer.CACertificates))
 		if err != nil {
@@ -693,10 +692,8 @@ func getNodeConfigFromServers(ctx context.Context, bootConfig *nodeup.BootConfig
 		defer challengeListener.Stop()
 	}
 
-	client := &kopscontrollerclient.Client{
-		Authenticator: authenticator,
-		CAs:           []byte(bootConfig.ConfigServer.CACertificates),
-	}
+	// Note: The url is overridden in every iteration of the loop below.
+	client := kopscontrollerclient.New(authenticator, []byte(bootConfig.ConfigServer.CACertificates), url.URL{})
 	defer client.Close()
 
 	var merr error


### PR DESCRIPTION
This is a cosmetic change. It's a bit cleaner to use a constructor because now the http client doesn't have to be initialized in the request path.

/assign @hakman 