### PR TITLE
Replace deprecated kops CLI flags

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -200,7 +200,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 	}
 	args = appendIfUnset(args, "--admin-access", adminAccess)
 
-	// Dont set --master-count if either --control-plane-count or --master-count
+	// Dont set --control-plane-count if either --control-plane-count or --master-count
 	// has been provided in --create-args
 	foundCPCount := false
 	for _, existingArg := range args {
@@ -211,16 +211,16 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		}
 	}
 	if !foundCPCount {
-		args = appendIfUnset(args, "--master-count", fmt.Sprintf("%d", d.ControlPlaneCount))
+		args = appendIfUnset(args, "--control-plane-count", fmt.Sprintf("%d", d.ControlPlaneCount))
 	}
 
 	switch d.CloudProvider {
 	case "aws":
 		if isArm {
-			args = appendIfUnset(args, "--master-size", "c6g.large")
+			args = appendIfUnset(args, "--control-plane-size", "c6g.large")
 			args = appendIfUnset(args, "--node-size", "c6g.large")
 		} else {
-			args = appendIfUnset(args, "--master-size", "c5.large")
+			args = appendIfUnset(args, "--control-plane-size", "c5.large")
 		}
 	case "azure":
 		// Use SKUs for which there is enough quota
@@ -228,10 +228,10 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		args = appendIfUnset(args, "--node-size", "Standard_D2s_v3")
 	case "gce":
 		if isArm {
-			args = appendIfUnset(args, "--master-size", "t2a-standard-2")
+			args = appendIfUnset(args, "--control-plane-size", "t2a-standard-2")
 			args = appendIfUnset(args, "--node-size", "t2a-standard-2")
 		} else {
-			args = appendIfUnset(args, "--master-size", "e2-standard-2")
+			args = appendIfUnset(args, "--control-plane-size", "e2-standard-2")
 			args = appendIfUnset(args, "--node-size", "e2-standard-2")
 		}
 		if d.GCPProject != "" {
@@ -244,11 +244,11 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		// We used to set the --vpc flag to split clusters into different networks, this is now the default.
 		// args = appendIfUnset(args, "--vpc", strings.Split(d.ClusterName, ".")[0])
 	case "digitalocean":
-		args = appendIfUnset(args, "--master-size", "c2-16vcpu-32gb")
+		args = appendIfUnset(args, "--control-plane-size", "c2-16vcpu-32gb")
 		args = appendIfUnset(args, "--node-size", "c2-16vcpu-32gb")
 	}
 
-	args = appendIfUnset(args, "--master-volume-size", "48")
+	args = appendIfUnset(args, "--control-plane-volume-size", "48")
 	args = appendIfUnset(args, "--node-count", "4")
 	args = appendIfUnset(args, "--node-volume-size", "48")
 	args = appendIfUnset(args, "--zones", strings.Join(zones, ","))

--- a/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
+++ b/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
@@ -22,7 +22,7 @@ kops-acquire-latest
 OVERRIDES="${OVERRIDES-} --set=cluster.spec.cloudProvider.aws.ebsCSIDriver.enabled=true"
 OVERRIDES="$OVERRIDES --set=cluster.spec.snapshotController.enabled=true"
 OVERRIDES="$OVERRIDES --set=cluster.spec.certManager.enabled=true"
-OVERRIDES="$OVERRIDES --master-size=t3.medium --node-size=c5.large"
+OVERRIDES="$OVERRIDES --control-plane-size=t3.medium --node-size=c5.large"
 
 kops-up
 

--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -32,7 +32,7 @@ fi
 CREATE_ARGS="--networking amazonvpc"
 CREATE_ARGS="${CREATE_ARGS} --set=cluster.spec.cloudProvider.aws.loadBalancerController.enabled=true"
 CREATE_ARGS="${CREATE_ARGS} --set=cluster.spec.certManager.enabled=true"
-CREATE_ARGS="${CREATE_ARGS} --master-size=t3.medium --node-size=t3.medium"
+CREATE_ARGS="${CREATE_ARGS} --control-plane-size=t3.medium --node-size=t3.medium"
 CREATE_ARGS="${CREATE_ARGS} --image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id}"
 CREATE_ARGS="${CREATE_ARGS} --zones=eu-west-1a,eu-west-1b,eu-west-1c"
 

--- a/tests/e2e/scenarios/keypair-rotation/run-test.sh
+++ b/tests/e2e/scenarios/keypair-rotation/run-test.sh
@@ -19,7 +19,7 @@ source "${REPO_ROOT}"/tests/e2e/scenarios/lib/common.sh
 
 kops-acquire-latest
 
-OVERRIDES="${OVERRIDES-} --master-size=t4g.medium --node-size=t4g.medium"
+OVERRIDES="${OVERRIDES-} --control-plane-size=t4g.medium --node-size=t4g.medium"
 
 kops-up
 

--- a/tests/e2e/scenarios/metrics-server/run-test.sh
+++ b/tests/e2e/scenarios/metrics-server/run-test.sh
@@ -32,6 +32,6 @@ kubetest2 kops \
     --up --down \
     "${KUBETEST2_ARGS[@]}" \
     --cloud-provider=aws \
-    --create-args="--set=cluster.spec.metricsServer.enabled=true --set=cluster.spec.certManager.enabled=true --master-size=m6g.large --node-size=m6g.large" \
+    --create-args="--set=cluster.spec.metricsServer.enabled=true --set=cluster.spec.certManager.enabled=true --control-plane-size=m6g.large --node-size=m6g.large" \
     --kubernetes-version=https://dl.k8s.io/release/stable.txt \
     --test=exec -- "${REPO_ROOT}/tests/e2e/scenarios/metrics-server/test.sh"

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -56,7 +56,7 @@ if [[ "${CLOUD_PROVIDER}" == "aws" ]]; then
   create_args+=("--network-cidr=10.0.0.0/16,10.1.0.0/16,10.2.0.0/16,10.3.0.0/16,10.4.0.0/16,10.5.0.0/16,10.6.0.0/16,10.7.0.0/16,10.8.0.0/16,10.9.0.0/16,10.10.0.0/16,10.11.0.0/16,10.12.0.0/16")
   create_args+=("--node-size=${NODE_SIZE:-t3a.medium,t3.medium,t3a.large,c5a.large,t3.large,c5.large,m5a.large,m6a.large,m5.large,c7a.large,r5a.large,r6a.large,m7a.large}")
   create_args+=("--node-volume-size=20")
-  create_args+=("--master-volume-size=500")
+  create_args+=("--control-plane-volume-size=500")
   create_args+=("--zones=us-east-2a,us-east-2b,us-east-2c")
   create_args+=("--image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id}")
   # TODO: track failures of tests (HostPort & OIDC) when using `--dns=none`
@@ -66,7 +66,7 @@ if [[ "${CLOUD_PROVIDER}" == "gce" ]]; then
   create_args+=("--zones=us-east1-b,us-east1-c,us-east1-d")
   create_args+=("--node-size=${NODE_SIZE:-e2-medium}")
   create_args+=("--node-volume-size=30")
-  create_args+=("--master-volume-size=1000")
+  create_args+=("--control-plane-volume-size=1000")
   create_args+=("--gce-service-account=default")
   create_args+=("--topology=private")
   create_args+=("--image=${INSTANCE_IMAGE:-ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20251001}")
@@ -119,7 +119,7 @@ create_args+=("--set spec.kubeProxy.proxyMode=${KUBE_PROXY_MODE:-iptables}")
 create_args+=("--set spec.kubeProxy.metricsBindAddress=0.0.0.0:10249")
 create_args+=("--node-count=${KUBE_NODE_COUNT:-100}")
 create_args+=("--control-plane-count=${CONTROL_PLANE_COUNT:-1}")
-create_args+=("--master-size=${CONTROL_PLANE_SIZE:-c5.2xlarge}")
+create_args+=("--control-plane-size=${CONTROL_PLANE_SIZE:-c5.2xlarge}")
 
 # Enable HTTP for events etcd to reduce TLS overhead in scale tests
 KOPS_FEATURE_FLAGS="EtcdEventsHTTP,${KOPS_FEATURE_FLAGS:-}"


### PR DESCRIPTION
This will remove these warnings from all prow jobs:

```
Flag --master-count has been deprecated, use --control-plane-count instead
Flag --master-size has been deprecated, use --control-plane-size instead
Flag --master-volume-size has been deprecated, use --control-plane-volume-size instead
```

The new flags have been present for years so there's no risk in migrating: https://github.com/kubernetes/kops/commit/01684ac2067c161a2186bfab0b1abcafd83003c9