### PR TITLE
Shorten AWS cluster names in kubetest2-kops

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -410,6 +410,19 @@ func (d *deployer) defaultClusterName() (string, error) {
 		jobName = jobName[:gcpLimit]
 	}
 
+	// AWS launch template names have a 128-char limit. The longest
+	// resource name prefix is "{ig}.apiservers." (~37 chars), so
+	// the cluster name must be at most 91 chars.
+	if d.CloudProvider == "aws" {
+		awsLimit := 91
+		if suffix != "" {
+			awsLimit -= len(suffix) + 1
+		}
+		if len(jobName) > awsLimit {
+			jobName = jobName[:awsLimit]
+		}
+	}
+
 	if suffix != "" {
 		jobName = jobName + "." + suffix
 	}


### PR DESCRIPTION
Some presubmit job names are so long that the resulting cluster names aren't accepted. This shortens kubetest2-kops' generated cluster names.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/18152/pull-kops-aws-upgrade-k133-ko133-to-kstable-kolatest-many-addons/2039944759954378752

`W0403 06:13:56.677631   58468 executor.go:141] error running task "LaunchTemplate/master-ap-southeast-2b.masters.e2e-pr18152.pull-kops-aws-upgrade-k133-ko133-to-kstable-kolatest-many-addons.tests-kops-aws.k8s.io" (3m39s remaining to succeed): operation error EC2: DescribeLaunchTemplateVersions, https response error StatusCode: 400, RequestID: 38269238-47fb-425d-92c5-d8d1e9f9098b, api error InvalidLaunchTemplateName.MalformedException: A launch template name must be between 3 and 128 characters, and may contain letters, numbers, and the following characters: - ( ) . / _.`

`Error: error running tasks: deadline exceeded executing task SQS/e2e-pr18152-pull-kops-aws-upgrade-k133-ko133-to-kstable-kolatest-many-addons-tests-kops-aws-k8s-io-nth. Example error: error creating SQS queue: operation error SQS: CreateQueue, https response error StatusCode: 400, RequestID: 6979b7ae-7ccd-556f-8022-d5e7202c1849, api error InvalidParameterValue: Can only include alphanumeric characters, hyphens, or underscores. 1 to 80 in length`