### PR TITLE
gce: Force delete IG with a missing Instance

### DIFF
--- a/cloudmock/gce/mock_gce_cloud.go
+++ b/cloudmock/gce/mock_gce_cloud.go
@@ -71,8 +71,8 @@ func (c *MockGCECloud) AllResources() map[string]interface{} {
 }
 
 // GetCloudGroups is not implemented yet
-func (c *MockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
-	return gce.GetCloudGroups(c, cluster, instancegroups, warnUnmatched, nodes)
+func (c *MockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+	return gce.GetCloudGroups(c, cluster, instancegroups, options, nodes)
 }
 
 func (c *MockGCECloud) Zones() ([]string, error) {

--- a/cloudmock/gce/mock_gce_cloud.go
+++ b/cloudmock/gce/mock_gce_cloud.go
@@ -70,7 +70,6 @@ func (c *MockGCECloud) AllResources() map[string]interface{} {
 	return c.computeClient.AllResources()
 }
 
-// GetCloudGroups is not implemented yet
 func (c *MockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	return gce.GetCloudGroups(c, cluster, instancegroups, options, nodes)
 }

--- a/cloudmock/gce/mock_gce_cloud.go
+++ b/cloudmock/gce/mock_gce_cloud.go
@@ -75,7 +75,6 @@ func (c *MockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*k
 	return gce.GetCloudGroups(c, cluster, instancegroups, warnUnmatched, nodes)
 }
 
-// Zones is not implemented yet
 func (c *MockGCECloud) Zones() ([]string, error) {
 	return gce.GetZones(c)
 }

--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kops/pkg/instancegroups"
 	"k8s.io/kops/pkg/kubeconfig"
 	"k8s.io/kops/pkg/validation"
+	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -211,7 +212,7 @@ func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, opti
 		return err
 	}
 
-	groups, err := cloud.GetCloudGroups(cluster, instanceGroups, false, nodes)
+	groups, err := cloud.GetCloudGroups(cluster, instanceGroups, &fi.GetCloudGroupsOptions{}, nodes)
 	if err != nil {
 		return err
 	}
@@ -361,7 +362,7 @@ func completeInstanceOrNode(f commandutils.Factory, options *DeleteInstanceOptio
 			return commandutils.CompletionError("initializing cloud", err)
 		}
 
-		groups, err := cloud.GetCloudGroups(cluster, instanceGroups, false, nodes)
+		groups, err := cloud.GetCloudGroups(cluster, instanceGroups, &fi.GetCloudGroupsOptions{}, nodes)
 		if err != nil {
 			return commandutils.CompletionError("listing instances", err)
 		}

--- a/cmd/kops/delete_instancegroup.go
+++ b/cmd/kops/delete_instancegroup.go
@@ -54,6 +54,7 @@ type DeleteInstanceGroupOptions struct {
 	Yes         bool
 	ClusterName string
 	GroupName   string
+	Force       bool
 }
 
 func NewCmdDeleteInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
@@ -114,6 +115,7 @@ func NewCmdDeleteInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&options.Yes, "yes", "y", options.Yes, "Specify --yes to immediately delete the instance group")
+	cmd.Flags().BoolVarP(&options.Force, "force", "f", options.Force, "Specify --force to force the deletion of the instance group even if not all instances can be found.")
 
 	return cmd
 }
@@ -181,7 +183,7 @@ func RunDeleteInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer,
 	d.Cloud = cloud
 	d.Clientset = clientset
 
-	err = d.DeleteInstanceGroup(group)
+	err = d.DeleteInstanceGroup(group, options.Force)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/delete_instancegroup.go
+++ b/cmd/kops/delete_instancegroup.go
@@ -183,7 +183,7 @@ func RunDeleteInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer,
 	d.Cloud = cloud
 	d.Clientset = clientset
 
