### PR TITLE
Automated cherry pick of #17722: scaleway: Fix failing terraform test

### DIFF
--- a/tests/integration/update_cluster/minimal_scaleway/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_scaleway/kubernetes.tf
@@ -240,7 +240,7 @@ resource "scaleway_lb_backend" "lb-backend-https" {
   lb_id            = scaleway_lb.api-scw-minimal-k8s-local.id
   name             = "lb-backend-https"
   proxy_protocol   = "none"
-  server_ips       = [scaleway_instance_server.control-plane-fr-par-1-0.private_ip]
+  server_ips       = [scaleway_instance_server.control-plane-fr-par-1-0.private_ips[0].address]
 }
 
 resource "scaleway_lb_backend" "lb-backend-kops-controller" {
@@ -249,7 +249,7 @@ resource "scaleway_lb_backend" "lb-backend-kops-controller" {
   lb_id            = scaleway_lb.api-scw-minimal-k8s-local.id
   name             = "lb-backend-kops-controller"
   proxy_protocol   = "none"
-  server_ips       = [scaleway_instance_server.control-plane-fr-par-1-0.private_ip]
+  server_ips       = [scaleway_instance_server.control-plane-fr-par-1-0.private_ips[0].address]
 }
 
 resource "scaleway_lb_frontend" "lb-frontend-https" {

--- a/upup/pkg/fi/cloudup/scalewaytasks/lb_backend.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/lb_backend.go
@@ -221,7 +221,7 @@ func (l *LBBackend) RenderTerraform(t *terraform.TerraformTarget, actual, expect
 	for _, server := range servers {
 		tfInstance := server.(terraformInstance)
 		if role := scaleway.InstanceRoleFromTags(tfInstance.Tags); role == scaleway.TagRoleControlPlane {
-			serverIPs = append(serverIPs, terraformWriter.LiteralProperty("scaleway_instance_server", fi.ValueOf(tfInstance.Name), "private_ip"))
+			serverIPs = append(serverIPs, terraformWriter.LiteralProperty("scaleway_instance_server", fi.ValueOf(tfInstance.Name), "private_ips[0].address"))
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #17722 on release-1.32.

#17722: scaleway: Fix failing terraform test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```