### PR TITLE
Migrate e2e template AMIs to SSM params

### DIFF
--- a/tests/e2e/templates/apiserver.yaml.tmpl
+++ b/tests/e2e/templates/apiserver.yaml.tmpl
@@ -69,7 +69,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610
+  image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required
@@ -90,7 +90,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610
+  image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required
@@ -111,7 +111,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610
+  image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/e2e/templates/many-addons.yaml.tmpl
+++ b/tests/e2e/templates/many-addons.yaml.tmpl
@@ -96,7 +96,7 @@ metadata:
     kops.k8s.io/cluster: {{$.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610
+  image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
   machineType: t3.medium
   maxSize: 2
   minSize: 2
@@ -115,7 +115,7 @@ metadata:
     kops.k8s.io/cluster: {{$.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610
+  image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
   machineType: c5.large
   maxSize: 1
   minSize: 1

--- a/tests/e2e/templates/simple.yaml.tmpl
+++ b/tests/e2e/templates/simple.yaml.tmpl
@@ -60,7 +60,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610
+  image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
   machineType: t3.medium
   maxSize: 4
   minSize: 4
@@ -78,7 +78,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610
+  image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
   machineType: c5.large
   maxSize: 1
   minSize: 1

--- a/tests/e2e/templates/staticcpumanagerpolicy.tmpl
+++ b/tests/e2e/templates/staticcpumanagerpolicy.tmpl
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610
+  image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
   machineType: t3.medium
   maxSize: 4
   minSize: 4
@@ -88,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610
+  image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
   machineType: c5.large
   maxSize: 1
   minSize: 1


### PR DESCRIPTION
These are all failing because the AMI was deprecated and no longer discoverable

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-apiserver-nodes/2023039505631547392

`Error: apiserver-eu-west-1c.spec.image: Invalid value: "099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610": specified image "099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610" is invalid: could not find Image for "099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250610"`

We can reference the SSM parameter to avoid needing to bump this in the future. This param is already used in e2e:

https://github.com/kubernetes/kops/blob/e0d9e7b3c6e4f520d18a9f21ed418f3f814b80a4/tests/e2e/scenarios/scalability/run-test.sh#L61