### PR TITLE
Automated cherry pick of #17899: Update Cilium to v1.18.6

### DIFF
--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.18.2"
+		c.Version = "v1.18.6"
 	}
 
 	if c.EnableEndpointHealthChecking == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -217,7 +217,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.18.2
+      version: v1.18.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: f80bd9be1cd1484edd7d5ba7b44c5c2db67539b08cdc3d2f7b2c50453d8153ac
+    manifestHash: beb0496ec99d2bfb237f088d6033dd59501bb18fd8763b0f9a0c5c504b03e1b8
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -120,6 +120,7 @@ data:
   external-envoy-proxy: "false"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
+  http-stream-idle-timeout: "300"
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   identity-gc-interval: 15m0s
@@ -149,8 +150,6 @@ data:
   operator-api-serve-addr: '[::1]:9234'
   policy-cidr-match-mode: ""
   policy-default-local-cluster: "false"
-  policy-secrets-namespace: kube-system
-  policy-secrets-only-from-secrets-namespace: "true"
   preallocate-bpf-maps: "false"
   procfs: /host/proc
   proxy-connect-timeout: "2"
@@ -224,6 +223,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - secrets
   verbs:
   - get
   - list
@@ -685,7 +685,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -807,7 +807,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -826,7 +826,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -856,7 +856,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -882,7 +882,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -917,7 +917,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -943,7 +943,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1119,7 +1119,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.18.2
+        image: quay.io/cilium/operator:v1.18.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -149,7 +149,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal-warmpool.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 81bpbkS01Cg4Nin5mNkhs0v4Ek2h3d5Ir9MutScQpTo=
+NodeupConfigHash: i/jU5dJKM4pu0uzL5ook6hNG0uKIKFxeJUH5WE9ArmE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -211,7 +211,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.18.2
+      version: v1.18.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 2bab7e0b0228b301b1796bb3fe663947edcefd96d8a6b2cf870c961b9f1bb347
+    manifestHash: 6bd890997541788cd00972513c7e5fd5a561d053e95baa5411b654537ba6031a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -120,6 +120,7 @@ data:
   external-envoy-proxy: "false"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
+  http-stream-idle-timeout: "300"
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   identity-gc-interval: 15m0s
@@ -149,8 +150,6 @@ data:
   operator-api-serve-addr: 127.0.0.1:9234
   policy-cidr-match-mode: ""
   policy-default-local-cluster: "false"
-  policy-secrets-namespace: kube-system
-  policy-secrets-only-from-secrets-namespace: "true"
   preallocate-bpf-maps: "false"
   procfs: /host/proc
   proxy-connect-timeout: "2"
@@ -227,6 +226,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - secrets
   verbs:
   - get
   - list
@@ -688,7 +688,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.2
+        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -810,7 +810,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.2
+        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -829,7 +829,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.2
+        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -859,7 +859,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.2
+        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -885,7 +885,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.2
+        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -920,7 +920,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.2
+        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -946,7 +946,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.2
+        image: kops.k8s.io/remapped-image/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1122,7 +1122,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: kops.k8s.io/remapped-image/cilium/operator:v1.18.2
+        image: kops.k8s.io/remapped-image/cilium/operator:v1.18.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -57,8 +57,8 @@ containerdConfig:
 usesLegacyGossip: false
 usesNoneDNS: false
 warmPoolImages:
-- kops.k8s.io/remapped-image/cilium/cilium:v1.18.2
-- kops.k8s.io/remapped-image/cilium/operator:v1.18.2
+- kops.k8s.io/remapped-image/cilium/cilium:v1.18.6
+- kops.k8s.io/remapped-image/cilium/operator:v1.18.6
 - kops.k8s.io/remapped-image/kube-proxy:v1.32.0
 - kops.k8s.io/remapped-image/provider-aws/aws-ebs-csi-driver:v1.47.0
 - kops.k8s.io/remapped-image/provider-aws/cloud-controller-manager:v1.32.5

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -205,7 +205,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.18.2
+      version: v1.18.6
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://tests/scw-minimal.k8s.local/secrets

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: bd39764fa09c8e75831372a8aa3281586f471d52626568ccbe23f69fecf50aa5
+    manifestHash: 93caa103d778466ed15999c0e1d9e3e896585992f4ff62b0502944dd67905e3b
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
@@ -120,6 +120,7 @@ data:
   external-envoy-proxy: "false"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
