### PR TITLE
Update distribution matrix for Amazon Linux 2

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -33,7 +33,7 @@ The following table provides the support status for various distros with regards
 
 | Distro                                  | Experimental | Stable | Deprecated | Removed |
 | --------------------------------------- | -----------: | -----: | ---------: | ------: |
-| [Amazon Linux 2](#amazon-linux-2)       |         1.10 |   1.18 |          - |       - |
+| Amazon Linux 2                          |         1.10 |   1.18 |       1.35 |    1.36 |
 | [Amazon Linux 2023](#amazon-linux-2023) |         1.27 |      - |          - |       - |
 | CentOS 7                                |            - |    1.5 |       1.21 |    1.23 |
 | CentOS 8                                |         1.15 |      - |       1.21 |    1.23 |
@@ -62,21 +62,6 @@ The following table provides the support status for various distros with regards
 | [Ubuntu 24.04](#ubuntu-2404-noble)      |         1.29 |   1.31 |          - |       - |
 
 ## Supported Distros
-
-### Amazon Linux 2
-
-Amazon Linux 2 has variants using Kernel versions 4.14 and 5.10. Be sure to use the 5.10 images as specified in the image filter below. More information is available in the [AWS Documentation](https://aws.amazon.com/amazon-linux-2/faqs/).
-
-For kOps versions 1.16 and 1.17, the only supported Docker version is `18.06.3`. Newer versions of Docker cannot be installed due to missing dependencies for `container-selinux`. This issue is fixed in kOps **1.18**.
-
-Available images can be listed using:
-
-```bash
-aws ec2 describe-images --region us-east-1 --output table \
-  --filters "Name=owner-alias,Values=amazon" \
-  --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
-  --filters "Name=name,Values=amzn2-ami-kernel-5.10-hvm-2*-*-gp2"
-```
 
 ### Amazon Linux 2023
 


### PR DESCRIPTION
AL2 support was removed in https://github.com/kubernetes/kops/pull/17898 for kops 1.36.