### PR TITLE
Keep skipping certain tests on older cilium versions

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -76,6 +76,13 @@ func (t *Tester) setSkipRegexFlag() error {
 		// https://github.com/cilium/cilium/issues/14287
 		skipRegex += "|same.hostPort.but.different.hostIP.and.protocol"
 
+		if networking.Cilium.Version < "v1.17" {
+			// https://github.com/cilium/cilium/issues/14287
+			skipRegex += "|same.port.number.but.different.protocols"
+			// https://github.com/cilium/cilium/issues/9207
+			skipRegex += "|serve.endpoints.on.same.port.and.different.protocols"
+		}
+
 		// https://github.com/kubernetes/kubernetes/blob/418ae605ec1b788d43bff7ac44af66d8b669b833/test/e2e/network/networking.go#L135
 		skipRegex += "|should.check.kube-proxy.urls"
 


### PR DESCRIPTION
In https://github.com/kubernetes/kops/pull/17865 we removed skips for certain tests that are now passing on newer cilium versions.

I forgot that the kubetest2-kops on master is used to test older kops versions, which still use older cilium versions. 

These cilium jobs started failing because we reintroduced those tests:

https://testgrid.k8s.io/kops-grid#kops-grid-cilium-eni-deb12-k32-ko32
https://testgrid.k8s.io/kops-grid#kops-grid-cilium-eni-deb12-k32-ko33
https://testgrid.k8s.io/kops-grid#kops-grid-cilium-eni-deb12-k33-ko33

This PR adds back the skips which we'll need to keep until we stop testing kops 1.33.