+  http-stream-idle-timeout: "300"
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   identity-gc-interval: 15m0s
@@ -149,8 +150,6 @@ data:
   operator-api-serve-addr: 127.0.0.1:9234
   policy-cidr-match-mode: ""
   policy-default-local-cluster: "false"
-  policy-secrets-namespace: kube-system
-  policy-secrets-only-from-secrets-namespace: "true"
   preallocate-bpf-maps: "false"
   procfs: /host/proc
   proxy-connect-timeout: "2"
@@ -227,6 +226,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - secrets
   verbs:
   - get
   - list
@@ -688,7 +688,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -810,7 +810,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -829,7 +829,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -859,7 +859,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -885,7 +885,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -920,7 +920,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -946,7 +946,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1122,7 +1122,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.18.2
+        image: quay.io/cilium/operator:v1.18.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -211,7 +211,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.18.2
+      version: v1.18.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 77e31820b7e310c670cd1a18d799ab6b66d83719d8de00820eb48d20413709c4
+    manifestHash: 67b3ea6813bb591b4543524fbdc4cc6c909ece2330bbfece99b511a52d22ca7e
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -123,6 +123,7 @@ data:
   external-envoy-proxy: "false"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
+  http-stream-idle-timeout: "300"
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   identity-gc-interval: 15m0s
@@ -152,8 +153,6 @@ data:
   operator-api-serve-addr: 127.0.0.1:9234
   policy-cidr-match-mode: ""
   policy-default-local-cluster: "false"
-  policy-secrets-namespace: kube-system
-  policy-secrets-only-from-secrets-namespace: "true"
   preallocate-bpf-maps: "false"
   procfs: /host/proc
   proxy-connect-timeout: "2"
@@ -227,6 +226,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - secrets
   verbs:
   - get
   - list
@@ -688,7 +688,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -835,7 +835,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -854,7 +854,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -884,7 +884,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -910,7 +910,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -945,7 +945,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -971,7 +971,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1147,7 +1147,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.18.2
+        image: quay.io/cilium/operator:v1.18.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -219,7 +219,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.18.2
+      version: v1.18.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: af3680a134c6d131da09b5722d51dc58461fc58fba474099f71ba8cacf5e1d1d
+    manifestHash: a1bb43c838b23644106822792781eced953f3326cf049799c2c63f0cba38d0e1
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -120,6 +120,7 @@ data:
   external-envoy-proxy: "false"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
+  http-stream-idle-timeout: "300"
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   identity-gc-interval: 15m0s
@@ -149,8 +150,6 @@ data:
   operator-api-serve-addr: 127.0.0.1:9234
   policy-cidr-match-mode: ""
   policy-default-local-cluster: "false"
-  policy-secrets-namespace: kube-system
-  policy-secrets-only-from-secrets-namespace: "true"
   preallocate-bpf-maps: "false"
   procfs: /host/proc
   proxy-connect-timeout: "2"
@@ -227,6 +226,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - secrets
   verbs:
   - get
   - list
@@ -691,7 +691,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -813,7 +813,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -832,7 +832,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -862,7 +862,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -888,7 +888,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -923,7 +923,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -949,7 +949,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1129,7 +1129,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.18.2
+        image: quay.io/cilium/operator:v1.18.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -231,7 +231,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.18.2
+      version: v1.18.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -154,7 +154,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: edb78e78b19f31086d0bf0367827ba6b42f2a976f68a362d8e658cec5b6ad92e
+    manifestHash: 9b451283987f83208a50a19117ff1ad246dd95225c17aa56947d2a8f09688266
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -139,9 +139,11 @@ data:
   envoy-base-id: "0"
   envoy-config-retry-interval: 15s
   envoy-keep-cap-netbindservice: "false"
