### PR TITLE
Automated cherry pick of #17854: Add iam:ListInstanceProfiles permission to Karpenter

### DIFF
--- a/pkg/model/components/addonmanifests/karpenter/iam.go
+++ b/pkg/model/components/addonmanifests/karpenter/iam.go
@@ -87,5 +87,6 @@ func addKarpenterPermissions(p *iam.Policy) {
 	// AllowInstanceProfileReadActions
 	p.AddUnconditionalActions(
 		"iam:GetInstanceProfile",
+		"iam:ListInstanceProfiles",
 	)
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
@@ -19,6 +19,7 @@
         "iam:AddRoleToInstanceProfile",
         "iam:DeleteInstanceProfile",
         "iam:GetInstanceProfile",
+        "iam:ListInstanceProfiles",
         "iam:PassRole",
         "iam:RemoveRoleFromInstanceProfile",
         "iam:TagInstanceProfile",


### PR DESCRIPTION
Cherry pick of #17854 on release-1.34.

#17854: Add iam:ListInstanceProfiles permission to Karpenter

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```