### PR TITLE
Restore metrics-server kubelet preferred address types to upstream defaults

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -165,7 +165,7 @@ spec:
         - --secure-port=10250
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=Hostname
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
         image: registry.k8s.io/metrics-server/metrics-server:v0.8.0

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -165,7 +165,7 @@ spec:
         - --secure-port=10250
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=Hostname
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
         image: registry.k8s.io/metrics-server/metrics-server:v0.8.0

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -165,7 +165,7 @@ spec:
         - --secure-port=10250
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=Hostname
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
         image: registry.k8s.io/metrics-server/metrics-server:v0.8.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -165,7 +165,7 @@ spec:
         - --secure-port=10250
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=Hostname
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
         image: registry.k8s.io/metrics-server/metrics-server:v0.8.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -165,7 +165,7 @@ spec:
         - --secure-port=10250
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=Hostname
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --tls-cert-file=/srv/tls.crt
         - --tls-private-key-file=/srv/tls.key
         image: registry.k8s.io/metrics-server/metrics-server:v0.8.0


### PR DESCRIPTION
This change updates the metrics-server addon configuration to use the upstream/default kubelet preferred address types instead of Hostname.

Before:
```
--kubelet-preferred-address-types=Hostname
```
After:
```
--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
```

We observed intermittent metrics-server scrape failures like:

```
Failed to scrape node, timeout to access kubelet err="Get "https://<node>.<REGION>.compute.internal:10250/metrics/resource": context deadline exceeded node="node-ID" timeout="10s"
```

I think using `Hostname` only is more fragile in environments where hostname resolution or the DNS/network path is intermittently slower than direct node IP access. Restoring the upstream/default order allows metrics-server to prefer InternalIP first, which is generally the most direct and reliable path for kubelet scraping. This also aligns our addon behavior with the upstream metrics-server manifests. 

`I'm not sure why the default behavior was changed. As you likely have more context around the reason for this modification, I'll leave the decision on whether to keep or change to you`

Expected impact

This change should reduce intermittent kubelet scrape failures from metrics-server

Reference
metrics-server README / requirements: https://github.com/kubernetes-sigs/metrics-server?tab=readme-ov-file#requirements