+  envoy-secrets-namespace: kube-system
   external-envoy-proxy: "false"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
+  http-stream-idle-timeout: "300"
   hubble-disable-tls: "false"
   hubble-listen-address: :4244
   hubble-metrics: drop
@@ -188,8 +190,6 @@ data:
   operator-api-serve-addr: 127.0.0.1:9234
   policy-cidr-match-mode: ""
   policy-default-local-cluster: "false"
-  policy-secrets-namespace: kube-system
-  policy-secrets-only-from-secrets-namespace: "true"
   preallocate-bpf-maps: "false"
   procfs: /host/proc
   proxy-connect-timeout: "2"
@@ -293,6 +293,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - secrets
   verbs:
   - get
   - list
@@ -706,6 +707,28 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/part-of: cilium
     role.kubernetes.io/networking: "1"
+  name: cilium-envoy-config-secrets
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    addon.kops.k8s.io/name: networking.cilium.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/part-of: cilium
+    role.kubernetes.io/networking: "1"
   name: cilium-operator-ingress-secrets
   namespace: kube-system
 rules:
@@ -756,6 +779,27 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: cilium-ingress-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    addon.kops.k8s.io/name: networking.cilium.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/part-of: cilium
+    role.kubernetes.io/networking: "1"
+  name: cilium-envoy-config-secrets
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-envoy-config-secrets
 subjects:
 - kind: ServiceAccount
   name: cilium
@@ -931,7 +975,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1064,7 +1108,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -1083,7 +1127,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -1113,7 +1157,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -1139,7 +1183,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -1174,7 +1218,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -1200,7 +1244,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1390,7 +1434,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.18.2
+        image: quay.io/cilium/operator:v1.18.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1495,7 +1539,7 @@ spec:
         - serve
         command:
         - hubble-relay
-        image: quay.io/cilium/hubble-relay:v1.18.2
+        image: quay.io/cilium/hubble-relay:v1.18.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 12

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -223,7 +223,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.18.2
+      version: v1.18.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: ed4baa80e96a429efedc550509b721924d428bf988269f31a068a52661d1fad1
+    manifestHash: 28144cae2e4a7f0b6c6287894415ef330cde18f76a7ad06f66ff7c3878a45df7
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -130,6 +130,7 @@ data:
   external-envoy-proxy: "false"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
+  http-stream-idle-timeout: "300"
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   identity-gc-interval: 15m0s
@@ -161,8 +162,6 @@ data:
   operator-api-serve-addr: 127.0.0.1:9234
   policy-cidr-match-mode: ""
   policy-default-local-cluster: "false"
-  policy-secrets-namespace: kube-system
-  policy-secrets-only-from-secrets-namespace: "true"
   preallocate-bpf-maps: "false"
   procfs: /host/proc
   proxy-connect-timeout: "2"
@@ -236,6 +235,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - secrets
   verbs:
   - get
   - list
@@ -697,7 +697,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -850,7 +850,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -869,7 +869,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -899,7 +899,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -925,7 +925,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -960,7 +960,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -986,7 +986,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.18.2
+        image: quay.io/cilium/cilium:v1.18.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1173,7 +1173,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.18.2
+        image: quay.io/cilium/operator:v1.18.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/helm-values.yaml
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/helm-values.yaml
@@ -22,6 +22,7 @@ serviceAccounts:
 envoy:
   enabled: false
 envoyConfig:
+  enabled: true
   secretsNamespace:
     create: false
     name: kube-system

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/helm-values.yaml
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/helm-values.yaml
@@ -48,6 +48,7 @@ tls:
   secretsNamespace:
     create: false
     name: kube-system
+  readSecretsOnlyFromSecretsNamespace: false
   secretSync:
     enabled: false
 operator:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -455,6 +455,7 @@ data:
   proxy-idle-timeout-seconds: "60"
   proxy-max-concurrent-retries: "128"
   http-retry-count: "3"
