### PR TITLE
Fix creation of discovery and state store buckets

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -96,12 +96,13 @@ type deployer struct {
 
 	aws *aws.Client
 
-	createBucket       bool
-	stateStoreName     string
-	discoveryStoreName string
-	stagingStoreName   string
-	region             string
-	zones              []string
+	createStateStore     bool
+	createDiscoveryStore bool
+	stateStoreName       string
+	discoveryStoreName   string
+	stagingStoreName     string
+	region               string
+	zones                []string
 
 	// boskos struct field will be non-nil when the deployer is
 	// using boskos to acquire a GCP project

--- a/tests/e2e/kubetest2-kops/deployer/down.go
+++ b/tests/e2e/kubetest2-kops/deployer/down.go
@@ -73,17 +73,21 @@ func (d *deployer) Down() error {
 		return err
 	}
 
-	if d.createBucket {
-		switch d.CloudProvider {
-		case "aws":
-			ctx := context.Background()
+	switch d.CloudProvider {
+	case "aws":
+		ctx := context.Background()
+		if d.createStateStore {
 			if err := d.aws.DeleteS3Bucket(ctx, d.stateStore()); err != nil {
 				return err
 			}
+		}
+		if d.createDiscoveryStore {
 			if err := d.aws.DeleteS3Bucket(ctx, d.discoveryStore()); err != nil {
 				return err
 			}
-		case "gce":
+		}
+	case "gce":
+		if d.createStateStore {
 			gce.DeleteGCSBucket(d.stateStore(), d.GCPProject)
 			gce.DeleteGCSBucket(d.stagingStore(), d.GCPProject)
 		}

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -66,17 +66,21 @@ func (d *deployer) Up() error {
 		_ = d.Down()
 	}
 
-	if d.createBucket {
-		switch d.CloudProvider {
-		case "aws":
-			ctx := context.Background()
+	switch d.CloudProvider {
+	case "aws":
+		ctx := context.Background()
+		if d.createStateStore {
 			if err := d.aws.EnsureS3Bucket(ctx, d.region, d.stateStore(), false); err != nil {
 				return err
 			}
+		}
+		if d.createDiscoveryStore {
 			if err := d.aws.EnsureS3Bucket(ctx, d.region, d.discoveryStore(), true); err != nil {
 				return err
 			}
-		case "gce":
+		}
+	case "gce":
+		if d.createStateStore {
 			if err := gce.EnsureGCSBucket(d.stateStore(), d.region, d.GCPProject, false); err != nil {
 				return err
 			}


### PR DESCRIPTION
When KOPS_STATE_STORE is set but KOPS_DISCOVERY_STORE is not set, kubetest2-kops generates a dynamic name for discovery bucket but doesn't actually create it. This is because the stateStore() and discoveryStore() methods had side effects, so they need to be called before we check the value of `b.createBucket`.

This PR removes the side effects from those methods and splits the createbucket boolean into separate bools for state store and discovery store, so they can be created (or reused) independently.

/cc @ameukam 