### PR TITLE
Automated cherry pick of #17144: Normalize the hardcoded images used for warmpool pre-pulling
#17861: Feature: pull user defined images for warm pool instances

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -6437,11 +6437,22 @@ spec:
                 description: WarmPool defines the default warm pool settings for instance
                   groups (AWS only).
                 properties:
+                  additionalImages:
+                    description: AdditionalImages is a list of additional container
+                      images to pull into the warm pool instances.
+                    items:
+                      type: string
+                    type: array
                   enableLifecycleHook:
                     description: |-
                       EnableLifecycleHook determines if an ASG lifecycle hook will be added ensuring that nodeup runs to completion.
                       Note that the metadata API must be protected from arbitrary Pods when this is enabled.
                     type: boolean
+                  lifecycleHookTimeout:
+                    description: LifecycleHookTimeout is the timeout for the ASG lifecycle
+                      hook in seconds.
+                    format: int32
+                    type: integer
                   maxSize:
                     description: |-
                       MaxSize is the maximum size of the warm pool. The desired size of the instance group

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -1170,11 +1170,22 @@ spec:
                 description: WarmPool configures an ASG warm pool for the instance
                   group
                 properties:
+                  additionalImages:
+                    description: AdditionalImages is a list of additional container
+                      images to pull into the warm pool instances.
+                    items:
+                      type: string
+                    type: array
                   enableLifecycleHook:
                     description: |-
                       EnableLifecycleHook determines if an ASG lifecycle hook will be added ensuring that nodeup runs to completion.
                       Note that the metadata API must be protected from arbitrary Pods when this is enabled.
                     type: boolean
