### PR TITLE
scaletest: Align kops scalability configuration with kube-up for kubelet kubeAPIQPS

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -4359,6 +4359,11 @@ spec:
                     description: Integrate with the kernel memcg notification to determine
                       if memory eviction thresholds are crossed rather than polling.
                     type: boolean
+                  kubeAPIQPS:
+                    description: KubeAPIQPS Burst to use while talking with kubernetes
+                      apiserver. (default 50)
+                    format: int32
+                    type: integer
                   kubeReserved:
                     additionalProperties:
                       type: string
@@ -4828,6 +4833,11 @@ spec:
                     description: Integrate with the kernel memcg notification to determine
                       if memory eviction thresholds are crossed rather than polling.
                     type: boolean
+                  kubeAPIQPS:
+                    description: KubeAPIQPS Burst to use while talking with kubernetes
+                      apiserver. (default 50)
+                    format: int32
+                    type: integer
                   kubeReserved:
                     additionalProperties:
                       type: string

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -660,6 +660,11 @@ spec:
                     description: Integrate with the kernel memcg notification to determine
                       if memory eviction thresholds are crossed rather than polling.
                     type: boolean
+                  kubeAPIQPS:
+                    description: KubeAPIQPS Burst to use while talking with kubernetes
+                      apiserver. (default 50)
+                    format: int32
+                    type: integer
                   kubeReserved:
                     additionalProperties:
                       type: string

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -252,6 +252,8 @@ type KubeletConfigSpec struct {
 	MemorySwapBehavior string `json:"memorySwapBehavior,omitempty"`
 	// CrashLoopBackOffMaxContainerRestartPeriod is the maximum duration the backoff delay can accrue to for container restarts, minimum 1 second, maximum 300 seconds. If not set, defaults to the internal crashloopbackoff maximum (300s).
 	CrashLoopBackOffMaxContainerRestartPeriod *metav1.Duration `json:"crashLoopBackOffMaxContainerRestartPeriod,omitempty"`
+	// KubeAPIQPS Burst to use while talking with kubernetes apiserver. (default 50)
+	KubeAPIQPS *int32 `json:"kubeAPIQPS,omitempty" flag:"kube-api-qps"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -252,6 +252,8 @@ type KubeletConfigSpec struct {
 	MemorySwapBehavior string `json:"memorySwapBehavior,omitempty"`
 	// CrashLoopBackOffMaxContainerRestartPeriod is the maximum duration the backoff delay can accrue to for container restarts, minimum 1 second, maximum 300 seconds. If not set, defaults to the internal crashloopbackoff maximum (300s).
 	CrashLoopBackOffMaxContainerRestartPeriod *metav1.Duration `json:"crashLoopBackOffMaxContainerRestartPeriod,omitempty"`
+	// KubeAPIQPS Burst to use while talking with kubernetes apiserver. (default 50)
+	KubeAPIQPS *int32 `json:"kubeAPIQPS,omitempty" flag:"kube-api-qps"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5870,6 +5870,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior
 	out.CrashLoopBackOffMaxContainerRestartPeriod = in.CrashLoopBackOffMaxContainerRestartPeriod
+	out.KubeAPIQPS = in.KubeAPIQPS
 	return nil
 }
 
@@ -5976,6 +5977,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior
 	out.CrashLoopBackOffMaxContainerRestartPeriod = in.CrashLoopBackOffMaxContainerRestartPeriod
+	out.KubeAPIQPS = in.KubeAPIQPS
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -4429,6 +4429,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.KubeAPIQPS != nil {
+		in, out := &in.KubeAPIQPS, &out.KubeAPIQPS
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -250,6 +250,8 @@ type KubeletConfigSpec struct {
 	MemorySwapBehavior string `json:"memorySwapBehavior,omitempty"`
 	// CrashLoopBackOffMaxContainerRestartPeriod is the maximum duration the backoff delay can accrue to for container restarts, minimum 1 second, maximum 300 seconds. If not set, defaults to the internal crashloopbackoff maximum (300s).
 	CrashLoopBackOffMaxContainerRestartPeriod *metav1.Duration `json:"crashLoopBackOffMaxContainerRestartPeriod,omitempty"`
+	// KubeAPIQPS Burst to use while talking with kubernetes apiserver. (default 50)
+	KubeAPIQPS *int32 `json:"kubeAPIQPS,omitempty" flag:"kube-api-qps"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6275,6 +6275,7 @@ func autoConvert_v1alpha3_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior
 	out.CrashLoopBackOffMaxContainerRestartPeriod = in.CrashLoopBackOffMaxContainerRestartPeriod
+	out.KubeAPIQPS = in.KubeAPIQPS
 	return nil
 }
 
@@ -6381,6 +6382,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha3_KubeletConfigSpec(in *kops.K
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior
 	out.CrashLoopBackOffMaxContainerRestartPeriod = in.CrashLoopBackOffMaxContainerRestartPeriod
+	out.KubeAPIQPS = in.KubeAPIQPS
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -4408,6 +4408,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.KubeAPIQPS != nil {
+		in, out := &in.KubeAPIQPS, &out.KubeAPIQPS
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4587,6 +4587,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.KubeAPIQPS != nil {
+		in, out := &in.KubeAPIQPS, &out.KubeAPIQPS
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -89,6 +89,7 @@ create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_QUOTA_BACKEND_BYTES=$
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_ENABLE_PPROF=true")
 create_args+=("--set spec.cloudControllerManager.concurrentNodeSyncs=10")
 create_args+=("--set spec.kubelet.maxPods=96")
+create_args+=("--set spec.kubelet.kubeAPIQPS=100")
 create_args+=("--set spec.kubeScheduler.authorizationAlwaysAllowPaths=/healthz")
 create_args+=("--set spec.kubeScheduler.authorizationAlwaysAllowPaths=/livez")
 create_args+=("--set spec.kubeScheduler.authorizationAlwaysAllowPaths=/readyz")


### PR DESCRIPTION


Align kops scalability configuration with kube-up for `kubelet.kubeAPIQPS`.

Changes:
1. Define `kubeAPIQPS` in the kubeletSpecification
2. Set the value to 100 (default kubernetes value)

Contributes to https://github.com/kubernetes/kops/issues/18070


## Testing

`make crds`
`make apimachinery crds`