### PR TITLE
Refactor interface type check to more idiomatic syntax

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -108,9 +108,9 @@ type AutoscalingGroup struct {
 	deletions []fi.CloudupDeletion
 }
 
-var _ fi.CloudupProducesDeletions = &AutoscalingGroup{}
-var _ fi.CompareWithID = &AutoscalingGroup{}
-var _ fi.CloudupTaskNormalize = &AutoscalingGroup{}
+var _ fi.CloudupProducesDeletions = (*AutoscalingGroup)(nil)
+var _ fi.CompareWithID = (*AutoscalingGroup)(nil)
+var _ fi.CloudupTaskNormalize = (*AutoscalingGroup)(nil)
 
 // CompareWithID returns the ID of the ASG
 func (e *AutoscalingGroup) CompareWithID() *string {
@@ -1108,7 +1108,7 @@ type deleteAutoscalingTargetGroupAttachment struct {
 	targetGroupARN       string
 }
 
-var _ fi.CloudupDeletion = &deleteAutoscalingTargetGroupAttachment{}
+var _ fi.CloudupDeletion = (*deleteAutoscalingTargetGroupAttachment)(nil)
 
 func buildDeleteAutoscalingTargetGroupAttachment(autoScalingGroupName string, targetGroupARN string) *deleteAutoscalingTargetGroupAttachment {
 	d := &deleteAutoscalingTargetGroupAttachment{}

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // AutoscalingGroup
 
-var _ fi.HasLifecycle = &AutoscalingGroup{}
+var _ fi.HasLifecycle = (*AutoscalingGroup)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *AutoscalingGroup) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *AutoscalingGroup) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &AutoscalingGroup{}
+var _ fi.HasName = (*AutoscalingGroup)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *AutoscalingGroup) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
@@ -48,7 +48,7 @@ type AutoscalingLifecycleHook struct {
 	Enabled *bool
 }
 
-var _ fi.CompareWithID = &AutoscalingLifecycleHook{}
+var _ fi.CompareWithID = (*AutoscalingLifecycleHook)(nil)
 
 func (h *AutoscalingLifecycleHook) CompareWithID() *string {
 	return h.Name

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // AutoscalingLifecycleHook
 
-var _ fi.HasLifecycle = &AutoscalingLifecycleHook{}
+var _ fi.HasLifecycle = (*AutoscalingLifecycleHook)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *AutoscalingLifecycleHook) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *AutoscalingLifecycleHook) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &AutoscalingLifecycleHook{}
+var _ fi.HasName = (*AutoscalingLifecycleHook)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *AutoscalingLifecycleHook) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/block_device_mappings.go
+++ b/upup/pkg/fi/cloudup/awstasks/block_device_mappings.go
@@ -181,7 +181,7 @@ func (i *BlockDeviceMapping) ToLaunchTemplateBootDeviceRequest(deviceName string
 	return o
 }
 
-var _ fi.CloudupHasDependencies = &BlockDeviceMapping{}
+var _ fi.CloudupHasDependencies = (*BlockDeviceMapping)(nil)
 
 // GetDependencies is for future use
 func (i *BlockDeviceMapping) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {

--- a/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
@@ -38,7 +38,7 @@ import (
 
 // LoadBalancer manages an ELB.  We find the existing ELB using the Name tag.
 
-var _ DNSTarget = &ClassicLoadBalancer{}
+var _ DNSTarget = (*ClassicLoadBalancer)(nil)
 
 // +kops:fitask
 type ClassicLoadBalancer struct {
@@ -79,8 +79,8 @@ type ClassicLoadBalancer struct {
 	WellKnownServices []wellknownservices.WellKnownService
 }
 
-var _ fi.CompareWithID = &ClassicLoadBalancer{}
-var _ fi.CloudupTaskNormalize = &ClassicLoadBalancer{}
+var _ fi.CompareWithID = (*ClassicLoadBalancer)(nil)
+var _ fi.CloudupTaskNormalize = (*ClassicLoadBalancer)(nil)
 
 func (e *ClassicLoadBalancer) CompareWithID() *string {
 	return e.Name
@@ -109,7 +109,7 @@ func (e *ClassicLoadBalancerListener) mapToAWS(loadBalancerPort int32) elbtypes.
 	return l
 }
 
-var _ fi.CloudupHasDependencies = &ClassicLoadBalancerListener{}
+var _ fi.CloudupHasDependencies = (*ClassicLoadBalancerListener)(nil)
 
 func (e *ClassicLoadBalancerListener) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
@@ -342,7 +342,7 @@ func (e *ClassicLoadBalancer) Find(c *fi.CloudupContext) (*ClassicLoadBalancer, 
 	return actual, nil
 }
 
-var _ fi.HasAddress = &ClassicLoadBalancer{}
+var _ fi.HasAddress = (*ClassicLoadBalancer)(nil)
 
 // GetWellKnownServices implements fi.HasAddress::GetWellKnownServices.
 // It indicates which services we support with this address (likely attached to a load balancer).

--- a/upup/pkg/fi/cloudup/awstasks/classic_loadbalancer_healthchecks.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_loadbalancer_healthchecks.go
@@ -31,7 +31,7 @@ type ClassicLoadBalancerHealthCheck struct {
 	Timeout  *int32
 }
 
-var _ fi.CloudupHasDependencies = &ClassicLoadBalancerListener{}
+var _ fi.CloudupHasDependencies = (*ClassicLoadBalancerListener)(nil)
 
 func (e *ClassicLoadBalancerHealthCheck) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil

--- a/upup/pkg/fi/cloudup/awstasks/classicloadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/classicloadbalancer_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // ClassicLoadBalancer
 
-var _ fi.HasLifecycle = &ClassicLoadBalancer{}
+var _ fi.HasLifecycle = (*ClassicLoadBalancer)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ClassicLoadBalancer) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *ClassicLoadBalancer) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &ClassicLoadBalancer{}
+var _ fi.HasName = (*ClassicLoadBalancer)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *ClassicLoadBalancer) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -47,7 +47,7 @@ type DHCPOptions struct {
 	Tags map[string]string
 }
 
-var _ fi.CompareWithID = &DHCPOptions{}
+var _ fi.CompareWithID = (*DHCPOptions)(nil)
 
 func (e *DHCPOptions) CompareWithID() *string {
 	return e.ID

--- a/upup/pkg/fi/cloudup/awstasks/dhcpoptions_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcpoptions_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // DHCPOptions
 
-var _ fi.HasLifecycle = &DHCPOptions{}
+var _ fi.HasLifecycle = (*DHCPOptions)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *DHCPOptions) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *DHCPOptions) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &DHCPOptions{}
+var _ fi.HasName = (*DHCPOptions)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *DHCPOptions) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/dnsname_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // DNSName
 
-var _ fi.HasLifecycle = &DNSName{}
+var _ fi.HasLifecycle = (*DNSName)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *DNSName) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *DNSName) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &DNSName{}
+var _ fi.HasName = (*DNSName)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *DNSName) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/dnszone.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnszone.go
@@ -47,7 +47,7 @@ type DNSZone struct {
 	PrivateVPC *VPC
 }
 
-var _ fi.CompareWithID = &DNSZone{}
+var _ fi.CompareWithID = (*DNSZone)(nil)
 
 func (e *DNSZone) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/awstasks/dnszone_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnszone_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // DNSZone
 
-var _ fi.HasLifecycle = &DNSZone{}
+var _ fi.HasLifecycle = (*DNSZone)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *DNSZone) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *DNSZone) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &DNSZone{}
+var _ fi.HasName = (*DNSZone)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *DNSZone) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -47,8 +47,8 @@ type EBSVolume struct {
 	VolumeType       ec2types.VolumeType
 }
 
-var _ fi.CompareWithID = &EBSVolume{}
-var _ fi.CloudupTaskNormalize = &EBSVolume{}
+var _ fi.CompareWithID = (*EBSVolume)(nil)
+var _ fi.CloudupTaskNormalize = (*EBSVolume)(nil)
 
 func (e *EBSVolume) CompareWithID() *string {
 	return e.ID

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // EBSVolume
 
-var _ fi.HasLifecycle = &EBSVolume{}
+var _ fi.HasLifecycle = (*EBSVolume)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *EBSVolume) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *EBSVolume) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &EBSVolume{}
+var _ fi.HasName = (*EBSVolume)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *EBSVolume) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway.go
@@ -43,7 +43,7 @@ type EgressOnlyInternetGateway struct {
 	Tags map[string]string
 }
 
-var _ fi.CompareWithID = &EgressOnlyInternetGateway{}
+var _ fi.CompareWithID = (*EgressOnlyInternetGateway)(nil)
 
 func (e *EgressOnlyInternetGateway) CompareWithID() *string {
 	return e.ID

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // EgressOnlyInternetGateway
 
-var _ fi.HasLifecycle = &EgressOnlyInternetGateway{}
+var _ fi.HasLifecycle = (*EgressOnlyInternetGateway)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *EgressOnlyInternetGateway) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *EgressOnlyInternetGateway) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &EgressOnlyInternetGateway{}
+var _ fi.HasName = (*EgressOnlyInternetGateway)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *EgressOnlyInternetGateway) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -54,7 +54,7 @@ type ElasticIP struct {
 	AssociatedNatGatewayRouteTable *RouteTable
 }
 
-var _ fi.CompareWithID = &ElasticIP{}
+var _ fi.CompareWithID = (*ElasticIP)(nil)
 
 func (e *ElasticIP) CompareWithID() *string {
 	return e.ID

--- a/upup/pkg/fi/cloudup/awstasks/elasticip_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/elasticip_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // ElasticIP
 
-var _ fi.HasLifecycle = &ElasticIP{}
+var _ fi.HasLifecycle = (*ElasticIP)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ElasticIP) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *ElasticIP) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &ElasticIP{}
+var _ fi.HasName = (*ElasticIP)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *ElasticIP) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
@@ -43,7 +43,7 @@ type EventBridgeRule struct {
 	Tags map[string]string
 }
 
-var _ fi.CompareWithID = &EventBridgeRule{}
+var _ fi.CompareWithID = (*EventBridgeRule)(nil)
 
 func (eb *EventBridgeRule) CompareWithID() *string {
 	return eb.Name

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgerule_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgerule_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // EventBridgeRule
 
-var _ fi.HasLifecycle = &EventBridgeRule{}
+var _ fi.HasLifecycle = (*EventBridgeRule)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *EventBridgeRule) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *EventBridgeRule) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &EventBridgeRule{}
+var _ fi.HasName = (*EventBridgeRule)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *EventBridgeRule) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
@@ -41,7 +41,7 @@ type EventBridgeTarget struct {
 	SQSQueue *SQS
 }
 
-var _ fi.CompareWithID = &EventBridgeTarget{}
+var _ fi.CompareWithID = (*EventBridgeTarget)(nil)
 
 func (eb *EventBridgeTarget) CompareWithID() *string {
 	return eb.Name

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgetarget_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgetarget_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // EventBridgeTarget
 
-var _ fi.HasLifecycle = &EventBridgeTarget{}
+var _ fi.HasLifecycle = (*EventBridgeTarget)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *EventBridgeTarget) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *EventBridgeTarget) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &EventBridgeTarget{}
+var _ fi.HasName = (*EventBridgeTarget)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *EventBridgeTarget) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
@@ -42,7 +42,7 @@ type IAMInstanceProfile struct {
 	Shared *bool
 }
 
-var _ fi.CompareWithID = &IAMInstanceProfile{}
+var _ fi.CompareWithID = (*IAMInstanceProfile)(nil)
 
 func (e *IAMInstanceProfile) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // IAMInstanceProfile
 
-var _ fi.HasLifecycle = &IAMInstanceProfile{}
+var _ fi.HasLifecycle = (*IAMInstanceProfile)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *IAMInstanceProfile) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *IAMInstanceProfile) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &IAMInstanceProfile{}
+var _ fi.HasName = (*IAMInstanceProfile)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *IAMInstanceProfile) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // IAMInstanceProfileRole
 
-var _ fi.HasLifecycle = &IAMInstanceProfileRole{}
+var _ fi.HasLifecycle = (*IAMInstanceProfileRole)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *IAMInstanceProfileRole) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *IAMInstanceProfileRole) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &IAMInstanceProfileRole{}
+var _ fi.HasName = (*IAMInstanceProfileRole)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *IAMInstanceProfileRole) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
@@ -45,7 +45,7 @@ type IAMOIDCProvider struct {
 	arn *string
 }
 
-var _ fi.CompareWithID = &IAMOIDCProvider{}
+var _ fi.CompareWithID = (*IAMOIDCProvider)(nil)
 
 func (e *IAMOIDCProvider) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/awstasks/iamoidcprovider_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamoidcprovider_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // IAMOIDCProvider
 
-var _ fi.HasLifecycle = &IAMOIDCProvider{}
+var _ fi.HasLifecycle = (*IAMOIDCProvider)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *IAMOIDCProvider) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *IAMOIDCProvider) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &IAMOIDCProvider{}
+var _ fi.HasName = (*IAMOIDCProvider)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *IAMOIDCProvider) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/iamrole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole.go
@@ -55,7 +55,7 @@ type IAMRole struct {
 	ExportWithID *string
 }
 
-var _ fi.CompareWithID = &IAMRole{}
+var _ fi.CompareWithID = (*IAMRole)(nil)
 
 func (e *IAMRole) CompareWithID() *string {
 	return e.ID

--- a/upup/pkg/fi/cloudup/awstasks/iamrole_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // IAMRole
 
-var _ fi.HasLifecycle = &IAMRole{}
+var _ fi.HasLifecycle = (*IAMRole)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *IAMRole) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *IAMRole) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &IAMRole{}
+var _ fi.HasName = (*IAMRole)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *IAMRole) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // IAMRolePolicy
 
-var _ fi.HasLifecycle = &IAMRolePolicy{}
+var _ fi.HasLifecycle = (*IAMRolePolicy)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *IAMRolePolicy) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *IAMRolePolicy) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &IAMRolePolicy{}
+var _ fi.HasName = (*IAMRolePolicy)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *IAMRolePolicy) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -58,7 +58,7 @@ type Instance struct {
 	IAMInstanceProfile *IAMInstanceProfile
 }
 
-var _ fi.CompareWithID = &Instance{}
+var _ fi.CompareWithID = (*Instance)(nil)
 
 func (s *Instance) CompareWithID() *string {
 	return s.ID

--- a/upup/pkg/fi/cloudup/awstasks/instance_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Instance
 
-var _ fi.HasLifecycle = &Instance{}
+var _ fi.HasLifecycle = (*Instance)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Instance) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Instance) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Instance{}
+var _ fi.HasName = (*Instance)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Instance) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/instancerequirements.go
+++ b/upup/pkg/fi/cloudup/awstasks/instancerequirements.go
@@ -30,7 +30,7 @@ type InstanceRequirements struct {
 	MemoryMax    *int32
 }
 
-var _ fi.CloudupHasDependencies = &InstanceRequirements{}
+var _ fi.CloudupHasDependencies = (*InstanceRequirements)(nil)
 
 func (e *InstanceRequirements) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -43,7 +43,7 @@ type InternetGateway struct {
 	Tags map[string]string
 }
 
-var _ fi.CompareWithID = &InternetGateway{}
+var _ fi.CompareWithID = (*InternetGateway)(nil)
 
 func (e *InternetGateway) CompareWithID() *string {
 	return e.ID

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // InternetGateway
 
-var _ fi.HasLifecycle = &InternetGateway{}
+var _ fi.HasLifecycle = (*InternetGateway)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *InternetGateway) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *InternetGateway) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &InternetGateway{}
+var _ fi.HasName = (*InternetGateway)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *InternetGateway) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LaunchTemplate
 
-var _ fi.HasLifecycle = &LaunchTemplate{}
+var _ fi.HasLifecycle = (*LaunchTemplate)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LaunchTemplate) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LaunchTemplate) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LaunchTemplate{}
+var _ fi.HasName = (*LaunchTemplate)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LaunchTemplate) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -416,7 +416,7 @@ type deleteLaunchTemplate struct {
 	lc *ec2types.LaunchTemplate
 }
 
-var _ fi.CloudupDeletion = &deleteLaunchTemplate{}
+var _ fi.CloudupDeletion = (*deleteLaunchTemplate)(nil)
 
 // TaskName returns the task name
 func (d *deleteLaunchTemplate) TaskName() string {

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -53,7 +53,7 @@ type NatGateway struct {
 	AssociatedRouteTable *RouteTable
 }
 
-var _ fi.CompareWithID = &NatGateway{}
+var _ fi.CompareWithID = (*NatGateway)(nil)
 
 func (e *NatGateway) CompareWithID() *string {
 	// Match by ID (NAT Gateways don't have tags, so they don't have a name in EC2)

--- a/upup/pkg/fi/cloudup/awstasks/natgateway_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // NatGateway
 
-var _ fi.HasLifecycle = &NatGateway{}
+var _ fi.HasLifecycle = (*NatGateway)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *NatGateway) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *NatGateway) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &NatGateway{}
+var _ fi.HasName = (*NatGateway)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *NatGateway) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -39,7 +39,7 @@ import (
 )
 
 // NetworkLoadBalancer manages an NLB.  We find the existing NLB using the Name tag.
-var _ DNSTarget = &NetworkLoadBalancer{}
+var _ DNSTarget = (*NetworkLoadBalancer)(nil)
 
 // +kops:fitask
 type NetworkLoadBalancer struct {
@@ -97,9 +97,9 @@ func (e *NetworkLoadBalancer) SetWaitForLoadBalancerReady(v bool) {
 	e.waitForLoadBalancerReady = v
 }
 
-var _ fi.CompareWithID = &NetworkLoadBalancer{}
-var _ fi.CloudupTaskNormalize = &NetworkLoadBalancer{}
-var _ fi.CloudupProducesDeletions = &NetworkLoadBalancer{}
+var _ fi.CompareWithID = (*NetworkLoadBalancer)(nil)
+var _ fi.CloudupTaskNormalize = (*NetworkLoadBalancer)(nil)
+var _ fi.CloudupProducesDeletions = (*NetworkLoadBalancer)(nil)
 
 func (e *NetworkLoadBalancer) CompareWithID() *string {
 	return e.Name
@@ -341,7 +341,7 @@ func (e *NetworkLoadBalancer) Find(c *fi.CloudupContext) (*NetworkLoadBalancer, 
 	return actual, nil
 }
 
-var _ fi.HasAddress = &NetworkLoadBalancer{}
+var _ fi.HasAddress = (*NetworkLoadBalancer)(nil)
 
 // GetWellKnownServices implements fi.HasAddress::GetWellKnownServices.
 // It indicates which services we support with this load balancer.
@@ -765,7 +765,7 @@ type deleteNLB struct {
 	obj *awsup.LoadBalancerInfo
 }
 
-var _ fi.CloudupDeletion = &deleteNLB{}
+var _ fi.CloudupDeletion = (*deleteNLB)(nil)
 
 func (d *deleteNLB) Delete(t fi.CloudupTarget) error {
 	ctx := context.TODO()

--- a/upup/pkg/fi/cloudup/awstasks/networkloadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/networkloadbalancer_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // NetworkLoadBalancer
 
-var _ fi.HasLifecycle = &NetworkLoadBalancer{}
+var _ fi.HasLifecycle = (*NetworkLoadBalancer)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *NetworkLoadBalancer) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *NetworkLoadBalancer) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &NetworkLoadBalancer{}
+var _ fi.HasName = (*NetworkLoadBalancer)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *NetworkLoadBalancer) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/networkloadbalancerlistener.go
+++ b/upup/pkg/fi/cloudup/awstasks/networkloadbalancerlistener.go
@@ -47,8 +47,8 @@ type NetworkLoadBalancerListener struct {
 	listenerArn string
 }
 
