### PR TITLE
test: Skip dumping not found nodes for GCE

### DIFF
--- a/pkg/resources/gce/dump.go
+++ b/pkg/resources/gce/dump.go
@@ -62,18 +62,19 @@ func DumpManagedInstance(op *resources.DumpOperation, r *resources.Resource) err
 	instanceDetails := instanceMap[u.Name]
 	if instanceDetails == nil {
 		klog.Warningf("instance %q not found", instance.Instance)
-	} else {
-		for _, ni := range instanceDetails.NetworkInterfaces {
-			if ni.NetworkIP != "" {
-				i.PrivateAddresses = append(i.PrivateAddresses, ni.NetworkIP)
-			}
-			if ni.Ipv6Address != "" {
-				i.PrivateAddresses = append(i.PrivateAddresses, ni.Ipv6Address)
-			}
-			for _, ac := range ni.AccessConfigs {
-				if ac.NatIP != "" {
-					i.PublicAddresses = append(i.PublicAddresses, ac.NatIP)
-				}
+		return nil
+	}
+
+	for _, ni := range instanceDetails.NetworkInterfaces {
+		if ni.NetworkIP != "" {
+			i.PrivateAddresses = append(i.PrivateAddresses, ni.NetworkIP)
+		}
+		if ni.Ipv6Address != "" {
+			i.PrivateAddresses = append(i.PrivateAddresses, ni.Ipv6Address)
+		}
+		for _, ac := range ni.AccessConfigs {
+			if ac.NatIP != "" {
+				i.PublicAddresses = append(i.PublicAddresses, ac.NatIP)
 			}
 		}
 	}


### PR DESCRIPTION
```
I0309 16:05:32.533490   57537 gce.go:97] Scanning zones: [us-east1-b us-east1-c us-east1-d]
W0309 16:05:38.678601   57537 dump.go:64] instance "https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-scale-28/zones/us-east1-b/instances/addons-4m6z" not found
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0xe8 pc=0x65387a1]

goroutine 1 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
	go.opentelemetry.io/otel/sdk@v1.39.0/trace/span.go:478 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc00072e1e0, {0x0, 0x0, 0x0?})
	go.opentelemetry.io/otel/sdk@v1.39.0/trace/span.go:528 +0xd14
panic({0x72cc4c0?, 0xc47e600?})
	runtime/panic.go:783 +0x132
k8s.io/kops/pkg/resources/gce.DumpManagedInstance(0xc000916d40, 0x4c?)
	k8s.io/kops/pkg/resources/gce/dump.go:82 +0x2a1
k8s.io/kops/pkg/resources.BuildDump({0x909d758, 0xc00070df20}, {0x7abfdcaaf918, 0xc0006b8720}, 0xc000cb0150)
	k8s.io/kops/pkg/resources/dump.go:58 +0x24f
main.RunToolboxDump({0x909d758, 0xc00070df20}, {0x90804f0?, 0xc0005b5860?}, {0x901b220, 0xc0000aa020}, 0xc00058f7a0)
	k8s.io/kops/cmd/kops/toolbox_dump.go:143 +0x131
main.NewCmdToolboxDump.func1(0xc0005c9600?, {0xc000c7d360?, 0x4?, 0x815c5d8?})
	k8s.io/kops/cmd/kops/toolbox_dump.go:96 +0x38
github.com/spf13/cobra.(*Command).execute(0xc000c5f808, {0xc000c7d220, 0xa, 0xa})
	github.com/spf13/cobra@v1.10.2/command.go:1015 +0xb02
github.com/spf13/cobra.(*Command).ExecuteC(0xc4d0420)
	github.com/spf13/cobra@v1.10.2/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.10.2/command.go:1071
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.10.2/command.go:1064
main.Execute({0x909d668, 0xc5243a0})
	k8s.io/kops/cmd/kops/root.go:100 +0x356
main.run({0x909d668, 0xc5243a0})
	k8s.io/kops/cmd/kops/main.go:55 +0x15a
main.main()
	k8s.io/kops/cmd/kops/main.go:29 +0x25
W0309 16:05:38.684372   16433 dumplogs.go:59] kops toolbox dump failed: exit status 2
```

/cc @rifelpet @ameukam @upodroid 