### PR TITLE
enable metrics server for scale tests

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/kops v1.34.1
 	k8s.io/release v0.20.0
 	sigs.k8s.io/boskos v0.0.0-20250922191614-14f95fc7cd0b
-	sigs.k8s.io/kubetest2 v0.0.0-20250219121027-1cc02edeb0b6
+	sigs.k8s.io/kubetest2 v0.0.0-20260209083522-21e91ebc6d51
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -170,7 +170,7 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
 	github.com/go-openapi/validate v0.25.1 // indirect
 	github.com/go-piv/piv-go/v2 v2.4.0 // indirect
-	github.com/go-resty/resty/v2 v2.16.2 // indirect
+	github.com/go-resty/resty/v2 v2.16.5 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -455,8 +455,8 @@ github.com/go-piv/piv-go/v2 v2.4.0 h1:xamQ/fR4MJiw/Ndbk6yi7MVwhjrwlnDAPuaH9zcGb+
 github.com/go-piv/piv-go/v2 v2.4.0/go.mod h1:ShZi74nnrWNQEdWzRUd/3cSig3uNOcEZp+EWl0oewnI=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
-github.com/go-resty/resty/v2 v2.16.2 h1:CpRqTjIzq/rweXUt9+GxzzQdlkqMdt8Lm/fuK/CAbAg=
-github.com/go-resty/resty/v2 v2.16.2/go.mod h1:0fHAoK7JoBy/Ch36N8VFeMsK7xQOHhvWaC3iOktwmIU=
+github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
+github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/go-rod/rod v0.116.2 h1:A5t2Ky2A+5eD/ZJQr1EfsQSe5rms5Xof/qj296e+ZqA=
 github.com/go-rod/rod v0.116.2/go.mod h1:H+CMO9SCNc2TJ2WfrG+pKhITz57uGNYU43qYHh438Mg=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
@@ -1375,8 +1375,8 @@ sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327U
 sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/kubetest2 v0.0.0-20250219121027-1cc02edeb0b6 h1:Qrq3FufC6BIPy4pAwHyaayBTO3RMvrSyU2ysfjTV73A=
-sigs.k8s.io/kubetest2 v0.0.0-20250219121027-1cc02edeb0b6/go.mod h1:KCWjzDnj7tqUREqslYVb2qN/De3f2X7S+k/I3i4rbyA=
+sigs.k8s.io/kubetest2 v0.0.0-20260209083522-21e91ebc6d51 h1:8gKeTc4j5emHEYnEqeBseYzGaWuijWIJuvz/wgqtZe4=
+sigs.k8s.io/kubetest2 v0.0.0-20260209083522-21e91ebc6d51/go.mod h1:pBd0cFaT0hDqmwQg+TIhyLgPMYaH66QMLcKd09XnKTI=
 sigs.k8s.io/promo-tools/v4 v4.1.0 h1:4N1tmjCzJwFlOgk00Woq3Rpd1esKbOr7t2okQBK7KWI=
 sigs.k8s.io/promo-tools/v4 v4.1.0/go.mod h1:cGIUUfU8heXsfy/ESu+rTmGOeRXn88XIsIOvoUJ4LJs=
 sigs.k8s.io/prow v0.0.0-20240619181241-cfb8754e0459 h1:t8nFAgqf4A53NMuaML7xbBkaKcQtN3aqPPHDsVLfWWs=

