### PR TITLE
scaletest: Increase scalability tests log verbosity to 3

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -108,7 +108,7 @@ create_args+=("--set spec.kubeAPIServer.maxRequestsInflight=${KOPS_APISERVER_MAX
 create_args+=("--set spec.kubeAPIServer.maxMutatingRequestsInflight=0")
 create_args+=("--set spec.kubeAPIServer.enableProfiling=true")
 create_args+=("--set spec.kubeAPIServer.enableContentionProfiling=true")
-create_args+=("--set spec.kubeAPIServer.logLevel=2")
+create_args+=("--set spec.kubeAPIServer.logLevel=3")
 # increase the --delete-collection-workers to 100 to speed up delete operations
 create_args+=("--set spec.kubeAPIServer.deleteCollectionWorkers=100")
 


### PR DESCRIPTION
Need level 3 to debug anything related to scalability

V3 was previously configured in:
https://github.com/kubernetes/test-infra/blob/7e7d0bbfe6d516cd4d1d2ab79498afbf0635da08/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml#L178-L179