### PR TITLE
scaletest: Use sleep instead of wait for large clusters

### DIFF
--- a/tests/e2e/scenarios/scalability/pre-test.sh
+++ b/tests/e2e/scenarios/scalability/pre-test.sh
@@ -26,5 +26,6 @@ if [[ "${CLOUD_PROVIDER}" == "gce" ]]; then
     --set=spec.maxSize=1 --set=spec.minSize=1 --set=spec.rootVolume.type=hyperdisk-balanced \
     --set=spec.image="${INSTANCE_IMAGE:-ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20251001}"
   kops update cluster --yes
-  kops validate cluster --wait 10m
+  # TODO: Replaced with `kops validate instancegroup --wait 10m` when it's fixed for 5k node clusters.
+  sleep 120 # should take around 2 minutes to get node read
 fi


### PR DESCRIPTION
Fixing https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-performance-5000/2032502308796895232

Investigation in https://kubernetes.slack.com/archives/C09QZTRH7/p1773429346033779?thread_ts=1773428126.202359&cid=C09QZTRH7

Looks like `kops validate cluster --wait 10m` timedout even though node was ready for over 8 minutes.

/assign @hakman @upodroid 