### PR TITLE
Create iproute2 symlink for kuberouter on older distros

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -110,7 +110,7 @@ spec:
           mountPath: /run/xtables.lock
           readOnly: false
         - name: rt-tables
-          mountPath: /etc/iproute2/rt_tables
+          mountPath: /usr/share/iproute2/rt_tables
           readOnly: false
         - name: containerd-sock
           mountPath: /run/containerd/containerd.sock
@@ -158,7 +158,7 @@ spec:
           type: FileOrCreate
       - name: rt-tables
         hostPath:
-          path: /etc/iproute2/rt_tables
+          path: /usr/share/iproute2/rt_tables
           type: FileOrCreate
       - name: containerd-sock
         hostPath:


### PR DESCRIPTION
Closes https://github.com/kubernetes/kops/issues/17914

We can use symlinks to ensure the daemonset hostPath volume works with both sets of distros.

I decided to symlink new path to old path (which requires updating the daemonset hostPath) rather than the other way around, so that once we drop support for the old distros with iproute2 installed to the old path, we can remove the symlink logic.

I also updated the volumeMount path for the kuberouter container. Their code supports both old and new paths: https://github.com/cloudnativelabs/kube-router/blob/a1e6de9f8fae1784063dc114953827922424cb6d/pkg/utils/linux_routing.go#L13-L22