### PR TITLE
Automated cherry pick of #18043: Fix node bootstrap challenge response hashing

### DIFF
--- a/pkg/bootstrap/challenge_server.go
+++ b/pkg/bootstrap/challenge_server.go
@@ -205,11 +205,11 @@ func (s *ChallengeServer) Challenge(ctx context.Context, req *pb.ChallengeReques
 	return response, nil
 }
 
-func buildChallengeResponse(nodeNonce []byte, kopsControllerNonde []byte) []byte {
+func buildChallengeResponse(nodeNonce []byte, kopsControllerNonce []byte) []byte {
 	// Arguably this is overkill because the TLS handshake is stronger and everything is encrypted.
 	hasher := sha256.New()
-	hasher.Sum(nodeNonce)
-	hasher.Sum(kopsControllerNonde)
+	hasher.Write(nodeNonce)
+	hasher.Write(kopsControllerNonce)
 
 	hash := hasher.Sum(nil)
 


### PR DESCRIPTION
Cherry pick of #18043 on release-1.35.

#18043: Fix node bootstrap challenge response hashing

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```