### PR TITLE
Automated cherry pick of #18113: Add excludedInstanceTypes to instanceRequirements

### DIFF
--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -294,6 +294,24 @@ spec:
 
 Note that burstable instances are always included in the set of eligible instances.
 
+You can exclude instance types from the set of eligible instances using `excludedInstanceTypes`.
+You can use strings with one or more wild cards, represented by an asterisk (*), to exclude an instance type, size, or generation.
+For example, `m7i.8xlarge`, `c7*.*`, `m7a.*`, `r*`, `*3*`.
+
+```
+spec:
+  mixedInstancesPolicy:
+    instanceRequirements:
+      cpu:
+        min: "2"
+        max: "16"
+      memory:
+        min: "2G"
+      excludedInstanceTypes:
+      - t2.*
+      - t3.*
+```
+
 ## warmPool (AWS Only)
 
 {{ kops_feature_table(kops_added_default='1.21') }}

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -934,6 +934,14 @@ spec:
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                         type: object
+                      excludedInstanceTypes:
+                        description: |-
+                          ExcludedInstanceTypes is a list of instance types which will not be used by the instance group.
+                          You can use strings with one or more wild cards, represented by an asterisk (*), to exclude an
+                          instance type, size, or generation.
+                        items:
+                          type: string
+                        type: array
                       memory:
                         properties:
                           max:

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -279,6 +279,10 @@ type MixedInstancesPolicySpec struct {
 type InstanceRequirementsSpec struct {
 	CPU    *MinMaxSpec `json:"cpu,omitempty"`
 	Memory *MinMaxSpec `json:"memory,omitempty"`
+	// ExcludedInstanceTypes is a list of instance types which will not be used by the instance group.
+	// You can use strings with one or more wild cards, represented by an asterisk (*), to exclude an
+	// instance type, size, or generation.
+	ExcludedInstanceTypes []string `json:"excludedInstanceTypes,omitempty"`
 }
 
 type MinMaxSpec struct {

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -225,6 +225,10 @@ type MixedInstancesPolicySpec struct {
 type InstanceRequirementsSpec struct {
 	CPU    *MinMaxSpec `json:"cpu,omitempty"`
 	Memory *MinMaxSpec `json:"memory,omitempty"`
+	// ExcludedInstanceTypes is a list of instance types which will not be used by the instance group.
+	// You can use strings with one or more wild cards, represented by an asterisk (*), to exclude an
+	// instance type, size, or generation.
+	ExcludedInstanceTypes []string `json:"excludedInstanceTypes,omitempty"`
 }
 
 type MinMaxSpec struct {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4851,6 +4851,7 @@ func autoConvert_v1alpha2_InstanceRequirementsSpec_To_kops_InstanceRequirementsS
 	} else {
 		out.Memory = nil
 	}
+	out.ExcludedInstanceTypes = in.ExcludedInstanceTypes
 	return nil
 }
 
@@ -4878,6 +4879,7 @@ func autoConvert_kops_InstanceRequirementsSpec_To_v1alpha2_InstanceRequirementsS
 	} else {
 		out.Memory = nil
 	}
+	out.ExcludedInstanceTypes = in.ExcludedInstanceTypes
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2921,6 +2921,11 @@ func (in *InstanceRequirementsSpec) DeepCopyInto(out *InstanceRequirementsSpec) 
 		*out = new(MinMaxSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExcludedInstanceTypes != nil {
+		in, out := &in.ExcludedInstanceTypes, &out.ExcludedInstanceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/instancegroup.go
+++ b/pkg/apis/kops/v1alpha3/instancegroup.go
@@ -218,6 +218,10 @@ type MixedInstancesPolicySpec struct {
 type InstanceRequirementsSpec struct {
 	CPU    *MinMaxSpec `json:"cpu,omitempty"`
 	Memory *MinMaxSpec `json:"memory,omitempty"`
+	// ExcludedInstanceTypes is a list of instance types which will not be used by the instance group.
+	// You can use strings with one or more wild cards, represented by an asterisk (*), to exclude an
+	// instance type, size, or generation.
+	ExcludedInstanceTypes []string `json:"excludedInstanceTypes,omitempty"`
 }
 
 type MinMaxSpec struct {

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5216,6 +5216,7 @@ func autoConvert_v1alpha3_InstanceRequirementsSpec_To_kops_InstanceRequirementsS
 	} else {
 		out.Memory = nil
 	}
+	out.ExcludedInstanceTypes = in.ExcludedInstanceTypes
 	return nil
 }
 
@@ -5243,6 +5244,7 @@ func autoConvert_kops_InstanceRequirementsSpec_To_v1alpha3_InstanceRequirementsS
 	} else {
 		out.Memory = nil
 	}
+	out.ExcludedInstanceTypes = in.ExcludedInstanceTypes
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -2849,6 +2849,11 @@ func (in *InstanceRequirementsSpec) DeepCopyInto(out *InstanceRequirementsSpec) 
 		*out = new(MinMaxSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExcludedInstanceTypes != nil {
+		in, out := &in.ExcludedInstanceTypes, &out.ExcludedInstanceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3012,6 +3012,11 @@ func (in *InstanceRequirementsSpec) DeepCopyInto(out *InstanceRequirementsSpec) 
 		*out = new(MinMaxSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExcludedInstanceTypes != nil {
+		in, out := &in.ExcludedInstanceTypes, &out.ExcludedInstanceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -577,6 +577,9 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.CloudupMo
 			} else {
 				ir.MemoryMin = fi.PtrTo(int32(0))
 			}
+			if len(spec.InstanceRequirements.ExcludedInstanceTypes) > 0 {
+				ir.ExcludedInstanceTypes = spec.InstanceRequirements.ExcludedInstanceTypes
+			}
 			t.InstanceRequirements = ir
 		}
 

--- a/upup/pkg/fi/cloudup/awstasks/instancerequirements.go
+++ b/upup/pkg/fi/cloudup/awstasks/instancerequirements.go
@@ -23,11 +23,12 @@ import (
 )
 
 type InstanceRequirements struct {
-	Architecture *string
-	CPUMin       *int32
-	CPUMax       *int32
-	MemoryMin    *int32
-	MemoryMax    *int32
+	Architecture          *string
+	CPUMin                *int32
+	CPUMax                *int32
+	MemoryMin             *int32
+	MemoryMax             *int32
+	ExcludedInstanceTypes []string
 }
 
 var _ fi.CloudupHasDependencies = &InstanceRequirements{}
@@ -49,6 +50,9 @@ func findInstanceRequirements(asg *autoscalingtypes.AutoScalingGroup) (*Instance
 					actual.MemoryMax = override.InstanceRequirements.MemoryMiB.Max
 					actual.MemoryMax = override.InstanceRequirements.MemoryMiB.Min
 				}
+				if len(override.InstanceRequirements.ExcludedInstanceTypes) > 0 {
+					actual.ExcludedInstanceTypes = override.InstanceRequirements.ExcludedInstanceTypes
+				}
 				return actual, nil
 			}
 		}
@@ -57,17 +61,21 @@ func findInstanceRequirements(asg *autoscalingtypes.AutoScalingGroup) (*Instance
 }
 
 func overridesFromInstanceRequirements(ir *InstanceRequirements) autoscalingtypes.LaunchTemplateOverrides {
-	return autoscalingtypes.LaunchTemplateOverrides{
-		InstanceRequirements: &autoscalingtypes.InstanceRequirements{
-			VCpuCount: &autoscalingtypes.VCpuCountRequest{
-				Max: ir.CPUMax,
-				Min: ir.CPUMin,
-			},
-			MemoryMiB: &autoscalingtypes.MemoryMiBRequest{
-				Max: ir.MemoryMax,
-				Min: ir.MemoryMin,
-			},
-			BurstablePerformance: autoscalingtypes.BurstablePerformanceIncluded,
+	req := &autoscalingtypes.InstanceRequirements{
+		VCpuCount: &autoscalingtypes.VCpuCountRequest{
+			Max: ir.CPUMax,
+			Min: ir.CPUMin,
 		},
+		MemoryMiB: &autoscalingtypes.MemoryMiBRequest{
+			Max: ir.MemoryMax,
+			Min: ir.MemoryMin,
+		},
+		BurstablePerformance: autoscalingtypes.BurstablePerformanceIncluded,
+	}
+	if len(ir.ExcludedInstanceTypes) > 0 {
+		req.ExcludedInstanceTypes = ir.ExcludedInstanceTypes
+	}
+	return autoscalingtypes.LaunchTemplateOverrides{
+		InstanceRequirements: req,
 	}
 }


### PR DESCRIPTION
Cherry pick of #18113 on release-1.35.

#18113: Add excludedInstanceTypes to instanceRequirements

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```