-var _ fi.CompareWithID = &NetworkLoadBalancerListener{}
-var _ fi.CloudupTaskNormalize = &NetworkLoadBalancerListener{}
+var _ fi.CompareWithID = (*NetworkLoadBalancerListener)(nil)
+var _ fi.CloudupTaskNormalize = (*NetworkLoadBalancerListener)(nil)
 
 func (e *NetworkLoadBalancerListener) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/awstasks/networkloadbalancerlistener_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/networkloadbalancerlistener_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // NetworkLoadBalancerListener
 
-var _ fi.HasLifecycle = &NetworkLoadBalancerListener{}
+var _ fi.HasLifecycle = (*NetworkLoadBalancerListener)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *NetworkLoadBalancerListener) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *NetworkLoadBalancerListener) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &NetworkLoadBalancerListener{}
+var _ fi.HasName = (*NetworkLoadBalancerListener)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *NetworkLoadBalancerListener) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/route_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/route_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Route
 
-var _ fi.HasLifecycle = &Route{}
+var _ fi.HasLifecycle = (*Route)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Route) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Route) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Route{}
+var _ fi.HasName = (*Route)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Route) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/routetable.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable.go
@@ -44,7 +44,7 @@ type RouteTable struct {
 	Tags map[string]string
 }
 
-var _ fi.CompareWithID = &RouteTable{}
+var _ fi.CompareWithID = (*RouteTable)(nil)
 
 func (e *RouteTable) CompareWithID() *string {
 	return e.ID

--- a/upup/pkg/fi/cloudup/awstasks/routetable_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // RouteTable
 
-var _ fi.HasLifecycle = &RouteTable{}
+var _ fi.HasLifecycle = (*RouteTable)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *RouteTable) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *RouteTable) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &RouteTable{}
+var _ fi.HasName = (*RouteTable)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *RouteTable) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // RouteTableAssociation
 
-var _ fi.HasLifecycle = &RouteTableAssociation{}
+var _ fi.HasLifecycle = (*RouteTableAssociation)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *RouteTableAssociation) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *RouteTableAssociation) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &RouteTableAssociation{}
+var _ fi.HasName = (*RouteTableAssociation)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *RouteTableAssociation) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -238,7 +238,7 @@ func buildDeleteSecurityGroupRule(rule ec2types.SecurityGroupRule) *deleteSecuri
 	return d
 }
 
-var _ fi.CloudupDeletion = &deleteSecurityGroupRule{}
+var _ fi.CloudupDeletion = (*deleteSecurityGroupRule)(nil)
 
 func (d *deleteSecurityGroupRule) Delete(t fi.CloudupTarget) error {
 	ctx := context.TODO()
@@ -435,7 +435,7 @@ type PortRemovalRule struct {
 	ToPort   int
 }
 
-var _ RemovalRule = &PortRemovalRule{}
+var _ RemovalRule = (*PortRemovalRule)(nil)
 
 func (r *PortRemovalRule) String() string {
 	return fi.DebugAsJsonString(r)

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // SecurityGroup
 
-var _ fi.HasLifecycle = &SecurityGroup{}
+var _ fi.HasLifecycle = (*SecurityGroup)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SecurityGroup) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *SecurityGroup) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &SecurityGroup{}
+var _ fi.HasName = (*SecurityGroup)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *SecurityGroup) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // SecurityGroupRule
 
-var _ fi.HasLifecycle = &SecurityGroupRule{}
+var _ fi.HasLifecycle = (*SecurityGroupRule)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SecurityGroupRule) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *SecurityGroupRule) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &SecurityGroupRule{}
+var _ fi.HasName = (*SecurityGroupRule)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *SecurityGroupRule) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/sqs.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs.go
@@ -49,7 +49,7 @@ type SQS struct {
 	Tags map[string]string
 }
 
-var _ fi.CompareWithID = &SQS{}
+var _ fi.CompareWithID = (*SQS)(nil)
 
 func (q *SQS) CompareWithID() *string {
 	return q.ARN

--- a/upup/pkg/fi/cloudup/awstasks/sqs_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // SQS
 
-var _ fi.HasLifecycle = &SQS{}
+var _ fi.HasLifecycle = (*SQS)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SQS) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *SQS) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &SQS{}
+var _ fi.HasName = (*SQS)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *SQS) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey.go
@@ -46,8 +46,8 @@ type SSHKey struct {
 	Tags map[string]string
 }
 
-var _ fi.CompareWithID = &SSHKey{}
-var _ fi.CloudupTaskNormalize = &SSHKey{}
+var _ fi.CompareWithID = (*SSHKey)(nil)
+var _ fi.CloudupTaskNormalize = (*SSHKey)(nil)
 
 func (e *SSHKey) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/awstasks/sshkey_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // SSHKey
 
-var _ fi.HasLifecycle = &SSHKey{}
+var _ fi.HasLifecycle = (*SSHKey)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SSHKey) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *SSHKey) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &SSHKey{}
+var _ fi.HasName = (*SSHKey)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *SSHKey) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -58,7 +58,7 @@ type Subnet struct {
 	Tags map[string]string
 }
 
-var _ fi.CompareWithID = &Subnet{}
+var _ fi.CompareWithID = (*Subnet)(nil)
 
 func (e *Subnet) CompareWithID() *string {
 	return e.ID
@@ -521,7 +521,7 @@ type deleteSubnetIPv6CIDRBlock struct {
 	associationID *string
 }
 
-var _ fi.CloudupDeletion = &deleteSubnetIPv6CIDRBlock{}
+var _ fi.CloudupDeletion = (*deleteSubnetIPv6CIDRBlock)(nil)
 
 func (d *deleteSubnetIPv6CIDRBlock) Delete(t fi.CloudupTarget) error {
 	ctx := context.TODO()

--- a/upup/pkg/fi/cloudup/awstasks/subnet_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Subnet
 
-var _ fi.HasLifecycle = &Subnet{}
+var _ fi.HasLifecycle = (*Subnet)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Subnet) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Subnet) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Subnet{}
+var _ fi.HasName = (*Subnet)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Subnet) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -81,7 +81,7 @@ func (e *TargetGroup) CreateNewRevisionsWith(nlb *NetworkLoadBalancer) {
 	e.networkLoadBalancer = nlb
 }
 
-var _ fi.CloudupHasDependencies = &TargetGroup{}
+var _ fi.CloudupHasDependencies = (*TargetGroup)(nil)
 
 // GetDependencies returns the dependencies of the TargetGroup task
 // We need to do this because we hide the networkLoadBalancer field
@@ -92,7 +92,7 @@ func (e *TargetGroup) GetDependencies(tasks map[string]fi.CloudupTask) []fi.Clou
 	return deps
 }
 
-var _ fi.CompareWithID = &TargetGroup{}
+var _ fi.CompareWithID = (*TargetGroup)(nil)
 
 func (e *TargetGroup) CompareWithID() *string {
 	if e.ARN != nil {
@@ -484,7 +484,7 @@ func (e *TargetGroup) TerraformLink() *terraformWriter.Literal {
 	return terraformWriter.LiteralProperty("aws_lb_target_group", *e.Name, "id")
 }
 
-var _ fi.CloudupProducesDeletions = &TargetGroup{}
+var _ fi.CloudupProducesDeletions = (*TargetGroup)(nil)
 
 // FindDeletions is responsible for finding launch templates which can be deleted
 func (e *TargetGroup) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletion, error) {
@@ -505,7 +505,7 @@ func buildDeleteTargetGroup(obj *awsup.TargetGroupInfo) *deleteTargetGroup {
 	return d
 }
 
-var _ fi.CloudupDeletion = &deleteTargetGroup{}
+var _ fi.CloudupDeletion = (*deleteTargetGroup)(nil)
 
 func (d *deleteTargetGroup) Delete(t fi.CloudupTarget) error {
 	ctx := context.TODO()

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // TargetGroup
 
-var _ fi.HasLifecycle = &TargetGroup{}
+var _ fi.HasLifecycle = (*TargetGroup)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *TargetGroup) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *TargetGroup) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &TargetGroup{}
+var _ fi.HasName = (*TargetGroup)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *TargetGroup) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -374,7 +374,7 @@ type deleteVPCCIDRBlock struct {
 	associationID *string
 }
 
-var _ fi.CloudupDeletion = &deleteVPCCIDRBlock{}
+var _ fi.CloudupDeletion = (*deleteVPCCIDRBlock)(nil)
 
 func (d *deleteVPCCIDRBlock) Delete(t fi.CloudupTarget) error {
 	ctx := context.TODO()

--- a/upup/pkg/fi/cloudup/awstasks/vpc_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // VPC
 
-var _ fi.HasLifecycle = &VPC{}
+var _ fi.HasLifecycle = (*VPC)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *VPC) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *VPC) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &VPC{}
+var _ fi.HasName = (*VPC)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *VPC) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // VPCAmazonIPv6CIDRBlock
 
-var _ fi.HasLifecycle = &VPCAmazonIPv6CIDRBlock{}
+var _ fi.HasLifecycle = (*VPCAmazonIPv6CIDRBlock)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *VPCAmazonIPv6CIDRBlock) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *VPCAmazonIPv6CIDRBlock) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &VPCAmazonIPv6CIDRBlock{}
+var _ fi.HasName = (*VPCAmazonIPv6CIDRBlock)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *VPCAmazonIPv6CIDRBlock) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/vpccidrblock_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpccidrblock_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // VPCCIDRBlock
 
-var _ fi.HasLifecycle = &VPCCIDRBlock{}
+var _ fi.HasLifecycle = (*VPCCIDRBlock)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *VPCCIDRBlock) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *VPCCIDRBlock) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &VPCCIDRBlock{}
+var _ fi.HasName = (*VPCCIDRBlock)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *VPCCIDRBlock) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/vpcdhcpoptionsassociation_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcdhcpoptionsassociation_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // VPCDHCPOptionsAssociation
 
-var _ fi.HasLifecycle = &VPCDHCPOptionsAssociation{}
+var _ fi.HasLifecycle = (*VPCDHCPOptionsAssociation)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *VPCDHCPOptionsAssociation) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *VPCDHCPOptionsAssociation) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &VPCDHCPOptionsAssociation{}
+var _ fi.HasName = (*VPCDHCPOptionsAssociation)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *VPCDHCPOptionsAssociation) GetName() *string {

--- a/upup/pkg/fi/cloudup/awstasks/warmpool.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool.go
@@ -45,7 +45,7 @@ type WarmPool struct {
 	AutoscalingGroup *AutoscalingGroup
 }
 
-var _ fi.CloudupHasDependencies = &WarmPool{}
+var _ fi.CloudupHasDependencies = (*WarmPool)(nil)
 
 // Warmpool depends on any Lifecycle hooks being in place first.
 func (e *WarmPool) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
@@ -67,7 +67,7 @@ func (e *WarmPool) GetDependencies(tasks map[string]fi.CloudupTask) []fi.Cloudup
 	return deps
 }
 
-var _ fi.CompareWithID = &WarmPool{}
+var _ fi.CompareWithID = (*WarmPool)(nil)
 
 // CompareWithID returns the ID of the WarmPool task
 func (e *WarmPool) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/warmpool_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // WarmPool
 
