### PR TITLE
feat(hetzner): generate HCLOUD_CLUSTER_CONFIG for cluster-autoscaler addon

### DIFF
--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -374,6 +374,18 @@ spec:
           env:
             - name: AWS_REGION
               value: "{{ Region }}"
+          {{ else if (eq GetCloudProvider "hetzner") }}
+          env:
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud
+                  key: token
+            - name: HCLOUD_NETWORK
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud
+                  key: network
           {{ end }}
           livenessProbe:
             failureThreshold: 3

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -281,6 +281,24 @@ data:
   priorities: |- {{ ClusterAutoscalerPriorities | nindent 4 }}
 {{ end }}
 ---
+{{ if (eq GetCloudProvider "hetzner") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hcloud-autoscaler-config
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+stringData:
+  # Base64-encoded JSON blob consumed by the Hetzner cluster-autoscaler cloud provider.
+  # Contains per-node-group labels so autoscaler-created servers carry the same
+  # kops tags as manually provisioned ones.
+  # NOTE: cloudInit within each nodeConfig is currently empty; nodes created by
+  # the autoscaler will not bootstrap correctly until cloud-init generation is
+  # implemented (see tracking issue).
+  clusterConfig: "{{ HetznerClusterAutoscalerConfig }}"
+---
+{{ end }}
 # Source: cluster-autoscaler/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -386,6 +404,11 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: network
+            - name: HCLOUD_CLUSTER_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud-autoscaler-config
+                  key: clusterConfig
           {{ end }}
           livenessProbe:
             failureThreshold: 3

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -992,6 +992,12 @@ func (tf *TemplateFunctions) GetClusterAutoscalerNodeGroups() map[string]Cluster
 				cloud := tf.cloud.(gce.GCECloud)
 				format := "https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instanceGroups/%s"
 				group.Other = fmt.Sprintf(format, cloud.Project(), ig.Spec.Zones[0], gce.NameForInstanceGroupManager(cluster.ObjectMeta.Name, ig.ObjectMeta.Name, ig.Spec.Zones[0]))
+			} else if cluster.GetCloudProvider() == kops.CloudProviderHetzner {
+				// Hetzner autoscaler expects --nodes=min:max:instanceType:region:name.
+				// The subnet name for Hetzner is the location (e.g. "hel1"), which is
+				// also used as the region argument by the Hetzner cloud provider.
+				region := ig.Spec.Subnets[0]
+				group.Other = fmt.Sprintf("%s:%s:%s", ig.Spec.MachineType, region, ig.Name)
 			} else {
 				group.Other = ig.Name + "." + cluster.Name
 			}

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -1007,6 +1007,78 @@ func (tf *TemplateFunctions) GetClusterAutoscalerNodeGroups() map[string]Cluster
 	return groups
 }
 
