### PR TITLE
Automated cherry pick of #17861: Feature: pull user defined images for warm pool instances

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -6572,11 +6572,22 @@ spec:
                 description: WarmPool defines the default warm pool settings for instance
                   groups (AWS only).
                 properties:
+                  additionalImages:
+                    description: AdditionalImages is a list of additional container
+                      images to pull into the warm pool instances.
+                    items:
+                      type: string
+                    type: array
                   enableLifecycleHook:
                     description: |-
                       EnableLifecycleHook determines if an ASG lifecycle hook will be added ensuring that nodeup runs to completion.
                       Note that the metadata API must be protected from arbitrary Pods when this is enabled.
                     type: boolean
+                  lifecycleHookTimeout:
+                    description: LifecycleHookTimeout is the timeout for the ASG lifecycle
+                      hook in seconds.
+                    format: int32
+                    type: integer
                   maxSize:
                     description: |-
                       MaxSize is the maximum size of the warm pool. The desired size of the instance group

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -1199,11 +1199,22 @@ spec:
                 description: WarmPool configures an ASG warm pool for the instance
                   group
                 properties:
+                  additionalImages:
+                    description: AdditionalImages is a list of additional container
+                      images to pull into the warm pool instances.
+                    items:
+                      type: string
+                    type: array
                   enableLifecycleHook:
                     description: |-
                       EnableLifecycleHook determines if an ASG lifecycle hook will be added ensuring that nodeup runs to completion.
                       Note that the metadata API must be protected from arbitrary Pods when this is enabled.
                     type: boolean
