### PR TITLE
Increase delete-collections-workers flag value to speed up namespace deletion

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -108,6 +108,9 @@ create_args+=("--set spec.kubeAPIServer.maxMutatingRequestsInflight=0")
 create_args+=("--set spec.kubeAPIServer.enableProfiling=true")
 create_args+=("--set spec.kubeAPIServer.enableContentionProfiling=true")
 create_args+=("--set spec.kubeAPIServer.logLevel=2")
+# increase the --delete-collection-workers to 100 to speed up delete operations
+create_args+=("--set spec.kubeAPIServer.deleteCollectionWorkers=100")
+
 # this is required for Prometheus server to scrape metrics endpoint on APIServer
 create_args+=("--set spec.kubeAPIServer.anonymousAuth=true")
 # this is required for kindnet to use nftables
@@ -180,12 +183,12 @@ if [[ "${DELETE_CLUSTER:-}" == "true" ]]; then
   KUBETEST2_ARGS+=("--down")
 fi
 
-# this is used as a label to select kube-proxy pods on kops for kube-proxy service 
+# this is used as a label to select kube-proxy pods on kops for kube-proxy service
 # used by CL2 Prometheus here https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/pkg/prometheus/manifests/default/kube-proxy-service.yaml#L2
 export PROMETHEUS_KUBE_PROXY_SELECTOR_KEY="k8s-app"
 export PROMETHEUS_SCRAPE_APISERVER_ONLY="true"
 export CL2_PROMETHEUS_TOLERATE_MASTER="true"
-export ETCD_PORT="4001" # we want cl2 to use this port for etcd instead of 2379 
+export ETCD_PORT="4001" # we want cl2 to use this port for etcd instead of 2379
 if [[ "${CLOUD_PROVIDER}" == "aws" && "${SCALE_SCENARIO}" == "performance" ]]; then
   # CL2 uses KUBE_SSH_KEY_PATH path to ssh to instances for scraping metrics
   cat > "${GOPATH}"/src/k8s.io/perf-tests/clusterloader2/testing/load/overrides.yaml <<EOL


### PR DESCRIPTION
## Background:
The ec2-master-scale-performance tests were failing due to not meeting DELETE events SLOs.

## Root cause
ec2-master-scale-performance had 1.2 Million pre-existing events that needed cleanup, causing cascading performance issues.

AWS scale tests started the test with 1.2Million events to delete. It created a huge backlog of events to clean up by the garbage collector.https://github.com/kubernetes/kubernetes/issues/135737#issuecomment-3832846840

Whereas GCE started the test with 150k events. https://github.com/kubernetes/kubernetes/issues/135737#issuecomment-3845111627


## Solution:
Increase `--delete-collections-workers` flag to 100 (arbitrary value) to accelerate namespace clean up.

Contributes to issue https://github.com/kubernetes/kubernetes/issues/135737

