### PR TITLE
Remove reference to unbound variable

### DIFF
--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -92,7 +92,7 @@ ${KUBETEST2} \
     --kubernetes-version="${K8S_VERSION_A}" \
     --control-plane-size="${KOPS_CONTROL_PLANE_COUNT:-1}" \
     --template-path="${KOPS_TEMPLATE:-}" \
-    --create-args="--networking calico ${KOPS_EXTRA_FLAGS:-} ${create_args}"
+    --create-args="--networking calico ${KOPS_EXTRA_FLAGS:-}"
 
 # Export kubeconfig-a
 KUBECONFIG_A=$(mktemp -t kops.XXXXXXXXX)


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kops/pull/17969

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-upgrade-k129-ko133-to-k130-kolatest/2024069153832308736

```
 ./tests/e2e/scenarios/upgrade-ab/run-test.sh: line 90: create_args: unbound variable 
```