+                  lifecycleHookTimeout:
+                    description: LifecycleHookTimeout is the timeout for the ASG lifecycle
+                      hook in seconds.
+                    format: int32
+                    type: integer
                   maxSize:
                     description: |-
                       MaxSize is the maximum size of the warm pool. The desired size of the instance group

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -1081,6 +1081,10 @@ type WarmPoolSpec struct {
 	// EnableLifecyleHook determines if an ASG lifecycle hook will be added ensuring that nodeup runs to completion.
 	// Note that the metadata API must be protected from arbitrary Pods when this is enabled.
 	EnableLifecycleHook bool `json:"enableLifecycleHook,omitempty"`
+	// LifecycleHookTimeout is the timeout for the ASG lifecycle hook in seconds.
+	LifecycleHookTimeout *int32 `json:"lifecycleHookTimeout,omitempty"`
+	// AdditionalImages is a list of additional container images to pull into the warm pool instances.
+	AdditionalImages []string `json:"additionalImages,omitempty"`
 }
 
 func (in *WarmPoolSpec) IsEnabled() bool {

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -897,4 +897,8 @@ type WarmPoolSpec struct {
 	// EnableLifecycleHook determines if an ASG lifecycle hook will be added ensuring that nodeup runs to completion.
 	// Note that the metadata API must be protected from arbitrary Pods when this is enabled.
 	EnableLifecycleHook bool `json:"enableLifecycleHook,omitempty"`
+	// LifecycleHookTimeout is the timeout for the ASG lifecycle hook in seconds.
+	LifecycleHookTimeout *int32 `json:"lifecycleHookTimeout,omitempty"`
+	// AdditionalImages is a list of additional container images to pull into the warm pool instances.
+	AdditionalImages []string `json:"additionalImages,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -7665,6 +7665,8 @@ func autoConvert_v1alpha2_WarmPoolSpec_To_kops_WarmPoolSpec(in *WarmPoolSpec, ou
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
 	out.EnableLifecycleHook = in.EnableLifecycleHook
+	out.LifecycleHookTimeout = in.LifecycleHookTimeout
+	out.AdditionalImages = in.AdditionalImages
 	return nil
 }
 
@@ -7677,6 +7679,8 @@ func autoConvert_kops_WarmPoolSpec_To_v1alpha2_WarmPoolSpec(in *kops.WarmPoolSpe
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
 	out.EnableLifecycleHook = in.EnableLifecycleHook
+	out.LifecycleHookTimeout = in.LifecycleHookTimeout
+	out.AdditionalImages = in.AdditionalImages
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -6030,6 +6030,16 @@ func (in *WarmPoolSpec) DeepCopyInto(out *WarmPoolSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.LifecycleHookTimeout != nil {
+		in, out := &in.LifecycleHookTimeout, &out.LifecycleHookTimeout
+		*out = new(int32)
+		**out = **in
+	}
+	if in.AdditionalImages != nil {
+		in, out := &in.AdditionalImages, &out.AdditionalImages
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -861,4 +861,8 @@ type WarmPoolSpec struct {
 	// EnableLifecycleHook determines if an ASG lifecycle hook will be added ensuring that nodeup runs to completion.
 	// Note that the metadata API must be protected from arbitrary Pods when this is enabled.
 	EnableLifecycleHook bool `json:"enableLifecycleHook,omitempty"`
+	// LifecycleHookTimeout is the timeout for the ASG lifecycle hook in seconds.
+	LifecycleHookTimeout *int32 `json:"lifecycleHookTimeout,omitempty"`
+	// AdditionalImages is a list of additional container images to pull into the warm pool instances.
+	AdditionalImages []string `json:"additionalImages,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -7957,6 +7957,8 @@ func autoConvert_v1alpha3_WarmPoolSpec_To_kops_WarmPoolSpec(in *WarmPoolSpec, ou
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
 	out.EnableLifecycleHook = in.EnableLifecycleHook
+	out.LifecycleHookTimeout = in.LifecycleHookTimeout
+	out.AdditionalImages = in.AdditionalImages
 	return nil
 }
 
@@ -7969,6 +7971,8 @@ func autoConvert_kops_WarmPoolSpec_To_v1alpha3_WarmPoolSpec(in *kops.WarmPoolSpe
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
 	out.EnableLifecycleHook = in.EnableLifecycleHook
+	out.LifecycleHookTimeout = in.LifecycleHookTimeout
+	out.AdditionalImages = in.AdditionalImages
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -5977,6 +5977,16 @@ func (in *WarmPoolSpec) DeepCopyInto(out *WarmPoolSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.LifecycleHookTimeout != nil {
+		in, out := &in.LifecycleHookTimeout, &out.LifecycleHookTimeout
+		*out = new(int32)
+		**out = **in
+	}
+	if in.AdditionalImages != nil {
+		in, out := &in.AdditionalImages, &out.AdditionalImages
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1937,6 +1937,8 @@ func validateWarmPool(warmPool *kops.WarmPoolSpec, fldPath *field.Path) (allErrs
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("maxSize"), *warmPool.MaxSize, "warm pool maxSize cannot be negative"))
 		} else if warmPool.MinSize > *warmPool.MaxSize {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("maxSize"), *warmPool.MaxSize, "warm pool maxSize cannot be set to lower than minSize"))
+		} else if len(warmPool.AdditionalImages) > 0 {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("additionalImages"), "warm pool additional images can only be set in the instance group spec"))
 		}
 	}
 	if warmPool.MinSize < 0 {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -6208,6 +6208,16 @@ func (in *WarmPoolSpec) DeepCopyInto(out *WarmPoolSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.LifecycleHookTimeout != nil {
+		in, out := &in.LifecycleHookTimeout, &out.LifecycleHookTimeout
+		*out = new(int32)
+		**out = **in
+	}
+	if in.AdditionalImages != nil {
+		in, out := &in.AdditionalImages, &out.AdditionalImages
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -144,7 +144,7 @@ func (a *AssetBuilder) RemapManifest(data []byte) ([]byte, error) {
 }
 
 // RemapImage normalizes a containers location if a user sets the AssetsLocation ContainerRegistry location.
-func (a *AssetBuilder) RemapImage(image string) (string, error) {
+func (a *AssetBuilder) RemapImage(image string) string {
 	asset := &ImageAsset{
 		DownloadLocation:  image,
 		CanonicalLocation: image,
@@ -225,20 +225,20 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 	a.ImageAssets = append(a.ImageAssets, asset)
 
 	if !featureflag.ImageDigest.Enabled() || os.Getenv("KOPS_BASE_URL") != "" {
-		return image, nil
+		return image
 	}
 
 	if strings.Contains(image, "@") {
-		return image, nil
+		return image
 	}
 
 	digest, err := crane.Digest(image, crane.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		klog.Warningf("failed to digest image %q: %s", image, err)
-		return image, nil
+		return image
 	}
 
-	return image + "@" + digest, nil
+	return image + "@" + digest
 }
 
 // RemapFile returns a remapped URL for the file, if AssetsLocation is defined.

--- a/pkg/assets/builder_test.go
+++ b/pkg/assets/builder_test.go
@@ -42,11 +42,7 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToDockerHub(t *testing.T) {
 
 	builder.AssetsLocation.ContainerProxy = &proxyURL
 
-	remapped, err := builder.RemapImage(image)
-	if err != nil {
-		t.Error("Error remapping image", err)
-	}
-
+	remapped := builder.RemapImage(image)
 	if remapped != expected {
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
@@ -61,11 +57,7 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToSimplifiedDockerHub(t *test
 
 	builder.AssetsLocation.ContainerProxy = &proxyURL
 
-	remapped, err := builder.RemapImage(image)
-	if err != nil {
-		t.Error("Error remapping image", err)
-	}
-
+	remapped := builder.RemapImage(image)
 	if remapped != expected {
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
@@ -80,11 +72,7 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToSimplifiedKubernetesURL(t *
 
 	builder.AssetsLocation.ContainerProxy = &proxyURL
 
-	remapped, err := builder.RemapImage(image)
-	if err != nil {
-		t.Error("Error remapping image", err)
-	}
-
+	remapped := builder.RemapImage(image)
 	if remapped != expected {
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
@@ -99,11 +87,7 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToLegacyKubernetesURL(t *test
 
 	builder.AssetsLocation.ContainerProxy = &proxyURL
 
-	remapped, err := builder.RemapImage(image)
-	if err != nil {
-		t.Error("Error remapping image", err)
-	}
-
+	remapped := builder.RemapImage(image)
 	if remapped != expected {
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
@@ -118,11 +102,7 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToImagesWithTags(t *testing.T
 
 	builder.AssetsLocation.ContainerProxy = &proxyURL
 
-	remapped, err := builder.RemapImage(image)
-	if err != nil {
-		t.Error("Error remapping image", err)
-	}
-
+	remapped := builder.RemapImage(image)
 	if remapped != expected {
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
@@ -140,11 +120,7 @@ func TestValidate_RemapImage_ContainerRegistry_MappingMultipleTimesConverges(t *
 	remapped := image
 	iterations := make([]map[int]int, 2)
 	for i := range iterations {
-		remapped, err := builder.RemapImage(remapped)
-		if err != nil {
-			t.Errorf("Error remapping image (iteration %d): %s", i, err)
-		}
-
+		remapped := builder.RemapImage(remapped)
 		if remapped != expected {
 			t.Errorf("Error remapping image (Expecting: %s, got %s, iteration: %d)", expected, remapped, i)
 		}

--- a/pkg/kubemanifest/images.go
+++ b/pkg/kubemanifest/images.go
@@ -17,13 +17,12 @@ limitations under the License.
 package kubemanifest
 
 import (
-	"fmt"
 	"strings"
 
 	"k8s.io/klog/v2"
 )
 
-type ImageRemapFunction func(image string) (string, error)
+type ImageRemapFunction func(image string) string
 
 func (m *Object) RemapImages(mapper ImageRemapFunction) error {
 	visitor := &imageRemapVisitor{
@@ -57,10 +56,7 @@ func (m *imageRemapVisitor) VisitString(path []string, v string, mutator func(st
 
 	image := v
 	klog.V(4).Infof("Consider image for re-mapping: %q", image)
-	remapped, err := m.mapper(v)
-	if err != nil {
-		return fmt.Errorf("error remapping image %q: %v", image, err)
-	}
+	remapped := m.mapper(v)
 	if remapped != image {
 		mutator(remapped)
 	}

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -122,6 +122,13 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 			hookName := "kops-warmpool"
 			name := fmt.Sprintf("%s-%s", hookName, ig.GetName())
 			enableHook := warmPool.IsEnabled() && warmPool.EnableLifecycleHook
+			heartbeatTimeout := aws.Int32(600)
+			// Check for heartbeatTimeout overrides at IG-level and cluster-level. IG-level takes precedence.
+			if ig.Spec.WarmPool != nil && ig.Spec.WarmPool.LifecycleHookTimeout != nil {
+				heartbeatTimeout = ig.Spec.WarmPool.LifecycleHookTimeout
+			} else if b.Cluster.Spec.CloudProvider.AWS.WarmPool != nil && b.Cluster.Spec.CloudProvider.AWS.WarmPool.LifecycleHookTimeout != nil {
+				heartbeatTimeout = b.Cluster.Spec.CloudProvider.AWS.WarmPool.LifecycleHookTimeout
+			}
 
 			lifecyleTask := &awstasks.AutoscalingLifecycleHook{
 				ID:               aws.String(name),
@@ -132,7 +139,7 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 				DefaultResult:    aws.String("ABANDON"),
 				// We let nodeup have 10 min to complete. Normally this should happen much faster,
 				// but CP nodes need 5 min or so to start on new clusters, and we need to wait for that.
-				HeartbeatTimeout:    aws.Int32(600),
+				HeartbeatTimeout:    heartbeatTimeout,
 				LifecycleTransition: aws.String("autoscaling:EC2_INSTANCE_LAUNCHING"),
 				Enabled:             &enableHook,
 			}

--- a/pkg/model/components/context.go
+++ b/pkg/model/components/context.go
@@ -150,11 +150,7 @@ func Image(component string, clusterSpec *kops.ClusterSpec, assetsBuilder *asset
 	if !kopsmodel.IsBaseURL(clusterSpec.KubernetesVersion) {
 		image := "registry.k8s.io/" + imageName + ":" + "v" + kubernetesVersion.String()
 
-		image, err := assetsBuilder.RemapImage(image)
-		if err != nil {
-			return "", fmt.Errorf("unable to remap container %q: %v", image, err)
-		}
-		return image, nil
+		return assetsBuilder.RemapImage(image), nil
 	}
 
 	// The simple name is valid when pulling.  But if we

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -314,11 +314,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 		// Remap image via AssetBuilder
 		for i := range pod.Spec.InitContainers {
 			initContainer := &pod.Spec.InitContainers[i]
-			remapped, err := b.AssetBuilder.RemapImage(initContainer.Image)
-			if err != nil {
-				return nil, fmt.Errorf("unable to remap init container image %q: %w", container.Image, err)
-			}
-			initContainer.Image = remapped
+			initContainer.Image = b.AssetBuilder.RemapImage(initContainer.Image)
 		}
 	}
 
@@ -334,11 +330,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 		}
 
 		// Remap image via AssetBuilder
-		remapped, err := b.AssetBuilder.RemapImage(container.Image)
-		if err != nil {
-			return nil, fmt.Errorf("unable to remap container image %q: %w", container.Image, err)
-		}
-		container.Image = remapped
+		container.Image = b.AssetBuilder.RemapImage(container.Image)
 	}
 
 	var clientHost string

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -138,13 +138,7 @@ func (b *KubeApiserverBuilder) buildHealthcheckSidecar() (*corev1.Pod, error) {
 	}
 
 	// Remap image via AssetBuilder
-	{
-		remapped, err := b.AssetBuilder.RemapImage(container.Image)
-		if err != nil {
-			return nil, fmt.Errorf("unable to remap container image %q: %v", container.Image, err)
-		}
-		container.Image = remapped
-	}
+	container.Image = b.AssetBuilder.RemapImage(container.Image)
 
 	return pod, nil
 }

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -166,11 +166,7 @@ func (b *KubeletOptionsBuilder) configureKubelet(cluster *kops.Cluster, kubelet 
 	// Prevent image GC from pruning the pause image
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2040-kubelet-cri#pinned-images
 	image := "registry.k8s.io/pause:3.9"
-	var err error
-	if image, err = b.AssetBuilder.RemapImage(image); err != nil {
-		return err
-	}
-	kubelet.PodInfraContainerImage = image
+	kubelet.PodInfraContainerImage = b.AssetBuilder.RemapImage(image)
 
 	if kubelet.FeatureGates == nil {
 		kubelet.FeatureGates = make(map[string]string)

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -509,7 +509,8 @@ func (n *nodeUpConfigBuilder) buildWarmPoolImages(ig *kops.InstanceGroup) []stri
 	if assetBuilder != nil {
 		for _, image := range assetBuilder.ImageAssets {
 			for _, prefix := range desiredImagePrefixes {
-				if strings.HasPrefix(image.DownloadLocation, prefix) {
+				remappedPrefix := assets.NormalizeImage(assetBuilder, prefix)
+				if strings.HasPrefix(image.DownloadLocation, remappedPrefix) {
 					images[image.DownloadLocation] = true
 				}
 			}

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -517,6 +517,14 @@ func (n *nodeUpConfigBuilder) buildWarmPoolImages(ig *kops.InstanceGroup) []stri
 		}
 	}
 
+	// Add ig-level extra images
+	if ig.Spec.WarmPool != nil && len(ig.Spec.WarmPool.AdditionalImages) > 0 {
+		for _, image := range ig.Spec.WarmPool.AdditionalImages {
+			remapped := assets.NormalizeImage(assetBuilder, image)
+			images[remapped] = true
+		}
+	}
+
 	var unique []string
 	for image := range images {
 		unique = append(unique, image)


### PR DESCRIPTION
Cherry pick of #17144 #17861 on release-1.33.

#17144: Normalize the hardcoded images used for warmpool pre-pulling
#17861: Feature: pull user defined images for warm pool instances

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```