-var _ fi.HasLifecycle = &WarmPool{}
+var _ fi.HasLifecycle = (*WarmPool)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *WarmPool) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *WarmPool) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &WarmPool{}
+var _ fi.HasName = (*WarmPool)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *WarmPool) GetName() *string {

--- a/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
@@ -29,7 +29,7 @@ type AWSAPITarget struct {
 	Cloud AWSCloud
 }
 
-var _ fi.CloudupTarget = &AWSAPITarget{}
+var _ fi.CloudupTarget = (*AWSAPITarget)(nil)
 
 func NewAWSAPITarget(cloud AWSCloud) *AWSAPITarget {
 	return &AWSAPITarget{

--- a/upup/pkg/fi/cloudup/awsup/aws_authenticator.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_authenticator.go
@@ -51,7 +51,7 @@ type awsAuthenticator struct {
 	credentialsProvider aws.CredentialsProvider
 }
 
-var _ bootstrap.Authenticator = &awsAuthenticator{}
+var _ bootstrap.Authenticator = (*awsAuthenticator)(nil)
 
 // RegionFromMetadata returns the current region from the aws metdata
 func RegionFromMetadata(ctx context.Context) (string, error) {

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -227,7 +227,7 @@ type instanceTypes struct {
 	typeMap map[string]*ec2types.InstanceTypeInfo
 }
 
-var _ fi.Cloud = &awsCloudImplementation{}
+var _ fi.Cloud = (*awsCloudImplementation)(nil)
 
 func (c *awsCloudImplementation) ProviderID() kops.CloudProviderID {
 	return kops.CloudProviderAWS

--- a/upup/pkg/fi/cloudup/awsup/aws_verifier.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_verifier.go
@@ -60,7 +60,7 @@ type awsVerifier struct {
 	stsRequestValidator *stsRequestValidator
 }
 
-var _ bootstrap.Verifier = &awsVerifier{}
+var _ bootstrap.Verifier = (*awsVerifier)(nil)
 
 func NewAWSVerifier(ctx context.Context, opt *AWSVerifierOptions) (bootstrap.Verifier, error) {
 	config, err := awsconfig.LoadDefaultConfig(

--- a/upup/pkg/fi/cloudup/azure/applicationsecuritygroup.go
+++ b/upup/pkg/fi/cloudup/azure/applicationsecuritygroup.go
@@ -37,7 +37,7 @@ type ApplicationSecurityGroupsClientImpl struct {
 	c *network.ApplicationSecurityGroupsClient
 }
 
-var _ ApplicationSecurityGroupsClient = &ApplicationSecurityGroupsClientImpl{}
+var _ ApplicationSecurityGroupsClient = (*ApplicationSecurityGroupsClientImpl)(nil)
 
 func (c *ApplicationSecurityGroupsClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName, applicationSecurityGroupName string, parameters network.ApplicationSecurityGroup) (*network.ApplicationSecurityGroup, error) {
 	future, err := c.c.BeginCreateOrUpdate(ctx, resourceGroupName, applicationSecurityGroupName, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/authenticator.go
+++ b/upup/pkg/fi/cloudup/azure/authenticator.go
@@ -30,7 +30,7 @@ const AzureAuthenticationTokenPrefix = "x-azure-id "
 type azureAuthenticator struct {
 }
 
-var _ bootstrap.Authenticator = &azureAuthenticator{}
+var _ bootstrap.Authenticator = (*azureAuthenticator)(nil)
 
 func NewAzureAuthenticator() (bootstrap.Authenticator, error) {
 	return &azureAuthenticator{}, nil

--- a/upup/pkg/fi/cloudup/azure/azure_apitarget.go
+++ b/upup/pkg/fi/cloudup/azure/azure_apitarget.go
@@ -25,7 +25,7 @@ type AzureAPITarget struct {
 	Cloud AzureCloud
 }
 
-var _ fi.CloudupTarget = &AzureAPITarget{}
+var _ fi.CloudupTarget = (*AzureAPITarget)(nil)
 
 // NewAzureAPITarget returns a new AzureAPITarget.
 func NewAzureAPITarget(cloud AzureCloud) *AzureAPITarget {

--- a/upup/pkg/fi/cloudup/azure/azure_cloud.go
+++ b/upup/pkg/fi/cloudup/azure/azure_cloud.go
@@ -86,7 +86,7 @@ type azureCloudImplementation struct {
 	storageAccountsClient           StorageAccountsClient
 }
 
-var _ fi.Cloud = &azureCloudImplementation{}
+var _ fi.Cloud = (*azureCloudImplementation)(nil)
 
 // NewAzureCloud creates a new AzureCloud.
 func NewAzureCloud(subscriptionID, resourceGroupName, location string, tags map[string]string) (AzureCloud, error) {

--- a/upup/pkg/fi/cloudup/azure/disk.go
+++ b/upup/pkg/fi/cloudup/azure/disk.go
@@ -35,7 +35,7 @@ type disksClientImpl struct {
 	c *compute.DisksClient
 }
 
-var _ DisksClient = &disksClientImpl{}
+var _ DisksClient = (*disksClientImpl)(nil)
 
 func (c *disksClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName, diskName string, parameters compute.Disk) (*compute.Disk, error) {
 	future, err := c.c.BeginCreateOrUpdate(ctx, resourceGroupName, diskName, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/azure/loadbalancer.go
@@ -39,7 +39,7 @@ type loadBalancersClientImpl struct {
 	c *network.LoadBalancersClient
 }
 
-var _ LoadBalancersClient = &loadBalancersClientImpl{}
+var _ LoadBalancersClient = (*loadBalancersClientImpl)(nil)
 
 func (c *loadBalancersClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName, loadBalancerName string, parameters network.LoadBalancer) (*network.LoadBalancer, error) {
 	future, err := c.c.BeginCreateOrUpdate(ctx, resourceGroupName, loadBalancerName, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/natgateway.go
+++ b/upup/pkg/fi/cloudup/azure/natgateway.go
@@ -37,7 +37,7 @@ type NatGatewaysClientImpl struct {
 	c *network.NatGatewaysClient
 }
 
-var _ NatGatewaysClient = &NatGatewaysClientImpl{}
+var _ NatGatewaysClient = (*NatGatewaysClientImpl)(nil)
 
 func (c *NatGatewaysClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName, natGatewayName string, parameters network.NatGateway) (*network.NatGateway, error) {
 	future, err := c.c.BeginCreateOrUpdate(ctx, resourceGroupName, natGatewayName, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/networkinterface.go
+++ b/upup/pkg/fi/cloudup/azure/networkinterface.go
@@ -33,7 +33,7 @@ type networkInterfacesClientImpl struct {
 	c *network.InterfacesClient
 }
 
-var _ NetworkInterfacesClient = &networkInterfacesClientImpl{}
+var _ NetworkInterfacesClient = (*networkInterfacesClientImpl)(nil)
 
 func (c *networkInterfacesClientImpl) ListScaleSetsNetworkInterfaces(ctx context.Context, resourceGroupName, vmssName string) ([]*network.Interface, error) {
 	var l []*network.Interface

--- a/upup/pkg/fi/cloudup/azure/networksecuritygroup.go
+++ b/upup/pkg/fi/cloudup/azure/networksecuritygroup.go
@@ -37,7 +37,7 @@ type NetworkSecurityGroupsClientImpl struct {
 	c *network.SecurityGroupsClient
 }
 
-var _ NetworkSecurityGroupsClient = &NetworkSecurityGroupsClientImpl{}
+var _ NetworkSecurityGroupsClient = (*NetworkSecurityGroupsClientImpl)(nil)
 
 func (c *NetworkSecurityGroupsClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName, NetworkSecurityGroupName string, parameters network.SecurityGroup) (*network.SecurityGroup, error) {
 	future, err := c.c.BeginCreateOrUpdate(ctx, resourceGroupName, NetworkSecurityGroupName, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/publicipaddress.go
+++ b/upup/pkg/fi/cloudup/azure/publicipaddress.go
@@ -37,7 +37,7 @@ type publicIPAddressesClientImpl struct {
 	c *network.PublicIPAddressesClient
 }
 
-var _ PublicIPAddressesClient = &publicIPAddressesClientImpl{}
+var _ PublicIPAddressesClient = (*publicIPAddressesClientImpl)(nil)
 
 func (c *publicIPAddressesClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName, publicIPAddressName string, parameters network.PublicIPAddress) (*network.PublicIPAddress, error) {
 	future, err := c.c.BeginCreateOrUpdate(ctx, resourceGroupName, publicIPAddressName, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/resourcegroup.go
+++ b/upup/pkg/fi/cloudup/azure/resourcegroup.go
@@ -35,7 +35,7 @@ type resourceGroupsClientImpl struct {
 	c *resources.ResourceGroupsClient
 }
 
-var _ ResourceGroupsClient = &resourceGroupsClientImpl{}
+var _ ResourceGroupsClient = (*resourceGroupsClientImpl)(nil)
 
 func (c *resourceGroupsClientImpl) CreateOrUpdate(ctx context.Context, name string, parameters resources.ResourceGroup) error {
 	_, err := c.c.CreateOrUpdate(ctx, name, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/roleassignment.go
+++ b/upup/pkg/fi/cloudup/azure/roleassignment.go
@@ -35,7 +35,7 @@ type roleAssignmentsClientImpl struct {
 	c *authz.RoleAssignmentsClient
 }
 
-var _ RoleAssignmentsClient = &roleAssignmentsClientImpl{}
+var _ RoleAssignmentsClient = (*roleAssignmentsClientImpl)(nil)
 
 func (c *roleAssignmentsClientImpl) Create(
 	ctx context.Context,

--- a/upup/pkg/fi/cloudup/azure/routetable.go
+++ b/upup/pkg/fi/cloudup/azure/routetable.go
@@ -37,7 +37,7 @@ type routeTablesClientImpl struct {
 	c *network.RouteTablesClient
 }
 
-var _ RouteTablesClient = &routeTablesClientImpl{}
+var _ RouteTablesClient = (*routeTablesClientImpl)(nil)
 
 func (c *routeTablesClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName, routeTableName string, parameters network.RouteTable) (*network.RouteTable, error) {
 	future, err := c.c.BeginCreateOrUpdate(ctx, resourceGroupName, routeTableName, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/status_test.go
+++ b/upup/pkg/fi/cloudup/azure/status_test.go
@@ -33,7 +33,7 @@ type mockVMScaleSetsClient struct {
 	vmsses []*compute.VirtualMachineScaleSet
 }
 
-var _ VMScaleSetsClient = &mockVMScaleSetsClient{}
+var _ VMScaleSetsClient = (*mockVMScaleSetsClient)(nil)
 
 // CreateOrUpdate creates or updates a VM Scale Set.
 func (c *mockVMScaleSetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vmScaleSetName string, parameters compute.VirtualMachineScaleSet) (*compute.VirtualMachineScaleSet, error) {
@@ -61,7 +61,7 @@ type mockVMScaleSetVMsClient struct {
 	vms []*compute.VirtualMachineScaleSetVM
 }
 
-var _ VMScaleSetVMsClient = &mockVMScaleSetVMsClient{}
+var _ VMScaleSetVMsClient = (*mockVMScaleSetVMsClient)(nil)
 
 func (c *mockVMScaleSetVMsClient) List(ctx context.Context, resourceGroupName, vmssName string) ([]*compute.VirtualMachineScaleSetVM, error) {
 	return c.vms, nil

--- a/upup/pkg/fi/cloudup/azure/storageaccount.go
+++ b/upup/pkg/fi/cloudup/azure/storageaccount.go
@@ -33,7 +33,7 @@ type storageAccountsClientImpl struct {
 	c *armstorage.AccountsClient
 }
 
-var _ StorageAccountsClient = &storageAccountsClientImpl{}
+var _ StorageAccountsClient = (*storageAccountsClientImpl)(nil)
 
 func (c *storageAccountsClientImpl) List(ctx context.Context) ([]*armstorage.Account, error) {
 	var l []*armstorage.Account

--- a/upup/pkg/fi/cloudup/azure/subnet.go
+++ b/upup/pkg/fi/cloudup/azure/subnet.go
@@ -35,7 +35,7 @@ type subnetsClientImpl struct {
 	c *network.SubnetsClient
 }
 
-var _ SubnetsClient = &subnetsClientImpl{}
+var _ SubnetsClient = (*subnetsClientImpl)(nil)
 
 func (c *subnetsClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName, virtualNetworkName, subnetName string, parameters network.Subnet) (*network.Subnet, error) {
 	future, err := c.c.BeginCreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, subnetName, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/verifier.go
+++ b/upup/pkg/fi/cloudup/azure/verifier.go
@@ -46,7 +46,7 @@ type azureVerifier struct {
 	clusterName string
 }
 
-var _ bootstrap.Verifier = &azureVerifier{}
+var _ bootstrap.Verifier = (*azureVerifier)(nil)
 
 func NewAzureVerifier(ctx context.Context, opt *AzureVerifierOptions) (bootstrap.Verifier, error) {
 	azureClient, err := newClient()

--- a/upup/pkg/fi/cloudup/azure/virtualnetwork.go
+++ b/upup/pkg/fi/cloudup/azure/virtualnetwork.go
@@ -37,7 +37,7 @@ type virtualNetworksClientImpl struct {
 	c *network.VirtualNetworksClient
 }
 
-var _ VirtualNetworksClient = &virtualNetworksClientImpl{}
+var _ VirtualNetworksClient = (*virtualNetworksClientImpl)(nil)
 
 func (c *virtualNetworksClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName, virtualNetworkName string, parameters network.VirtualNetwork) (*network.VirtualNetwork, error) {
 	future, err := c.c.BeginCreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azure/vmscaleset.go
@@ -39,7 +39,7 @@ type vmScaleSetsClientImpl struct {
 	c *compute.VirtualMachineScaleSetsClient
 }
 
-var _ VMScaleSetsClient = &vmScaleSetsClientImpl{}
+var _ VMScaleSetsClient = (*vmScaleSetsClientImpl)(nil)
 
 func (c *vmScaleSetsClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName, vmScaleSetName string, parameters compute.VirtualMachineScaleSet) (*compute.VirtualMachineScaleSet, error) {
 	future, err := c.c.BeginCreateOrUpdate(ctx, resourceGroupName, vmScaleSetName, parameters, nil)

--- a/upup/pkg/fi/cloudup/azure/vmscalesetvm.go
+++ b/upup/pkg/fi/cloudup/azure/vmscalesetvm.go
@@ -34,7 +34,7 @@ type vmScaleSetVMsClientImpl struct {
 	c *compute.VirtualMachineScaleSetVMsClient
 }
 
-var _ VMScaleSetVMsClient = &vmScaleSetVMsClientImpl{}
+var _ VMScaleSetVMsClient = (*vmScaleSetVMsClientImpl)(nil)
 
 func (c *vmScaleSetVMsClientImpl) List(ctx context.Context, resourceGroupName, vmssName string) ([]*compute.VirtualMachineScaleSetVM, error) {
 	var l []*compute.VirtualMachineScaleSetVM

--- a/upup/pkg/fi/cloudup/azuretasks/applicationsecuritygroup_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/applicationsecuritygroup_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // ApplicationSecurityGroup
 
-var _ fi.HasLifecycle = &ApplicationSecurityGroup{}
+var _ fi.HasLifecycle = (*ApplicationSecurityGroup)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ApplicationSecurityGroup) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *ApplicationSecurityGroup) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &ApplicationSecurityGroup{}
+var _ fi.HasName = (*ApplicationSecurityGroup)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *ApplicationSecurityGroup) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/disk_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/disk_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Disk
 
-var _ fi.HasLifecycle = &Disk{}
+var _ fi.HasLifecycle = (*Disk)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Disk) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Disk) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Disk{}
+var _ fi.HasName = (*Disk)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Disk) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LoadBalancer
 
-var _ fi.HasLifecycle = &LoadBalancer{}
+var _ fi.HasLifecycle = (*LoadBalancer)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LoadBalancer) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LoadBalancer) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LoadBalancer{}
+var _ fi.HasName = (*LoadBalancer)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LoadBalancer) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/natgateway_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/natgateway_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // NatGateway
 
-var _ fi.HasLifecycle = &NatGateway{}
+var _ fi.HasLifecycle = (*NatGateway)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *NatGateway) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *NatGateway) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &NatGateway{}
+var _ fi.HasName = (*NatGateway)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *NatGateway) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/networksecuritygroup.go
+++ b/upup/pkg/fi/cloudup/azuretasks/networksecuritygroup.go
@@ -246,7 +246,7 @@ type NetworkSecurityRule struct {
 	DestinationPortRange                     *string
 }
 
-var _ fi.CloudupHasDependencies = &NetworkSecurityRule{}
+var _ fi.CloudupHasDependencies = (*NetworkSecurityRule)(nil)
 
 func (e *NetworkSecurityRule) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil

--- a/upup/pkg/fi/cloudup/azuretasks/networksecuritygroup_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/networksecuritygroup_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // NetworkSecurityGroup
 
-var _ fi.HasLifecycle = &NetworkSecurityGroup{}
+var _ fi.HasLifecycle = (*NetworkSecurityGroup)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *NetworkSecurityGroup) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *NetworkSecurityGroup) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &NetworkSecurityGroup{}
+var _ fi.HasName = (*NetworkSecurityGroup)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *NetworkSecurityGroup) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/publicipaddress_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/publicipaddress_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // PublicIPAddress
 
-var _ fi.HasLifecycle = &PublicIPAddress{}
+var _ fi.HasLifecycle = (*PublicIPAddress)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *PublicIPAddress) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *PublicIPAddress) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &PublicIPAddress{}
+var _ fi.HasName = (*PublicIPAddress)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *PublicIPAddress) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/resourcegroup_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/resourcegroup_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // ResourceGroup
 
-var _ fi.HasLifecycle = &ResourceGroup{}
+var _ fi.HasLifecycle = (*ResourceGroup)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ResourceGroup) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *ResourceGroup) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &ResourceGroup{}
+var _ fi.HasName = (*ResourceGroup)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *ResourceGroup) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/roleassignment_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/roleassignment_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // RoleAssignment
 
-var _ fi.HasLifecycle = &RoleAssignment{}
+var _ fi.HasLifecycle = (*RoleAssignment)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *RoleAssignment) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *RoleAssignment) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &RoleAssignment{}
+var _ fi.HasName = (*RoleAssignment)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *RoleAssignment) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/routetable_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/routetable_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // RouteTable
 
-var _ fi.HasLifecycle = &RouteTable{}
+var _ fi.HasLifecycle = (*RouteTable)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *RouteTable) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *RouteTable) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &RouteTable{}
+var _ fi.HasName = (*RouteTable)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *RouteTable) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/subnet_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/subnet_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Subnet
 
-var _ fi.HasLifecycle = &Subnet{}
+var _ fi.HasLifecycle = (*Subnet)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Subnet) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Subnet) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Subnet{}
+var _ fi.HasName = (*Subnet)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Subnet) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/testing.go
+++ b/upup/pkg/fi/cloudup/azuretasks/testing.go
@@ -60,7 +60,7 @@ type MockAzureCloud struct {
 	StorageAccountsClient           *MockStorageAccountsClient
 }
 
-var _ azure.AzureCloud = &MockAzureCloud{}
+var _ azure.AzureCloud = (*MockAzureCloud)(nil)
 
 // NewMockAzureCloud returns a new MockAzureCloud.
 func NewMockAzureCloud(location string) *MockAzureCloud {
@@ -268,7 +268,7 @@ type MockResourceGroupsClient struct {
 	RGs map[string]*resources.ResourceGroup
 }
 
-var _ azure.ResourceGroupsClient = &MockResourceGroupsClient{}
+var _ azure.ResourceGroupsClient = (*MockResourceGroupsClient)(nil)
 
 // CreateOrUpdate creates or updates a resource group.
 func (c *MockResourceGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, parameters resources.ResourceGroup) error {
@@ -301,7 +301,7 @@ type MockVirtualNetworksClient struct {
 	VNets map[string]*network.VirtualNetwork
 }
 
-var _ azure.VirtualNetworksClient = &MockVirtualNetworksClient{}
+var _ azure.VirtualNetworksClient = (*MockVirtualNetworksClient)(nil)
 
 // CreateOrUpdate creates or updates a virtual network.
 func (c *MockVirtualNetworksClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters network.VirtualNetwork) (*network.VirtualNetwork, error) {
@@ -338,7 +338,7 @@ type MockSubnetsClient struct {
 	Subnets map[string]*network.Subnet
 }
 
-var _ azure.SubnetsClient = &MockSubnetsClient{}
+var _ azure.SubnetsClient = (*MockSubnetsClient)(nil)
 
 // CreateOrUpdate creates or updates a subnet.
 func (c *MockSubnetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName, virtualNetworkName, subnetName string, parameters network.Subnet) (*network.Subnet, error) {
@@ -376,7 +376,7 @@ type MockRouteTablesClient struct {
 	RTs map[string]*network.RouteTable
 }
 
-var _ azure.RouteTablesClient = &MockRouteTablesClient{}
+var _ azure.RouteTablesClient = (*MockRouteTablesClient)(nil)
 
 // CreateOrUpdate creates or updates a route table.
 func (c *MockRouteTablesClient) CreateOrUpdate(ctx context.Context, resourceGroupName, routeTableName string, parameters network.RouteTable) (*network.RouteTable, error) {
@@ -414,7 +414,7 @@ type MockVMScaleSetsClient struct {
 	VMSSes map[string]*compute.VirtualMachineScaleSet
 }
 
-var _ azure.VMScaleSetsClient = &MockVMScaleSetsClient{}
+var _ azure.VMScaleSetsClient = (*MockVMScaleSetsClient)(nil)
 
 // CreateOrUpdate creates or updates a VM Scale Set.
 func (c *MockVMScaleSetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vmScaleSetName string, parameters compute.VirtualMachineScaleSet) (*compute.VirtualMachineScaleSet, error) {
@@ -462,7 +462,7 @@ type MockVMScaleSetVMsClient struct {
 	VMs map[string]*compute.VirtualMachineScaleSetVM
 }
 
-var _ azure.VMScaleSetVMsClient = &MockVMScaleSetVMsClient{}
+var _ azure.VMScaleSetVMsClient = (*MockVMScaleSetVMsClient)(nil)
 
 // List returns a slice of VM Scale Set VMs.
 func (c *MockVMScaleSetVMsClient) List(ctx context.Context, resourceGroupName, vmssName string) ([]*compute.VirtualMachineScaleSetVM, error) {
@@ -486,7 +486,7 @@ type MockDisksClient struct {
 	Disks map[string]*compute.Disk
 }
 
-var _ azure.DisksClient = &MockDisksClient{}
+var _ azure.DisksClient = (*MockDisksClient)(nil)
 
 // CreateOrUpdate creates or updates a disk.
 func (c *MockDisksClient) CreateOrUpdate(ctx context.Context, resourceGroupName, diskName string, parameters compute.Disk) (*compute.Disk, error) {
@@ -524,7 +524,7 @@ type MockRoleAssignmentsClient struct {
 	RAs map[string]*authz.RoleAssignment
 }
 
-var _ azure.RoleAssignmentsClient = &MockRoleAssignmentsClient{}
+var _ azure.RoleAssignmentsClient = (*MockRoleAssignmentsClient)(nil)
 
 // Create creates a new role assignment.
 func (c *MockRoleAssignmentsClient) Create(
@@ -573,7 +573,7 @@ type MockNetworkInterfacesClient struct {
 	NIs map[string]*network.Interface
 }
 
-var _ azure.NetworkInterfacesClient = &MockNetworkInterfacesClient{}
+var _ azure.NetworkInterfacesClient = (*MockNetworkInterfacesClient)(nil)
 
 // List returns a slice of VM Scale Set Network Interfaces.
 func (c *MockNetworkInterfacesClient) ListScaleSetsNetworkInterfaces(ctx context.Context, resourceGroupName, vmssName string) ([]*network.Interface, error) {
@@ -590,7 +590,7 @@ type MockLoadBalancersClient struct {
 	LBs map[string]*network.LoadBalancer
 }
 
-var _ azure.LoadBalancersClient = &MockLoadBalancersClient{}
+var _ azure.LoadBalancersClient = (*MockLoadBalancersClient)(nil)
 
 // CreateOrUpdate creates a new loadbalancer.
 func (c *MockLoadBalancersClient) CreateOrUpdate(ctx context.Context, resourceGroupName, loadBalancerName string, parameters network.LoadBalancer) (*network.LoadBalancer, error) {
@@ -637,7 +637,7 @@ type MockPublicIPAddressesClient struct {
 	PubIPs map[string]*network.PublicIPAddress
 }
 
-var _ azure.PublicIPAddressesClient = &MockPublicIPAddressesClient{}
+var _ azure.PublicIPAddressesClient = (*MockPublicIPAddressesClient)(nil)
 
 // CreateOrUpdate creates a new public ip address.
 func (c *MockPublicIPAddressesClient) CreateOrUpdate(ctx context.Context, resourceGroupName, publicIPAddressName string, parameters network.PublicIPAddress) (*network.PublicIPAddress, error) {
@@ -674,7 +674,7 @@ type MockNetworkSecurityGroupsClient struct {
 	NSGs map[string]*network.SecurityGroup
 }
 
-var _ azure.NetworkSecurityGroupsClient = &MockNetworkSecurityGroupsClient{}
+var _ azure.NetworkSecurityGroupsClient = (*MockNetworkSecurityGroupsClient)(nil)
 
 // CreateOrUpdate creates or updates a Network Security Group.
 func (c *MockNetworkSecurityGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName, nsgName string, parameters network.SecurityGroup) (*network.SecurityGroup, error) {
@@ -721,7 +721,7 @@ type MockApplicationSecurityGroupsClient struct {
 	ASGs map[string]*network.ApplicationSecurityGroup
 }
 
-var _ azure.ApplicationSecurityGroupsClient = &MockApplicationSecurityGroupsClient{}
+var _ azure.ApplicationSecurityGroupsClient = (*MockApplicationSecurityGroupsClient)(nil)
 
 // CreateOrUpdate creates or updates a Application Security Group.
 func (c *MockApplicationSecurityGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName, asgName string, parameters network.ApplicationSecurityGroup) (*network.ApplicationSecurityGroup, error) {
@@ -768,7 +768,7 @@ type MockNatGatewaysClient struct {
 	NGWs map[string]*network.NatGateway
 }
 
-var _ azure.NatGatewaysClient = &MockNatGatewaysClient{}
+var _ azure.NatGatewaysClient = (*MockNatGatewaysClient)(nil)
 
 // CreateOrUpdate creates or updates a Nat Gateway.
 func (c *MockNatGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName, ngwName string, parameters network.NatGateway) (*network.NatGateway, error) {
@@ -815,7 +815,7 @@ type MockStorageAccountsClient struct {
 	SAs map[string]*armstorage.Account
 }
 
-var _ azure.StorageAccountsClient = &MockStorageAccountsClient{}
+var _ azure.StorageAccountsClient = (*MockStorageAccountsClient)(nil)
 
 // List returns a slice of Storage Accounts.
 func (c *MockStorageAccountsClient) List(ctx context.Context) ([]*armstorage.Account, error) {

--- a/upup/pkg/fi/cloudup/azuretasks/virtualnetwork_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/virtualnetwork_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // VirtualNetwork
 
-var _ fi.HasLifecycle = &VirtualNetwork{}
+var _ fi.HasLifecycle = (*VirtualNetwork)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *VirtualNetwork) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *VirtualNetwork) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &VirtualNetwork{}
+var _ fi.HasName = (*VirtualNetwork)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *VirtualNetwork) GetName() *string {

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
@@ -61,7 +61,7 @@ type VMScaleSet struct {
 	PrincipalID *string
 }
 
-var _ fi.CloudupTaskNormalize = &VMScaleSet{}
+var _ fi.CloudupTaskNormalize = (*VMScaleSet)(nil)
 
 // VMScaleSetStorageProfile wraps *compute.VirtualMachineScaleSetStorageProfile
 // and implements fi.HasDependencies.
@@ -74,7 +74,7 @@ type VMScaleSetStorageProfile struct {
 	*compute.VirtualMachineScaleSetStorageProfile
 }
 
-var _ fi.CloudupHasDependencies = &VMScaleSetStorageProfile{}
+var _ fi.CloudupHasDependencies = (*VMScaleSetStorageProfile)(nil)
 
 // GetDependencies returns a slice of tasks on which the tasks depends on.
 func (p *VMScaleSetStorageProfile) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // VMScaleSet
 
-var _ fi.HasLifecycle = &VMScaleSet{}
+var _ fi.HasLifecycle = (*VMScaleSet)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *VMScaleSet) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *VMScaleSet) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &VMScaleSet{}
+var _ fi.HasName = (*VMScaleSet)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *VMScaleSet) GetName() *string {

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -59,7 +59,7 @@ type BootstrapChannelBuilder struct {
 	assetBuilder  *assets.AssetBuilder
 }
 
-var _ fi.CloudupModelBuilder = &BootstrapChannelBuilder{}
+var _ fi.CloudupModelBuilder = (*BootstrapChannelBuilder)(nil)
 
 // networkingSelector is the labels set on networking addons
 //

--- a/upup/pkg/fi/cloudup/do/api_target.go
+++ b/upup/pkg/fi/cloudup/do/api_target.go
@@ -24,7 +24,7 @@ type DOAPITarget struct {
 	Cloud DOCloud
 }
 
-var _ fi.CloudupTarget = &DOAPITarget{}
+var _ fi.CloudupTarget = (*DOAPITarget)(nil)
 
 func NewDOAPITarget(cloud DOCloud) *DOAPITarget {
 	return &DOAPITarget{

--- a/upup/pkg/fi/cloudup/do/authenticator.go
+++ b/upup/pkg/fi/cloudup/do/authenticator.go
@@ -29,7 +29,7 @@ const DOAuthenticationTokenPrefix = "x-digitalocean-droplet-id "
 type doAuthenticator struct {
 }
 
-var _ bootstrap.Authenticator = &doAuthenticator{}
+var _ bootstrap.Authenticator = (*doAuthenticator)(nil)
 
 func NewAuthenticator() (bootstrap.Authenticator, error) {
 	return &doAuthenticator{}, nil

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -87,7 +87,7 @@ var readBackoff = wait.Backoff{
 }
 
 // static compile time check to validate DOCloud's fi.Cloud Interface.
-var _ fi.Cloud = &doCloudImplementation{}
+var _ fi.Cloud = (*doCloudImplementation)(nil)
 
 // doCloudImplementation holds the godo client object to interact with DO resources.
 type doCloudImplementation struct {

--- a/upup/pkg/fi/cloudup/do/verifier.go
+++ b/upup/pkg/fi/cloudup/do/verifier.go
@@ -39,7 +39,7 @@ type digitalOceanVerifier struct {
 	doClient *godo.Client
 }
 
-var _ bootstrap.Verifier = &digitalOceanVerifier{}
+var _ bootstrap.Verifier = (*digitalOceanVerifier)(nil)
 
 func NewVerifier(ctx context.Context, opt *DigitalOceanVerifierOptions) (bootstrap.Verifier, error) {
 	accessToken := os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")

--- a/upup/pkg/fi/cloudup/dotasks/droplet_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Droplet
 
-var _ fi.HasLifecycle = &Droplet{}
+var _ fi.HasLifecycle = (*Droplet)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Droplet) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Droplet) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Droplet{}
+var _ fi.HasName = (*Droplet)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Droplet) GetName() *string {

--- a/upup/pkg/fi/cloudup/dotasks/loadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/loadbalancer_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LoadBalancer
 
-var _ fi.HasLifecycle = &LoadBalancer{}
+var _ fi.HasLifecycle = (*LoadBalancer)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LoadBalancer) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LoadBalancer) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LoadBalancer{}
+var _ fi.HasName = (*LoadBalancer)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LoadBalancer) GetName() *string {

--- a/upup/pkg/fi/cloudup/dotasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/dotasks/sshkey.go
@@ -41,8 +41,8 @@ type SSHKey struct {
 	KeyFingerprint *string
 }
 
-var _ fi.CompareWithID = &SSHKey{}
-var _ fi.CloudupTaskNormalize = &SSHKey{}
+var _ fi.CompareWithID = (*SSHKey)(nil)
+var _ fi.CloudupTaskNormalize = (*SSHKey)(nil)
 
 func (e *SSHKey) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/dotasks/sshkey_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/sshkey_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // SSHKey
 
-var _ fi.HasLifecycle = &SSHKey{}
+var _ fi.HasLifecycle = (*SSHKey)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SSHKey) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *SSHKey) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &SSHKey{}
+var _ fi.HasName = (*SSHKey)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *SSHKey) GetName() *string {

--- a/upup/pkg/fi/cloudup/dotasks/volume.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume.go
@@ -39,7 +39,7 @@ type Volume struct {
 	Tags   map[string]string
 }
 
-var _ fi.CompareWithID = &Volume{}
+var _ fi.CompareWithID = (*Volume)(nil)
 
 func (v *Volume) CompareWithID() *string {
 	return v.ID

--- a/upup/pkg/fi/cloudup/dotasks/volume_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Volume
 
-var _ fi.HasLifecycle = &Volume{}
+var _ fi.HasLifecycle = (*Volume)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Volume) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Volume) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Volume{}
+var _ fi.HasName = (*Volume)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Volume) GetName() *string {

--- a/upup/pkg/fi/cloudup/dotasks/vpc.go
+++ b/upup/pkg/fi/cloudup/dotasks/vpc.go
@@ -34,7 +34,7 @@ type VPC struct {
 	Region    *string
 }
 
-var _ fi.CompareWithID = &VPC{}
+var _ fi.CompareWithID = (*VPC)(nil)
 
 func (v *VPC) CompareWithID() *string {
 	return v.ID

--- a/upup/pkg/fi/cloudup/dotasks/vpc_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/vpc_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // VPC
 
-var _ fi.HasLifecycle = &VPC{}
+var _ fi.HasLifecycle = (*VPC)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *VPC) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *VPC) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &VPC{}
+var _ fi.HasName = (*VPC)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *VPC) GetName() *string {

--- a/upup/pkg/fi/cloudup/gce/compute.go
+++ b/upup/pkg/fi/cloudup/gce/compute.go
@@ -48,7 +48,7 @@ type computeClientImpl struct {
 	srv *compute.Service
 }
 
-var _ ComputeClient = &computeClientImpl{}
+var _ ComputeClient = (*computeClientImpl)(nil)
 
 func newComputeClientImpl(ctx context.Context) (*computeClientImpl, error) {
 	srv, err := compute.NewService(ctx)
@@ -176,7 +176,7 @@ type projectClientImpl struct {
 	srv *compute.ProjectsService
 }
 
-var _ ProjectClient = &projectClientImpl{}
+var _ ProjectClient = (*projectClientImpl)(nil)
 
 func (c *projectClientImpl) Get(project string) (*compute.Project, error) {
 	return c.srv.Get(project).Do()
@@ -190,7 +190,7 @@ type regionClientImpl struct {
 	srv *compute.RegionsService
 }
 
-var _ RegionClient = &regionClientImpl{}
+var _ RegionClient = (*regionClientImpl)(nil)
 
 func (c *regionClientImpl) List(ctx context.Context, project string) ([]*compute.Region, error) {
 	var regions []*compute.Region
@@ -212,7 +212,7 @@ type zoneClientImpl struct {
 	srv *compute.ZonesService
 }
 
-var _ ZoneClient = &zoneClientImpl{}
+var _ ZoneClient = (*zoneClientImpl)(nil)
 
 func (c *zoneClientImpl) List(ctx context.Context, project string) ([]*compute.Zone, error) {
 	var zones []*compute.Zone
@@ -237,7 +237,7 @@ type networkClientImpl struct {
 	srv *compute.NetworksService
 }
 
-var _ NetworkClient = &networkClientImpl{}
+var _ NetworkClient = (*networkClientImpl)(nil)
 
 func (c *networkClientImpl) Insert(project string, nw *compute.Network) (*compute.Operation, error) {
 	return c.srv.Insert(project, nw).Do()
@@ -267,7 +267,7 @@ type subnetworkClientImpl struct {
 	srv *compute.SubnetworksService
 }
 
-var _ SubnetworkClient = &subnetworkClientImpl{}
+var _ SubnetworkClient = (*subnetworkClientImpl)(nil)
 
 func (c *subnetworkClientImpl) Insert(project, region string, subnet *compute.Subnetwork) (*compute.Operation, error) {
 	return c.srv.Insert(project, region, subnet).Do()
@@ -308,7 +308,7 @@ type regionBackendServiceClientImpl struct {
 	srv *compute.RegionBackendServicesService
 }
 
-var _ RegionBackendServiceClient = &regionBackendServiceClientImpl{}
+var _ RegionBackendServiceClient = (*regionBackendServiceClientImpl)(nil)
 
 func (c *regionBackendServiceClientImpl) Insert(project, region string, fr *compute.BackendService) (*compute.Operation, error) {
 	return c.srv.Insert(project, region, fr).Do()
@@ -344,7 +344,7 @@ type routeClientImpl struct {
 	srv *compute.RoutesService
 }
 
-var _ RouteClient = &routeClientImpl{}
+var _ RouteClient = (*routeClientImpl)(nil)
 
 func (c *routeClientImpl) Delete(project, name string) (*compute.Operation, error) {
 	return c.srv.Delete(project, name).Do()
@@ -373,7 +373,7 @@ type forwardingRuleClientImpl struct {
 	srv *compute.ForwardingRulesService
 }
 
-var _ ForwardingRuleClient = &forwardingRuleClientImpl{}
+var _ ForwardingRuleClient = (*forwardingRuleClientImpl)(nil)
 
 func (c *forwardingRuleClientImpl) Insert(ctx context.Context, project, region string, fr *compute.ForwardingRule) (*compute.Operation, error) {
 	return c.srv.Insert(project, region, fr).Context(ctx).Do()
@@ -413,7 +413,7 @@ type healthCheckClientImpl struct {
 	srv *compute.RegionHealthChecksService
 }
 
-var _ RegionHealthChecksClient = &healthCheckClientImpl{}
+var _ RegionHealthChecksClient = (*healthCheckClientImpl)(nil)
 
 func (c *healthCheckClientImpl) Insert(project, region string, fr *compute.HealthCheck) (*compute.Operation, error) {
 	return c.srv.Insert(project, region, fr).Do()
@@ -449,7 +449,7 @@ type httpHealthCheckClientImpl struct {
 	srv *compute.HttpHealthChecksService
 }
 
-var _ HttpHealthChecksClient = &httpHealthCheckClientImpl{}
+var _ HttpHealthChecksClient = (*httpHealthCheckClientImpl)(nil)
 
 func (c *httpHealthCheckClientImpl) Insert(project string, fr *compute.HttpHealthCheck) (*compute.Operation, error) {
 	return c.srv.Insert(project, fr).Do()
@@ -486,7 +486,7 @@ type addressClientImpl struct {
 	srv *compute.AddressesService
 }
 
-var _ AddressClient = &addressClientImpl{}
+var _ AddressClient = (*addressClientImpl)(nil)
 
 func (c *addressClientImpl) Insert(project, region string, addr *compute.Address) (*compute.Operation, error) {
 	return c.srv.Insert(project, region, addr).Do()
@@ -531,7 +531,7 @@ type firewallClientImpl struct {
 	srv *compute.FirewallsService
 }
 
-var _ FirewallClient = &firewallClientImpl{}
+var _ FirewallClient = (*firewallClientImpl)(nil)
 
 func (c *firewallClientImpl) Insert(project string, fw *compute.Firewall) (*compute.Operation, error) {
 	return c.srv.Insert(project, fw).Do()
@@ -571,7 +571,7 @@ type routerClientImpl struct {
 	srv *compute.RoutersService
 }
 
-var _ RouterClient = &routerClientImpl{}
+var _ RouterClient = (*routerClientImpl)(nil)
 
 func (c *routerClientImpl) Insert(project, region string, r *compute.Router) (*compute.Operation, error) {
 	return c.srv.Insert(project, region, r).Do()
@@ -608,7 +608,7 @@ type instanceClientImpl struct {
 	srv *compute.InstancesService
 }
 
-var _ InstanceClient = &instanceClientImpl{}
+var _ InstanceClient = (*instanceClientImpl)(nil)
 
 func (c *instanceClientImpl) Insert(project, zone string, i *compute.Instance) (*compute.Operation, error) {
 	return c.srv.Insert(project, zone, i).Do()
@@ -647,7 +647,7 @@ type instanceTemplateClientImpl struct {
 	srv *compute.InstanceTemplatesService
 }
 
-var _ InstanceTemplateClient = &instanceTemplateClientImpl{}
+var _ InstanceTemplateClient = (*instanceTemplateClientImpl)(nil)
 
 func (c *instanceTemplateClientImpl) Insert(project string, template *compute.InstanceTemplate) (*compute.Operation, error) {
 	return c.srv.Insert(project, template).Do()
@@ -684,7 +684,7 @@ type instanceGroupManagerClientImpl struct {
 	srv *compute.InstanceGroupManagersService
 }
 
-var _ InstanceGroupManagerClient = &instanceGroupManagerClientImpl{}
+var _ InstanceGroupManagerClient = (*instanceGroupManagerClientImpl)(nil)
 
 func (c *instanceGroupManagerClientImpl) Insert(project, zone string, i *compute.InstanceGroupManager) (*compute.Operation, error) {
 	return c.srv.Insert(project, zone, i).Do()
@@ -759,7 +759,7 @@ type targetPoolClientImpl struct {
 	srv *compute.TargetPoolsService
 }
 
-var _ TargetPoolClient = &targetPoolClientImpl{}
+var _ TargetPoolClient = (*targetPoolClientImpl)(nil)
 
 func (c *targetPoolClientImpl) Insert(project, region string, tp *compute.TargetPool) (*compute.Operation, error) {
 	return c.srv.Insert(project, region, tp).Do()
@@ -801,7 +801,7 @@ type diskClientImpl struct {
 	srv *compute.DisksService
 }
 
-var _ DiskClient = &diskClientImpl{}
+var _ DiskClient = (*diskClientImpl)(nil)
 
 func (c *diskClientImpl) Insert(project, zone string, disk *compute.Disk) (*compute.Operation, error) {
 	return c.srv.Insert(project, zone, disk).Do()

--- a/upup/pkg/fi/cloudup/gce/dns.go
+++ b/upup/pkg/fi/cloudup/gce/dns.go
@@ -33,7 +33,7 @@ type dnsClientImpl struct {
 	srv *dns.Service
 }
 
-var _ DNSClient = &dnsClientImpl{}
+var _ DNSClient = (*dnsClientImpl)(nil)
 
 func newDNSClientImpl(ctx context.Context) (*dnsClientImpl, error) {
 	srv, err := dns.NewService(ctx)
@@ -71,7 +71,7 @@ type managedZoneClientImpl struct {
 	srv *dns.ManagedZonesService
 }
 
-var _ ManagedZoneClient = &managedZoneClientImpl{}
+var _ ManagedZoneClient = (*managedZoneClientImpl)(nil)
 
 func (c *managedZoneClientImpl) List(project string) ([]*dns.ManagedZone, error) {
 	r, err := c.srv.List(project).Do()
@@ -89,7 +89,7 @@ type resourceRecordSetClientImpl struct {
 	srv *dns.ResourceRecordSetsService
 }
 
-var _ ResourceRecordSetClient = &resourceRecordSetClientImpl{}
+var _ ResourceRecordSetClient = (*resourceRecordSetClientImpl)(nil)
 
 func (c *resourceRecordSetClientImpl) List(project, zone string) ([]*dns.ResourceRecordSet, error) {
 	r, err := c.srv.List(project, zone).Do()
@@ -107,7 +107,7 @@ type changeClientImpl struct {
 	srv *dns.ChangesService
 }
 
-var _ ChangeClient = &changeClientImpl{}
+var _ ChangeClient = (*changeClientImpl)(nil)
 
 func (c *changeClientImpl) Create(project, zone string, ch *dns.Change) (*dns.Change, error) {
 	return c.srv.Create(project, zone, ch).Do()

--- a/upup/pkg/fi/cloudup/gce/gce_apitarget.go
+++ b/upup/pkg/fi/cloudup/gce/gce_apitarget.go
@@ -24,7 +24,7 @@ type GCEAPITarget struct {
 	Cloud GCECloud
 }
 
-var _ fi.CloudupTarget = &GCEAPITarget{}
+var _ fi.CloudupTarget = (*GCEAPITarget)(nil)
 
 func NewGCEAPITarget(cloud GCECloud) *GCEAPITarget {
 	return &GCEAPITarget{

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -81,7 +81,7 @@ type gceCloudImplementation struct {
 	labels map[string]string
 }
 
-var _ fi.Cloud = &gceCloudImplementation{}
+var _ fi.Cloud = (*gceCloudImplementation)(nil)
 
 func (c *gceCloudImplementation) ProviderID() kops.CloudProviderID {
 	return kops.CloudProviderGCE

--- a/upup/pkg/fi/cloudup/gce/gcediscovery/resolver.go
+++ b/upup/pkg/fi/cloudup/gce/gcediscovery/resolver.go
@@ -39,7 +39,7 @@ type Discovery struct {
 	allZonesInRegion []string
 }
 
-var _ gossip.SeedProvider = &Discovery{}
+var _ gossip.SeedProvider = (*Discovery)(nil)
 
 func (r *Discovery) GetSeeds() ([]string, error) {
 	var seeds []string

--- a/upup/pkg/fi/cloudup/gce/iam.go
+++ b/upup/pkg/fi/cloudup/gce/iam.go
@@ -31,7 +31,7 @@ type iamClientImpl struct {
 	srv *iam.Service
 }
 
-var _ IamClient = &iamClientImpl{}
+var _ IamClient = (*iamClientImpl)(nil)
 
 func newIamClientImpl(ctx context.Context) (*iamClientImpl, error) {
 	srv, err := iam.NewService(ctx)
@@ -61,7 +61,7 @@ type serviceAccountClientImpl struct {
 	srv *iam.ProjectsServiceAccountsService
 }
 
-var _ ServiceAccountClient = &serviceAccountClientImpl{}
+var _ ServiceAccountClient = (*serviceAccountClientImpl)(nil)
 
 func (s *serviceAccountClientImpl) Create(ctx context.Context, project string, req *iam.CreateServiceAccountRequest) (*iam.ServiceAccount, error) {
 	return s.srv.Create(project, req).Context(ctx).Do()

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmsigner/tpmauthenticator.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmsigner/tpmauthenticator.go
@@ -40,7 +40,7 @@ type tpmAuthenticator struct {
 	instance  string
 }
 
-var _ bootstrap.Authenticator = &tpmAuthenticator{}
+var _ bootstrap.Authenticator = (*tpmAuthenticator)(nil)
 
 func NewTPMAuthenticator() (bootstrap.Authenticator, error) {
 	projectID, err := metadata.ProjectID()

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
@@ -68,7 +68,7 @@ func NewTPMVerifier(opt *gcetpm.TPMVerifierOptions, capiManager *clusterapi.Mana
 	}, nil
 }
 
-var _ bootstrap.Verifier = &tpmVerifier{}
+var _ bootstrap.Verifier = (*tpmVerifier)(nil)
 
 func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request, authToken string, body []byte) (*bootstrap.VerifyResult, error) {
 	// Reminder: we shouldn't trust any data we get from the client until we've checked the signature (and even then...)

--- a/upup/pkg/fi/cloudup/gcetasks/address.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address.go
@@ -44,7 +44,7 @@ type Address struct {
 	WellKnownServices []wellknownservices.WellKnownService
 }
 
-var _ fi.CompareWithID = &ForwardingRule{}
+var _ fi.CompareWithID = (*ForwardingRule)(nil)
 
 func (e *Address) CompareWithID() *string {
 	return e.Name
@@ -129,7 +129,7 @@ func (e *Address) find(cloud gce.GCECloud) (*Address, error) {
 	return actual, nil
 }
 
-var _ fi.HasAddress = &Address{}
+var _ fi.HasAddress = (*Address)(nil)
 
 // GetWellKnownServices implements fi.HasAddress::GetWellKnownServices.
 // It indicates which services we support with this address (likely attached to a load balancer).

--- a/upup/pkg/fi/cloudup/gcetasks/address_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Address
 
-var _ fi.HasLifecycle = &Address{}
+var _ fi.HasLifecycle = (*Address)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Address) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Address) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Address{}
+var _ fi.HasName = (*Address)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Address) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/backend_service.go
+++ b/upup/pkg/fi/cloudup/gcetasks/backend_service.go
@@ -41,7 +41,7 @@ type BackendService struct {
 	ForAPIServer bool
 }
 
-var _ fi.CompareWithID = &BackendService{}
+var _ fi.CompareWithID = (*BackendService)(nil)
 
 func (e *BackendService) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/backendservice_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/backendservice_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // BackendService
 
-var _ fi.HasLifecycle = &BackendService{}
+var _ fi.HasLifecycle = (*BackendService)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *BackendService) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *BackendService) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &BackendService{}
+var _ fi.HasName = (*BackendService)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *BackendService) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/disk.go
+++ b/upup/pkg/fi/cloudup/gcetasks/disk.go
@@ -43,7 +43,7 @@ type Disk struct {
 	Labels           map[string]string
 }
 
-var _ fi.CompareWithID = &Disk{}
+var _ fi.CompareWithID = (*Disk)(nil)
 
 func (e *Disk) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/disk_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/disk_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Disk
 
-var _ fi.HasLifecycle = &Disk{}
+var _ fi.HasLifecycle = (*Disk)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Disk) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Disk) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Disk{}
+var _ fi.HasName = (*Disk)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Disk) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
@@ -53,8 +53,8 @@ type FirewallRule struct {
 	Disabled bool
 }
 
-var _ fi.CompareWithID = &FirewallRule{}
-var _ fi.CloudupTaskNormalize = &FirewallRule{}
+var _ fi.CompareWithID = (*FirewallRule)(nil)
+var _ fi.CloudupTaskNormalize = (*FirewallRule)(nil)
 
 func (e *FirewallRule) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // FirewallRule
 
-var _ fi.HasLifecycle = &FirewallRule{}
+var _ fi.HasLifecycle = (*FirewallRule)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *FirewallRule) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *FirewallRule) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &FirewallRule{}
+var _ fi.HasName = (*FirewallRule)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *FirewallRule) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
@@ -65,7 +65,7 @@ type forwardingRulePruneSpec struct {
 	Name string
 }
 
-var _ fi.CompareWithID = &ForwardingRule{}
+var _ fi.CompareWithID = (*ForwardingRule)(nil)
 
 func (e *ForwardingRule) CompareWithID() *string {
 	return e.Name
@@ -338,7 +338,7 @@ func (e *ForwardingRule) TerraformLink() *terraformWriter.Literal {
 	return terraformWriter.LiteralSelfLink("google_compute_forwarding_rule", name)
 }
 
-var _ fi.CloudupProducesDeletions = &ForwardingRule{}
+var _ fi.CloudupProducesDeletions = (*ForwardingRule)(nil)
 
 // FindDeletions implements fi.HasDeletions
 func (e *ForwardingRule) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletion, error) {
@@ -377,7 +377,7 @@ type deleteForwardingRule struct {
 	forwardingRule *compute.ForwardingRule
 }
 
-var _ fi.CloudupDeletion = &deleteForwardingRule{}
+var _ fi.CloudupDeletion = (*deleteForwardingRule)(nil)
 
 // TaskName returns the task name
 func (d *deleteForwardingRule) TaskName() string {

--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // ForwardingRule
 
-var _ fi.HasLifecycle = &ForwardingRule{}
+var _ fi.HasLifecycle = (*ForwardingRule)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ForwardingRule) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *ForwardingRule) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &ForwardingRule{}
+var _ fi.HasName = (*ForwardingRule)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *ForwardingRule) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
@@ -38,7 +38,7 @@ type HealthCheck struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.CompareWithID = &HealthCheck{}
+var _ fi.CompareWithID = (*HealthCheck)(nil)
 
 func (e *HealthCheck) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/healthcheck_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/healthcheck_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // HealthCheck
 
-var _ fi.HasLifecycle = &HealthCheck{}
+var _ fi.HasLifecycle = (*HealthCheck)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *HealthCheck) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *HealthCheck) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &HealthCheck{}
+var _ fi.HasName = (*HealthCheck)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *HealthCheck) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/httphealthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/httphealthcheck.go
@@ -38,7 +38,7 @@ type HTTPHealthcheck struct {
 	RequestPath *string
 }
 
-var _ fi.CompareWithID = &HTTPHealthcheck{}
+var _ fi.CompareWithID = (*HTTPHealthcheck)(nil)
 
 func (e *HTTPHealthcheck) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/httphealthcheck_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/httphealthcheck_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // HTTPHealthcheck
 
-var _ fi.HasLifecycle = &HTTPHealthcheck{}
+var _ fi.HasLifecycle = (*HTTPHealthcheck)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *HTTPHealthcheck) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *HTTPHealthcheck) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &HTTPHealthcheck{}
+var _ fi.HasName = (*HTTPHealthcheck)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *HTTPHealthcheck) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/instance.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance.go
@@ -57,7 +57,7 @@ type Instance struct {
 	metadataFingerprint string
 }
 
-var _ fi.CompareWithID = &Instance{}
+var _ fi.CompareWithID = (*Instance)(nil)
 
 func (e *Instance) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/instance_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Instance
 
-var _ fi.HasLifecycle = &Instance{}
+var _ fi.HasLifecycle = (*Instance)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Instance) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Instance) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Instance{}
+var _ fi.HasName = (*Instance)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Instance) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
@@ -42,7 +42,7 @@ type InstanceGroupManager struct {
 	TargetPools []*TargetPool
 }
 
-var _ fi.CompareWithID = &InstanceGroupManager{}
+var _ fi.CompareWithID = (*InstanceGroupManager)(nil)
 
 func (e *InstanceGroupManager) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // InstanceGroupManager
 
-var _ fi.HasLifecycle = &InstanceGroupManager{}
+var _ fi.HasLifecycle = (*InstanceGroupManager)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *InstanceGroupManager) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *InstanceGroupManager) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &InstanceGroupManager{}
+var _ fi.HasName = (*InstanceGroupManager)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *InstanceGroupManager) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // InstanceTemplate
 
-var _ fi.HasLifecycle = &InstanceTemplate{}
+var _ fi.HasLifecycle = (*InstanceTemplate)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *InstanceTemplate) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *InstanceTemplate) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &InstanceTemplate{}
+var _ fi.HasName = (*InstanceTemplate)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *InstanceTemplate) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/network.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network.go
@@ -40,7 +40,7 @@ type Network struct {
 	Shared *bool
 }
 
-var _ fi.CompareWithID = &Network{}
+var _ fi.CompareWithID = (*Network)(nil)
 
 func (e *Network) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/network_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Network
 
-var _ fi.HasLifecycle = &Network{}
+var _ fi.HasLifecycle = (*Network)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Network) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Network) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Network{}
+var _ fi.HasName = (*Network)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Network) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/poolhealthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/poolhealthcheck.go
@@ -36,7 +36,7 @@ type PoolHealthCheck struct {
 	Pool        *TargetPool
 }
 
-var _ fi.CompareWithID = &PoolHealthCheck{}
+var _ fi.CompareWithID = (*PoolHealthCheck)(nil)
 
 // GetDependencies returns the dependencies of the PoolHealthCheck task
 func (_ *PoolHealthCheck) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {

--- a/upup/pkg/fi/cloudup/gcetasks/poolhealthcheck_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/poolhealthcheck_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // PoolHealthCheck
 
-var _ fi.HasLifecycle = &PoolHealthCheck{}
+var _ fi.HasLifecycle = (*PoolHealthCheck)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *PoolHealthCheck) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *PoolHealthCheck) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &PoolHealthCheck{}
+var _ fi.HasName = (*PoolHealthCheck)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *PoolHealthCheck) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/projectiambinding.go
+++ b/upup/pkg/fi/cloudup/gcetasks/projectiambinding.go
@@ -39,7 +39,7 @@ type ProjectIAMBinding struct {
 	Role                 *string
 }
 
-var _ fi.CompareWithID = &ProjectIAMBinding{}
+var _ fi.CompareWithID = (*ProjectIAMBinding)(nil)
 
 func (e *ProjectIAMBinding) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/projectiambinding_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/projectiambinding_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // ProjectIAMBinding
 
-var _ fi.HasLifecycle = &ProjectIAMBinding{}
+var _ fi.HasLifecycle = (*ProjectIAMBinding)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ProjectIAMBinding) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *ProjectIAMBinding) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &ProjectIAMBinding{}
+var _ fi.HasName = (*ProjectIAMBinding)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *ProjectIAMBinding) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/router.go
+++ b/upup/pkg/fi/cloudup/gcetasks/router.go
@@ -57,7 +57,7 @@ type Router struct {
 	Subnetworks []*Subnet
 }
 
-var _ fi.CompareWithID = &Router{}
+var _ fi.CompareWithID = (*Router)(nil)
 
 // CompareWithID returns the name of the Router.
 func (r *Router) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/router_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/router_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Router
 
-var _ fi.HasLifecycle = &Router{}
+var _ fi.HasLifecycle = (*Router)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Router) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Router) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Router{}
+var _ fi.HasName = (*Router)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Router) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/serviceaccount.go
+++ b/upup/pkg/fi/cloudup/gcetasks/serviceaccount.go
@@ -41,7 +41,7 @@ type ServiceAccount struct {
 	Shared *bool
 }
 
-var _ fi.CompareWithID = &ServiceAccount{}
+var _ fi.CompareWithID = (*ServiceAccount)(nil)
 
 func (e *ServiceAccount) CompareWithID() *string {
 	return e.Email

--- a/upup/pkg/fi/cloudup/gcetasks/serviceaccount_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/serviceaccount_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // ServiceAccount
 
-var _ fi.HasLifecycle = &ServiceAccount{}
+var _ fi.HasLifecycle = (*ServiceAccount)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ServiceAccount) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *ServiceAccount) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &ServiceAccount{}
+var _ fi.HasName = (*ServiceAccount)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *ServiceAccount) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketacl.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketacl.go
@@ -38,7 +38,7 @@ type StorageBucketAcl struct {
 	Role *string
 }
 
-var _ fi.CompareWithID = &StorageBucketAcl{}
+var _ fi.CompareWithID = (*StorageBucketAcl)(nil)
 
 func (e *StorageBucketAcl) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketacl_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketacl_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // StorageBucketAcl
 
-var _ fi.HasLifecycle = &StorageBucketAcl{}
+var _ fi.HasLifecycle = (*StorageBucketAcl)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *StorageBucketAcl) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *StorageBucketAcl) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &StorageBucketAcl{}
+var _ fi.HasName = (*StorageBucketAcl)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *StorageBucketAcl) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketiam.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketiam.go
@@ -39,7 +39,7 @@ type StorageBucketIAM struct {
 	Role                 *string
 }
 
-var _ fi.CompareWithID = &StorageBucketIAM{}
+var _ fi.CompareWithID = (*StorageBucketIAM)(nil)
 
 func (e *StorageBucketIAM) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketiam_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketiam_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // StorageBucketIAM
 
-var _ fi.HasLifecycle = &StorageBucketIAM{}
+var _ fi.HasLifecycle = (*StorageBucketIAM)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *StorageBucketIAM) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *StorageBucketIAM) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &StorageBucketIAM{}
+var _ fi.HasName = (*StorageBucketIAM)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *StorageBucketIAM) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/storageobjectacl.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storageobjectacl.go
@@ -39,7 +39,7 @@ type StorageObjectAcl struct {
 	Role *string
 }
 