-	err = d.DeleteInstanceGroup(group, options.Force)
+	err = d.DeleteInstanceGroup(ctx, group, options.Force)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/delete_instancegroup_test.go
+++ b/cmd/kops/delete_instancegroup_test.go
@@ -69,9 +69,8 @@ func TestRunDeleteInstanceGroup(t *testing.T) {
 
 	ig := testutils.BuildMinimalNodeInstanceGroup("test-ig")
 
-	instanceName := "a-test-ig-test-k8s-io"
 	igm := &compute.InstanceGroupManager{
-		Name:             instanceName,
+		Name:             "a-test-ig-test-k8s-io",
 		Zone:             "us-test1-a",
 		InstanceTemplate: template.SelfLink,
 	}
@@ -89,6 +88,10 @@ func TestRunDeleteInstanceGroup(t *testing.T) {
 		Yes:         true,
 		Force:       false,
 	}
+
+	// Simulate missing Instance
+	_, err = cloud.Compute().Instances().Delete(cloud.Project(), igm.Zone, igm.Name)
+	assert.NoError(t, err, "error deleting Instance")
 
 	assert.ErrorContains(t, RunDeleteInstanceGroup(ctx, f, &stdout, options), "error getting Instance")
 

--- a/cmd/kops/delete_instancegroup_test.go
+++ b/cmd/kops/delete_instancegroup_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kops/cmd/kops/util"
+	"k8s.io/kops/pkg/testutils"
+)
+
+func TestRunDeleteInstanceGroup(t *testing.T) {
+	h := testutils.NewIntegrationTestHarness(t)
+	defer h.Close()
+
+	clusterName := "test.k8s.io"
+
+	cloud := h.SetupMockGCE()
+
+	ctx := context.Background()
+	f := util.NewFactory(&util.FactoryOptions{
+		RegistryPath: "memfs://tests",
+	})
+
+	cluster := testutils.BuildMinimalClusterGCE(clusterName, cloud.Project())
+
+	clientset, err := f.KopsClient()
+	assert.NoError(t, err, "error getting clientset")
+
+	_, err = clientset.CreateCluster(ctx, cluster)
+	assert.NoError(t, err, "error creating cluster")
+
+	template := &compute.InstanceTemplate{
+		Name: "test-template",
+		Properties: &compute.InstanceProperties{
+			Metadata: &compute.Metadata{
+				Items: []*compute.MetadataItems{
+					{
+						Key:   "cluster-name",
+						Value: &clusterName,
+					},
+				},
+			},
+		},
+	}
+
+	_, err = cloud.Compute().InstanceTemplates().Insert(cloud.Project(), template)
+	assert.NoError(t, err, "error creating InstanceTemplate")
+
+	ig := testutils.BuildMinimalNodeInstanceGroup("test-ig")
+
+	instanceName := "a-test-ig-test-k8s-io"
+	igm := &compute.InstanceGroupManager{
+		Name:             instanceName,
+		Zone:             "us-test1-a",
+		InstanceTemplate: template.SelfLink,
+	}
+
+	_, err = cloud.Compute().InstanceGroupManagers().Insert(cloud.Project(), igm.Zone, igm)
+	assert.NoError(t, err, "error creating InstanceGroupManager")
+
+	_, err = clientset.InstanceGroupsFor(cluster).Create(ctx, &ig, metav1.CreateOptions{})
+	assert.NoError(t, err, "error creating instance group")
+
+	var stdout bytes.Buffer
+	options := &DeleteInstanceGroupOptions{
+		ClusterName: clusterName,
+		GroupName:   ig.Name,
+		Yes:         true,
+		Force:       false,
+	}
+
+	assert.Error(t, RunDeleteInstanceGroup(ctx, f, &stdout, options))
+
+	// Verify that the instance group was not deleted
+	_, err = clientset.InstanceGroupsFor(cluster).Get(ctx, ig.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	options.Force = true
+	assert.NoError(t, RunDeleteInstanceGroup(ctx, f, &stdout, options))
+
+	// Verify that the instance group is deleted
+	_, err = clientset.InstanceGroupsFor(cluster).Get(ctx, ig.Name, metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err), "unexpected error when getting deleted instance group")
+}

--- a/cmd/kops/delete_instancegroup_test.go
+++ b/cmd/kops/delete_instancegroup_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -74,7 +90,7 @@ func TestRunDeleteInstanceGroup(t *testing.T) {
 		Force:       false,
 	}
 
-	assert.Error(t, RunDeleteInstanceGroup(ctx, f, &stdout, options))
+	assert.ErrorContains(t, RunDeleteInstanceGroup(ctx, f, &stdout, options), "error getting Instance")
 
 	// Verify that the instance group was not deleted
 	_, err = clientset.InstanceGroupsFor(cluster).Get(ctx, ig.Name, metav1.GetOptions{})

--- a/cmd/kops/delete_instancegroup_test.go
+++ b/cmd/kops/delete_instancegroup_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/kops/delete_instancegroup_test.go
+++ b/cmd/kops/delete_instancegroup_test.go
@@ -89,6 +89,74 @@ func TestRunDeleteInstanceGroup(t *testing.T) {
 		Force:       false,
 	}
 
