### PR TITLE
Set MACAddressPolicy=none for AWS VPC CNI on AL2023

### DIFF
--- a/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
+++ b/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
@@ -68,11 +68,11 @@ ManageForeignRoutingPolicyRules=no
 		})
 	}
 
-	// Running Amazon VPC CNI on Ubuntu 22.04+ requires
+	// Running Amazon VPC CNI on Ubuntu 22.04+ and AL2023 requires
 	// setting MACAddressPolicy to `none` (ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/2103
 	// & https://github.com/aws/amazon-vpc-cni-k8s/issues/2839
 	// & https://github.com/kubernetes/kops/issues/16255)
-	if b.Distribution.IsUbuntu() && b.Distribution.Version() >= 22.04 {
+	if b.Distribution.IsUbuntu() && b.Distribution.Version() >= 22.04 || b.Distribution == distributions.DistributionAmazonLinux2023 {
 		contents := `
 [Match]
 OriginalName=*


### PR DESCRIPTION
This configuration has been failing cluster validation:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-amazonvpc-al2023-k35/2019554270835118080

non-hostnetwork pods are losing their ability to reach the k8s api service ip:

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-grid-amazonvpc-al2023-k35/2019554270835118080/artifacts/cluster-info/kube-system/ebs-csi-node-k4d9w/ebs-plugin.previous.log

```
E0205 23:58:26.469795       1 metadata.go:81] "Retrieving Kubernetes metadata failed" err="error getting Node i-05a3089380c826a18: Get \"https://100.64.0.1:443/api/v1/nodes/i-05a3089380c826a18\": dial tcp 100.64.0.1:443: i/o timeout"
E0205 23:58:26.469840       1 main.go:175] "Failed to initialize metadata when it is required" err="all specified --metadata-sources '[imds kubernetes]' are unavailable"
```

after they initially succeed. This is because systemd-networkd is overwriting the VPC CNI's routes. More context [here](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/troubleshooting.md#:~:text=k8s%2Dcni.yaml-,systemd%2Dudev,-%2D%20Linux%20distributions%20that). We originally had this file set for AL2023 but I removed it in https://github.com/kubernetes/kops/pull/17867 thinking it wasn't needed. After some local testing I confirmed that both are needed.