### PR TITLE
hetzner: add cluster-autoscaler addon for Hetzner cloud provider

### DIFF
--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -374,6 +374,18 @@ spec:
           env:
             - name: AWS_REGION
               value: "{{ Region }}"
+          {{ else if (eq GetCloudProvider "hetzner") }}
+          env:
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud
+                  key: token
+            - name: HCLOUD_NETWORK
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud
+                  key: network
           {{ end }}
           livenessProbe:
             failureThreshold: 3

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -992,6 +992,12 @@ func (tf *TemplateFunctions) GetClusterAutoscalerNodeGroups() map[string]Cluster
 				cloud := tf.cloud.(gce.GCECloud)
 				format := "https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instanceGroups/%s"
 				group.Other = fmt.Sprintf(format, cloud.Project(), ig.Spec.Zones[0], gce.NameForInstanceGroupManager(cluster.ObjectMeta.Name, ig.ObjectMeta.Name, ig.Spec.Zones[0]))
+			} else if cluster.GetCloudProvider() == kops.CloudProviderHetzner {
+				// Hetzner autoscaler expects --nodes=min:max:instanceType:region:name.
+				// The subnet name for Hetzner is the location (e.g. "hel1"), which is
+				// also used as the region argument by the Hetzner cloud provider.
+				region := ig.Spec.Subnets[0]
+				group.Other = fmt.Sprintf("%s:%s:%s", ig.Spec.MachineType, region, ig.Name)
 			} else {
 				group.Other = ig.Name + "." + cluster.Name
 			}


### PR DESCRIPTION
## Summary

Two fixes to make the kops-managed cluster-autoscaler addon work correctly on Hetzner. Without these the addon is completely non-functional: the autoscaler pod cannot authenticate and node groups are never registered.

Fixes #18133
Fixes #18134

Also related to #17543 (original HCLOUD_TOKEN report).

## Changes

### 1. Pass HCLOUD_TOKEN and HCLOUD_NETWORK to the autoscaler pod

**File:** `upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template`

The addon template only had an `env:` block for AWS (`AWS_REGION`). Added an `else if hetzner` block that injects `HCLOUD_TOKEN` and `HCLOUD_NETWORK` from the `hcloud` secret in `kube-system`. This secret already exists because the CCM addon creates it — no new secrets are required.

### 2. Fix the `--nodes` flag format for Hetzner

**File:** `upup/pkg/fi/cloudup/template_functions.go`

`GetClusterAutoscalerNodeGroups()` was using `ig.Name + "." + cluster.Name` as the `--nodes` suffix for all non-GCE providers. This produces a 3-field format (`min:max:name.cluster`) that the Hetzner autoscaler cloud provider does not recognise.

Hetzner requires 5 fields: `min:max:instanceType:region:name`. Added a Hetzner branch that computes:
```go
region := ig.Spec.Subnets[0]   // subnet name == Hetzner location, e.g. "hel1"
group.Other = fmt.Sprintf("%s:%s:%s", ig.Spec.MachineType, region, ig.Name)
```
Producing e.g. `--nodes=1:5:cpx32:hel1:nodes-hel1`.

## Testing

Manually verified against a live Hetzner kops cluster (`kops 1.35`, Hetzner hel1). The generated addon manifest now contains the correct env vars and `--nodes` format, and the autoscaler pod authenticates and registers node groups successfully.