-var _ fi.CompareWithID = &StorageObjectAcl{}
+var _ fi.CompareWithID = (*StorageObjectAcl)(nil)
 
 func (e *StorageObjectAcl) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/storageobjectacl_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storageobjectacl_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // StorageObjectAcl
 
-var _ fi.HasLifecycle = &StorageObjectAcl{}
+var _ fi.HasLifecycle = (*StorageObjectAcl)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *StorageObjectAcl) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *StorageObjectAcl) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &StorageObjectAcl{}
+var _ fi.HasName = (*StorageObjectAcl)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *StorageObjectAcl) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/subnet.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet.go
@@ -48,7 +48,7 @@ type Subnet struct {
 	Shared *bool
 }
 
-var _ fi.CompareWithID = &Subnet{}
+var _ fi.CompareWithID = (*Subnet)(nil)
 
 func (e *Subnet) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/subnet_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Subnet
 
-var _ fi.HasLifecycle = &Subnet{}
+var _ fi.HasLifecycle = (*Subnet)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Subnet) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Subnet) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Subnet{}
+var _ fi.HasName = (*Subnet)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Subnet) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool.go
@@ -36,7 +36,7 @@ type TargetPool struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.CompareWithID = &TargetPool{}
+var _ fi.CompareWithID = (*TargetPool)(nil)
 
 func (e *TargetPool) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // TargetPool
 
