### PR TITLE
traceserver tool: fix compilation error

### DIFF
--- a/tools/otel/traceserver/main.go
+++ b/tools/otel/traceserver/main.go
@@ -91,7 +91,7 @@ func run(ctx context.Context) error {
 	}
 
 	klog.Infof("listing files under %v", srcPath)
-	srcFiles, err := srcPath.ReadTree()
+	srcFiles, err := srcPath.ReadTree(ctx)
 	if err != nil {
 		return fmt.Errorf("reading tree %q: %w", srcFiles, err)
 	}


### PR DESCRIPTION
Fix simple compilation error in traceserver tool.
