### PR TITLE
allow pods to reach metric ports running on control plane nodes when using gce alias ip

### DIFF
--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -154,6 +154,12 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.EtcdCiliumClientPort))
 			}
 		}
+		if b.NetworkingIsIPAlias() {
+			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.KubeControllerManagerMetricsPort))
+			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.KubeSchedulerMetricsPort))
+			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.KubeProxyMetricsPort))
+			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.EtcdMetricsPort))
+		}
 		c.AddTask(t)
 	}
 

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -20,6 +20,9 @@ const (
 	// KubeAPIServer is the port where kube-apiserver listens.
 	KubeAPIServer = 443
 
+	// EtcdMetricsPort is used to serve etcd metrics
+	EtcdMetricsPort = 2382
+
 	// NodeupChallenge is the port where nodeup listens for challenges.
 	NodeupChallenge = 3987
 
@@ -90,6 +93,15 @@ const (
 
 	// KubeletAPI is the port where kubelet listens
 	KubeletAPI = 10250
+
+	// KubeProxyMetricsPort is used by kube-proxy to expose metrics
+	KubeProxyMetricsPort = 10249
+
+	// KubeSchedulerMetricsPort is used by kube-scheduler to expose metrics
+	KubeSchedulerMetricsPort = 10259
+
+	// KubeControllerManagerMetricsPort is used by kube-controller-manager to expose metrics
+	KubeControllerManagerMetricsPort = 10257
 )
 
 type PortRange struct {


### PR DESCRIPTION
@serathius @hakman

This should fix the GCE scale jobs unable to read metrics from control plane nodes.

Also, this feature should already exist for amazonvpc but it doesn't work. https://github.com/kubernetes/kops/blob/3df86187bb0382384c645bd40d997223f2af1043/pkg/model/awsmodel/firewall.go#L216 I don't see a `all-nodes-to-master-*` SG being created for aws cni jobs.