### PR TITLE
Automated cherry pick of #17917: hetzner: Update default server type to cx23

### DIFF
--- a/tests/integration/create_cluster/ha_hetzner/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_hetzner/expected-v1alpha2.yaml
@@ -72,7 +72,7 @@ metadata:
   name: control-plane-fsn1-1
 spec:
   image: ubuntu-24.04
-  machineType: cx22
+  machineType: cx23
   maxSize: 1
   minSize: 1
   role: Master
@@ -90,7 +90,7 @@ metadata:
   name: control-plane-fsn1-2
 spec:
   image: ubuntu-24.04
-  machineType: cx22
+  machineType: cx23
   maxSize: 1
   minSize: 1
   role: Master
@@ -108,7 +108,7 @@ metadata:
   name: control-plane-fsn1-3
 spec:
   image: ubuntu-24.04
-  machineType: cx22
+  machineType: cx23
   maxSize: 1
   minSize: 1
   role: Master
@@ -126,7 +126,7 @@ metadata:
   name: nodes-fsn1
 spec:
   image: ubuntu-24.04
-  machineType: cx22
+  machineType: cx23
   maxSize: 1
   minSize: 1
   role: Node

--- a/tests/integration/create_cluster/minimal_hetzner/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal_hetzner/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
   name: control-plane-fsn1
 spec:
   image: ubuntu-24.04
-  machineType: cx22
+  machineType: cx23
   maxSize: 1
   minSize: 1
   role: Master
@@ -82,7 +82,7 @@ metadata:
   name: nodes-fsn1
 spec:
   image: ubuntu-24.04
-  machineType: cx22
+  machineType: cx23
   maxSize: 1
   minSize: 1
   role: Node

--- a/tests/integration/update_cluster/minimal_hetzner/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal_hetzner/in-v1alpha2.yaml
@@ -60,7 +60,7 @@ metadata:
   name: master-fsn1
 spec:
   image: ubuntu-20.04
-  machineType: cx22
+  machineType: cx23
   maxSize: 1
   minSize: 1
   role: Master
@@ -78,7 +78,7 @@ metadata:
   name: nodes-fsn1
 spec:
   image: ubuntu-20.04
-  machineType: cx22
+  machineType: cx23
   maxSize: 1
   minSize: 1
   role: Node

--- a/tests/integration/update_cluster/minimal_hetzner/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_hetzner/kubernetes.tf
@@ -251,7 +251,7 @@ resource "hcloud_server" "master-fsn1" {
     ipv4_enabled = true
     ipv6_enabled = false
   }
-  server_type = "cx22"
+  server_type = "cx23"
   ssh_keys    = [hcloud_ssh_key.minimal-example-com-c4_a6_ed_9a_a8_89_b9_e2_c3_9c_d6_63_eb_9c_71_57.id]
   user_data   = filebase64("${path.module}/data/hcloud_server_master-fsn1_user_data")
 }
@@ -274,7 +274,7 @@ resource "hcloud_server" "nodes-fsn1" {
     ipv4_enabled = true
     ipv6_enabled = false
   }
-  server_type = "cx22"
+  server_type = "cx23"
   ssh_keys    = [hcloud_ssh_key.minimal-example-com-c4_a6_ed_9a_a8_89_b9_e2_c3_9c_d6_63_eb_9c_71_57.id]
   user_data   = filebase64("${path.module}/data/hcloud_server_nodes-fsn1_user_data")
 }

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -40,17 +40,17 @@ const (
 	defaultNodeMachineTypeGCE      = "e2-medium"
 	defaultNodeMachineTypeDO       = "s-2vcpu-4gb"
 	defaultNodeMachineTypeAzure    = "Standard_B2s"
-	defaultNodeMachineTypeHetzner  = "cx22"
+	defaultNodeMachineTypeHetzner  = "cx23"
 	defaultNodeMachineTypeScaleway = "DEV1-M"
 
 	defaultBastionMachineTypeGCE     = "e2-micro"
 	defaultBastionMachineTypeAzure   = "Standard_B2s"
-	defaultBastionMachineTypeHetzner = "cx11"
+	defaultBastionMachineTypeHetzner = "cx23"
 
 	defaultMasterMachineTypeGCE      = "e2-medium"
 	defaultMasterMachineTypeDO       = "s-2vcpu-4gb"
 	defaultMasterMachineTypeAzure    = "Standard_B2s"
-	defaultMasterMachineTypeHetzner  = "cx22"
+	defaultMasterMachineTypeHetzner  = "cx23"
 	defaultMasterMachineTypeScaleway = "DEV1-M"
 
 	defaultDOImageFocal       = "ubuntu-20-04-x64"


### PR DESCRIPTION
Cherry pick of #17917 on release-1.34.

#17917: hetzner: Update default server type to cx23

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```