### PR TITLE
Align kops scalability configuration with kube-up

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -681,7 +681,7 @@ spec:
                     type: string
                   concurrentNodeSyncs:
                     description: 'ConcurrentNodeSyncs is the number of workers concurrently
-                      synchronizing nodes. (default: 1)'
+                      synchronizing nodes. (default: 5)'
                     format: int32
                     type: integer
                   configureCloudRoutes:
@@ -1880,6 +1880,11 @@ spec:
                   cloudProvider:
                     description: CloudProvider is the name of the cloudProvider we
                       are using, aws, gce etcd
+                    type: string
+                  compactionInterval:
+                    description: |-
+                      CompactionInterval is an interval of requesting compaction from apiserver.
+                      If the value is 0, no compaction will be issued.
                     type: string
                   corsAllowedOrigins:
                     description: |-
@@ -4359,6 +4364,11 @@ spec:
                     description: Integrate with the kernel memcg notification to determine
                       if memory eviction thresholds are crossed rather than polling.
                     type: boolean
+                  kubeAPIQPS:
+                    description: KubeAPIQPS Burst to use while talking with kubernetes
+                      apiserver. (default 50)
+                    format: int32
+                    type: integer
                   kubeReserved:
                     additionalProperties:
                       type: string
@@ -4828,6 +4838,11 @@ spec:
                     description: Integrate with the kernel memcg notification to determine
                       if memory eviction thresholds are crossed rather than polling.
                     type: boolean
+                  kubeAPIQPS:
+                    description: KubeAPIQPS Burst to use while talking with kubernetes
+                      apiserver. (default 50)
+                    format: int32
+                    type: integer
                   kubeReserved:
                     additionalProperties:
                       type: string

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -660,6 +660,11 @@ spec:
                     description: Integrate with the kernel memcg notification to determine
                       if memory eviction thresholds are crossed rather than polling.
                     type: boolean
