### PR TITLE
LBC Scenario - Pass region to AWS CLI

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/test.sh
@@ -21,12 +21,12 @@ set -o pipefail
 # Get the cluster name from the KUBECONFIG context
 CLUSTER_NAME=$(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
 
-# Get VPC ID by looking at the cluster's subnet
-VPC=$(kubectl get nodes -o jsonpath='{.items[0].spec.providerID}' | cut -d'/' -f5 | xargs -I{} aws ec2 describe-instances --instance-ids {} --query 'Reservations[0].Instances[0].VpcId' --output text)
-
 # Get the zone from a node
 ZONE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.topology\.kubernetes\.io/zone}')
 REGION=${ZONE%?}
+
+# Get VPC ID by looking at the cluster's subnet
+VPC=$(kubectl get nodes -o jsonpath='{.items[0].spec.providerID}' | cut -d'/' -f5 | xargs -I{} aws --region "${REGION}" ec2 describe-instances --instance-ids {} --query 'Reservations[0].Instances[0].VpcId' --output text)
 
 REPORT_DIR="${ARTIFACTS:-$(pwd)/_artifacts}/aws-lb-controller"
 mkdir -p "${REPORT_DIR}"


### PR DESCRIPTION
Should fix this failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-aws-load-balancer-controller/2023149733375119360

`An error occurred (InvalidInstanceID.NotFound) when calling the DescribeInstances operation: The instance ID 'i-0024398494e2e7698' does not exist`