-var _ fi.HasLifecycle = &TargetPool{}
+var _ fi.HasLifecycle = (*TargetPool)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *TargetPool) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *TargetPool) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &TargetPool{}
+var _ fi.HasName = (*TargetPool)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *TargetPool) GetName() *string {

--- a/upup/pkg/fi/cloudup/gcetasks/updatepolicy.go
+++ b/upup/pkg/fi/cloudup/gcetasks/updatepolicy.go
@@ -24,7 +24,7 @@ type UpdatePolicy struct {
 	Type          string
 }
 
-var _ fi.CloudupHasDependencies = &UpdatePolicy{}
+var _ fi.CloudupHasDependencies = (*UpdatePolicy)(nil)
 
 func (_ *UpdatePolicy) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil

--- a/upup/pkg/fi/cloudup/hetzner/api_target.go
+++ b/upup/pkg/fi/cloudup/hetzner/api_target.go
@@ -24,7 +24,7 @@ type HetznerAPITarget struct {
 	Cloud HetznerCloud
 }
 
-var _ fi.CloudupTarget = &HetznerAPITarget{}
+var _ fi.CloudupTarget = (*HetznerAPITarget)(nil)
 
 func NewHetznerAPITarget(cloud HetznerCloud) *HetznerAPITarget {
 	return &HetznerAPITarget{

--- a/upup/pkg/fi/cloudup/hetzner/authenticator.go
+++ b/upup/pkg/fi/cloudup/hetzner/authenticator.go
@@ -29,7 +29,7 @@ const HetznerAuthenticationTokenPrefix = "x-hetzner-id "
 type hetznerAuthenticator struct {
 }
 
-var _ bootstrap.Authenticator = &hetznerAuthenticator{}
+var _ bootstrap.Authenticator = (*hetznerAuthenticator)(nil)
 
 func NewHetznerAuthenticator() (bootstrap.Authenticator, error) {
 	return &hetznerAuthenticator{}, nil

--- a/upup/pkg/fi/cloudup/hetzner/cloud.go
+++ b/upup/pkg/fi/cloudup/hetzner/cloud.go
@@ -64,7 +64,7 @@ type HetznerCloud interface {
 }
 
 // static compile time check to validate HetznerCloud's fi.Cloud Interface.
-var _ fi.Cloud = &hetznerCloudImplementation{}
+var _ fi.Cloud = (*hetznerCloudImplementation)(nil)
 
 // hetznerCloudImplementation holds the godo client object to interact with Hetzner resources.
 type hetznerCloudImplementation struct {

--- a/upup/pkg/fi/cloudup/hetzner/verifier.go
+++ b/upup/pkg/fi/cloudup/hetzner/verifier.go
@@ -39,7 +39,7 @@ type hetznerVerifier struct {
 	client *hcloud.Client
 }
 
-var _ bootstrap.Verifier = &hetznerVerifier{}
+var _ bootstrap.Verifier = (*hetznerVerifier)(nil)
 
 func NewHetznerVerifier(opt *HetznerVerifierOptions) (bootstrap.Verifier, error) {
 	hcloudToken := os.Getenv("HCLOUD_TOKEN")

--- a/upup/pkg/fi/cloudup/hetznertasks/firewall.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/firewall.go
@@ -39,7 +39,7 @@ type Firewall struct {
 	Labels map[string]string
 }
 
-var _ fi.CompareWithID = &Firewall{}
+var _ fi.CompareWithID = (*Firewall)(nil)
 
 func (v *Firewall) CompareWithID() *string {
 	return fi.PtrTo(strconv.FormatInt(fi.ValueOf(v.ID), 10))
@@ -201,7 +201,7 @@ type FirewallRule struct {
 	Port      *string
 }
 
-var _ fi.CloudupHasDependencies = &FirewallRule{}
+var _ fi.CloudupHasDependencies = (*FirewallRule)(nil)
 
 func (e *FirewallRule) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil

--- a/upup/pkg/fi/cloudup/hetznertasks/firewall_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/firewall_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Firewall
 
-var _ fi.HasLifecycle = &Firewall{}
+var _ fi.HasLifecycle = (*Firewall)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Firewall) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Firewall) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Firewall{}
+var _ fi.HasName = (*Firewall)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Firewall) GetName() *string {

--- a/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
@@ -53,13 +53,13 @@ type LoadBalancer struct {
 	WellKnownServices []wellknownservices.WellKnownService
 }
 
-var _ fi.CompareWithID = &LoadBalancer{}
+var _ fi.CompareWithID = (*LoadBalancer)(nil)
 
 func (v *LoadBalancer) CompareWithID() *string {
 	return fi.PtrTo(strconv.FormatInt(fi.ValueOf(v.ID), 10))
 }
 
-var _ fi.HasAddress = &LoadBalancer{}
+var _ fi.HasAddress = (*LoadBalancer)(nil)
 
 // GetWellKnownServices implements fi.HasAddress::GetWellKnownServices.
 // It indicates which services we support with this load balancer.
@@ -363,7 +363,7 @@ type LoadBalancerService struct {
 	DestinationPort *int
 }
 
-var _ fi.CloudupHasDependencies = &LoadBalancerService{}
+var _ fi.CloudupHasDependencies = (*LoadBalancerService)(nil)
 
 func (e *LoadBalancerService) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil

--- a/upup/pkg/fi/cloudup/hetznertasks/loadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/loadbalancer_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LoadBalancer
 
-var _ fi.HasLifecycle = &LoadBalancer{}
+var _ fi.HasLifecycle = (*LoadBalancer)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LoadBalancer) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LoadBalancer) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LoadBalancer{}
+var _ fi.HasName = (*LoadBalancer)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LoadBalancer) GetName() *string {

--- a/upup/pkg/fi/cloudup/hetznertasks/network.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/network.go
@@ -43,7 +43,7 @@ type Network struct {
 	Labels map[string]string
 }
 
-var _ fi.CompareWithID = &Network{}
+var _ fi.CompareWithID = (*Network)(nil)
 
 func (v *Network) CompareWithID() *string {
 	return v.ID

--- a/upup/pkg/fi/cloudup/hetznertasks/network_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/network_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Network
 
-var _ fi.HasLifecycle = &Network{}
+var _ fi.HasLifecycle = (*Network)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Network) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Network) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Network{}
+var _ fi.HasName = (*Network)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Network) GetName() *string {

--- a/upup/pkg/fi/cloudup/hetznertasks/servergroup_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/servergroup_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // ServerGroup
 
-var _ fi.HasLifecycle = &ServerGroup{}
+var _ fi.HasLifecycle = (*ServerGroup)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ServerGroup) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *ServerGroup) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &ServerGroup{}
+var _ fi.HasName = (*ServerGroup)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *ServerGroup) GetName() *string {

--- a/upup/pkg/fi/cloudup/hetznertasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/sshkey.go
@@ -41,7 +41,7 @@ type SSHKey struct {
 	Labels map[string]string
 }
 
-var _ fi.CompareWithID = &SSHKey{}
+var _ fi.CompareWithID = (*SSHKey)(nil)
 
 func (v *SSHKey) CompareWithID() *string {
 	return fi.PtrTo(strconv.FormatInt(fi.ValueOf(v.ID), 10))

--- a/upup/pkg/fi/cloudup/hetznertasks/sshkey_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/sshkey_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // SSHKey
 
-var _ fi.HasLifecycle = &SSHKey{}
+var _ fi.HasLifecycle = (*SSHKey)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SSHKey) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *SSHKey) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &SSHKey{}
+var _ fi.HasName = (*SSHKey)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *SSHKey) GetName() *string {

--- a/upup/pkg/fi/cloudup/hetznertasks/volume.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/volume.go
@@ -38,7 +38,7 @@ type Volume struct {
 	Labels map[string]string
 }
 
-var _ fi.CompareWithID = &Volume{}
+var _ fi.CompareWithID = (*Volume)(nil)
 
 func (v *Volume) CompareWithID() *string {
 	return fi.PtrTo(strconv.FormatInt(fi.ValueOf(v.ID), 10))

--- a/upup/pkg/fi/cloudup/hetznertasks/volume_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/volume_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Volume
 
-var _ fi.HasLifecycle = &Volume{}
+var _ fi.HasLifecycle = (*Volume)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Volume) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Volume) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Volume{}
+var _ fi.HasName = (*Volume)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Volume) GetName() *string {

--- a/upup/pkg/fi/cloudup/metal/api_target.go
+++ b/upup/pkg/fi/cloudup/metal/api_target.go
@@ -27,7 +27,7 @@ type APITarget struct {
 	OtherClouds []fi.Cloud
 }
 
-var _ fi.CloudupTarget = &APITarget{}
+var _ fi.CloudupTarget = (*APITarget)(nil)
 
 func NewAPITarget(cloud *Cloud, otherClouds []fi.Cloud) *APITarget {
 	return &APITarget{

--- a/upup/pkg/fi/cloudup/metal/cloud.go
+++ b/upup/pkg/fi/cloudup/metal/cloud.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 )
 
-var _ fi.Cloud = &Cloud{}
+var _ fi.Cloud = (*Cloud)(nil)
 
 // Cloud holds the fi.Cloud implementation for metal resources.
 type Cloud struct {

--- a/upup/pkg/fi/cloudup/openstack/apitarget.go
+++ b/upup/pkg/fi/cloudup/openstack/apitarget.go
@@ -24,7 +24,7 @@ type OpenstackAPITarget struct {
 	Cloud OpenstackCloud
 }
 
-var _ fi.CloudupTarget = &OpenstackAPITarget{}
+var _ fi.CloudupTarget = (*OpenstackAPITarget)(nil)
 
 func NewOpenstackAPITarget(cloud OpenstackCloud) *OpenstackAPITarget {
 	return &OpenstackAPITarget{

--- a/upup/pkg/fi/cloudup/openstack/authenticator.go
+++ b/upup/pkg/fi/cloudup/openstack/authenticator.go
@@ -27,7 +27,7 @@ const OpenstackAuthenticationTokenPrefix = "x-openstack-id "
 type openstackAuthenticator struct {
 }
 
-var _ bootstrap.Authenticator = &openstackAuthenticator{}
+var _ bootstrap.Authenticator = (*openstackAuthenticator)(nil)
 
 func NewOpenstackAuthenticator() (bootstrap.Authenticator, error) {
 	return &openstackAuthenticator{}, nil

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -320,7 +320,7 @@ type openstackCloud struct {
 	useVIPACL       *bool
 }
 
-var _ fi.Cloud = &openstackCloud{}
+var _ fi.Cloud = (*openstackCloud)(nil)
 
 var openstackCloudInstances = make(map[string]OpenstackCloud)
 

--- a/upup/pkg/fi/cloudup/openstack/verifier.go
+++ b/upup/pkg/fi/cloudup/openstack/verifier.go
@@ -47,7 +47,7 @@ type openstackVerifier struct {
 	kubeClient *kubernetes.Clientset
 }
 
-var _ bootstrap.Verifier = &openstackVerifier{}
+var _ bootstrap.Verifier = (*openstackVerifier)(nil)
 
 func NewOpenstackVerifier(opt *OpenStackVerifierOptions) (bootstrap.Verifier, error) {
 	env, err := gos.AuthOptionsFromEnv()

--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
@@ -46,7 +46,7 @@ type FloatingIP struct {
 	WellKnownServices []wellknownservices.WellKnownService
 }
 
-var _ fi.HasAddress = &FloatingIP{}
+var _ fi.HasAddress = (*FloatingIP)(nil)
 
 var readBackoff = wait.Backoff{
 	Duration: time.Second,
@@ -129,7 +129,7 @@ func (e *FloatingIP) GetDependencies(tasks map[string]fi.CloudupTask) []fi.Cloud
 	return deps
 }
 
-var _ fi.CompareWithID = &FloatingIP{}
+var _ fi.CompareWithID = (*FloatingIP)(nil)
 
 func (e *FloatingIP) CompareWithID() *string {
 	return e.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // FloatingIP
 
-var _ fi.HasLifecycle = &FloatingIP{}
+var _ fi.HasLifecycle = (*FloatingIP)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *FloatingIP) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *FloatingIP) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &FloatingIP{}
+var _ fi.HasName = (*FloatingIP)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *FloatingIP) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -99,7 +99,7 @@ func (e *Instance) GetDependencies(tasks map[string]fi.CloudupTask) []fi.Cloudup
 	return deps
 }
 
-var _ fi.CompareWithID = &Instance{}
+var _ fi.CompareWithID = (*Instance)(nil)
 
 func (e *Instance) CompareWithID() *string {
 	return e.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/instance_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Instance
 
-var _ fi.HasLifecycle = &Instance{}
+var _ fi.HasLifecycle = (*Instance)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Instance) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Instance) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Instance{}
+var _ fi.HasName = (*Instance)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Instance) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/lb.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lb.go
@@ -103,7 +103,7 @@ func (e *LB) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return deps
 }
 
-var _ fi.CompareWithID = &LB{}
+var _ fi.CompareWithID = (*LB)(nil)
 
 func (s *LB) CompareWithID() *string {
 	return s.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/lb_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lb_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LB
 
-var _ fi.HasLifecycle = &LB{}
+var _ fi.HasLifecycle = (*LB)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LB) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LB) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LB{}
+var _ fi.HasName = (*LB)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LB) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
@@ -51,7 +51,7 @@ func (e *LBListener) GetDependencies(tasks map[string]fi.CloudupTask) []fi.Cloud
 	return deps
 }
 
