### PR TITLE
Automated cherry pick of #17945: Create iproute2 symlink for kuberouter on older distros

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -110,7 +110,7 @@ spec:
           mountPath: /run/xtables.lock
           readOnly: false
         - name: rt-tables
-          mountPath: /etc/iproute2/rt_tables
+          mountPath: /usr/share/iproute2/rt_tables
           readOnly: false
         - name: containerd-sock
           mountPath: /run/containerd/containerd.sock
@@ -158,7 +158,7 @@ spec:
           type: FileOrCreate
       - name: rt-tables
         hostPath:
-          path: /etc/iproute2/rt_tables
+          path: /usr/share/iproute2/rt_tables
           type: FileOrCreate
       - name: containerd-sock
         hostPath:


### PR DESCRIPTION
Cherry pick of #17945 on release-1.34.

#17945: Create iproute2 symlink for kuberouter on older distros

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```