### PR TITLE
kube-router: bump version v2.5.0 -> 2.7.1

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v2.5.0
+        image: docker.io/cloudnativelabs/kube-router:v2.7.1
         args:
         - --run-router=true
         - --run-firewall=true
@@ -117,7 +117,7 @@ spec:
           readOnly: true
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v2.5.0
+        image: docker.io/cloudnativelabs/kube-router:v2.7.1
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
@hakman 

Updates kube-router from 2.5.0 -> 2.7.1

Did a full run through of the e2e suite's network related functions and everything stays the same as previous releases.