### PR TITLE
Enable E2E external CSI testing on GCP

### DIFF
--- a/tests/e2e/csi-manifests/gcp-pd/driver.yaml
+++ b/tests/e2e/csi-manifests/gcp-pd/driver.yaml
@@ -1,0 +1,32 @@
+# Manifest for Kubernetes external tests.
+# See https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
+
+ShortName: gcp-pd
+StorageClass:
+  FromFile: tests/e2e/csi-manifests/gcp-pd/sc.yaml
+# kOps does not install snapshotClass by default
+#SnapshotClass:
+#  FromFile: snapshotclass.yaml
+DriverInfo:
+  Name: pd.csi.storage.gke.io
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 16Ti
+  SupportedFsType:
+    xfs: {}
+    ext4: {}
+  SupportedMountOption:
+    dirsync: {}
+  TopologyKeys: ["topology.gke.io/zone"]
+  Capabilities:
+    persistence: true
+    fsGroup: true
+    block: true
+    exec: true
+    snapshotDataSource: false
+    pvcDataSource: false
+    multipods: true
+    controllerExpansion: true
+    nodeExpansion: true
+    volumeLimits: false
+    topology: true

--- a/tests/e2e/csi-manifests/gcp-pd/sc.yaml
+++ b/tests/e2e/csi-manifests/gcp-pd/sc.yaml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: balanced-csi
+allowVolumeExpansion: true
+parameters:
+  type: pd-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -421,21 +421,32 @@ func (t *Tester) addCSIDriverFlags() error {
 		return err
 	}
 
-	if cluster.Spec.CloudConfig != nil &&
-		cluster.Spec.CloudConfig.AWSEBSCSIDriver != nil &&
-		cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled != nil &&
-		*cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled {
+	var driverFlags string
+	if cluster.Spec.CloudConfig != nil {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return err
 		}
-		klog.Infof("Setting --storage.testdriver=%s/tests/e2e/csi-manifests/ebs.yaml --storage.migratedPlugins=kubernetes.io/aws-ebs", cwd)
-		t.TestArgs += fmt.Sprintf(" --storage.testdriver=%s/tests/e2e/csi-manifests/aws-ebs/driver.yaml --storage.migratedPlugins=kubernetes.io/aws-ebs", cwd)
+
+		switch {
+		case cluster.Spec.CloudConfig.AWSEBSCSIDriver != nil &&
+			cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled != nil &&
+			*cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled:
+			driverFlags = fmt.Sprintf(" --storage.testdriver=%s/tests/e2e/csi-manifests/aws-ebs/driver.yaml --storage.migratedPlugins=kubernetes.io/aws-ebs", cwd)
+		case cluster.Spec.CloudConfig.GCPPDCSIDriver != nil &&
+			cluster.Spec.CloudConfig.GCPPDCSIDriver.Enabled != nil &&
+			*cluster.Spec.CloudConfig.GCPPDCSIDriver.Enabled:
+			driverFlags = fmt.Sprintf(" --storage.testdriver=%s/tests/e2e/csi-manifests/gcp-pd/driver.yaml --storage.migratedPlugins=kubernetes.io/gce-pd", cwd)
+		}
+	}
+
+	if driverFlags != "" {
+		klog.Infof("Setting %v", driverFlags)
+		t.TestArgs += driverFlags
 	} else {
-		klog.Info("EBS CSI driver not enabled. Skipping tests")
+		klog.Info("CSI driver not enabled. Skipping tests")
 	}
 	return nil
-
 }
 
 func (t *Tester) execute() error {


### PR DESCRIPTION
We were only setting the `--storage.testdriver` flag for AWS. Now we set it for GCP as well. kops enables GCP's PD CSI driver by default so we shouldn't need to adjust anything on the cluster spec side.