-var _ fi.CompareWithID = &LBListener{}
+var _ fi.CompareWithID = (*LBListener)(nil)
 
 func (s *LBListener) CompareWithID() *string {
 	return s.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/lblistener_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lblistener_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LBListener
 
-var _ fi.HasLifecycle = &LBListener{}
+var _ fi.HasLifecycle = (*LBListener)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LBListener) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LBListener) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LBListener{}
+var _ fi.HasName = (*LBListener)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LBListener) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/lbpool.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lbpool.go
@@ -44,7 +44,7 @@ func (e *LBPool) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTa
 	return deps
 }
 
-var _ fi.CompareWithID = &LBPool{}
+var _ fi.CompareWithID = (*LBPool)(nil)
 
 func (s *LBPool) CompareWithID() *string {
 	return s.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/lbpool_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lbpool_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LBPool
 
-var _ fi.HasLifecycle = &LBPool{}
+var _ fi.HasLifecycle = (*LBPool)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LBPool) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LBPool) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LBPool{}
+var _ fi.HasName = (*LBPool)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LBPool) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/network.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/network.go
@@ -34,7 +34,7 @@ type Network struct {
 	AvailabilityZoneHints []*string
 }
 
-var _ fi.CompareWithID = &Network{}
+var _ fi.CompareWithID = (*Network)(nil)
 
 func (n *Network) CompareWithID() *string {
 	return n.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/network_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/network_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Network
 
-var _ fi.HasLifecycle = &Network{}
+var _ fi.HasLifecycle = (*Network)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Network) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Network) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Network{}
+var _ fi.HasName = (*Network)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Network) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
@@ -58,7 +58,7 @@ func (e *PoolAssociation) GetDependencies(tasks map[string]fi.CloudupTask) []fi.
 	return deps
 }
 
-var _ fi.CompareWithID = &PoolAssociation{}
+var _ fi.CompareWithID = (*PoolAssociation)(nil)
 
 func (s *PoolAssociation) CompareWithID() *string {
 	return s.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/poolassociation_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolassociation_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // PoolAssociation
 
-var _ fi.HasLifecycle = &PoolAssociation{}
+var _ fi.HasLifecycle = (*PoolAssociation)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *PoolAssociation) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *PoolAssociation) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &PoolAssociation{}
+var _ fi.HasName = (*PoolAssociation)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *PoolAssociation) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/poolmonitor.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolmonitor.go
@@ -44,7 +44,7 @@ func (p *PoolMonitor) GetDependencies(tasks map[string]fi.CloudupTask) []fi.Clou
 	return deps
 }
 
-var _ fi.CompareWithID = &PoolMonitor{}
+var _ fi.CompareWithID = (*PoolMonitor)(nil)
 
 func (p *PoolMonitor) CompareWithID() *string {
 	return p.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/poolmonitor_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolmonitor_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // PoolMonitor
 
-var _ fi.HasLifecycle = &PoolMonitor{}
+var _ fi.HasLifecycle = (*PoolMonitor)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *PoolMonitor) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *PoolMonitor) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &PoolMonitor{}
+var _ fi.HasName = (*PoolMonitor)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *PoolMonitor) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/port_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Port
 
-var _ fi.HasLifecycle = &Port{}
+var _ fi.HasLifecycle = (*Port)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Port) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Port) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Port{}
+var _ fi.HasName = (*Port)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Port) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/router.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/router.go
@@ -33,7 +33,7 @@ type Router struct {
 	AvailabilityZoneHints []*string
 }
 
-var _ fi.CompareWithID = &Router{}
+var _ fi.CompareWithID = (*Router)(nil)
 
 func (n *Router) CompareWithID() *string {
 	return n.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/router_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/router_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Router
 
-var _ fi.HasLifecycle = &Router{}
+var _ fi.HasLifecycle = (*Router)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Router) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Router) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Router{}
+var _ fi.HasName = (*Router)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Router) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/routerinterface.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/routerinterface.go
@@ -49,7 +49,7 @@ func (e *RouterInterface) GetDependencies(tasks map[string]fi.CloudupTask) []fi.
 	return deps
 }
 
-var _ fi.CompareWithID = &RouterInterface{}
+var _ fi.CompareWithID = (*RouterInterface)(nil)
 
 func (i *RouterInterface) CompareWithID() *string {
 	return i.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/routerinterface_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/routerinterface_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // RouterInterface
 
-var _ fi.HasLifecycle = &RouterInterface{}
+var _ fi.HasLifecycle = (*RouterInterface)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *RouterInterface) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *RouterInterface) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &RouterInterface{}
+var _ fi.HasName = (*RouterInterface)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *RouterInterface) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
@@ -47,7 +47,7 @@ func (a SecurityGroupsByID) Less(i, j int) bool {
 	return fi.ValueOf(a[i].ID) < fi.ValueOf(a[j].ID)
 }
 
-var _ fi.CompareWithID = &SecurityGroup{}
+var _ fi.CompareWithID = (*SecurityGroup)(nil)
 
 func (s *SecurityGroup) CompareWithID() *string {
 	return s.ID
@@ -234,7 +234,7 @@ type deleteSecurityGroup struct {
 	securityGroup *SecurityGroup
 }
 
-var _ fi.CloudupDeletion = &deleteSecurityGroup{}
+var _ fi.CloudupDeletion = (*deleteSecurityGroup)(nil)
 
 func (d *deleteSecurityGroup) Delete(t fi.CloudupTarget) error {
 	klog.V(2).Infof("deleting security group: %v", fi.DebugAsJsonString(d.securityGroup.Name))
@@ -268,7 +268,7 @@ type deleteSecurityGroupRule struct {
 	securityGroup *SecurityGroup
 }
 
-var _ fi.CloudupDeletion = &deleteSecurityGroupRule{}
+var _ fi.CloudupDeletion = (*deleteSecurityGroupRule)(nil)
 
 func (d *deleteSecurityGroupRule) Delete(t fi.CloudupTarget) error {
 	klog.V(2).Infof("deleting security group permission: %v", fi.DebugAsJsonString(d.rule))
@@ -340,7 +340,7 @@ type PortRemovalRule struct {
 	Port int
 }
 
-var _ RemovalRule = &PortRemovalRule{}
+var _ RemovalRule = (*PortRemovalRule)(nil)
 
 func (r *PortRemovalRule) String() string {
 	return fi.DebugAsJsonString(r)

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygroup_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygroup_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // SecurityGroup
 
-var _ fi.HasLifecycle = &SecurityGroup{}
+var _ fi.HasLifecycle = (*SecurityGroup)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SecurityGroup) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *SecurityGroup) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &SecurityGroup{}
+var _ fi.HasName = (*SecurityGroup)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *SecurityGroup) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygrouprule.go
@@ -63,7 +63,7 @@ func (e *SecurityGroupRule) GetDependencies(tasks map[string]fi.CloudupTask) []f
 	return deps
 }
 