+	assert.NoError(t, RunDeleteInstanceGroup(ctx, f, &stdout, options))
+
+	// Verify that the instance group was deleted
+	_, err = clientset.InstanceGroupsFor(cluster).Get(ctx, ig.Name, metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err), "unexpected error when getting deleted instance group")
+}
+
+func TestRunDeleteInstanceGroup_MissingInstance(t *testing.T) {
+	h := testutils.NewIntegrationTestHarness(t)
+	defer h.Close()
+
+	clusterName := "test.k8s.io"
+
+	cloud := h.SetupMockGCE()
+
+	ctx := context.Background()
+	f := util.NewFactory(&util.FactoryOptions{
+		RegistryPath: "memfs://tests",
+	})
+
+	cluster := testutils.BuildMinimalClusterGCE(clusterName, cloud.Project())
+
+	clientset, err := f.KopsClient()
+	assert.NoError(t, err, "error getting clientset")
+
+	_, err = clientset.CreateCluster(ctx, cluster)
+	assert.NoError(t, err, "error creating cluster")
+
+	template := &compute.InstanceTemplate{
+		Name: "test-template",
+		Properties: &compute.InstanceProperties{
+			Metadata: &compute.Metadata{
+				Items: []*compute.MetadataItems{
+					{
+						Key:   "cluster-name",
+						Value: &clusterName,
+					},
+				},
+			},
+		},
+	}
+
+	_, err = cloud.Compute().InstanceTemplates().Insert(cloud.Project(), template)
+	assert.NoError(t, err, "error creating InstanceTemplate")
+
+	ig := testutils.BuildMinimalNodeInstanceGroup("test-ig")
+
+	igm := &compute.InstanceGroupManager{
+		Name:             "a-test-ig-test-k8s-io",
+		Zone:             "us-test1-a",
+		InstanceTemplate: template.SelfLink,
+	}
+
+	_, err = cloud.Compute().InstanceGroupManagers().Insert(cloud.Project(), igm.Zone, igm)
+	assert.NoError(t, err, "error creating InstanceGroupManager")
+
+	_, err = clientset.InstanceGroupsFor(cluster).Create(ctx, &ig, metav1.CreateOptions{})
+	assert.NoError(t, err, "error creating instance group")
+
+	var stdout bytes.Buffer
+	options := &DeleteInstanceGroupOptions{
+		ClusterName: clusterName,
+		GroupName:   ig.Name,
+		Yes:         true,
+		Force:       false,
+	}
+
 	// Simulate missing Instance
 	_, err = cloud.Compute().Instances().Delete(cloud.Project(), igm.Zone, igm.Name)
 	assert.NoError(t, err, "error deleting Instance")

--- a/cmd/kops/get_instances.go
+++ b/cmd/kops/get_instances.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/kops/cmd/kops/util"
+	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 )
 
@@ -142,7 +143,7 @@ func RunGetInstances(ctx context.Context, f *util.Factory, out io.Writer, option
 
 	var cloudInstances []*cloudinstances.CloudInstance
 
-	cloudGroups, err := cloud.GetCloudGroups(cluster, instanceGroups, false, nodeList.Items)
+	cloudGroups, err := cloud.GetCloudGroups(cluster, instanceGroups, &fi.GetCloudGroupsOptions{}, nodeList.Items)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/rolling-update_cluster.go
+++ b/cmd/kops/rolling-update_cluster.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kops/pkg/kubeconfig"
 	"k8s.io/kops/pkg/pretty"
 	"k8s.io/kops/pkg/validation"
+	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/util/pkg/tables"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -348,7 +349,8 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 		return err
 	}
 
-	groups, err := cloud.GetCloudGroups(cluster, instanceGroups, warnUnmatched, nodes)
+	groups, err := cloud.GetCloudGroups(cluster, instanceGroups, &fi.GetCloudGroupsOptions{WarnUnmatched: warnUnmatched},
+		nodes)
 	if err != nil {
 		return err
 	}

--- a/docs/cli/kops_delete_instancegroup.md
+++ b/docs/cli/kops_delete_instancegroup.md
@@ -25,8 +25,9 @@ kops delete instancegroup INSTANCE_GROUP [flags]
 ### Options
 
 ```
-  -h, --help   help for instancegroup
-  -y, --yes    Specify --yes to immediately delete the instance group
+  -f, --force   Specify --force to force the deletion of the instance group even if not all instances can be found.
+  -h, --help    help for instancegroup
+  -y, --yes     Specify --yes to immediately delete the instance group
 ```
 
 ### Options inherited from parent commands

--- a/pkg/instancegroups/delete.go
+++ b/pkg/instancegroups/delete.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/client/simple"
+	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -35,10 +36,13 @@ type DeleteInstanceGroup struct {
 }
 
 // DeleteInstanceGroup deletes a cloud instance group
