### PR TITLE
Migrate karpenter and LBC scenario scripts to use --test=exec

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Get the cluster name from the KUBECONFIG context
+CLUSTER_NAME=$(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
+
+# Get VPC ID by looking at the cluster's subnet
+VPC=$(kubectl get nodes -o jsonpath='{.items[0].spec.providerID}' | cut -d'/' -f5 | xargs -I{} aws ec2 describe-instances --instance-ids {} --query 'Reservations[0].Instances[0].VpcId' --output text)
+
+# Get the zone from a node
+ZONE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.topology\.kubernetes\.io/zone}')
+REGION=${ZONE%?}
+
+REPORT_DIR="${ARTIFACTS:-$(pwd)/_artifacts}/aws-lb-controller"
+mkdir -p "${REPORT_DIR}"
+
+# Clone the aws-load-balancer-controller repo at the version deployed in the cluster
+LBC_VERSION=$(kubectl get deployment -n kube-system aws-load-balancer-controller -o jsonpath='{.spec.template.spec.containers[?(@.name=="controller")].image}' | cut -d':' -f2-)
+TEMPDIR=$(mktemp -dt kops.XXXXXXXXX)
+cd "${TEMPDIR}"
+
+go install github.com/onsi/ginkgo/v2/ginkgo@latest
+
+CLONE_ARGS=
+if [ -n "$LBC_VERSION" ]; then
+    CLONE_ARGS="-b ${LBC_VERSION}"
+fi
+# shellcheck disable=SC2086
+git clone ${CLONE_ARGS} https://github.com/kubernetes-sigs/aws-load-balancer-controller .
+
+ginkgo -v -r test/e2e/ingress -- \
+    -cluster-name="${CLUSTER_NAME}" \
+    -aws-region="${REGION}" \
+    -aws-vpc-id="$VPC" \
+    -ginkgo.junit-report="${REPORT_DIR}/junit-ingress.xml"
+
+ginkgo -v -r test/e2e/service -- \
+    -cluster-name="${CLUSTER_NAME}" \
+    -aws-region="${REGION}" \
+    -aws-vpc-id="$VPC" \
+    -ginkgo.junit-report="${REPORT_DIR}/junit-service.xml"

--- a/tests/e2e/scenarios/karpenter/test.sh
+++ b/tests/e2e/scenarios/karpenter/test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Get the cluster name from the KUBECONFIG context
+CLUSTER_NAME=$(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
+
+# Get KOPS_STATE_STORE from kubeconfig server URL (the bucket name is embedded)
+# Alternatively, we can get it from environment if kubetest2 passes it
+if [[ -z "${KOPS_STATE_STORE:-}" ]]; then
+  echo "KOPS_STATE_STORE must be set"
+  exit 1
+fi
+
+# Get the node instance group user data script from the kOps state store
+USER_DATA=$(aws s3 cp "${KOPS_STATE_STORE}/${CLUSTER_NAME}/igconfig/node/nodes/nodeupscript.sh" -)
+# Indent the user data script for embedding in the EC2NodeClass
+USER_DATA=${USER_DATA//$'\n'/$'\n    '}
+
+# Create a EC2NodeClass for Karpenter
+kubectl apply -f - <<YAML
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiFamily: Custom
+  amiSelectorTerms:
+    - ssmParameter: /aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id
+  associatePublicIPAddress: true
+  tags:
+    KubernetesCluster: ${CLUSTER_NAME}
+    kops.k8s.io/instancegroup: nodes
+    k8s.io/role/node: "1"
+  subnetSelectorTerms:
+    - tags:
+        KubernetesCluster: ${CLUSTER_NAME}
+  securityGroupSelectorTerms:
+    - tags:
+        KubernetesCluster: ${CLUSTER_NAME}
+        Name: nodes.${CLUSTER_NAME}
+  instanceProfile: nodes.${CLUSTER_NAME}
+  userData: |
+    ${USER_DATA}
+YAML
+
+# Create a NodePool for Karpenter
+# Effectively disable consolidation for 30 minutes to avoid flakes in the tests
+kubectl apply -f - <<YAML
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values: ["m6g.large"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+  replicas: 4
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 30m
+YAML
+
+# Wait for the nodes to start being provisioned
+sleep 30
+
+# Download kops to validate cluster
+KOPS_BASE_URL="$(curl -s https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt)"
+KOPS=$(mktemp -t kops.XXXXXXXXX)
+wget -qO "${KOPS}" "$KOPS_BASE_URL/$(go env GOOS)/$(go env GOARCH)/kops"
+chmod +x "${KOPS}"
+
+# Wait for the nodes to be ready
+"${KOPS}" validate cluster --wait=10m
+
+if [[ -z "${K8S_VERSION:-}" ]]; then
+  K8S_VERSION="$(curl -s -L https://dl.k8s.io/release/stable.txt)"
+fi
+
+# Download test binaries
+BINDIR=$(mktemp -d)
+wget -qO- "https://dl.k8s.io/${K8S_VERSION}/kubernetes-test-linux-amd64.tar.gz" | tar xz -C "${BINDIR}" --strip-components=3 kubernetes/test/bin/e2e.test kubernetes/test/bin/ginkgo
+
+# Run conformance tests
+"${BINDIR}/ginkgo" \
+    --nodes=20 \
+    --focus="\[Conformance\]" \
+    --no-color \
+    "${BINDIR}/e2e.test" \
+    -- \
+    --provider=skeleton \
+    --kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}" \
+    --report-dir="${ARTIFACTS:-/tmp}"


### PR DESCRIPTION
These are currently failing with a bug in the shell scripts:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-aws-load-balancer-controller/2020129724134592512

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-karpenter/2020169235073863680

`/home/prow/go/src/k8s.io/kops/tests/e2e/scenarios/lib/common.sh: line 136: CLUSTER_NAME: unbound variable`

We can migrate them to use kubetest2's --text=exec to run the dedicated LBC and karpenter test suites, fixing the unbound variable in the process.