### PR TITLE
Automated cherry pick of #17740: Fix HasHighlyAvailableControlPlane to use AllInstanceGroups

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -506,7 +506,7 @@ func (tf *TemplateFunctions) APIServerNodeRole() string {
 // HasHighlyAvailableControlPlane returns true of the cluster has more than one control plane node. False otherwise.
 func (tf *TemplateFunctions) HasHighlyAvailableControlPlane() bool {
 	cp := 0
-	for _, ig := range tf.InstanceGroups {
+	for _, ig := range tf.AllInstanceGroups {
 		if ig.Spec.Role == kops.InstanceGroupRoleControlPlane {
 			cp++
 			if cp > 1 {


### PR DESCRIPTION
Cherry pick of #17740 on release-1.35.

#17740: Fix HasHighlyAvailableControlPlane to use AllInstanceGroups

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```