+// HetznerClusterAutoscalerConfig returns a base64-encoded JSON blob for the
+// HCLOUD_CLUSTER_CONFIG environment variable expected by the Hetzner
+// cluster-autoscaler cloud provider.
+//
+// The JSON encodes a ClusterConfig value (see hetzner_manager.go in the
+// cluster-autoscaler source). Each node instance group gets a NodeConfig entry
+// whose Labels map contains the same Hetzner server labels that kops applies
+// to servers it creates directly, ensuring autoscaler-created nodes are
+// recognised by kops' cloud instance group reconciliation.
+//
+// The NodeConfig.CloudInit field is intentionally left empty in this
+// implementation. Generating the nodeup bootstrap script requires keypairs
+// and node-up binary asset URLs that are not yet accessible at addon-template
+// render time. Completing this requires either threading the keystore and
+// NodeUpAssets through TemplateFunctions, or implementing a dedicated task
+// that builds and stores the config after the bootstrap-script tasks execute.
+// Until then, the cluster-autoscaler should be deployed with
+// HCLOUD_CLOUD_INIT / HCLOUD_IMAGE as a fallback (legacy mode).
+func (tf *TemplateFunctions) HetznerClusterAutoscalerConfig() (string, error) {
+        type imageList struct {
+                Amd64 string `json:"amd64,omitempty"`
+                Arm64 string `json:"arm64,omitempty"`
+        }
+        type nodeConfig struct {
+                CloudInit string            `json:"cloudInit"`
+                Labels    map[string]string `json:"labels,omitempty"`
+        }
+        type clusterConfig struct {
+                ImagesForArch imageList             `json:"imagesForArch"`
+                NodeConfigs   map[string]*nodeConfig `json:"nodeConfigs"`
+        }
+
+        cfg := clusterConfig{
+                NodeConfigs: make(map[string]*nodeConfig),
+        }
+
+        for _, ig := range tf.KopsModelContext.InstanceGroups {
+                if ig.Spec.Role != kops.InstanceGroupRoleNode {
+                        continue
+                }
+                if ig.Spec.Autoscale != nil && !fi.ValueOf(ig.Spec.Autoscale) {
+                        continue
+                }
+
+                labels, err := tf.CloudTagsForInstanceGroup(ig)
+                if err != nil {
+                        return "", fmt.Errorf("error getting labels for instance group %q: %w", ig.Name, err)
+                }
+
+                // The node group name in the Hetzner autoscaler is the 5th field of the
+                // --nodes flag (min:max:instanceType:region:name), which equals ig.Name.
+                cfg.NodeConfigs[ig.Name] = &nodeConfig{
+                        Labels: labels,
+                        // CloudInit intentionally empty; see function comment.
+                }
+
+                // Use the image from the first eligible IG (same image per cluster is typical for Hetzner).
+                if cfg.ImagesForArch.Amd64 == "" && ig.Spec.Image != "" {
+                        cfg.ImagesForArch.Amd64 = ig.Spec.Image
+                        cfg.ImagesForArch.Arm64 = ig.Spec.Image
+                }
+        }
+
+        data, err := json.Marshal(cfg)
+        if err != nil {
+                return "", fmt.Errorf("error marshaling Hetzner cluster autoscaler config: %w", err)
+        }
+
+        // The autoscaler reads HCLOUD_CLUSTER_CONFIG as a base64-encoded JSON string.
+        return base64.StdEncoding.EncodeToString(data), nil
+}
+
 func (tf *TemplateFunctions) architectureOfAMI(amiID string) string {
 	image, _ := tf.cloud.(awsup.AWSCloud).ResolveImage(amiID)
 	switch image.Architecture {


### PR DESCRIPTION
## Summary

Partial implementation of #18136. This draft establishes the overall approach for generating `HCLOUD_CLUSTER_CONFIG` and wiring it through the cluster-autoscaler addon for Hetzner.

Builds on #18135 (HCLOUD_TOKEN and --nodes format fixes).

Requires kubernetes/autoscaler#9430 to be merged for the labels to be applied to autoscaler-created servers.

## What this PR does

### 1. `HetznerClusterAutoscalerConfig()` template function

A new template function in `template_functions.go` that generates the base64-encoded JSON blob for `HCLOUD_CLUSTER_CONFIG`. For each autoscalable node instance group it produces a `NodeConfig` entry containing:

- **`labels`**: The full set of Hetzner server labels computed by `CloudTagsForInstanceGroup()` — the same labels that kops stamps on servers it creates directly. With autoscaler PR kubernetes/autoscaler#9430, these are applied to autoscaler-created servers at creation time, so kops cloud instance group reconciliation correctly counts them.
- **`imagesForArch`**: The Hetzner image name from `ig.Spec.Image`.
- **`cloudInit`**: Intentionally empty (see below).

### 2. `hcloud-autoscaler-config` Secret

A new `Secret` resource added to the cluster-autoscaler addon template (Hetzner only), populated with the output of the template function above.

### 3. `HCLOUD_CLUSTER_CONFIG` env var

Added to the autoscaler container's env block, sourced from the new secret, alongside the existing `HCLOUD_TOKEN` and `HCLOUD_NETWORK`.

## What is still missing — cloud-init generation

The `NodeConfig.CloudInit` field is left empty in this implementation. **This means autoscaler-created nodes will have the correct Hetzner labels but will not bootstrap into the cluster.** Completing the implementation requires generating the nodeup bootstrap shell script for each node IG.

This is blocked by the fact that addon-template rendering happens before task execution: the CA keypairs, nodeup binary asset URLs, and `NodeupConfigHash` are not yet available when `TemplateFunctions` methods are called.

Two paths to resolve this:

**Option A — thread through TemplateFunctions** (simpler, focused change):  
Pass `fi.KeystoreReader`, `NodeUpAssets map[architectures.Architecture]*assets.MirroredAsset`, and `NodeUpConfigBuilder` into `TemplateFunctions` at construction time in `apply_cluster.go`. The `NodeupConfigHash` can be computed by running the config builder for each IG before tasks are scheduled.

**Option B — dedicated post-build task** (more correct architecture):  
Introduce a `HetznerClusterAutoscalerConfigSecret` task in `hetznertasks/` that declares dependencies on each node IG's `BootstrapScript` task. After those tasks run, it reads the rendered cloud-init via `fi.ResourceAsString()`, assembles the `ClusterConfig` JSON, and creates or updates the `hcloud-autoscaler-config` Secret via the Kubernetes API. The addon template would still reference the secret; the task guarantees it is populated before the autoscaler deployment starts.

Feedback on which option to pursue would be welcome before completing this draft.

## Testing

Partially verified against a live kops 1.35 Hetzner cluster: `kops update cluster` renders the addon template without error and produces the `hcloud-autoscaler-config` secret with the expected JSON (correct labels, image name). Full end-to-end test (autoscaler creating nodes that join the cluster) is blocked on completing cloud-init generation.