+                  kubeAPIQPS:
+                    description: KubeAPIQPS Burst to use while talking with kubernetes
+                      apiserver. (default 50)
+                    format: int32
+                    type: integer
                   kubeReserved:
                     additionalProperties:
                       type: string

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -252,6 +252,9 @@ type KubeletConfigSpec struct {
 	MemorySwapBehavior string `json:"memorySwapBehavior,omitempty"`
 	// CrashLoopBackOffMaxContainerRestartPeriod is the maximum duration the backoff delay can accrue to for container restarts, minimum 1 second, maximum 300 seconds. If not set, defaults to the internal crashloopbackoff maximum (300s).
 	CrashLoopBackOffMaxContainerRestartPeriod *metav1.Duration `json:"crashLoopBackOffMaxContainerRestartPeriod,omitempty"`
+
+	// KubeAPIQPS Burst to use while talking with kubernetes apiserver. (default 50)
+	KubeAPIQPS *int32 `json:"kubeAPIQPS,omitempty" flag:"kube-api-qps"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy
@@ -564,6 +567,10 @@ type KubeAPIServerConfig struct {
 	// DeleteCollectionWorkers indicates the number of workers spawned for DeleteCollection call. These are used to speed up namespace cleanup.
 	DeleteCollectionWorkers int `json:"deleteCollectionWorkers,omitempty" flag:"delete-collection-workers" flag-empty:"0"`
 
+	// CompactionInterval is an interval of requesting compaction from apiserver.
+	// If the value is 0, no compaction will be issued.
+	CompactionInterval *metav1.Duration `json:"compactionInterval,omitempty" flag:"etcd-compaction-interval"`
+
 	// Env allows users to pass in env variables to the apiserver container.
 	// This can be useful to control some environment runtime settings, such as GOMEMLIMIT and GOCG to tweak the memory settings of the apiserver
 	// This also allows the flexibility for adding any other variables for future use cases
@@ -766,7 +773,7 @@ type CloudControllerManagerConfig struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// NodeStatusUpdateFrequency is the duration between node status updates. (default: 5m)
 	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
-	// ConcurrentNodeSyncs is the number of workers concurrently synchronizing nodes. (default: 1)
+	// ConcurrentNodeSyncs is the number of workers concurrently synchronizing nodes. (default: 5)
 	ConcurrentNodeSyncs *int32 `json:"concurrentNodeSyncs,omitempty" flag:"concurrent-node-syncs"`
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -252,6 +252,9 @@ type KubeletConfigSpec struct {
 	MemorySwapBehavior string `json:"memorySwapBehavior,omitempty"`
 	// CrashLoopBackOffMaxContainerRestartPeriod is the maximum duration the backoff delay can accrue to for container restarts, minimum 1 second, maximum 300 seconds. If not set, defaults to the internal crashloopbackoff maximum (300s).
 	CrashLoopBackOffMaxContainerRestartPeriod *metav1.Duration `json:"crashLoopBackOffMaxContainerRestartPeriod,omitempty"`
+
+	// KubeAPIQPS Burst to use while talking with kubernetes apiserver. (default 50)
+	KubeAPIQPS *int32 `json:"kubeAPIQPS,omitempty" flag:"kube-api-qps"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy
@@ -571,6 +574,10 @@ type KubeAPIServerConfig struct {
 	// DeleteCollectionWorkers indicates the number of workers spawned for DeleteCollection call. These are used to speed up namespace cleanup.
 	DeleteCollectionWorkers int `json:"deleteCollectionWorkers,omitempty" flag:"delete-collection-workers" flag-empty:"0"`
 
+	// CompactionInterval is an interval of requesting compaction from apiserver.
+	// If the value is 0, no compaction will be issued.
+	CompactionInterval *metav1.Duration `json:"compactionInterval,omitempty" flag:"etcd-compaction-interval"`
+
 	// Env allows users to pass in env variables to the apiserver container.
 	// This can be useful to control some environment runtime settings, such as GOMEMLIMIT and GOCG to tweak the memory settings of the apiserver
 	// This also allows the flexibility for adding any other variables for future use cases
@@ -772,7 +779,7 @@ type CloudControllerManagerConfig struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// NodeStatusUpdateFrequency is the duration between node status updates. (default: 5m)
 	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
-	// ConcurrentNodeSyncs is the number of workers concurrently synchronizing nodes. (default: 1)
+	// ConcurrentNodeSyncs is the number of workers concurrently synchronizing nodes. (default: 5)
 	ConcurrentNodeSyncs *int32 `json:"concurrentNodeSyncs,omitempty" flag:"concurrent-node-syncs"`
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5286,6 +5286,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.DefaultNotReadyTolerationSeconds = in.DefaultNotReadyTolerationSeconds
 	out.DefaultUnreachableTolerationSeconds = in.DefaultUnreachableTolerationSeconds
 	out.DeleteCollectionWorkers = in.DeleteCollectionWorkers
+	out.CompactionInterval = in.CompactionInterval
 	out.Env = in.Env
 	return nil
 }
@@ -5400,6 +5401,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.DefaultNotReadyTolerationSeconds = in.DefaultNotReadyTolerationSeconds
 	out.DefaultUnreachableTolerationSeconds = in.DefaultUnreachableTolerationSeconds
 	out.DeleteCollectionWorkers = in.DeleteCollectionWorkers
+	out.CompactionInterval = in.CompactionInterval
 	out.Env = in.Env
 	return nil
 }
@@ -5870,6 +5872,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior
 	out.CrashLoopBackOffMaxContainerRestartPeriod = in.CrashLoopBackOffMaxContainerRestartPeriod
+	out.KubeAPIQPS = in.KubeAPIQPS
 	return nil
 }
 
@@ -5976,6 +5979,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior
 	out.CrashLoopBackOffMaxContainerRestartPeriod = in.CrashLoopBackOffMaxContainerRestartPeriod
