### PR TITLE
Automated cherry pick of #18128: vfs: Silence warnings when the S3 provider has no supported

### DIFF
--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -114,6 +114,7 @@ func (s *S3Context) getClient(ctx context.Context, region string) (*s3.Client, e
 			if endpoint != "" {
 				o.BaseEndpoint = aws.String(endpoint)
 				o.UsePathStyle = true
+				o.DisableLogOutputChecksumValidationSkipped = true
 			} else {
 				o.EndpointResolverV2 = &ResolverV2{}
 			}


### PR DESCRIPTION
Cherry pick of #18128 on release-1.35.

#18128: vfs: Silence warnings when the S3 provider has no supported

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```