### PR TITLE
gce: Wait to delete InstanceManagers and InstanceTemplates

### DIFF
--- a/cloudmock/gce/mock_gce_cloud.go
+++ b/cloudmock/gce/mock_gce_cloud.go
@@ -23,7 +23,6 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/storage/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 	"k8s.io/kops/cloudmock/gce/mockcloudresourcemanager"
 	mockcompute "k8s.io/kops/cloudmock/gce/mockcompute"
 	"k8s.io/kops/cloudmock/gce/mockdns"
@@ -73,13 +72,12 @@ func (c *MockGCECloud) AllResources() map[string]interface{} {
 
 // GetCloudGroups is not implemented yet
 func (c *MockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
-	klog.V(8).Infof("MockGCECloud cloud provider GetCloudGroups not implemented yet")
-	return nil, fmt.Errorf("MockGCECloud cloud provider does not support getting cloud groups at this time")
+	return gce.GetCloudGroups(c, cluster, instancegroups, warnUnmatched, nodes)
 }
 
 // Zones is not implemented yet
 func (c *MockGCECloud) Zones() ([]string, error) {
-	return nil, fmt.Errorf("not yet implemented")
+	return gce.GetZones(c)
 }
 
 // WithLabels returns a copy of the MockGCECloud bound to the specified labels
@@ -170,8 +168,7 @@ func (c *MockGCECloud) Labels() map[string]string {
 
 // DeleteGroup implements fi.Cloud::DeleteGroup
 func (c *MockGCECloud) DeleteGroup(g *cloudinstances.CloudInstanceGroup) error {
-	return nil
-	//	return deleteCloudInstanceGroup(c, g)
+	return gce.DeleteCloudInstanceGroup(c, g)
 }
 
 // DeleteInstance deletes a GCE instance

--- a/cloudmock/gce/mockcompute/api.go
+++ b/cloudmock/gce/mockcompute/api.go
@@ -37,6 +37,7 @@ type MockClient struct {
 	addressClient          *addressClient
 	firewallClient         *firewallClient
 	routerClient           *routerClient
+	instanceClient         *instanceClient
 
 	instanceTemplateClient     *instanceTemplateClient
 	instanceGroupManagerClient *instanceGroupManagerClient
@@ -49,6 +50,8 @@ var _ gce.ComputeClient = &MockClient{}
 
 // NewMockClient creates a new mock client.
 func NewMockClient(project string) *MockClient {
+	instanceClient := newInstanceClient()
+
 	return &MockClient{
 		projectClient: newProjectClient(project),
 		zoneClient:    newZoneClient(project),
@@ -63,9 +66,10 @@ func NewMockClient(project string) *MockClient {
 		addressClient:          newAddressClient(),
 		firewallClient:         newFirewallClient(),
 		routerClient:           newRouterClient(),
+		instanceClient:         instanceClient,
 
 		instanceTemplateClient:     newInstanceTemplateClient(),
-		instanceGroupManagerClient: newInstanceGroupManagerClient(),
+		instanceGroupManagerClient: newInstanceGroupManagerClient(instanceClient),
 		targetPoolClient:           newTargetPoolClient(),
 
 		diskClient: newDiskClient(),
@@ -158,8 +162,7 @@ func (c *MockClient) Routers() gce.RouterClient {
 }
 
 func (c *MockClient) Instances() gce.InstanceClient {
-	// Not implemented.
-	return nil
+	return c.instanceClient
 }
 
 func (c *MockClient) InstanceTemplates() gce.InstanceTemplateClient {

--- a/cloudmock/gce/mockcompute/instance.go
+++ b/cloudmock/gce/mockcompute/instance.go
@@ -1,0 +1,124 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockcompute
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+)
+
+type instanceClient struct {
+	// instances are instances keyed by project, zone, and name.
+	instances map[string]map[string]map[string]*compute.Instance
+	sync.Mutex
+}
+
+var _ gce.InstanceClient = &instanceClient{}
+
+func newInstanceClient() *instanceClient {
+	return &instanceClient{
+		instances: map[string]map[string]map[string]*compute.Instance{},
+	}
+}
+
+func (c *instanceClient) All() map[string]interface{} {
+	return nil
+}
+
+func (c *instanceClient) Insert(project, zone string, instance *compute.Instance) (*compute.Operation, error) {
+	c.Lock()
+	defer c.Unlock()
+	zones, ok := c.instances[project]
+	if !ok {
+		zones = map[string]map[string]*compute.Instance{}
+		c.instances[project] = zones
+	}
+	instances, ok := zones[zone]
+	if !ok {
+		instances = map[string]*compute.Instance{}
+		zones[zone] = instances
+	}
+	instance.SelfLink = instance.Name
+	instances[instance.Name] = instance
+
+	return doneOperation(), nil
+}
+
+func (c *instanceClient) Delete(project, zone, name string) (*compute.Operation, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	zones, ok := c.instances[project]
+	if !ok {
+		return nil, notFoundError()
+	}
+	instances, ok := zones[zone]
+	if !ok {
+		return nil, notFoundError()
+	}
+	if _, ok := instances[name]; !ok {
+		return nil, notFoundError()
+	}
+	delete(instances, name)
+	return doneOperation(), nil
+}
+
+func (c *instanceClient) Get(project, zone, name string) (*compute.Instance, error) {
+	c.Lock()
+	defer c.Unlock()
+	zones, ok := c.instances[project]
+	if !ok {
+		return nil, notFoundError()
+	}
+	res, ok := zones[zone]
+	if !ok {
+		return nil, notFoundError()
+	}
+	igm, ok := res[name]
+	if !ok {
+		return nil, notFoundError()
+	}
+	return igm, nil
+}
+
+func (c *instanceClient) List(ctx context.Context, project, zone string) ([]*compute.Instance, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	zones, ok := c.instances[project]
+	if !ok {
+		return nil, nil
+	}
+	instances, ok := zones[zone]
+	if !ok {
+		return nil, nil
+	}
+
+	var l []*compute.Instance
+	for _, instance := range instances {
+		l = append(l, instance)
+	}
+	return l, nil
+}
+
+func (c *instanceClient) SetMetadata(project, zone, name string, metadata *compute.Metadata) (*compute.Operation, error) {
+	return nil, fmt.Errorf("setmetadata unimplemented")
+}

--- a/pkg/instancegroups/delete_test.go
+++ b/pkg/instancegroups/delete_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancegroups
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/compute/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kops/cmd/kops/util"
+	"k8s.io/kops/pkg/testutils"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+)
+
+func TestDeleteInstanceGroup_GCEWaitOnInstanceDeletion(t *testing.T) {
+	h := testutils.NewIntegrationTestHarness(t)
+	defer h.Close()
+
+	gce.PollingInterval = 5 * time.Millisecond
+	defer func() {
+		gce.PollingInterval = 5 * time.Second
+	}()
+
+	clusterName := "test.k8s.io"
+	cloud := h.SetupMockGCE()
+
+	zones, err := cloud.Zones()
+	require.NoError(t, err)
+	require.NotEmpty(t, zones)
+	zone := zones[0]
+
+	ctx := context.Background()
+	f := util.NewFactory(&util.FactoryOptions{
+		RegistryPath: "memfs://tests",
+	})
+
+	cluster := testutils.BuildMinimalClusterGCE(clusterName, cloud.Project())
+
+	clientset, err := f.KopsClient()
+	require.NoError(t, err)
+	_, err = clientset.CreateCluster(ctx, cluster)
+	require.NoError(t, err)
+
+	ig := testutils.BuildMinimalNodeInstanceGroup("nodes-1", zone)
+
+	_, err = clientset.InstanceGroupsFor(cluster).Create(context.TODO(), &ig, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	templateName := "test-template"
+	templateURL := "https://www.googleapis.com/compute/v1/projects/testproject/global/instanceTemplates/" + templateName
+
+	migName := gce.NameForInstanceGroupManager(clusterName, "nodes-1", zone)
+
+	_, err = cloud.Compute().InstanceGroupManagers().Insert(cloud.Project(), zone, &compute.InstanceGroupManager{
+		Name:             migName,
+		InstanceTemplate: templateURL,
+		Zone:             zone,
+	})
+	require.NoError(t, err)
+
+	_, err = cloud.Compute().InstanceTemplates().Insert(cloud.Project(),
+		&compute.InstanceTemplate{
+			Name: templateName,
+			Properties: &compute.InstanceProperties{
+				Metadata: &compute.Metadata{
+					Items: []*compute.MetadataItems{
+						{
+							Key:   "cluster-name",
+							Value: fi.PtrTo(clusterName),
+						},
+					},
+				},
+			},
+		})
+	require.NoError(t, err)
+
+	d := &DeleteInstanceGroup{
+		Cluster:   cluster,
+		Cloud:     cloud,
+		Clientset: clientset,
+	}
+
+	err = d.DeleteInstanceGroup(&ig)
+	assert.NoError(t, err)
+
+	// Check that all resources related to the CloudInstanceGroup were successfully deleted
+	instances, err := cloud.Compute().Instances().List(ctx, cloud.Project(), zone)
+	assert.NoError(t, err)
+	assert.Len(t, instances, 0)
+
+	_, err = cloud.Compute().InstanceGroupManagers().Get(cloud.Project(), zone, migName)
+	assert.True(t, gce.IsNotFound(err))
+
+	migs, err := cloud.Compute().InstanceGroupManagers().List(ctx, cloud.Project(), zone)
+	assert.NoError(t, err)
+	assert.Len(t, migs, 0)
+
+	instanceTemplates, err := cloud.Compute().InstanceTemplates().List(ctx, cloud.Project())
+	assert.NoError(t, err)
+	assert.Len(t, instanceTemplates, 0)
+}

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -280,11 +280,7 @@ func (c *gceCloudImplementation) Labels() map[string]string {
 	return tags
 }
 
-// TODO refactor this out of resources
-// this is needed for delete groups and other new methods
-
-// Zones returns the zones in a region
-func (c *gceCloudImplementation) Zones() ([]string, error) {
+func GetZones(c GCECloud) ([]string, error) {
 	var zones []string
 	// TODO: Only zones in api.Cluster object, if we have one?
 	gceZones, err := c.Compute().Zones().List(context.Background(), c.Project())
@@ -307,6 +303,14 @@ func (c *gceCloudImplementation) Zones() ([]string, error) {
 
 	klog.Infof("Scanning zones: %v", zones)
 	return zones, nil
+}
+
+// TODO refactor this out of resources
+// this is needed for delete groups and other new methods
+
+// Zones returns the zones in a region
+func (c *gceCloudImplementation) Zones() ([]string, error) {
+	return GetZones(c)
 }
 
 func (c *gceCloudImplementation) WaitForOp(op *compute.Operation) error {


### PR DESCRIPTION
* This commit waits until all related Instances have been deleted before proceeding with the deletion of InstanceManagers and InstanceTemplates
* Closes https://github.com/kubernetes/kops/issues/17619

 /assign @hakman