--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -47,6 +47,8 @@ func (d *deployer) Build() error {
 	if results.KopsBaseURL != "" {
 		klog.Infof("setting kops base url to %q from build results", results.KopsBaseURL)
 		d.KopsBaseURL = results.KopsBaseURL
+		// In PreTestCmd, we need KOPS_BASE_URL to be set for kops calls
+		os.Setenv("KOPS_BASE_URL", d.KopsBaseURL)
 	}
 
 	if results.KubernetesBaseURL != "" {

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -58,6 +58,11 @@ func (d *deployer) Up() error {
 		d.KopsBaseURL = baseURL
 	}
 
+	// In PreTestCmd, we need KOPS_BASE_URL to be set for kops calls
+	if os.Getenv("KOPS_BASE_URL") == "" {
+		os.Setenv("KOPS_BASE_URL", d.KopsBaseURL)
+	}
+
 	if d.terraform == nil {
 		klog.Info("Cleaning up any leaked resources from previous cluster")
 		// Intentionally ignore errors:

--- a/tests/e2e/scenarios/scalability/pre-test.sh
+++ b/tests/e2e/scenarios/scalability/pre-test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We need to install metrics-server in the cluster and schedule it on the control-plane
+helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+helm upgrade --install metrics-server metrics-server/metrics-server \
+    -n kube-system --set "args={--kubelet-insecure-tls}" \
+    --set addonResizer.enabled=true
+
+# We need an IG that has a single node for addons such as metrics-server, exec-service
+# We used to call it heapster IG but its now called addons
+
+if [[ "${CLOUD_PROVIDER}" == "aws" ]]; then
+  kops create instancegroup addons --edit=false --role node --zone us-east-2b
+  kops edit instancegroup addons --set=spec.machineType="${ADDONS_NODE_SIZE:-c7a.8xlarge}" \
+    --set=spec.maxSize=1 --set=spec.minSize=1 --set=spec.image="ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id"
+elif [[ "${CLOUD_PROVIDER}" == "gce" ]]; then
+  kops create instancegroup addons-us-east1-b-y86s --edit=false --role node --zone us-east1-b
+  kops edit instancegroup addons-us-east1-b-y86s --set=spec.machineType="${ADDONS_NODE_SIZE:-c3-standard-22}" \
+    --set=spec.maxSize=1 --set=spec.minSize=1 --set=spec.rootVolume.type=hyperdisk-balanced
+fi
+
+kops update cluster --yes
+sleep 120 # it shouldn't take long to have the node up and ready
+# To be replaced with kops validate instancegroup instead of the wait

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -19,6 +19,7 @@ set -x
 
 make test-e2e-install
 
+REPO_ROOT=$(git rev-parse --show-toplevel)
 if [[ -z "${K8S_VERSION:-}" ]]; then
   K8S_VERSION=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt
 fi
@@ -83,7 +84,7 @@ create_args+=("--networking=${CNI_PLUGIN:-calico}")
 if [[ "${CNI_PLUGIN}" == "amazonvpc" ]]; then
   create_args+=("--set spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true")
 fi
-create_args+=("--set spec.etcdClusters[0].manager.listenMetricsURLs=http://localhost:2382")
+create_args+=("--set spec.etcdClusters[0].manager.listenMetricsURLs=http://0.0.0.0:2382")
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_QUOTA_BACKEND_BYTES=${ETCD_QUOTA_BACKEND_BYTES}")
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_ENABLE_PPROF=true")
 create_args+=("--set spec.cloudControllerManager.concurrentNodeSyncs=10")
@@ -143,6 +144,7 @@ KUBETEST2_ARGS+=("--cloud-provider=${CLOUD_PROVIDER}")
 KUBETEST2_ARGS+=("--cluster-name=${CLUSTER_NAME:-}")
 KUBETEST2_ARGS+=("--admin-access=${ADMIN_ACCESS:-}")
 KUBETEST2_ARGS+=("--env=KOPS_FEATURE_FLAGS=${KOPS_FEATURE_FLAGS}")
+KUBETEST2_ARGS+=("--pre-test-cmd=${REPO_ROOT}/tests/e2e/scenarios/scalability/pre-test.sh")
 if [[ "${JOB_TYPE}" == "presubmit" && "${REPO_OWNER}/${REPO_NAME}" == "kubernetes/kops" ]]; then
   KUBETEST2_ARGS+=("--build")
   KUBETEST2_ARGS+=("--kops-binary-path=${GOPATH}/src/k8s.io/kops/.build/dist/linux/$(go env GOARCH)/kops")


### PR DESCRIPTION
The kubeup scale jobs used to run metrics-server, so we need to run it as well.

@serathius 