+  http-stream-idle-timeout: "300"
 
   external-envoy-proxy: "false"
   envoy-base-id: "0"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -190,9 +190,6 @@ data:
   gateway-api-hostnetwork-nodelabelselector: ""
   {{ end }}
 
-  policy-secrets-only-from-secrets-namespace: "true"
-  policy-secrets-namespace: "kube-system"
-
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
   # address.
   enable-ipv4: "{{ not IsIPv6Only }}"
@@ -533,6 +530,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - secrets
   verbs:
   - get
   - list
@@ -1022,28 +1020,6 @@ rules:
 ---
 {{ end }}
 ---
-{{ if CiliumSecret }}
----
-# Source: cilium/templates/cilium-agent/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: cilium-tlsinterception-secrets
-  namespace: "kube-system"
-  labels:
-    app.kubernetes.io/part-of: cilium
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
----
-{{ end }}
----
 {{ if WithDefaultBool .Ingress.Enabled false }}
 # Source: cilium/templates/cilium-operator/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1138,27 +1114,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: cilium-gateway-secrets
-subjects:
-- kind: ServiceAccount
-  name: "cilium"
-  namespace: kube-system
----
-{{ end }}
----
-{{ if CiliumSecret }}
----
-# Source: cilium/templates/cilium-agent/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: cilium-tlsinterception-secrets
-  namespace: "kube-system"
-  labels:
-    app.kubernetes.io/part-of: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: cilium-tlsinterception-secrets
 subjects:
 - kind: ServiceAccount
   name: "cilium"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -149,9 +149,12 @@ data:
   enable-metrics: "true"
   {{ end }}
 
-  {{ if WithDefaultBool .Ingress.Enabled false }}
+  {{ if or (WithDefaultBool .GatewayAPI.Enabled false) (WithDefaultBool .Ingress.Enabled false) }}
   enable-envoy-config: "true"
   envoy-config-retry-interval: "15s"
+  envoy-secrets-namespace: "kube-system"
+  {{ end }}
+  {{ if WithDefaultBool .Ingress.Enabled false }}
   enable-ingress-controller: "true"
   {{ if .Ingress.EnforceHttps }}
   enforce-ingress-https: "{{ .Ingress.EnforceHttps }}"
@@ -1020,6 +1023,28 @@ rules:
 ---
 {{ end }}
 ---
+{{ if or (WithDefaultBool .GatewayAPI.Enabled false) (WithDefaultBool .Ingress.Enabled false) }}
+---
+# Source: cilium/templates/cilium-agent/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-envoy-config-secrets
+  namespace: "kube-system"
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+{{ end }}
+---
 {{ if WithDefaultBool .Ingress.Enabled false }}
 # Source: cilium/templates/cilium-operator/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1114,6 +1139,27 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: cilium-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: "cilium"
+  namespace: kube-system
+---
+{{ end }}
+---
+{{ if or (WithDefaultBool .GatewayAPI.Enabled false) (WithDefaultBool .Ingress.Enabled false) }}
+---
+# Source: cilium/templates/cilium-agent/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-envoy-config-secrets
+  namespace: "kube-system"
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-envoy-config-secrets
 subjects:
 - kind: ServiceAccount
   name: "cilium"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 9e79dca3fc51e00ed1da78c704408e82b47c8ccbe89b1ebec4be269b11d23915
+    manifestHash: f1c91987ced18d3459a733919130699dd565c0122d90f029e40d4de76cf1840d
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 9e79dca3fc51e00ed1da78c704408e82b47c8ccbe89b1ebec4be269b11d23915
+    manifestHash: f1c91987ced18d3459a733919130699dd565c0122d90f029e40d4de76cf1840d
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -162,7 +162,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 9e79dca3fc51e00ed1da78c704408e82b47c8ccbe89b1ebec4be269b11d23915
+    manifestHash: f1c91987ced18d3459a733919130699dd565c0122d90f029e40d4de76cf1840d
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #17899 on release-1.34.

#17899: Update Cilium to v1.18.6

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```