### PR TITLE
Add tip to use gotestfail when doing local development

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -8,6 +8,24 @@ To run all tests:
 ```
 go test -v ./...
 ```
+### Development
+
+kOps has a lot of tests. This is great, but when writing code that causes test
+failures, it sometimes becomes hard to identify the failing tests due to how `go
+test` outputs results.
+
+If you are encountering this issue, you can install the following wrapper:
+
+```
+go install github.com/rramkumar1/gotestfail
+```
+
+This tool wraps standard `go test` arguments but only outputs failures and makes
+it easier to consume logs for the failed tests. You can run it like so:
+
+```
+gotestfail ./...
+```
 
 ### Adding an integration test
 


### PR DESCRIPTION
@hakman @justinsb Thoughts on this? 

While doing development I found it quite annoying dealing with larger scale unit test failures as it became hard to navigate the output and find the actual tests that were failing..

I came up with a quick `go test` wrapper that made my life easier in this regard and figured it might help someone else later on.