### PR TITLE
scaletest: Align kops scalability configuration with kube-up for kubelet maxPods

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -88,7 +88,7 @@ create_args+=("--set spec.etcdClusters[0].manager.listenMetricsURLs=http://local
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_QUOTA_BACKEND_BYTES=${ETCD_QUOTA_BACKEND_BYTES}")
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_ENABLE_PPROF=true")
 create_args+=("--set spec.cloudControllerManager.concurrentNodeSyncs=10")
-create_args+=("--set spec.kubelet.maxPods=96")
+create_args+=("--set spec.kubelet.maxPods=110")
 create_args+=("--set spec.kubelet.kubeAPIQPS=100")
 create_args+=("--set spec.kubeScheduler.authorizationAlwaysAllowPaths=/healthz")
 create_args+=("--set spec.kubeScheduler.authorizationAlwaysAllowPaths=/livez")


### PR DESCRIPTION
Align kops scalability configuration with kube-up by setting `spec.kubelet.maxPods=110` to match the kubernetes default values.

Contributes to https://github.com/kubernetes/kops/issues/18070