### PR TITLE
Fix existing VPCs/Subnets with IPv6

### DIFF
--- a/upup/pkg/fi/cloudup/subnets.go
+++ b/upup/pkg/fi/cloudup/subnets.go
@@ -233,9 +233,15 @@ func assignCIDRsToSubnets(c *kops.Cluster, cloud fi.Cloud) error {
 func allSubnetsHaveCIDRs(c *kops.Cluster) bool {
 	for i := range c.Spec.Networking.Subnets {
 		subnet := &c.Spec.Networking.Subnets[i]
-		if subnet.CIDR == "" {
-			return false
+		if subnet.CIDR != "" {
+			continue
 		}
+
+		if subnet.IPv6CIDR != "" && subnet.Type == kops.SubnetTypePrivate {
+			continue
+		}
+
+		return false
 	}
 
 	return true


### PR DESCRIPTION
KOPS supports private subnets that are IPv6 only. Unfortunately, the logic when `networkId` is set prevents KOPS from working when any subnet does not have `cidr` set.

See issue: https://github.com/kubernetes/kops/issues/18078

I could not see any tests for when an existing network is set. I guess because there is no "cloud", for that reason I did not update tests, just ensured existing tests passed.