### PR TITLE
tests/ai-conformance: create cluster with some non-GPU nodes

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -154,6 +154,12 @@ func (d *deployer) writeEnvFile(ctx context.Context) error {
 
 	log.V(2).Info("writing env file", "path", d.EnvFile)
 	env := d.env()
+
+	// Also export cluster name, in case we generated it
+	if d.ClusterName != "" {
+		env = append(env, fmt.Sprintf("CLUSTER_NAME=%v", d.ClusterName))
+	}
+
 	data := strings.Join(env, "\n") + "\n"
 	if err := os.WriteFile(d.EnvFile, []byte(data), 0o644); err != nil {
 		return fmt.Errorf("error writing env file %q: %v", d.EnvFile, err)

--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -58,6 +58,16 @@ fi
 
 # Always tear-down the cluster when we're done
 function kops-finish {
+    # If we failed to start the cluster, we might not have sourced KOPS_STATE_STORE, so try to source it if we have an env file
+    if [[ -z "${ENV_FILE-}" ]]; then
+        ENV_FILE="${WORKSPACE}/env"
+    fi
+    if [[ -f "${ENV_FILE}" ]]; then
+        # shellcheck disable=SC1090
+        . "${ENV_FILE}"
+        export KOPS_STATE_STORE
+    fi
+
     # shellcheck disable=SC2153
     ${KUBETEST2} --kops-binary-path="${KOPS}" --down || echo "kubetest2 down failed"
 }


### PR DESCRIPTION
Because GPU nodes are tainted, the cluster won't come up if we
don't have any non-GPU nodes.

Start the cluster with c5.large nodes, and then add GPU nodes.
