### PR TITLE
vfs: Silence warnings when the S3 provider has no supported checksum

### DIFF
--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -114,6 +114,7 @@ func (s *S3Context) getClient(ctx context.Context, region string) (*s3.Client, e
 			if endpoint != "" {
 				o.BaseEndpoint = aws.String(endpoint)
 				o.UsePathStyle = true
+				o.DisableLogOutputChecksumValidationSkipped = true
 			} else {
 				o.EndpointResolverV2 = &ResolverV2{}
 			}


### PR DESCRIPTION
The fix silences the warning when the S3 provider has no supported checksum, leaving it enabled for AWS.
This is more common than not and can be seen for DO, Hetzner, and possibly Linode/Akamai.
```bash
% kops --name my.k8s export kubeconfig --admin
SDK 2026/03/29 12:30:27 WARN Response has no supported checksum. Not validating response payload.
SDK 2026/03/29 12:30:27 WARN Response has no supported checksum. Not validating response payload.
kOps has set your kubectl context to my.k8s
```

/cc @rifelpet @moshevayner @justinsb 

Ref: https://github.com/kubernetes/kops/pull/18105