+	out.KubeAPIQPS = in.KubeAPIQPS
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3579,6 +3579,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.CompactionInterval != nil {
+		in, out := &in.CompactionInterval, &out.CompactionInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]corev1.EnvVar, len(*in))
@@ -4427,6 +4432,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 	if in.CrashLoopBackOffMaxContainerRestartPeriod != nil {
 		in, out := &in.CrashLoopBackOffMaxContainerRestartPeriod, &out.CrashLoopBackOffMaxContainerRestartPeriod
 		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.KubeAPIQPS != nil {
+		in, out := &in.KubeAPIQPS, &out.KubeAPIQPS
+		*out = new(int32)
 		**out = **in
 	}
 	return

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -250,6 +250,9 @@ type KubeletConfigSpec struct {
 	MemorySwapBehavior string `json:"memorySwapBehavior,omitempty"`
 	// CrashLoopBackOffMaxContainerRestartPeriod is the maximum duration the backoff delay can accrue to for container restarts, minimum 1 second, maximum 300 seconds. If not set, defaults to the internal crashloopbackoff maximum (300s).
 	CrashLoopBackOffMaxContainerRestartPeriod *metav1.Duration `json:"crashLoopBackOffMaxContainerRestartPeriod,omitempty"`
+
+	// KubeAPIQPS Burst to use while talking with kubernetes apiserver. (default 50)
+	KubeAPIQPS *int32 `json:"kubeAPIQPS,omitempty" flag:"kube-api-qps"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy
@@ -562,6 +565,10 @@ type KubeAPIServerConfig struct {
 	// DeleteCollectionWorkers indicates the number of workers spawned for DeleteCollection call. These are used to speed up namespace cleanup.
 	DeleteCollectionWorkers int `json:"deleteCollectionWorkers,omitempty" flag:"delete-collection-workers" flag-empty:"0"`
 
+	// CompactionInterval is an interval of requesting compaction from apiserver.
+	// If the value is 0, no compaction will be issued.
+	CompactionInterval *metav1.Duration `json:"compactionInterval,omitempty" flag:"etcd-compaction-interval"`
+
 	// Env allows users to pass in env variables to the apiserver container.
 	// This can be useful to control some environment runtime settings, such as GOMEMLIMIT and GOCG to tweak the memory settings of the apiserver
 	// This also allows the flexibility for adding any other variables for future use cases
@@ -763,7 +770,7 @@ type CloudControllerManagerConfig struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// NodeStatusUpdateFrequency is the duration between node status updates. (default: 5m)
 	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
-	// ConcurrentNodeSyncs is the number of workers concurrently synchronizing nodes. (default: 1)
+	// ConcurrentNodeSyncs is the number of workers concurrently synchronizing nodes. (default: 5)
 	ConcurrentNodeSyncs *int32 `json:"concurrentNodeSyncs,omitempty" flag:"concurrent-node-syncs"`
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5683,6 +5683,7 @@ func autoConvert_v1alpha3_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.DefaultNotReadyTolerationSeconds = in.DefaultNotReadyTolerationSeconds
 	out.DefaultUnreachableTolerationSeconds = in.DefaultUnreachableTolerationSeconds
 	out.DeleteCollectionWorkers = in.DeleteCollectionWorkers
+	out.CompactionInterval = in.CompactionInterval
 	out.Env = in.Env
 	return nil
 }
@@ -5802,6 +5803,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha3_KubeAPIServerConfig(in *ko
 	out.DefaultNotReadyTolerationSeconds = in.DefaultNotReadyTolerationSeconds
 	out.DefaultUnreachableTolerationSeconds = in.DefaultUnreachableTolerationSeconds
 	out.DeleteCollectionWorkers = in.DeleteCollectionWorkers
+	out.CompactionInterval = in.CompactionInterval
 	out.Env = in.Env
 	return nil
 }
@@ -6275,6 +6277,7 @@ func autoConvert_v1alpha3_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior
 	out.CrashLoopBackOffMaxContainerRestartPeriod = in.CrashLoopBackOffMaxContainerRestartPeriod
+	out.KubeAPIQPS = in.KubeAPIQPS
 	return nil
 }
 
@@ -6381,6 +6384,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha3_KubeletConfigSpec(in *kops.K
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior
 	out.CrashLoopBackOffMaxContainerRestartPeriod = in.CrashLoopBackOffMaxContainerRestartPeriod
+	out.KubeAPIQPS = in.KubeAPIQPS
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3558,6 +3558,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.CompactionInterval != nil {
+		in, out := &in.CompactionInterval, &out.CompactionInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]corev1.EnvVar, len(*in))
@@ -4406,6 +4411,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 	if in.CrashLoopBackOffMaxContainerRestartPeriod != nil {
 		in, out := &in.CrashLoopBackOffMaxContainerRestartPeriod, &out.CrashLoopBackOffMaxContainerRestartPeriod
 		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.KubeAPIQPS != nil {
+		in, out := &in.KubeAPIQPS, &out.KubeAPIQPS
+		*out = new(int32)
 		**out = **in
 	}
 	return

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3737,6 +3737,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.CompactionInterval != nil {
+		in, out := &in.CompactionInterval, &out.CompactionInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]corev1.EnvVar, len(*in))
@@ -4585,6 +4590,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 	if in.CrashLoopBackOffMaxContainerRestartPeriod != nil {
 		in, out := &in.CrashLoopBackOffMaxContainerRestartPeriod, &out.CrashLoopBackOffMaxContainerRestartPeriod
 		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.KubeAPIQPS != nil {
+		in, out := &in.KubeAPIQPS, &out.KubeAPIQPS
+		*out = new(int32)
 		**out = **in
 	}
 	return

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -40,11 +40,11 @@ if [[ -z "${ADMIN_ACCESS:-}" ]]; then
 fi
 echo "ADMIN_ACCESS=${ADMIN_ACCESS}"
 
-KOPS_SCHEDULER_QPS="${KOPS_SCHEDULER_QPS:-500}"
-KOPS_SCHEDULER_BURST="${KOPS_SCHEDULER_BURST:-500}"
-KOPS_CONTROLLER_MANAGER_QPS="${KOPS_CONTROLLER_MANAGER_QPS:-500}"
-KOPS_CONTROLLER_MANAGER_BURST="${KOPS_CONTROLLER_MANAGER_BURST:-500}"
-KOPS_APISERVER_MAX_REQUESTS_INFLIGHT="${KOPS_APISERVER_MAX_REQUESTS_INFLIGHT:-800}"
+KOPS_SCHEDULER_QPS="${KOPS_SCHEDULER_QPS:-100}"
+KOPS_SCHEDULER_BURST="${KOPS_SCHEDULER_BURST:-100}"
+KOPS_CONTROLLER_MANAGER_QPS="${KOPS_CONTROLLER_MANAGER_QPS:-100}"
+KOPS_CONTROLLER_MANAGER_BURST="${KOPS_CONTROLLER_MANAGER_BURST:-100}"
+KOPS_APISERVER_MAX_REQUESTS_INFLIGHT="${KOPS_APISERVER_MAX_REQUESTS_INFLIGHT:-640}"
 ETCD_QUOTA_BACKEND_BYTES="${ETCD_QUOTA_BACKEND_BYTES:-8589934592}"
 echo "KOPS_SCHEDULER_QPS=${KOPS_SCHEDULER_QPS} KOPS_SCHEDULER_BURST=${KOPS_SCHEDULER_BURST}"
 echo "KOPS_CONTROLLER_MANAGER_QPS=${KOPS_CONTROLLER_MANAGER_QPS} KOPS_CONTROLLER_MANAGER_BURST=${KOPS_CONTROLLER_MANAGER_BURST}"
@@ -87,8 +87,9 @@ fi
 create_args+=("--set spec.etcdClusters[0].manager.listenMetricsURLs=http://localhost:2382")
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_QUOTA_BACKEND_BYTES=${ETCD_QUOTA_BACKEND_BYTES}")
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_ENABLE_PPROF=true")
-create_args+=("--set spec.cloudControllerManager.concurrentNodeSyncs=10")
-create_args+=("--set spec.kubelet.maxPods=96")
+create_args+=("--set spec.cloudControllerManager.concurrentNodeSyncs=5")
+create_args+=("--set spec.kubelet.maxPods=110")
+create_args+=("--set spec.kubelet.kubeApiQPS=50")
 create_args+=("--set spec.kubeScheduler.authorizationAlwaysAllowPaths=/healthz")
 create_args+=("--set spec.kubeScheduler.authorizationAlwaysAllowPaths=/livez")
 create_args+=("--set spec.kubeScheduler.authorizationAlwaysAllowPaths=/readyz")
@@ -109,8 +110,9 @@ create_args+=("--set spec.kubeAPIServer.maxMutatingRequestsInflight=0")
 create_args+=("--set spec.kubeAPIServer.enableProfiling=true")
 create_args+=("--set spec.kubeAPIServer.enableContentionProfiling=true")
 create_args+=("--set spec.kubeAPIServer.logLevel=3")
-# increase the --delete-collection-workers to 100 to speed up delete operations
-create_args+=("--set spec.kubeAPIServer.deleteCollectionWorkers=100")
+# increase the --delete-collection-workers to 16 to speed up delete operations
+create_args+=("--set spec.kubeAPIServer.deleteCollectionWorkers=16")
+create_args+=("--set spec.kubeAPIServer.compactionInterval=150")
 
 # this is required for Prometheus server to scrape metrics endpoint on APIServer
 create_args+=("--set spec.kubeAPIServer.anonymousAuth=true")


### PR DESCRIPTION
## Context:

This PR aims at applying kops configurations back to the values in kube-up. 
Contributes to https://github.com/kubernetes/kops/issues/18070

## Testing
Locally ran `make apimachinery crds` and `make crds`
To be ran: `/test pull-kops-gce-master-scale-performance-100` and `/test pull-kops-ec2-master-scale-performance-100`
