### PR TITLE
Use protobuf

### DIFF
--- a/cmd/kops/util/factory.go
+++ b/cmd/kops/util/factory.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/dynamic"
@@ -200,6 +201,8 @@ func configureRESTConfig(restConfig *rest.Config) {
 	restConfig.UserAgent = "kops"
 	restConfig.Burst = 50
 	restConfig.QPS = 20
+	restConfig.AcceptContentTypes = runtime.ContentTypeProtobuf
+	restConfig.ContentType = runtime.ContentTypeProtobuf
 }
 
 func (f *Factory) HTTPClient(restConfig *rest.Config) (*http.Client, error) {

--- a/pkg/commands/toolbox_enroll.go
+++ b/pkg/commands/toolbox_enroll.go
@@ -216,7 +216,12 @@ func enrollHost(ctx context.Context, ig *kops.InstanceGroup, bootstrapData *Boot
 	if err := v1alpha2.AddToScheme(scheme); err != nil {
 		return fmt.Errorf("building kubernetes scheme: %w", err)
 	}
-	kubeClient, err := client.New(restConfig, client.Options{
+	// Ensure that we don't try to use proto with our CRD
+	restConfigNoProto := rest.CopyConfig(restConfig)
+	restConfigNoProto.ContentType = runtime.ContentTypeJSON
+	restConfigNoProto.AcceptContentTypes = runtime.ContentTypeJSON
+
+	kubeClient, err := client.New(restConfigNoProto, client.Options{
 		Scheme: scheme,
 	})
 	if err != nil {


### PR DESCRIPTION
Experimenting with fixing `kops validate cluster --wait` not working for large cluster https://github.com/kubernetes/kops/pull/18065 

First rule of K8s, always use protobuf