### PR TITLE
scaletest: Align kops scalability configuration with kube-up for kubeapisever `CompactionInterval`

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1881,6 +1881,11 @@ spec:
                     description: CloudProvider is the name of the cloudProvider we
                       are using, aws, gce etcd
                     type: string
+                  compactionInterval:
+                    description: |-
+                      CompactionInterval is an interval of requesting compaction from apiserver.
+                      If the value is 0, no compaction will be issued.
+                    type: string
                   corsAllowedOrigins:
                     description: |-
                       CorsAllowedOrigins is a list of origins for CORS. An allowed origin can be a regular

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -311,6 +311,9 @@ type KubeAPIServerConfig struct {
 	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
 	// CloudProvider is the name of the cloudProvider we are using, aws, gce etcd
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
+	// CompactionInterval is an interval of requesting compaction from apiserver.
+	// If the value is 0, no compaction will be issued.
+	CompactionInterval *metav1.Duration `json:"compactionInterval,omitempty" flag:"etcd-compaction-interval"`
 	// SecurePort is the port the kube runs on
 	SecurePort int32 `json:"securePort,omitempty" flag:"secure-port"`
 	// InsecurePort is the port the insecure api runs

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -311,6 +311,9 @@ type KubeAPIServerConfig struct {
 	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
 	// CloudProvider is the name of the cloudProvider we are using, aws, gce etcd
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
+	// CompactionInterval is an interval of requesting compaction from apiserver.
+	// If the value is 0, no compaction will be issued.
+	CompactionInterval *metav1.Duration `json:"compactionInterval,omitempty" flag:"etcd-compaction-interval"`
 	// SecurePort is the port the kube runs on
 	SecurePort int32 `json:"securePort,omitempty" flag:"secure-port"`
 	// InsecurePort is the port the insecure api runs

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5182,6 +5182,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.LogFormat = in.LogFormat
 	out.LogLevel = in.LogLevel
 	out.CloudProvider = in.CloudProvider
+	out.CompactionInterval = in.CompactionInterval
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
@@ -5296,6 +5297,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.LogFormat = in.LogFormat
 	out.LogLevel = in.LogLevel
 	out.CloudProvider = in.CloudProvider
+	out.CompactionInterval = in.CompactionInterval
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3200,6 +3200,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CompactionInterval != nil {
+		in, out := &in.CompactionInterval, &out.CompactionInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.InsecurePort != nil {
 		in, out := &in.InsecurePort, &out.InsecurePort
 		*out = new(int32)

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -309,6 +309,9 @@ type KubeAPIServerConfig struct {
 	LogLevel int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
 	// CloudProvider is the name of the cloudProvider we are using, aws, gce etcd
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
+	// CompactionInterval is an interval of requesting compaction from apiserver.
+	// If the value is 0, no compaction will be issued.
+	CompactionInterval *metav1.Duration `json:"compactionInterval,omitempty" flag:"etcd-compaction-interval"`
 	// SecurePort is the port the kube runs on
 	SecurePort int32 `json:"securePort,omitempty" flag:"secure-port"`
 	// InsecurePort is the port the insecure api runs

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5579,6 +5579,7 @@ func autoConvert_v1alpha3_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.LogFormat = in.LogFormat
 	out.LogLevel = in.LogLevel
 	out.CloudProvider = in.CloudProvider
+	out.CompactionInterval = in.CompactionInterval
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
@@ -5698,6 +5699,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha3_KubeAPIServerConfig(in *ko
 	out.LogFormat = in.LogFormat
 	out.LogLevel = in.LogLevel
 	out.CloudProvider = in.CloudProvider
+	out.CompactionInterval = in.CompactionInterval
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3179,6 +3179,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CompactionInterval != nil {
+		in, out := &in.CompactionInterval, &out.CompactionInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.InsecurePort != nil {
 		in, out := &in.InsecurePort, &out.InsecurePort
 		*out = new(int32)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3358,6 +3358,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CompactionInterval != nil {
+		in, out := &in.CompactionInterval, &out.CompactionInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.InsecurePort != nil {
 		in, out := &in.InsecurePort, &out.InsecurePort
 		*out = new(int32)

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -110,6 +110,7 @@ create_args+=("--set spec.kubeAPIServer.enableProfiling=true")
 create_args+=("--set spec.kubeAPIServer.enableContentionProfiling=true")
 create_args+=("--set spec.kubeAPIServer.logLevel=3")
 create_args+=("--set spec.kubeAPIServer.deleteCollectionWorkers=16")
+create_args+=("--set spec.kubeAPIServer.compactionInterval=150s")
 
 # this is required for Prometheus server to scrape metrics endpoint on APIServer
 create_args+=("--set spec.kubeAPIServer.anonymousAuth=true")


### PR DESCRIPTION
Align kops scalability configuration with kube-up for `kubeAPIServer.compactionInterval`

Changes:
1. Define compactionInterval in the KubeletAPIServerConfig
2. Set the value to 150 (default kubernetes value)

Contributes to https://github.com/kubernetes/kops/issues/18070