-func (d *DeleteInstanceGroup) DeleteInstanceGroup(group *api.InstanceGroup) error {
+func (d *DeleteInstanceGroup) DeleteInstanceGroup(group *api.InstanceGroup, force bool) error {
 	ctx := context.TODO()
+	var groups map[string]*cloudinstances.CloudInstanceGroup
+	var err error
 
-	groups, err := d.Cloud.GetCloudGroups(d.Cluster, []*api.InstanceGroup{group}, false, nil)
+	groups, err = d.Cloud.GetCloudGroups(d.Cluster, []*api.InstanceGroup{group}, &fi.GetCloudGroupsOptions{WarnMissingInstance: force}, nil)
+
 	if err != nil {
 		return fmt.Errorf("error finding CloudInstanceGroups: %v", err)
 	}

--- a/pkg/instancegroups/delete.go
+++ b/pkg/instancegroups/delete.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/klog/v2"
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/client/simple"
-	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -36,12 +35,8 @@ type DeleteInstanceGroup struct {
 }
 
 // DeleteInstanceGroup deletes a cloud instance group
-func (d *DeleteInstanceGroup) DeleteInstanceGroup(group *api.InstanceGroup, force bool) error {
-	ctx := context.TODO()
-	var groups map[string]*cloudinstances.CloudInstanceGroup
-	var err error
-
-	groups, err = d.Cloud.GetCloudGroups(d.Cluster, []*api.InstanceGroup{group}, &fi.GetCloudGroupsOptions{WarnMissingInstance: force}, nil)
+func (d *DeleteInstanceGroup) DeleteInstanceGroup(ctx context.Context, group *api.InstanceGroup, force bool) error {
+	groups, err := d.Cloud.GetCloudGroups(d.Cluster, []*api.InstanceGroup{group}, &fi.GetCloudGroupsOptions{WarnMissingInstance: force}, nil)
 
 	if err != nil {
 		return fmt.Errorf("error finding CloudInstanceGroups: %v", err)

--- a/pkg/instancegroups/delete_test.go
+++ b/pkg/instancegroups/delete_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/instancegroups/delete_test.go
+++ b/pkg/instancegroups/delete_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/instancegroups/delete_test.go
+++ b/pkg/instancegroups/delete_test.go
@@ -34,6 +34,8 @@ package instancegroups
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -42,6 +44,7 @@ import (
 	"google.golang.org/api/compute/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops/cmd/kops/util"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/testutils"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
@@ -133,4 +136,130 @@ func TestDeleteInstanceGroup_GCEWaitOnInstanceDeletion(t *testing.T) {
 	instanceTemplates, err := cloud.Compute().InstanceTemplates().List(ctx, cloud.Project())
 	assert.NoError(t, err)
 	assert.Len(t, instanceTemplates, 0)
+}
+
+func TestDeleteInstanceGroup(t *testing.T) {
+	h := testutils.NewIntegrationTestHarness(t)
+	defer h.Close()
+
+	clusterName := "test.k8s.io"
+
+	cloud := h.SetupMockGCE()
+
+	ctx := context.Background()
+	f := util.NewFactory(&util.FactoryOptions{
+		RegistryPath: "memfs://tests",
+	})
+
+	cluster := testutils.BuildMinimalClusterGCE(clusterName, cloud.Project())
+
+	clientset, err := f.KopsClient()
+
+	_, err = clientset.CreateCluster(ctx, cluster)
+	if err != nil {
+		t.Fatalf("error creating cluster: %v", err)
+	}
+
+	i := &compute.InstanceTemplate{
+		Name: "test-template",
+		Properties: &compute.InstanceProperties{
+			Metadata: &compute.Metadata{
+				Kind: "compute#metadata",
+				Items: []*compute.MetadataItems{
+					{
+						Key:   "cluster-name",
+						Value: &clusterName,
+					},
+				},
+			},
+		},
+	}
+
+	op, err := cloud.Compute().InstanceTemplates().Insert(cloud.Project(), i)
+	if err != nil {
+		t.Fatalf("error creating InstanceTemplate: %v", err)
+	}
+
+	if err := cloud.WaitForOp(op); err != nil {
+		t.Fatalf("error creating InstanceTemplate: %v", err)
+	}
+
+	ig := &kops.InstanceGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ig",
+			Labels: map[string]string{
+				kops.LabelClusterName: clusterName,
+			},
+		},
+		Spec: kops.InstanceGroupSpec{
+			Role:        kops.InstanceGroupRoleNode,
+			MinSize:     fi.PtrTo(int32(1)),
+			MaxSize:     fi.PtrTo(int32(1)),
+			MachineType: "e2-medium",
+			Zones:       []string{"us-central1-a"},
+		},
+	}
+	igm := &compute.InstanceGroupManager{
+		Name:             "a-test-ig-test-k8s-io",
+		Zone:             "us-central1-a",
+		InstanceTemplate: i.SelfLink,
+	}
+
+	op, err = cloud.Compute().InstanceGroupManagers().Insert(cloud.Project(), "us-test1-a", igm)
+	if err != nil {
+		t.Fatalf("error creating InstanceGroupManager: %v", err)
+	}
+
+	if err := cloud.WaitForOp(op); err != nil {
+		t.Fatalf("error creating InstanceGroupManager: %v", err)
+	}
+
+	_, err = clientset.InstanceGroupsFor(cluster).Create(ctx, ig, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating instance group: %v", err)
+	}
+
+	op, err = cloud.Compute().InstanceGroupManagers().RecreateInstances("testproject", "us-central1-a", "a-test-ig-test-k8s-io", "0")
+	if err != nil {
+		t.Fatalf("error recreating Instance: %v", err)
+	}
+
+	list, _ := clientset.InstanceGroupsFor(cluster).List(ctx, metav1.ListOptions{})
+	fmt.Println(list)
+
+	deleteIG := &DeleteInstanceGroup{
+		Cluster:   cluster,
+		Cloud:     cloud,
+		Clientset: clientset,
+	}
+
+	err = deleteIG.DeleteInstanceGroup(ig)
+	if err != nil {
+		t.Fatalf("error deleting instance group: %v", err)
+	}
+
+	// Verify that the instance group is deleted from the clientset
+	_, err = clientset.InstanceGroupsFor(cluster).Get(ctx, ig.Name, metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("instance group %q was not deleted from clientset", ig.Name)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unexpected error when getting deleted instance group: %v", err)
+	}
+
+	// // Verify that the cloud resources are deleted (MIG and InstanceTemplate)
+	// // This requires inspecting the mock cloud's internal state.
+	// allResources := cloud.AllResources()
+	// for name, resource := range allResources {
+	// 	switch v := resource.(type) {
+	// 	case *compute.InstanceGroupManager:
+	// 		if strings.Contains(v.Name, ig.Name) {
+	// 			t.Fatalf("InstanceGroupManager %q was not deleted from cloud", v.Name)
+	// 		}
+	// 	case *compute.InstanceTemplate:
+	// 		if strings.Contains(v.Name, ig.Name) {
+	// 			t.Fatalf("InstanceTemplate %q was not deleted from cloud", v.Name)
+	// 		}
+	// 	}
+	// }
 }

--- a/pkg/instancegroups/delete_test.go
+++ b/pkg/instancegroups/delete_test.go
@@ -1,21 +1,5 @@
 /*
-Copyright The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-/*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -207,8 +191,12 @@ func TestDeleteInstanceGroup(t *testing.T) {
 		Clientset: clientset,
 	}
 
-	assert.NoError(t, deleteIG.DeleteInstanceGroup(&ig, false /*force*/))
+	assert.ErrorContains(t, deleteIG.DeleteInstanceGroup(&ig, false /*force*/), "error getting Instance")
+	// Verify that the instance group was not deleted
+	_, err = clientset.InstanceGroupsFor(cluster).Get(ctx, ig.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
 
+	assert.NoError(t, deleteIG.DeleteInstanceGroup(&ig, true /*force*/))
 	// Verify that the instance group was deleted from the clientset
 	_, err = clientset.InstanceGroupsFor(cluster).Get(ctx, ig.Name, metav1.GetOptions{})
 	assert.Error(t, err)

--- a/pkg/instancegroups/delete_test.go
+++ b/pkg/instancegroups/delete_test.go
@@ -196,12 +196,12 @@ func TestDeleteInstanceGroup(t *testing.T) {
 	_, err = cloud.Compute().Instances().Delete(cloud.Project(), igm.Zone, igm.Name)
 	assert.NoError(t, err, "error deleting Instance")
 
-	assert.ErrorContains(t, deleteIG.DeleteInstanceGroup(&ig, false /*force*/), "error getting Instance")
+	assert.ErrorContains(t, deleteIG.DeleteInstanceGroup(ctx, &ig, false /*force*/), "error getting Instance")
 	// Verify that the instance group was not deleted
 	_, err = clientset.InstanceGroupsFor(cluster).Get(ctx, ig.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 
-	assert.NoError(t, deleteIG.DeleteInstanceGroup(&ig, true /*force*/))
+	assert.NoError(t, deleteIG.DeleteInstanceGroup(ctx, &ig, true /*force*/))
 	// Verify that the instance group was deleted from the clientset
 	_, err = clientset.InstanceGroupsFor(cluster).Get(ctx, ig.Name, metav1.GetOptions{})
 	assert.Error(t, err)

--- a/pkg/instancegroups/delete_test.go
+++ b/pkg/instancegroups/delete_test.go
@@ -101,7 +101,7 @@ func TestDeleteInstanceGroup_GCEWaitOnInstanceDeletion(t *testing.T) {
 		Clientset: clientset,
 	}
 
-	err = d.DeleteInstanceGroup(&ig, false /*force*/)
+	err = d.DeleteInstanceGroup(ctx, &ig, false /*force*/)
 	assert.NoError(t, err)
 
 	// Check that all resources related to the CloudInstanceGroup were successfully deleted
@@ -181,6 +181,71 @@ func TestDeleteInstanceGroup(t *testing.T) {
 	}
 
 	_, err = cloud.Compute().InstanceGroupManagers().Insert(cloud.Project(), zone, igm)
+	assert.NoError(t, err, "error inserting InstanceGroupManager")
+
+	_, err = clientset.InstanceGroupsFor(cluster).Create(ctx, &ig, metav1.CreateOptions{})
+	assert.NoError(t, err, "error creating InstanceGroup")
+
+	deleteIG := &DeleteInstanceGroup{
+		Cluster:   cluster,
+		Cloud:     cloud,
+		Clientset: clientset,
+	}
+
+	assert.NoError(t, deleteIG.DeleteInstanceGroup(ctx, &ig, false /*force*/))
+
+	// Verify that the instance group was deleted from the clientset
+	_, err = clientset.InstanceGroupsFor(cluster).Get(ctx, ig.Name, metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err), "unexpected error when getting deleted instance group: %v", err)
+}
+
+func TestDeleteInstanceGroup_MissingInstance(t *testing.T) {
+	h := testutils.NewIntegrationTestHarness(t)
+	defer h.Close()
+
+	clusterName := "test.k8s.io"
+
+	cloud := h.SetupMockGCE()
+
+	ctx := context.Background()
+	f := util.NewFactory(&util.FactoryOptions{
+		RegistryPath: "memfs://tests",
+	})
+
+	cluster := testutils.BuildMinimalClusterGCE(clusterName, cloud.Project())
+
+	clientset, err := f.KopsClient()
+	assert.NoError(t, err, "error getting clientset")
+	_, err = clientset.CreateCluster(ctx, cluster)
+	assert.NoError(t, err, "error creating cluster")
+
+	template := &compute.InstanceTemplate{
+		Name: "test-template",
+		Properties: &compute.InstanceProperties{
+			Metadata: &compute.Metadata{
+				Items: []*compute.MetadataItems{
+					{
+						Key:   "cluster-name",
+						Value: &clusterName,
+					},
+				},
+			},
+		},
+	}
+
+	_, err = cloud.Compute().InstanceTemplates().Insert(cloud.Project(), template)
+	assert.NoError(t, err, "error creating InstanceTemplate")
+
+	ig := testutils.BuildMinimalNodeInstanceGroup("test-ig")
+
+	igm := &compute.InstanceGroupManager{
+		Name:             "a-test-ig-test-k8s-io",
+		Zone:             "us-test1-a",
+		InstanceTemplate: template.SelfLink,
+	}
+
+	_, err = cloud.Compute().InstanceGroupManagers().Insert(cloud.Project(), igm.Zone, igm)
 	assert.NoError(t, err, "error inserting InstanceGroupManager")
 
 	_, err = clientset.InstanceGroupsFor(cluster).Create(ctx, &ig, metav1.CreateOptions{})

--- a/pkg/instancegroups/main_test.go
+++ b/pkg/instancegroups/main_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancegroups
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+)
+
+// TestMain executes the tests for this package
+func TestMain(m *testing.M) {
+	gce.PollingInterval = 5 * time.Millisecond
+
+	klog.InitFlags(nil)
+	exitCode := m.Run()
+
+	gce.PollingInterval = 5 * time.Second
+	os.Exit(exitCode)
+}

--- a/pkg/kubeconfig/create_kubecfg_test.go
+++ b/pkg/kubeconfig/create_kubecfg_test.go
@@ -77,7 +77,7 @@ func (f fakeStatusCloud) DeregisterInstance(instance *cloudinstances.CloudInstan
 	panic("not implemented")
 }
 
-func (f fakeStatusCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+func (f fakeStatusCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	panic("not implemented")
 }
 

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -183,7 +183,7 @@ func (v *clusterValidatorImpl) Validate(ctx context.Context) (*ValidationCluster
 	}
 
 	warnUnmatched := false
-	cloudGroups, err := v.cloud.GetCloudGroups(v.cluster, v.allInstanceGroups, warnUnmatched, nodeList.Items)
+	cloudGroups, err := v.cloud.GetCloudGroups(v.cluster, v.allInstanceGroups, &fi.GetCloudGroupsOptions{WarnUnmatched: warnUnmatched}, nodeList.Items)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -56,7 +56,7 @@ func BuildMockCloud(t *testing.T, groups map[string]*cloudinstances.CloudInstanc
 	return &m
 }
 
-func (c *MockCloud) GetCloudGroups(cluster *kopsapi.Cluster, instancegroups []*kopsapi.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+func (c *MockCloud) GetCloudGroups(cluster *kopsapi.Cluster, instancegroups []*kopsapi.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	assert.Equal(c.t, c.expectedCluster, cluster, "cluster")
 
 	igs := make([]kopsapi.InstanceGroup, 0, len(instancegroups))

--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -44,7 +44,7 @@ type Cloud interface {
 
 	// GetCloudGroups returns a map of cloud instances that back a kops cluster.
 	// Detached instances must be returned in the NeedUpdate slice.
-	GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error)
+	GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error)
 
 	// Region returns the cloud region bound to the cloud instance.
 	// If the region concept does not apply, returns "".
@@ -53,6 +53,12 @@ type Cloud interface {
 	// FindClusterStatus discovers the status of the cluster, by inspecting the cloud objects
 	FindClusterStatus(cluster *kops.Cluster) (*kops.ClusterStatus, error)
 	GetApiIngressStatus(cluster *kops.Cluster) ([]ApiIngressStatus, error)
+}
+
+// GetCloudGroupsOptions are options for GetCloudGroups
+type GetCloudGroupsOptions struct {
+	WarnUnmatched       bool
+	WarnMissingInstance bool
 }
 
 type VPCInfo struct {

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -703,17 +703,17 @@ func detachInstance(ctx context.Context, c AWSCloud, i *cloudinstances.CloudInst
 }
 
 // GetCloudGroups returns a groups of instances that back a kops instance groups
-func (c *awsCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+func (c *awsCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	ctx := context.TODO()
 
 	if c.spotinst != nil {
-		sgroups, err := spotinst.GetCloudGroups(c.spotinst, cluster, instancegroups, warnUnmatched, nodes)
+		sgroups, err := spotinst.GetCloudGroups(c.spotinst, cluster, instancegroups, options.WarnUnmatched, nodes)
 		if err != nil {
 			return nil, err
 		}
 
 		if featureflag.SpotinstHybrid.Enabled() {
-			agroups, err := getCloudGroups(ctx, c, cluster, instancegroups, warnUnmatched, nodes)
+			agroups, err := getCloudGroups(ctx, c, cluster, instancegroups, options.WarnUnmatched, nodes)
 			if err != nil {
 				return nil, err
 			}
@@ -726,7 +726,7 @@ func (c *awsCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instanceg
 		return sgroups, nil
 	}
 
-	cloudGroups, err := getCloudGroups(ctx, c, cluster, instancegroups, warnUnmatched, nodes)
+	cloudGroups, err := getCloudGroups(ctx, c, cluster, instancegroups, options.WarnUnmatched, nodes)
 	if err != nil {
 		return nil, err
 	}

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -101,9 +101,9 @@ func (c *MockAWSCloud) DetachInstance(i *cloudinstances.CloudInstance) error {
 	return detachInstance(ctx, c, i)
 }
 
-func (c *MockAWSCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+func (c *MockAWSCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	ctx := context.TODO()
-	return getCloudGroups(ctx, c, cluster, instancegroups, warnUnmatched, nodes)
+	return getCloudGroups(ctx, c, cluster, instancegroups, options.WarnUnmatched, nodes)
 }
 
 func (c *MockCloud) ProviderID() kops.CloudProviderID {

--- a/upup/pkg/fi/cloudup/azure/status.go
+++ b/upup/pkg/fi/cloudup/azure/status.go
@@ -117,7 +117,7 @@ func (c *azureCloudImplementation) isDiskForCluster(disk *compute.Disk) bool {
 func (c *azureCloudImplementation) GetCloudGroups(
 	cluster *kops.Cluster,
 	instancegroups []*kops.InstanceGroup,
-	warnUnmatched bool,
+	options *fi.GetCloudGroupsOptions,
 	nodes []v1.Node,
 ) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	igsByName, err := keyedByName(instancegroups, cluster.Name)
@@ -141,7 +141,7 @@ func (c *azureCloudImplementation) GetCloudGroups(
 
 		ig, ok := igsByName[*vmss.Name]
 		if !ok {
-			if warnUnmatched {
+			if options.WarnUnmatched {
 				klog.Warningf("Found VM Scale Set with no corresponding instance group %q", *vmss.Name)
 			}
 			continue

--- a/upup/pkg/fi/cloudup/azure/status_test.go
+++ b/upup/pkg/fi/cloudup/azure/status_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi"
 )
 
 type mockVMScaleSetsClient struct {
@@ -281,7 +282,7 @@ func TestGetCloudGroups(t *testing.T) {
 		},
 	}
 
-	groups, err := c.GetCloudGroups(cluster, instancegroups, false /* warnUnmatched */, nodes)
+	groups, err := c.GetCloudGroups(cluster, instancegroups, &fi.GetCloudGroupsOptions{}, nodes)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/upup/pkg/fi/cloudup/azuretasks/testing.go
+++ b/upup/pkg/fi/cloudup/azuretasks/testing.go
@@ -167,7 +167,7 @@ func (c *MockAzureCloud) DetachInstance(i *cloudinstances.CloudInstance) error {
 func (c *MockAzureCloud) GetCloudGroups(
 	cluster *kops.Cluster,
 	instancegroups []*kops.InstanceGroup,
-	warnUnmatched bool,
+	options *fi.GetCloudGroupsOptions,
 	nodes []v1.Node,
 ) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	return nil, errors.New("GetCloudGroups not implemented on azureCloud")

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -129,8 +129,8 @@ func NewDOCloud(region string) (DOCloud, error) {
 	}, nil
 }
 
-func (c *doCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
-	return getCloudGroups(c, cluster, instancegroups, warnUnmatched, nodes)
+func (c *doCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+	return getCloudGroups(c, cluster, instancegroups, options.WarnUnmatched, nodes)
 }
 
 // DeleteGroup is not implemented yet, is a func that needs to delete a DO instance group.

--- a/upup/pkg/fi/cloudup/do/mock_do_cloud.go
+++ b/upup/pkg/fi/cloudup/do/mock_do_cloud.go
@@ -78,7 +78,7 @@ func (c *doCloudMockImplementation) DetachInstance(i *cloudinstances.CloudInstan
 	return fmt.Errorf("digital ocean cloud provider does not support surging")
 }
 
-func (c *doCloudMockImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+func (c *doCloudMockImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	return nil, errors.New("not tested")
 }
 

--- a/upup/pkg/fi/cloudup/hetzner/cloud.go
+++ b/upup/pkg/fi/cloudup/hetzner/cloud.go
@@ -304,7 +304,7 @@ func (c *hetznerCloudImplementation) Region() string {
 	return c.region
 }
 
-func (c *hetznerCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instanceGroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+func (c *hetznerCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instanceGroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	nodeMap := cloudinstances.GetNodeMap(nodes, cluster)
 
 	serverGroups, err := findServerGroups(c, cluster.Name)
@@ -323,7 +323,7 @@ func (c *hetznerCloudImplementation) GetCloudGroups(cluster *kops.Cluster, insta
 			}
 		}
 		if instanceGroup == nil {
-			if warnUnmatched {
+			if options.WarnUnmatched {
 				klog.Warningf("Server group %q has no corresponding instance group", name)
 			}
 			continue

--- a/upup/pkg/fi/cloudup/metal/cloud.go
+++ b/upup/pkg/fi/cloudup/metal/cloud.go
@@ -74,7 +74,7 @@ func (c *Cloud) DetachInstance(instance *cloudinstances.CloudInstance) error {
 
 // GetCloudGroups returns a map of cloud instances that back a kops cluster.
 // Detached instances must be returned in the NeedUpdate slice.
-func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	for _, ig := range instancegroups {
 		cloudInstanceGroup := &cloudinstances.CloudInstanceGroup{

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -693,8 +693,8 @@ func deleteGroup(c OpenstackCloud, g *cloudinstances.CloudInstanceGroup) error {
 	return nil
 }
 
-func (c *openstackCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
-	return getCloudGroups(c, cluster, instancegroups, warnUnmatched, nodes)
+func (c *openstackCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+	return getCloudGroups(c, cluster, instancegroups, options.WarnUnmatched, nodes)
 }
 
 func getCloudGroups(c OpenstackCloud, cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {

--- a/upup/pkg/fi/cloudup/openstack/mock_cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/mock_cloud.go
@@ -138,8 +138,8 @@ func (c *MockCloud) DetachInstance(i *cloudinstances.CloudInstance) error {
 	return detachInstance(c, i)
 }
 
-func (c *MockCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
-	return getCloudGroups(c, cluster, instancegroups, warnUnmatched, nodes)
+func (c *MockCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+	return getCloudGroups(c, cluster, instancegroups, options.WarnUnmatched, nodes)
 }
 
 func (c *MockCloud) ProviderID() kops.CloudProviderID {

--- a/upup/pkg/fi/cloudup/scaleway/cloud.go
+++ b/upup/pkg/fi/cloudup/scaleway/cloud.go
@@ -73,7 +73,7 @@ type ScwCloud interface {
 	FindClusterStatus(cluster *kops.Cluster) (*kops.ClusterStatus, error)
 	FindVPCInfo(id string) (*fi.VPCInfo, error)
 	GetApiIngressStatus(cluster *kops.Cluster) ([]fi.ApiIngressStatus, error)
-	GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error)
+	GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error)
 
 	GetClusterDNSRecords(clusterName string) ([]*domain.Record, error)
 	GetClusterLoadBalancers(clusterName string) ([]*lb.LB, error)
@@ -340,7 +340,7 @@ func (s *scwCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]f
 	return ingresses, nil
 }
 
-func (s *scwCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+func (s *scwCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, options *fi.GetCloudGroupsOptions, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 
 	nodeMap := cloudinstances.GetNodeMap(nodes, cluster)
@@ -353,7 +353,7 @@ func (s *scwCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instanceg
 	for _, ig := range instancegroups {
 		serverGroup, ok := serverGroups[ig.Name]
 		if !ok {
-			if warnUnmatched {
+			if options.WarnUnmatched {
 				klog.Warningf("Server group %q has no corresponding instance group", ig.Name)
 			}
 			continue


### PR DESCRIPTION
* Added a `--force` flag to `kops delete instancegroup`
* Updated the fi.Cloud interface's GetCloudGroups method to accept a GetCloudGroupsOptions struct 
* Added logic to handle missing instances gracefully when fetching clouds and the WarnMissingInstance option is enabled
* Implemented an instanceClient in cloudmock to track GCE instances.
*  Added new integration tests in cmd/kops/delete_instancegroup_test.go and pkg/instancegroups/delete_test.go to verify the new deletion logic and the --force flag
* Depends on https://github.com/kubernetes/kops/pull/17849
* Ref: #17626