### PR TITLE
Automated cherry pick of #18123: Fix instanceRequirements memory assignment bug

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/instancerequirements.go
+++ b/upup/pkg/fi/cloudup/awstasks/instancerequirements.go
@@ -48,7 +48,7 @@ func findInstanceRequirements(asg *autoscalingtypes.AutoScalingGroup) (*Instance
 				}
 				if override.InstanceRequirements.MemoryMiB != nil {
 					actual.MemoryMax = override.InstanceRequirements.MemoryMiB.Max
-					actual.MemoryMax = override.InstanceRequirements.MemoryMiB.Min
+					actual.MemoryMin = override.InstanceRequirements.MemoryMiB.Min
 				}
 				if len(override.InstanceRequirements.ExcludedInstanceTypes) > 0 {
 					actual.ExcludedInstanceTypes = override.InstanceRequirements.ExcludedInstanceTypes


### PR DESCRIPTION
Cherry pick of #18123 on release-1.35.

#18123: Fix instanceRequirements memory assignment bug

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```