### PR TITLE
chore: fix govet issue in tester.go

### DIFF
--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -60,7 +60,7 @@ func parseKubeconfig(jsonPath string) (string, error) {
 
 	s := strings.TrimSpace(stdout.String())
 	if s == "" {
-		return "", fmt.Errorf("kubeconfig did not contain " + jsonPath)
+		return "", fmt.Errorf("kubeconfig did not contain %q", jsonPath)
 	}
 	return s, nil
 }


### PR DESCRIPTION
Replace a non-constant format string in fmt.Errorf:

pkg/tester/tester.go:63:25: non-constant format string in call to fmt.Errorf
