### PR TITLE
Automated cherry pick of #17956: versionbump: go 1.25.7

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: "E2_HIGHCPU_32"
 steps:
   # Push the images
-  - name: "mirror.gcr.io/library/golang:1.25.6-trixie"
+  - name: "mirror.gcr.io/library/golang:1.25.7-trixie"
     id: images
     entrypoint: make
     env:
@@ -22,7 +22,7 @@ steps:
       - kube-apiserver-healthcheck-push
       - discovery-server-push
   # Push the artifacts
-  - name: "mirror.gcr.io/library/golang:1.25.6-trixie"
+  - name: "mirror.gcr.io/library/golang:1.25.7-trixie"
     id: artifacts
     entrypoint: make
     env:
@@ -37,7 +37,7 @@ steps:
     args:
       - gcs-upload-and-tag
   # Build cloudbuild artifacts (for attestation)
-  - name: "mirror.gcr.io/library/golang:1.25.6-trixie"
+  - name: "mirror.gcr.io/library/golang:1.25.7-trixie"
     id: cloudbuild-artifacts
     entrypoint: make
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module k8s.io/kops
 
 // This should be kept in sync with cloudbuild.yaml and the other go.mod files
-go 1.25.6
+go 1.25.7
 
 godebug default=go1.25
 

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/hack
 
-go 1.25.6
+go 1.25.7
 
 tool (
 	github.com/client9/misspell/cmd/misspell

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/tests/e2e
 
-go 1.25.6
+go 1.25.7
 
 replace k8s.io/kops => ../../.
 

--- a/tools/metal/dhcp/go.mod
+++ b/tools/metal/dhcp/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes/kops/tools/metal/dhcp
 
-go 1.25.6
+go 1.25.7
 
 require github.com/insomniacslk/dhcp v0.0.0-20240812123929-b105c29bd1b5
 

--- a/tools/metal/storage/go.mod
+++ b/tools/metal/storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes/kops/tools/metal/dhcp
 
-go 1.25.6
+go 1.25.7
 
 require (
 	google.golang.org/grpc v1.66.0

--- a/tools/otel/traceserver/go.mod
+++ b/tools/otel/traceserver/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/tools/otel/traceserver
 
-go 1.25.6
+go 1.25.7
 
 require (
 	go.opentelemetry.io/proto/otlp v1.9.0


### PR DESCRIPTION
Cherry pick of #17956 on release-1.35.

#17956: versionbump: go 1.25.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```