### PR TITLE
Fix RequestTag key for LBC's Create actions

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/test.sh
@@ -49,13 +49,13 @@ fi
 # shellcheck disable=SC2086
 git clone ${CLONE_ARGS} https://github.com/kubernetes-sigs/aws-load-balancer-controller .
 
-ginkgo -v -r test/e2e/ingress -- \
+ginkgo -v -p -r test/e2e/ingress -- \
     -cluster-name="${CLUSTER_NAME}" \
     -aws-region="${REGION}" \
     -aws-vpc-id="$VPC" \
     -ginkgo.junit-report="${REPORT_DIR}/junit-ingress.xml"
 
-ginkgo -v -r test/e2e/service -- \
+ginkgo -v -p -r test/e2e/service -- \
     -cluster-name="${CLUSTER_NAME}" \
     -aws-region="${REGION}" \
     -aws-vpc-id="$VPC" \

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -2,6 +2,37 @@
   "Statement": [
     {
       "Action": [
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteRule",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:ModifyCapacityReservation",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyListenerAttributes",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:ModifyRule",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",
         "elasticloadbalancing:CreateRule",
@@ -108,27 +139,7 @@
       "Action": [
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:DeleteSecurityGroup",
-        "ec2:RevokeSecurityGroupIngress",
-        "elasticloadbalancing:AddListenerCertificates",
-        "elasticloadbalancing:AddTags",
-        "elasticloadbalancing:DeleteListener",
-        "elasticloadbalancing:DeleteLoadBalancer",
-        "elasticloadbalancing:DeleteRule",
-        "elasticloadbalancing:DeleteTargetGroup",
-        "elasticloadbalancing:DeregisterTargets",
-        "elasticloadbalancing:ModifyCapacityReservation",
-        "elasticloadbalancing:ModifyListener",
-        "elasticloadbalancing:ModifyListenerAttributes",
-        "elasticloadbalancing:ModifyLoadBalancerAttributes",
-        "elasticloadbalancing:ModifyRule",
-        "elasticloadbalancing:ModifyTargetGroup",
-        "elasticloadbalancing:ModifyTargetGroupAttributes",
-        "elasticloadbalancing:RegisterTargets",
-        "elasticloadbalancing:RemoveListenerCertificates",
-        "elasticloadbalancing:RemoveTags",
-        "elasticloadbalancing:SetIpAddressType",
-        "elasticloadbalancing:SetSecurityGroups",
-        "elasticloadbalancing:SetSubnets"
+        "ec2:RevokeSecurityGroupIngress"
       ],
       "Condition": {
         "StringEquals": {

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -16,6 +16,30 @@
       "Resource": "*"
     },
     {
+      "Action": "elasticloadbalancing:AddTags",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "minimal.example.com",
+          "elasticloadbalancing:CreateAction": [
+            "CreateListener",
+            "CreateLoadBalancer",
+            "CreateRule",
+            "CreateTargetGroup"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:elasticloadbalancing:*:*:listener-rule/app/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener/app/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener/net/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:targetgroup/*/*"
+      ]
+    },
+    {
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -1,6 +1,21 @@
 {
   "Statement": [
     {
+      "Action": [
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:CreateTargetGroup"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
@@ -100,13 +115,7 @@
       "Resource": "*"
     },
     {
-      "Action": [
-        "ec2:CreateSecurityGroup",
-        "elasticloadbalancing:CreateListener",
-        "elasticloadbalancing:CreateLoadBalancer",
-        "elasticloadbalancing:CreateRule",
-        "elasticloadbalancing:CreateTargetGroup"
-      ],
+      "Action": "ec2:CreateSecurityGroup",
       "Condition": {
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com"

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -2,6 +2,37 @@
   "Statement": [
     {
       "Action": [
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteRule",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:ModifyCapacityReservation",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyListenerAttributes",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:ModifyRule",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",
         "elasticloadbalancing:CreateRule",
@@ -108,27 +139,7 @@
       "Action": [
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:DeleteSecurityGroup",
-        "ec2:RevokeSecurityGroupIngress",
-        "elasticloadbalancing:AddListenerCertificates",
-        "elasticloadbalancing:AddTags",
-        "elasticloadbalancing:DeleteListener",
-        "elasticloadbalancing:DeleteLoadBalancer",
-        "elasticloadbalancing:DeleteRule",
-        "elasticloadbalancing:DeleteTargetGroup",
-        "elasticloadbalancing:DeregisterTargets",
-        "elasticloadbalancing:ModifyCapacityReservation",
-        "elasticloadbalancing:ModifyListener",
-        "elasticloadbalancing:ModifyListenerAttributes",
-        "elasticloadbalancing:ModifyLoadBalancerAttributes",
-        "elasticloadbalancing:ModifyRule",
-        "elasticloadbalancing:ModifyTargetGroup",
-        "elasticloadbalancing:ModifyTargetGroupAttributes",
-        "elasticloadbalancing:RegisterTargets",
-        "elasticloadbalancing:RemoveListenerCertificates",
-        "elasticloadbalancing:RemoveTags",
-        "elasticloadbalancing:SetIpAddressType",
-        "elasticloadbalancing:SetSecurityGroups",
-        "elasticloadbalancing:SetSubnets"
+        "ec2:RevokeSecurityGroupIngress"
       ],
       "Condition": {
         "StringEquals": {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -16,6 +16,30 @@
       "Resource": "*"
     },
     {
+      "Action": "elasticloadbalancing:AddTags",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "minimal.example.com",
+          "elasticloadbalancing:CreateAction": [
+            "CreateListener",
+            "CreateLoadBalancer",
+            "CreateRule",
+            "CreateTargetGroup"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:elasticloadbalancing:*:*:listener-rule/app/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener/app/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener/net/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:targetgroup/*/*"
+      ]
+    },
+    {
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -1,6 +1,21 @@
 {
   "Statement": [
     {
+      "Action": [
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:CreateTargetGroup"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
@@ -100,13 +115,7 @@
       "Resource": "*"
     },
     {
-      "Action": [
-        "ec2:CreateSecurityGroup",
-        "elasticloadbalancing:CreateListener",
-        "elasticloadbalancing:CreateLoadBalancer",
-        "elasticloadbalancing:CreateRule",
-        "elasticloadbalancing:CreateTargetGroup"
-      ],
+      "Action": "ec2:CreateSecurityGroup",
       "Condition": {
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com"

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -212,6 +212,37 @@
     },
     {
       "Action": [
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteRule",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:ModifyCapacityReservation",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyListenerAttributes",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:ModifyRule",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",
         "elasticloadbalancing:CreateRule",
@@ -376,7 +407,6 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume",
         "ec2:RevokeSecurityGroupIngress",
-        "elasticloadbalancing:AddListenerCertificates",
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -386,27 +416,18 @@
         "elasticloadbalancing:DeleteListener",
         "elasticloadbalancing:DeleteLoadBalancer",
         "elasticloadbalancing:DeleteLoadBalancerListeners",
-        "elasticloadbalancing:DeleteRule",
         "elasticloadbalancing:DeleteTargetGroup",
         "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
         "elasticloadbalancing:DeregisterTargets",
         "elasticloadbalancing:DetachLoadBalancerFromSubnets",
-        "elasticloadbalancing:ModifyCapacityReservation",
         "elasticloadbalancing:ModifyListener",
-        "elasticloadbalancing:ModifyListenerAttributes",
         "elasticloadbalancing:ModifyLoadBalancerAttributes",
-        "elasticloadbalancing:ModifyRule",
         "elasticloadbalancing:ModifyTargetGroup",
         "elasticloadbalancing:ModifyTargetGroupAttributes",
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:RegisterTargets",
-        "elasticloadbalancing:RemoveListenerCertificates",
-        "elasticloadbalancing:RemoveTags",
-        "elasticloadbalancing:SetIpAddressType",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
-        "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
-        "elasticloadbalancing:SetSecurityGroups",
-        "elasticloadbalancing:SetSubnets"
+        "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
       "Condition": {
         "StringEquals": {

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -226,6 +226,30 @@
       "Resource": "*"
     },
     {
+      "Action": "elasticloadbalancing:AddTags",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "minimal.example.com",
+          "elasticloadbalancing:CreateAction": [
+            "CreateListener",
+            "CreateLoadBalancer",
+            "CreateRule",
+            "CreateTargetGroup"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:elasticloadbalancing:*:*:listener-rule/app/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener/app/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener/net/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:targetgroup/*/*"
+      ]
+    },
+    {
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -211,6 +211,21 @@
       ]
     },
     {
+      "Action": [
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:CreateTargetGroup"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
@@ -385,7 +400,6 @@
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",
-        "elasticloadbalancing:CreateRule",
         "elasticloadbalancing:CreateTargetGroup"
       ],
       "Condition": {

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
@@ -212,6 +212,37 @@
     },
     {
       "Action": [
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteRule",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:ModifyCapacityReservation",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyListenerAttributes",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:ModifyRule",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "many-addons.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",
         "elasticloadbalancing:CreateRule",
@@ -376,7 +407,6 @@
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume",
         "ec2:RevokeSecurityGroupIngress",
-        "elasticloadbalancing:AddListenerCertificates",
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
@@ -386,27 +416,18 @@
         "elasticloadbalancing:DeleteListener",
         "elasticloadbalancing:DeleteLoadBalancer",
         "elasticloadbalancing:DeleteLoadBalancerListeners",
-        "elasticloadbalancing:DeleteRule",
         "elasticloadbalancing:DeleteTargetGroup",
         "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
         "elasticloadbalancing:DeregisterTargets",
         "elasticloadbalancing:DetachLoadBalancerFromSubnets",
-        "elasticloadbalancing:ModifyCapacityReservation",
         "elasticloadbalancing:ModifyListener",
-        "elasticloadbalancing:ModifyListenerAttributes",
         "elasticloadbalancing:ModifyLoadBalancerAttributes",
-        "elasticloadbalancing:ModifyRule",
         "elasticloadbalancing:ModifyTargetGroup",
         "elasticloadbalancing:ModifyTargetGroupAttributes",
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:RegisterTargets",
-        "elasticloadbalancing:RemoveListenerCertificates",
-        "elasticloadbalancing:RemoveTags",
-        "elasticloadbalancing:SetIpAddressType",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
-        "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
-        "elasticloadbalancing:SetSecurityGroups",
-        "elasticloadbalancing:SetSubnets"
+        "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
       ],
       "Condition": {
         "StringEquals": {

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
@@ -211,6 +211,21 @@
       ]
     },
     {
+      "Action": [
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:CreateTargetGroup"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "many-addons.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
@@ -385,7 +400,6 @@
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",
-        "elasticloadbalancing:CreateRule",
         "elasticloadbalancing:CreateTargetGroup"
       ],
       "Condition": {

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
@@ -226,6 +226,30 @@
       "Resource": "*"
     },
     {
+      "Action": "elasticloadbalancing:AddTags",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "many-addons.example.com",
+          "elasticloadbalancing:CreateAction": [
+            "CreateListener",
+            "CreateLoadBalancer",
+            "CreateRule",
+            "CreateTargetGroup"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:elasticloadbalancing:*:*:listener-rule/app/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener/app/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:listener/net/*/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws-test:elasticloadbalancing:*:*:targetgroup/*/*"
+      ]
+    },
+    {
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
LBC E2E is failing this test consistently:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-aws-load-balancer-controller/2025686326782726144

```
{"level":"info","ts":1771799636.0397868,"msg":"allocated namespace","name":"aws-lb-e2e-acbefb"}
...
{"level":"info","ts":1771800058.779905,"msg":"resource becomes deleted","kind":"Deployment","key":{"name":"app","namespace":"aws-lb-e2e-acbefb"}}
{"level":"info","ts":1771800058.7799432,"msg":"deleting resource","kind":"Service","key":{"name":"app","namespace":"aws-lb-e2e-acbefb"}}
{"level":"info","ts":1771800058.8802516,"msg":"deleted resource","kind":"Service","key":{"name":"app","namespace":"aws-lb-e2e-acbefb"}}
{"level":"info","ts":1771800058.880282,"msg":"wait resource becomes deleted","kind":"Service","key":{"name":"app","namespace":"aws-lb-e2e-acbefb"}}
{"level":"info","ts":1771800058.963916,"msg":"resource becomes deleted","kind":"Service","key":{"name":"app","namespace":"aws-lb-e2e-acbefb"}}
[FAILED] Timed out after 60.001s.
The function passed to Eventually failed at /tmp/kops.rAsUlFShh/test/e2e/ingress/vanilla_ingress_test.go:916 with:
Expected
    <string>: 
not to be empty
```

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-aws-aws-load-balancer-controller/2025686326782726144/artifacts/cluster-info/kube-system/aws-load-balancer-controller-5d49db9994-phx65/controller.log

`{"level":"error","ts":"2026-02-22T22:34:01Z","msg":"Reconciler error","controller":"ingress","object":{"name":"ing","namespace":"aws-lb-e2e-acbefb"},"namespace":"aws-lb-e2e-acbefb","name":"ing","reconcileID":"13f2aafe-928d-453c-831e-ea969143a936","error":"operation error Elastic Load Balancing v2: CreateTargetGroup, https response error StatusCode: 403, RequestID: acda28fa-d4b3-4664-a429-b7a965e317b4, api error AccessDenied: User: arn:aws:sts::808842816990:assumed-role/aws-load-balancer-controller.kube-system.sa.e2e-e2e-kops--b10k46/1771796925893256016 is not authorized to perform: elasticloadbalancing:CreateTargetGroup on resource: arn:aws:elasticloadbalancing:eu-west-1:808842816990:targetgroup/k8s-awslbe2e-ing-cca17c2065/* because no identity-based policy allows the elasticloadbalancing:CreateTargetGroup action"}`