### PR TITLE
Announce AL2 deprecation in 1.35

### DIFF
--- a/docs/releases/1.35-NOTES.md
+++ b/docs/releases/1.35-NOTES.md
@@ -39,3 +39,5 @@ This is a document to gather the release notes prior to the release.
 * Support for Kubernetes version 1.29 is removed in kOps 1.35.
 
 * Support for Kubernetes version 1.30 is deprecated and will be removed in kOps 1.36.
+
+* Support for Amazon Linux 2 is deprecated and will be removed in kOps 1.36


### PR DESCRIPTION
Pushing back to the AL2 removal until kops 1.36: https://github.com/kubernetes/kops/pull/17898#discussion_r2750324710

We'll announce the deprecation in 1.35. 