### PR TITLE
Add EtcdEventsHTTP feature flag for HTTP on events etcd

### DIFF
--- a/docs/advanced/experimental.md
+++ b/docs/advanced/experimental.md
@@ -16,4 +16,5 @@ The following experimental features are currently available:
 * `+SpotinstHybrid` - Toggles between hybrid and full instance group implementations
 * `-SpotinstController` - Toggles the installation of the Spot controller addon off
 * `+SkipEtcdVersionCheck` - Bypasses the check that etcd-manager is using a supported etcd version
+* `+EtcdEventsHTTP` - Enables HTTP (non-TLS) for the events etcd cluster, matching GCE scale test patterns
 * `+APIServerNodes` - Enables support for dedicated API server nodes

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -71,6 +71,11 @@ var (
 	VPCSkipEnableDNSSupport = new("VPCSkipEnableDNSSupport", Bool(false))
 	// SkipEtcdVersionCheck will bypass the check that etcd-manager is using a supported etcd version
 	SkipEtcdVersionCheck = new("SkipEtcdVersionCheck", Bool(false))
+	// EtcdEventsHTTP enables HTTP (non-TLS) for the events etcd cluster.
+	// This matches the pattern used by GCE scale tests and can help with
+	// TLS handshake overhead for the ephemeral events data.
+	// The main etcd cluster always uses HTTPS for security.
+	EtcdEventsHTTP = new("EtcdEventsHTTP", Bool(false))
 	// ClusterAddons activates experimental cluster-addons support
 	ClusterAddons = new("ClusterAddons", Bool(false))
 	// Azure toggles the Azure support.

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
 
@@ -147,7 +148,12 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(cluster *kops.Cluster) error 
 		case "main":
 			c.EtcdServers = append(c.EtcdServers, "https://127.0.0.1:4001")
 		case "events":
-			c.EtcdServersOverrides = append(c.EtcdServersOverrides, "/events#https://127.0.0.1:4002")
+			// Use HTTP for events etcd when EtcdEventsHTTP feature flag is enabled
+			scheme := "https"
+			if featureflag.EtcdEventsHTTP.Enabled() {
+				scheme = "http"
+			}
+			c.EtcdServersOverrides = append(c.EtcdServersOverrides, fmt.Sprintf("/events#%s://127.0.0.1:4002", scheme))
 		}
 	}
 


### PR DESCRIPTION
Adds a feature flag to enable HTTP (non-TLS) for the events etcd cluster. This matches what GCE scale tests do and helps avoid TLS handshake overhead for ephemeral events data.

Main etcd always uses HTTPS - no way to disable TLS there.

Usage: export KOPS_FEATURE_FLAGS=EtcdEventsHTTP

re-do of a previous PR - https://github.com/kubernetes/kops/pull/17878