+                  lifecycleHookTimeout:
+                    description: LifecycleHookTimeout is the timeout for the ASG lifecycle
+                      hook in seconds.
+                    format: int32
+                    type: integer
                   maxSize:
                     description: |-
                       MaxSize is the maximum size of the warm pool. The desired size of the instance group

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -1115,6 +1115,10 @@ type WarmPoolSpec struct {
 	// EnableLifecyleHook determines if an ASG lifecycle hook will be added ensuring that nodeup runs to completion.
 	// Note that the metadata API must be protected from arbitrary Pods when this is enabled.
 	EnableLifecycleHook bool `json:"enableLifecycleHook,omitempty"`
+	// LifecycleHookTimeout is the timeout for the ASG lifecycle hook in seconds.
+	LifecycleHookTimeout *int32 `json:"lifecycleHookTimeout,omitempty"`
+	// AdditionalImages is a list of additional container images to pull into the warm pool instances.
+	AdditionalImages []string `json:"additionalImages,omitempty"`
 }
 
 func (in *WarmPoolSpec) IsEnabled() bool {

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -906,4 +906,8 @@ type WarmPoolSpec struct {
 	// EnableLifecycleHook determines if an ASG lifecycle hook will be added ensuring that nodeup runs to completion.
 	// Note that the metadata API must be protected from arbitrary Pods when this is enabled.
 	EnableLifecycleHook bool `json:"enableLifecycleHook,omitempty"`
+	// LifecycleHookTimeout is the timeout for the ASG lifecycle hook in seconds.
+	LifecycleHookTimeout *int32 `json:"lifecycleHookTimeout,omitempty"`
+	// AdditionalImages is a list of additional container images to pull into the warm pool instances.
+	AdditionalImages []string `json:"additionalImages,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -7849,6 +7849,8 @@ func autoConvert_v1alpha2_WarmPoolSpec_To_kops_WarmPoolSpec(in *WarmPoolSpec, ou
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
 	out.EnableLifecycleHook = in.EnableLifecycleHook
+	out.LifecycleHookTimeout = in.LifecycleHookTimeout
+	out.AdditionalImages = in.AdditionalImages
 	return nil
 }
 
@@ -7861,6 +7863,8 @@ func autoConvert_kops_WarmPoolSpec_To_v1alpha2_WarmPoolSpec(in *kops.WarmPoolSpe
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
 	out.EnableLifecycleHook = in.EnableLifecycleHook
+	out.LifecycleHookTimeout = in.LifecycleHookTimeout
+	out.AdditionalImages = in.AdditionalImages
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -6096,6 +6096,16 @@ func (in *WarmPoolSpec) DeepCopyInto(out *WarmPoolSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.LifecycleHookTimeout != nil {
+		in, out := &in.LifecycleHookTimeout, &out.LifecycleHookTimeout
+		*out = new(int32)
+		**out = **in
+	}
+	if in.AdditionalImages != nil {
+		in, out := &in.AdditionalImages, &out.AdditionalImages
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -870,4 +870,8 @@ type WarmPoolSpec struct {
 	// EnableLifecycleHook determines if an ASG lifecycle hook will be added ensuring that nodeup runs to completion.
 	// Note that the metadata API must be protected from arbitrary Pods when this is enabled.
 	EnableLifecycleHook bool `json:"enableLifecycleHook,omitempty"`
+	// LifecycleHookTimeout is the timeout for the ASG lifecycle hook in seconds.
+	LifecycleHookTimeout *int32 `json:"lifecycleHookTimeout,omitempty"`
+	// AdditionalImages is a list of additional container images to pull into the warm pool instances.
+	AdditionalImages []string `json:"additionalImages,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -8151,6 +8151,8 @@ func autoConvert_v1alpha3_WarmPoolSpec_To_kops_WarmPoolSpec(in *WarmPoolSpec, ou
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
 	out.EnableLifecycleHook = in.EnableLifecycleHook
+	out.LifecycleHookTimeout = in.LifecycleHookTimeout
+	out.AdditionalImages = in.AdditionalImages
 	return nil
 }
 
@@ -8163,6 +8165,8 @@ func autoConvert_kops_WarmPoolSpec_To_v1alpha3_WarmPoolSpec(in *kops.WarmPoolSpe
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
 	out.EnableLifecycleHook = in.EnableLifecycleHook
+	out.LifecycleHookTimeout = in.LifecycleHookTimeout
+	out.AdditionalImages = in.AdditionalImages
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -6043,6 +6043,16 @@ func (in *WarmPoolSpec) DeepCopyInto(out *WarmPoolSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.LifecycleHookTimeout != nil {
+		in, out := &in.LifecycleHookTimeout, &out.LifecycleHookTimeout
+		*out = new(int32)
+		**out = **in
+	}
+	if in.AdditionalImages != nil {
+		in, out := &in.AdditionalImages, &out.AdditionalImages
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1928,6 +1928,8 @@ func validateWarmPool(warmPool *kops.WarmPoolSpec, fldPath *field.Path) (allErrs
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("maxSize"), *warmPool.MaxSize, "warm pool maxSize cannot be negative"))
 		} else if warmPool.MinSize > *warmPool.MaxSize {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("maxSize"), *warmPool.MaxSize, "warm pool maxSize cannot be set to lower than minSize"))
+		} else if len(warmPool.AdditionalImages) > 0 {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("additionalImages"), "warm pool additional images can only be set in the instance group spec"))
 		}
 	}
 	if warmPool.MinSize < 0 {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -6350,6 +6350,16 @@ func (in *WarmPoolSpec) DeepCopyInto(out *WarmPoolSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.LifecycleHookTimeout != nil {
+		in, out := &in.LifecycleHookTimeout, &out.LifecycleHookTimeout
+		*out = new(int32)
+		**out = **in
+	}
+	if in.AdditionalImages != nil {
+		in, out := &in.AdditionalImages, &out.AdditionalImages
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -522,6 +522,14 @@ func (n *nodeUpConfigBuilder) buildWarmPoolImages(ig *kops.InstanceGroup) []stri
 		}
 	}
 
+	// Add ig-level extra images
+	if ig.Spec.WarmPool != nil && len(ig.Spec.WarmPool.AdditionalImages) > 0 {
+		for _, image := range ig.Spec.WarmPool.AdditionalImages {
+			remapped := assets.NormalizeImage(assetBuilder, image)
+			images[remapped] = true
+		}
+	}
+
 	var unique []string
 	for image := range images {
 		unique = append(unique, image)


### PR DESCRIPTION
Cherry pick of #17861 on release-1.35.

#17861: Feature: pull user defined images for warm pool instances

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```