-var _ fi.CompareWithID = &SecurityGroupRule{}
+var _ fi.CompareWithID = (*SecurityGroupRule)(nil)
 
 func (r *SecurityGroupRule) CompareWithID() *string {
 	return r.ID
@@ -186,7 +186,7 @@ func (*SecurityGroupRule) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e,
 	return nil
 }
 
-var _ fi.HasLifecycle = &SecurityGroupRule{}
+var _ fi.HasLifecycle = (*SecurityGroupRule)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SecurityGroupRule) GetLifecycle() fi.Lifecycle {
@@ -198,7 +198,7 @@ func (o *SecurityGroupRule) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasLifecycle = &SecurityGroupRule{}
+var _ fi.HasLifecycle = (*SecurityGroupRule)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *SecurityGroupRule) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
@@ -37,7 +37,7 @@ type ServerGroup struct {
 	Lifecycle   fi.Lifecycle
 }
 
-var _ fi.CompareWithID = &ServerGroup{}
+var _ fi.CompareWithID = (*ServerGroup)(nil)
 
 func (s *ServerGroup) CompareWithID() *string {
 	return s.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/servergroup_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/servergroup_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // ServerGroup
 
-var _ fi.HasLifecycle = &ServerGroup{}
+var _ fi.HasLifecycle = (*ServerGroup)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ServerGroup) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *ServerGroup) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &ServerGroup{}
+var _ fi.HasName = (*ServerGroup)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *ServerGroup) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
@@ -38,8 +38,8 @@ type SSHKey struct {
 	KeyFingerprint *string
 }
 
-var _ fi.CompareWithID = &SSHKey{}
-var _ fi.CloudupTaskNormalize = &SSHKey{}
+var _ fi.CompareWithID = (*SSHKey)(nil)
+var _ fi.CloudupTaskNormalize = (*SSHKey)(nil)
 
 func (e *SSHKey) CompareWithID() *string {
 	return e.Name

--- a/upup/pkg/fi/cloudup/openstacktasks/sshkey_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/sshkey_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // SSHKey
 
-var _ fi.HasLifecycle = &SSHKey{}
+var _ fi.HasLifecycle = (*SSHKey)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SSHKey) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *SSHKey) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &SSHKey{}
+var _ fi.HasName = (*SSHKey)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *SSHKey) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/subnet.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/subnet.go
@@ -49,7 +49,7 @@ func (e *Subnet) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTa
 	return deps
 }
 
