### PR TITLE
scaletest: Align kops scalability configuration with kube-up for CCM `concurrentNodeSyncs`

### DIFF
--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -794,7 +794,7 @@ type CloudControllerManagerConfig struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// NodeStatusUpdateFrequency is the duration between node status updates. (default: 5m)
 	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
-	// ConcurrentNodeSyncs is the number of workers concurrently synchronizing nodes. (default: 1)
+	// ConcurrentNodeSyncs is the number of workers concurrently synchronizing nodes. (default: 5)
 	ConcurrentNodeSyncs *int32 `json:"concurrentNodeSyncs,omitempty" flag:"concurrent-node-syncs"`
 	// AzureNodeManagerImage is the OCI image of the Azure cloud node manager.
 	AzureNodeManagerImage string `json:"azureNodeManagerImage,omitempty"`

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -94,7 +94,7 @@ create_args+=("--set spec.etcdClusters[1].manager.listenClientHTTPURLs=http://lo
 if [[ -n "${ETCD_VERSION:-}" ]]; then
   create_args+=("--set spec.etcdClusters[*].version=${ETCD_VERSION}")
 fi
-create_args+=("--set spec.cloudControllerManager.concurrentNodeSyncs=10")
+create_args+=("--set spec.cloudControllerManager.concurrentNodeSyncs=5")
 create_args+=("--set spec.kubelet.maxPods=96")
 create_args+=("--set spec.kubelet.kubeAPIQPS=100")
 create_args+=("--set spec.kubeScheduler.authorizationAlwaysAllowPaths=/healthz")


### PR DESCRIPTION
Align kops scalability configuration with kube-up by setting `cloudControllerManager.concurrentNodeSyncs=5` to match the kubernetes default values.

Contributes to https://github.com/kubernetes/kops/issues/18070