-var _ fi.CompareWithID = &Subnet{}
+var _ fi.CompareWithID = (*Subnet)(nil)
 
 func (s *Subnet) CompareWithID() *string {
 	return s.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/subnet_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/subnet_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Subnet
 
-var _ fi.HasLifecycle = &Subnet{}
+var _ fi.HasLifecycle = (*Subnet)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Subnet) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Subnet) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Subnet{}
+var _ fi.HasName = (*Subnet)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Subnet) GetName() *string {

--- a/upup/pkg/fi/cloudup/openstacktasks/volume.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume.go
@@ -36,8 +36,8 @@ type Volume struct {
 	Lifecycle        fi.Lifecycle
 }
 
-var _ fi.CompareWithID = &Volume{}
-var _ fi.CloudupTaskNormalize = &Volume{}
+var _ fi.CompareWithID = (*Volume)(nil)
+var _ fi.CloudupTaskNormalize = (*Volume)(nil)
 
 func (c *Volume) CompareWithID() *string {
 	return c.ID

--- a/upup/pkg/fi/cloudup/openstacktasks/volume_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Volume
 
-var _ fi.HasLifecycle = &Volume{}
+var _ fi.HasLifecycle = (*Volume)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Volume) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Volume) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Volume{}
+var _ fi.HasName = (*Volume)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Volume) GetName() *string {

--- a/upup/pkg/fi/cloudup/scaleway/api_target.go
+++ b/upup/pkg/fi/cloudup/scaleway/api_target.go
@@ -22,7 +22,7 @@ type ScwAPITarget struct {
 	Cloud ScwCloud
 }
 
-var _ fi.CloudupTarget = &ScwAPITarget{}
+var _ fi.CloudupTarget = (*ScwAPITarget)(nil)
 
 func NewScwAPITarget(cloud ScwCloud) *ScwAPITarget {
 	return &ScwAPITarget{

--- a/upup/pkg/fi/cloudup/scaleway/authenticator.go
+++ b/upup/pkg/fi/cloudup/scaleway/authenticator.go
@@ -27,7 +27,7 @@ const ScalewayAuthenticationTokenPrefix = "x-scaleway-instance-server-id "
 
 type scalewayAuthenticator struct{}
 
-var _ bootstrap.Authenticator = &scalewayAuthenticator{}
+var _ bootstrap.Authenticator = (*scalewayAuthenticator)(nil)
 
 func NewScalewayAuthenticator() (bootstrap.Authenticator, error) {
 	return &scalewayAuthenticator{}, nil

--- a/upup/pkg/fi/cloudup/scaleway/cloud.go
+++ b/upup/pkg/fi/cloudup/scaleway/cloud.go
@@ -90,7 +90,7 @@ type ScwCloud interface {
 }
 
 // static compile time check to validate ScwCloud's fi.Cloud Interface.
-var _ fi.Cloud = &scwCloudImplementation{}
+var _ fi.Cloud = (*scwCloudImplementation)(nil)
 
 // scwCloudImplementation holds the scw.Client object to interact with Scaleway resources.
 type scwCloudImplementation struct {

--- a/upup/pkg/fi/cloudup/scaleway/verifier.go
+++ b/upup/pkg/fi/cloudup/scaleway/verifier.go
@@ -39,7 +39,7 @@ type scalewayVerifier struct {
 	scwClient *scw.Client
 }
 
-var _ bootstrap.Verifier = &scalewayVerifier{}
+var _ bootstrap.Verifier = (*scalewayVerifier)(nil)
 
 func NewScalewayVerifier(ctx context.Context, opt *ScalewayVerifierOptions) (bootstrap.Verifier, error) {
 	profile, err := CreateValidScalewayProfile()

--- a/upup/pkg/fi/cloudup/scalewaytasks/dns_record.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/dns_record.go
@@ -38,8 +38,8 @@ type DNSRecord struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.CloudupTask = &DNSRecord{}
-var _ fi.CompareWithID = &DNSRecord{}
+var _ fi.CloudupTask = (*DNSRecord)(nil)
+var _ fi.CompareWithID = (*DNSRecord)(nil)
 
 func (d *DNSRecord) CompareWithID() *string {
 	return d.ID

--- a/upup/pkg/fi/cloudup/scalewaytasks/dnsrecord_fitask.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/dnsrecord_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // DNSRecord
 
-var _ fi.HasLifecycle = &DNSRecord{}
+var _ fi.HasLifecycle = (*DNSRecord)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *DNSRecord) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *DNSRecord) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &DNSRecord{}
+var _ fi.HasName = (*DNSRecord)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *DNSRecord) GetName() *string {

--- a/upup/pkg/fi/cloudup/scalewaytasks/instance.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/instance.go
@@ -51,14 +51,14 @@ type Instance struct {
 	LoadBalancer *LoadBalancer
 }
 
-var _ fi.CloudupTask = &Instance{}
-var _ fi.CompareWithID = &Instance{}
+var _ fi.CloudupTask = (*Instance)(nil)
+var _ fi.CompareWithID = (*Instance)(nil)
 
 func (s *Instance) CompareWithID() *string {
 	return s.Name
 }
 
-var _ fi.CloudupHasDependencies = &Instance{}
+var _ fi.CloudupHasDependencies = (*Instance)(nil)
 
 func (s *Instance) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	var deps []fi.CloudupTask

--- a/upup/pkg/fi/cloudup/scalewaytasks/instance_fitask.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/instance_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Instance
 
-var _ fi.HasLifecycle = &Instance{}
+var _ fi.HasLifecycle = (*Instance)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Instance) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Instance) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Instance{}
+var _ fi.HasName = (*Instance)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Instance) GetName() *string {

--- a/upup/pkg/fi/cloudup/scalewaytasks/lb_backend.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/lb_backend.go
@@ -44,10 +44,10 @@ type LBBackend struct {
 	LoadBalancer *LoadBalancer
 }
 
-var _ fi.CloudupTask = &LBBackend{}
-var _ fi.CompareWithID = &LBBackend{}
+var _ fi.CloudupTask = (*LBBackend)(nil)
+var _ fi.CompareWithID = (*LBBackend)(nil)
 
-var _ fi.CloudupHasDependencies = &LBBackend{}
+var _ fi.CloudupHasDependencies = (*LBBackend)(nil)
 
 func (l *LBBackend) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	var deps []fi.CloudupTask

--- a/upup/pkg/fi/cloudup/scalewaytasks/lb_frontend.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/lb_frontend.go
@@ -40,10 +40,10 @@ type LBFrontend struct {
 	LBBackend    *LBBackend
 }
 
-var _ fi.CloudupTask = &LBFrontend{}
-var _ fi.CompareWithID = &LBFrontend{}
+var _ fi.CloudupTask = (*LBFrontend)(nil)
+var _ fi.CompareWithID = (*LBFrontend)(nil)
 
-var _ fi.CloudupHasDependencies = &LBFrontend{}
+var _ fi.CloudupHasDependencies = (*LBFrontend)(nil)
 
 func (l *LBFrontend) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	var deps []fi.CloudupTask

--- a/upup/pkg/fi/cloudup/scalewaytasks/lbbackend_fitask.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/lbbackend_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LBBackend
 
-var _ fi.HasLifecycle = &LBBackend{}
+var _ fi.HasLifecycle = (*LBBackend)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LBBackend) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LBBackend) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LBBackend{}
+var _ fi.HasName = (*LBBackend)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LBBackend) GetName() *string {

--- a/upup/pkg/fi/cloudup/scalewaytasks/lbfrontend_fitask.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/lbfrontend_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LBFrontend
 
-var _ fi.HasLifecycle = &LBFrontend{}
+var _ fi.HasLifecycle = (*LBFrontend)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LBFrontend) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LBFrontend) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LBFrontend{}
+var _ fi.HasName = (*LBFrontend)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LBFrontend) GetName() *string {

--- a/upup/pkg/fi/cloudup/scalewaytasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/loadbalancer.go
@@ -52,8 +52,8 @@ type LoadBalancer struct {
 	WellKnownServices []wellknownservices.WellKnownService
 }
 
-var _ fi.CompareWithID = &LoadBalancer{}
-var _ fi.HasAddress = &LoadBalancer{}
+var _ fi.CompareWithID = (*LoadBalancer)(nil)
+var _ fi.HasAddress = (*LoadBalancer)(nil)
 
 func (l *LoadBalancer) CompareWithID() *string {
 	return l.LBID

--- a/upup/pkg/fi/cloudup/scalewaytasks/loadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/loadbalancer_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LoadBalancer
 
-var _ fi.HasLifecycle = &LoadBalancer{}
+var _ fi.HasLifecycle = (*LoadBalancer)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LoadBalancer) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LoadBalancer) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LoadBalancer{}
+var _ fi.HasName = (*LoadBalancer)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LoadBalancer) GetName() *string {

--- a/upup/pkg/fi/cloudup/scalewaytasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/sshkey.go
@@ -39,7 +39,7 @@ type SSHKey struct {
 	KeyPairFingerPrint *string
 }
 
-var _ fi.CompareWithID = &SSHKey{}
+var _ fi.CompareWithID = (*SSHKey)(nil)
 
 func (s *SSHKey) CompareWithID() *string {
 	return s.Name

--- a/upup/pkg/fi/cloudup/scalewaytasks/sshkey_fitask.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/sshkey_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // SSHKey
 
-var _ fi.HasLifecycle = &SSHKey{}
+var _ fi.HasLifecycle = (*SSHKey)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *SSHKey) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *SSHKey) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &SSHKey{}
+var _ fi.HasName = (*SSHKey)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *SSHKey) GetName() *string {

--- a/upup/pkg/fi/cloudup/scalewaytasks/volume.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/volume.go
@@ -39,7 +39,7 @@ type Volume struct {
 	Type *string
 }
 
-var _ fi.CompareWithID = &Volume{}
+var _ fi.CompareWithID = (*Volume)(nil)
 
 func (v *Volume) CompareWithID() *string {
 	return v.ID

--- a/upup/pkg/fi/cloudup/scalewaytasks/volume_fitask.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/volume_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Volume
 
-var _ fi.HasLifecycle = &Volume{}
+var _ fi.HasLifecycle = (*Volume)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Volume) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Volume) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Volume{}
+var _ fi.HasName = (*Volume)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Volume) GetName() *string {

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -193,7 +193,7 @@ func (e *Elastigroup) find(svc spotinst.InstanceGroupService) (*aws.Group, error
 	return out, nil
 }
 
-var _ fi.CloudupHasCheckExisting = &Elastigroup{}
+var _ fi.CloudupHasCheckExisting = (*Elastigroup)(nil)
 
 func (e *Elastigroup) Find(c *fi.CloudupContext) (*Elastigroup, error) {
 	cloud := awsup.GetCloud(c)

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup_fitask.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Elastigroup
 
-var _ fi.HasLifecycle = &Elastigroup{}
+var _ fi.HasLifecycle = (*Elastigroup)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Elastigroup) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Elastigroup) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Elastigroup{}
+var _ fi.HasName = (*Elastigroup)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Elastigroup) GetName() *string {

--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -127,7 +127,7 @@ func (o *LaunchSpec) find(svc spotinst.LaunchSpecService, oceanID string) (*aws.
 	return out, nil
 }
 
-var _ fi.CloudupHasCheckExisting = &LaunchSpec{}
+var _ fi.CloudupHasCheckExisting = (*LaunchSpec)(nil)
 
 func (o *LaunchSpec) Find(c *fi.CloudupContext) (*LaunchSpec, error) {
 	cloud := awsup.GetCloud(c)

--- a/upup/pkg/fi/cloudup/spotinsttasks/launchspec_fitask.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launchspec_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // LaunchSpec
 
-var _ fi.HasLifecycle = &LaunchSpec{}
+var _ fi.HasLifecycle = (*LaunchSpec)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *LaunchSpec) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *LaunchSpec) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &LaunchSpec{}
+var _ fi.HasName = (*LaunchSpec)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *LaunchSpec) GetName() *string {

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -133,7 +133,7 @@ func (o *Ocean) find(svc spotinst.InstanceGroupService) (*aws.Cluster, error) {
 	return out, nil
 }
 
-var _ fi.CloudupHasCheckExisting = &Ocean{}
+var _ fi.CloudupHasCheckExisting = (*Ocean)(nil)
 
 func (o *Ocean) Find(c *fi.CloudupContext) (*Ocean, error) {
 	cloud := awsup.GetCloud(c)

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean_fitask.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Ocean
 
-var _ fi.HasLifecycle = &Ocean{}
+var _ fi.HasLifecycle = (*Ocean)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Ocean) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Ocean) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Ocean{}
+var _ fi.HasName = (*Ocean)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Ocean) GetName() *string {

--- a/upup/pkg/fi/cloudup/terraform/element.go
+++ b/upup/pkg/fi/cloudup/terraform/element.go
@@ -38,7 +38,7 @@ type object struct {
 	field map[string]element
 }
 
-var _ element = &object{}
+var _ element = (*object)(nil)
 
 func (o *object) IsSingleValue() bool {
 	return false

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -51,7 +51,7 @@ func NewTerraformTarget(cloud fi.Cloud, project string, outDir string, clusterSp
 	return &target
 }
 
-var _ fi.CloudupTarget = &TerraformTarget{}
+var _ fi.CloudupTarget = (*TerraformTarget)(nil)
 
 func (t *TerraformTarget) AddFileResource(resourceType string, resourceName string, key string, r fi.Resource, base64 bool) (*terraformWriter.Literal, error) {
 	d, err := fi.ResourceAsBytes(r)

--- a/upup/pkg/fi/cloudup/terraformWriter/literal.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/literal.go
@@ -32,7 +32,7 @@ type Literal struct {
 	String string `cty:"string"`
 }
 
-var _ json.Marshaler = &Literal{}
+var _ json.Marshaler = (*Literal)(nil)
 
 func (l *Literal) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&l.String)

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -79,7 +79,7 @@ func (a DeletionByTaskName[T]) Less(i, j int) bool {
 	return a[i].TaskName() < a[j].TaskName()
 }
 
-var _ Target[CloudupSubContext] = &DryRunTarget[CloudupSubContext]{}
+var _ Target[CloudupSubContext] = (*DryRunTarget[CloudupSubContext])(nil)
 
 func newDryRunTarget[T SubContext](assetBuilder *assets.AssetBuilder, defaultCheckExisting bool, out io.Writer) *DryRunTarget[T] {
 	t := &DryRunTarget[T]{}

--- a/upup/pkg/fi/dryruntarget_test.go
+++ b/upup/pkg/fi/dryruntarget_test.go
@@ -60,7 +60,7 @@ type testTask struct {
 	Tags      map[string]string
 }
 
-var _ CloudupTask = &testTask{}
+var _ CloudupTask = (*testTask)(nil)
 
 func (*testTask) Run(_ *CloudupContext) error {
 	panic("not implemented")

--- a/upup/pkg/fi/fitasks/keypair.go
+++ b/upup/pkg/fi/fitasks/keypair.go
@@ -63,7 +63,7 @@ func (e *Keypair) CheckExisting(c *fi.CloudupContext) bool {
 	return true
 }
 
-var _ fi.CompareWithID = &Keypair{}
+var _ fi.CompareWithID = (*Keypair)(nil)
 
 func (e *Keypair) CompareWithID() *string {
 	return &e.Subject

--- a/upup/pkg/fi/fitasks/keypair_fitask.go
+++ b/upup/pkg/fi/fitasks/keypair_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Keypair
 
-var _ fi.HasLifecycle = &Keypair{}
+var _ fi.HasLifecycle = (*Keypair)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Keypair) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Keypair) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Keypair{}
+var _ fi.HasName = (*Keypair)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Keypair) GetName() *string {

--- a/upup/pkg/fi/fitasks/managedfile_fitask.go
+++ b/upup/pkg/fi/fitasks/managedfile_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // ManagedFile
 
-var _ fi.HasLifecycle = &ManagedFile{}
+var _ fi.HasLifecycle = (*ManagedFile)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *ManagedFile) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *ManagedFile) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &ManagedFile{}
+var _ fi.HasName = (*ManagedFile)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *ManagedFile) GetName() *string {

--- a/upup/pkg/fi/fitasks/mirrorkeystore.go
+++ b/upup/pkg/fi/fitasks/mirrorkeystore.go
@@ -30,7 +30,7 @@ type MirrorKeystore struct {
 	MirrorPath vfs.Path
 }
 
-var _ fi.CloudupHasDependencies = &MirrorKeystore{}
+var _ fi.CloudupHasDependencies = (*MirrorKeystore)(nil)
 
 // GetDependencies returns the dependencies for a MirrorKeystore task - it must run after all secrets have been run
 func (e *MirrorKeystore) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {

--- a/upup/pkg/fi/fitasks/mirrorkeystore_fitask.go
+++ b/upup/pkg/fi/fitasks/mirrorkeystore_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // MirrorKeystore
 
-var _ fi.HasLifecycle = &MirrorKeystore{}
+var _ fi.HasLifecycle = (*MirrorKeystore)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *MirrorKeystore) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *MirrorKeystore) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &MirrorKeystore{}
+var _ fi.HasName = (*MirrorKeystore)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *MirrorKeystore) GetName() *string {

--- a/upup/pkg/fi/fitasks/mirrorsecrets.go
+++ b/upup/pkg/fi/fitasks/mirrorsecrets.go
@@ -31,7 +31,7 @@ type MirrorSecrets struct {
 	MirrorPath vfs.Path
 }
 
-var _ fi.CloudupHasDependencies = &MirrorSecrets{}
+var _ fi.CloudupHasDependencies = (*MirrorSecrets)(nil)
 
 // GetDependencies returns the dependencies for a MirrorSecrets task - it must run after all secrets have been run
 func (e *MirrorSecrets) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {

--- a/upup/pkg/fi/fitasks/mirrorsecrets_fitask.go
+++ b/upup/pkg/fi/fitasks/mirrorsecrets_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // MirrorSecrets
 
-var _ fi.HasLifecycle = &MirrorSecrets{}
+var _ fi.HasLifecycle = (*MirrorSecrets)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *MirrorSecrets) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *MirrorSecrets) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &MirrorSecrets{}
+var _ fi.HasName = (*MirrorSecrets)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *MirrorSecrets) GetName() *string {

--- a/upup/pkg/fi/fitasks/secret.go
+++ b/upup/pkg/fi/fitasks/secret.go
@@ -28,7 +28,7 @@ type Secret struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.CloudupHasCheckExisting = &Secret{}
+var _ fi.CloudupHasCheckExisting = (*Secret)(nil)
 
 // It's important always to check for the existing Secret, so we don't regenerate tokens e.g. on terraform
 func (e *Secret) CheckExisting(c *fi.CloudupContext) bool {

--- a/upup/pkg/fi/fitasks/secret_fitask.go
+++ b/upup/pkg/fi/fitasks/secret_fitask.go
@@ -27,7 +27,7 @@ import (
 
 // Secret
 
-var _ fi.HasLifecycle = &Secret{}
+var _ fi.HasLifecycle = (*Secret)(nil)
 
 // GetLifecycle returns the Lifecycle of the object, implementing fi.HasLifecycle
 func (o *Secret) GetLifecycle() fi.Lifecycle {
@@ -39,7 +39,7 @@ func (o *Secret) SetLifecycle(lifecycle fi.Lifecycle) {
 	o.Lifecycle = lifecycle
 }
 
-var _ fi.HasName = &Secret{}
+var _ fi.HasName = (*Secret)(nil)
 
 // GetName returns the Name of the object, implementing fi.HasName
 func (o *Secret) GetName() *string {

--- a/upup/pkg/fi/nodeup/install/install_target.go
+++ b/upup/pkg/fi/nodeup/install/install_target.go
@@ -25,7 +25,7 @@ import (
 type InstallTarget struct {
 }
 
-var _ fi.InstallTarget = &InstallTarget{}
+var _ fi.InstallTarget = (*InstallTarget)(nil)
 
 func (t *InstallTarget) Finish(taskMap map[string]fi.InstallTask) error {
 	return nil

--- a/upup/pkg/fi/nodeup/local/local_target.go
+++ b/upup/pkg/fi/nodeup/local/local_target.go
@@ -27,7 +27,7 @@ type LocalTarget struct {
 	Cloud    fi.Cloud
 }
 
-var _ fi.NodeupTarget = &LocalTarget{}
+var _ fi.NodeupTarget = (*LocalTarget)(nil)
 
 func (t *LocalTarget) Finish(taskMap map[string]fi.NodeupTask) error {
 	return nil

--- a/upup/pkg/fi/nodeup/nodetasks/archive.go
+++ b/upup/pkg/fi/nodeup/nodetasks/archive.go
@@ -57,7 +57,7 @@ const (
 	localArchiveStateDir = "/var/cache/nodeup/archives/state/"
 )
 
-var _ fi.NodeupHasDependencies = &Archive{}
+var _ fi.NodeupHasDependencies = (*Archive)(nil)
 
 // GetDependencies implements HasDependencies::GetDependencies
 func (e *Archive) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
@@ -69,7 +69,7 @@ func (e *Archive) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTas
 	return deps
 }
 
-var _ fi.HasName = &Archive{}
+var _ fi.HasName = (*Archive)(nil)
 
 func (e *Archive) GetName() *string {
 	return &e.Name
@@ -80,7 +80,7 @@ func (e *Archive) String() string {
 	return fmt.Sprintf("Archive: %s %s->%s", e.Name, e.Source, e.TargetDir)
 }
 
-var _ CreatesDir = &Archive{}
+var _ CreatesDir = (*Archive)(nil)
 
 // Dir implements CreatesDir::Dir
 func (e *Archive) Dir() string {

--- a/upup/pkg/fi/nodeup/nodetasks/bindmount.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bindmount.go
@@ -35,26 +35,26 @@ type BindMount struct {
 	Recursive  bool     `json:"recursive"`
 }
 
-var _ fi.NodeupTask = &BindMount{}
+var _ fi.NodeupTask = (*BindMount)(nil)
 
 func (s *BindMount) String() string {
 	return fmt.Sprintf("BindMount: %s->%s", s.Source, s.Mountpoint)
 }
 
-var _ CreatesDir = &BindMount{}
+var _ CreatesDir = (*BindMount)(nil)
 
 // Dir implements CreatesDir::Dir
 func (e *BindMount) Dir() string {
 	return e.Mountpoint
 }
 
-var _ fi.HasName = &Archive{}
+var _ fi.HasName = (*Archive)(nil)
 
 func (e *BindMount) GetName() *string {
 	return fi.PtrTo("BindMount-" + e.Mountpoint)
 }
 
-var _ fi.NodeupHasDependencies = &BindMount{}
+var _ fi.NodeupHasDependencies = (*BindMount)(nil)
 
 // GetDependencies implements HasDependencies::GetDependencies
 func (e *BindMount) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {

--- a/upup/pkg/fi/nodeup/nodetasks/bindmount_test.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bindmount_test.go
@@ -220,7 +220,7 @@ func (c *MockCommand) String() string {
 	return strings.Join(c.Args, " ")
 }
 
-var _ Executor = &MockExecutor{}
+var _ Executor = (*MockExecutor)(nil)
 
 func (m *MockExecutor) Expect(args []string) *MockCommand {
 	c := &MockCommand{

--- a/upup/pkg/fi/nodeup/nodetasks/chattr.go
+++ b/upup/pkg/fi/nodeup/nodetasks/chattr.go
@@ -33,19 +33,19 @@ type Chattr struct {
 	Deps []fi.NodeupTask `json:"-"`
 }
 
-var _ fi.NodeupTask = &Chattr{}
+var _ fi.NodeupTask = (*Chattr)(nil)
 
 func (s *Chattr) String() string {
 	return fmt.Sprintf("Chattr: chattr %s %s", s.Mode, s.File)
 }
 
-var _ fi.HasName = &Archive{}
+var _ fi.HasName = (*Archive)(nil)
 
 func (e *Chattr) GetName() *string {
 	return fi.PtrTo("Chattr-" + e.File)
 }
 
-var _ fi.NodeupHasDependencies = &Chattr{}
+var _ fi.NodeupHasDependencies = (*Chattr)(nil)
 
 // GetDependencies implements HasDependencies::GetDependencies
 func (e *Chattr) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {

--- a/upup/pkg/fi/nodeup/nodetasks/createsdir.go
+++ b/upup/pkg/fi/nodeup/nodetasks/createsdir.go
@@ -27,7 +27,7 @@ type CreatesDir interface {
 	Dir() string
 }
 
-var _ CreatesDir = &File{}
+var _ CreatesDir = (*File)(nil)
 
 // findCreatesDirParents finds the tasks which create parent directories for the given task
 func findCreatesDirParents(p string, tasks map[string]fi.NodeupTask) []fi.NodeupTask {

--- a/upup/pkg/fi/nodeup/nodetasks/discovery_service_register.go
+++ b/upup/pkg/fi/nodeup/nodetasks/discovery_service_register.go
@@ -66,20 +66,20 @@ type JSONWebKey struct {
 	discoveryapi.JSONWebKey
 }
 
-var _ fi.NodeupHasDependencies = &JSONWebKey{}
+var _ fi.NodeupHasDependencies = (*JSONWebKey)(nil)
 
 // GetDependencies returns the dependencies for the JSONWebKey; there are none.
 func (j *JSONWebKey) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
 	return nil
 }
 
-var _ fi.NodeupTask = &UpdateEtcHostsTask{}
+var _ fi.NodeupTask = (*UpdateEtcHostsTask)(nil)
 
 func (e *DiscoveryServiceRegisterTask) String() string {
 	return fmt.Sprintf("DiscoveryServiceRegisterTask: %s", e.Name)
 }
 
-var _ fi.HasName = &DiscoveryServiceRegisterTask{}
+var _ fi.HasName = (*DiscoveryServiceRegisterTask)(nil)
 
 func (f *DiscoveryServiceRegisterTask) GetName() *string {
 	return &f.Name

--- a/upup/pkg/fi/nodeup/nodetasks/file.go
+++ b/upup/pkg/fi/nodeup/nodetasks/file.go
@@ -113,8 +113,8 @@ func (f *File) String() string {
 	return fmt.Sprintf("File: %q", f.Path)
 }
 
-var _ CreatesDir = &InstallFile{}
-var _ CreatesDir = &File{}
+var _ CreatesDir = (*InstallFile)(nil)
+var _ CreatesDir = (*File)(nil)
 
 // Dir implements CreatesDir::Dir
 func (f *File) Dir() string {

--- a/upup/pkg/fi/nodeup/nodetasks/group.go
+++ b/upup/pkg/fi/nodeup/nodetasks/group.go
@@ -34,13 +34,13 @@ type GroupTask struct {
 	System bool
 }
 
-var _ fi.NodeupTask = &GroupTask{}
+var _ fi.NodeupTask = (*GroupTask)(nil)
 
 func (e *GroupTask) String() string {
 	return fmt.Sprintf("Group: %s", e.Name)
 }
 
-var _ fi.HasName = &File{}
+var _ fi.HasName = (*File)(nil)
 
 func (f *GroupTask) GetName() *string {
 	return &f.Name

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -61,7 +61,7 @@ func (t *LoadImageTask) GetDependencies(tasks map[string]fi.NodeupTask) []fi.Nod
 	return deps
 }
 
-var _ fi.HasName = &LoadImageTask{}
+var _ fi.HasName = (*LoadImageTask)(nil)
 
 func (t *LoadImageTask) GetName() *string {
 	if t.Name == "" {

--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -59,7 +59,7 @@ const (
 	dockerPackageName           = "docker-ce"
 )
 
-var _ fi.NodeupHasDependencies = &Package{}
+var _ fi.NodeupHasDependencies = (*Package)(nil)
 
 // GetDependencies computes dependencies for the package task
 func (e *Package) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
@@ -111,7 +111,7 @@ func (e *Package) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTas
 	return deps
 }
 
-var _ fi.HasName = &Package{}
+var _ fi.HasName = (*Package)(nil)
 
 func (f *Package) GetName() *string {
 	return &f.Name

--- a/upup/pkg/fi/nodeup/nodetasks/prefix.go
+++ b/upup/pkg/fi/nodeup/nodetasks/prefix.go
@@ -40,7 +40,7 @@ type Prefix struct {
 	Name string
 }
 
-var _ fi.HasName = &Prefix{}
+var _ fi.HasName = (*Prefix)(nil)
 
 func (f *Prefix) GetName() *string {
 	return &f.Name

--- a/upup/pkg/fi/nodeup/nodetasks/update_etc_hosts_task.go
+++ b/upup/pkg/fi/nodeup/nodetasks/update_etc_hosts_task.go
@@ -45,13 +45,13 @@ type HostRecord struct {
 	Addresses []string
 }
 
-var _ fi.NodeupTask = &UpdateEtcHostsTask{}
+var _ fi.NodeupTask = (*UpdateEtcHostsTask)(nil)
 
 func (e *UpdateEtcHostsTask) String() string {
 	return fmt.Sprintf("UpdateEtcHostsTask: %s", e.Name)
 }
 
-var _ fi.HasName = &UpdateEtcHostsTask{}
+var _ fi.HasName = (*UpdateEtcHostsTask)(nil)
 
 func (f *UpdateEtcHostsTask) GetName() *string {
 	return &f.Name

--- a/upup/pkg/fi/nodeup/nodetasks/user.go
+++ b/upup/pkg/fi/nodeup/nodetasks/user.go
@@ -36,13 +36,13 @@ type UserTask struct {
 	Home  string `json:"home"`
 }
 
-var _ fi.NodeupTask = &UserTask{}
+var _ fi.NodeupTask = (*UserTask)(nil)
 
 func (e *UserTask) String() string {
 	return fmt.Sprintf("User: %s", e.Name)
 }
 
-var _ fi.HasName = &File{}
+var _ fi.HasName = (*File)(nil)
 
 func (f *UserTask) GetName() *string {
 	return &f.Name

--- a/upup/pkg/fi/resources.go
+++ b/upup/pkg/fi/resources.go
@@ -125,7 +125,7 @@ func (r *StringResource) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&r.s)
 }
 
-var _ Resource = &StringResource{}
+var _ Resource = (*StringResource)(nil)
 
 func NewStringResource(s string) *StringResource {
 	return &StringResource{s: s}
@@ -146,7 +146,7 @@ func (b *BytesResource) MarshalJSON() ([]byte, error) {
 	return json.Marshal(string(b.data))
 }
 
-var _ Resource = &BytesResource{}
+var _ Resource = (*BytesResource)(nil)
 
 func NewBytesResource(data []byte) *BytesResource {
 	return &BytesResource{data: data}
@@ -161,7 +161,7 @@ type FileResource struct {
 	Path string
 }
 
-var _ Resource = &FileResource{}
+var _ Resource = (*FileResource)(nil)
 
 func NewFileResource(path string) *FileResource {
 	return &FileResource{Path: path}
@@ -182,7 +182,7 @@ type VFSResource struct {
 	Path vfs.Path
 }
 
-var _ Resource = &VFSResource{}
+var _ Resource = (*VFSResource)(nil)
 
 func NewVFSResource(path vfs.Path) *VFSResource {
 	return &VFSResource{Path: path}

--- a/upup/pkg/fi/secrets/clientset_secretstore.go
+++ b/upup/pkg/fi/secrets/clientset_secretstore.go
@@ -45,7 +45,7 @@ type ClientsetSecretStore struct {
 	clientset kopsinternalversion.KopsInterface
 }
 
-var _ fi.SecretStore = &ClientsetSecretStore{}
+var _ fi.SecretStore = (*ClientsetSecretStore)(nil)
 
 // NewClientsetSecretStore is the constructor for ClientsetSecretStore
 func NewClientsetSecretStore(cluster *kops.Cluster, clientset kopsinternalversion.KopsInterface, namespace string) fi.SecretStore {

--- a/upup/pkg/fi/secrets/vfs_secretstore.go
+++ b/upup/pkg/fi/secrets/vfs_secretstore.go
@@ -35,7 +35,7 @@ type VFSSecretStore struct {
 	cluster *kops.Cluster
 }
 
-var _ fi.SecretStore = &VFSSecretStore{}
+var _ fi.SecretStore = (*VFSSecretStore)(nil)
 
 func NewVFSSecretStore(cluster *kops.Cluster, basedir vfs.Path) fi.SecretStore {
 	c := &VFSSecretStore{

--- a/upup/pkg/fi/secrets/vfs_secretstorereader.go
+++ b/upup/pkg/fi/secrets/vfs_secretstorereader.go
@@ -30,7 +30,7 @@ type VFSSecretStoreReader struct {
 	basedir vfs.Path
 }
 
-var _ fi.SecretStoreReader = &VFSSecretStoreReader{}
+var _ fi.SecretStoreReader = (*VFSSecretStoreReader)(nil)
 
 func NewVFSSecretStoreReader(basedir vfs.Path) fi.SecretStoreReader {
 	c := &VFSSecretStoreReader{

--- a/upup/pkg/fi/topological_sort.go
+++ b/upup/pkg/fi/topological_sort.go
@@ -38,8 +38,8 @@ type NotADependency[T SubContext] struct{}
 type NodeupNotADependency = NotADependency[NodeupSubContext]
 type CloudupNotADependency = NotADependency[CloudupSubContext]
 
-var _ CloudupHasDependencies = &CloudupNotADependency{}
-var _ NodeupHasDependencies = &NodeupNotADependency{}
+var _ CloudupHasDependencies = (*CloudupNotADependency)(nil)
+var _ NodeupHasDependencies = (*NodeupNotADependency)(nil)
 
 func (NotADependency[T]) GetDependencies(map[string]Task[T]) []Task[T] {
 	return nil

--- a/upup/pkg/fi/vfs_keystorereader.go
+++ b/upup/pkg/fi/vfs_keystorereader.go
@@ -37,7 +37,7 @@ type VFSKeystoreReader struct {
 	cachedCA *Keyset
 }
 
-var _ KeystoreReader = &VFSKeystoreReader{}
+var _ KeystoreReader = (*VFSKeystoreReader)(nil)
 
 func NewVFSKeystoreReader(basedir vfs.Path) *VFSKeystoreReader {
 	k := &VFSKeystoreReader{


### PR DESCRIPTION
The end behavior is the same but casting the underlying struct type to a nil pointer is more idiomatic that declaring a pointer to an empty struct.

This isn't something that's explicity mentioned in the Go style guide but has been adopted as a common pattern (e.g https://github.com/uber-go/guide/blob/master/style.md#verify-interface-compliance)

(Note: I did manually edit one file and then prompt an LLM to do the rest for me)

/assign @hakman 