### PR TITLE
Fix nil pointer dereference in ValidateClusterUpdate when old cluster is nil

### DIFF
--- a/pkg/apis/kops/validation/cluster.go
+++ b/pkg/apis/kops/validation/cluster.go
@@ -29,6 +29,10 @@ import (
 func ValidateClusterUpdate(obj *kops.Cluster, status *kops.ClusterStatus, old *kops.Cluster, vfsContext *vfs.VFSContext) field.ErrorList {
 	allErrs := ValidateCluster(obj, false, vfsContext)
 
+	if old == nil {
+		return allErrs
+	}
+
 	// Validate etcd cluster changes
 	{
 		newClusters := make(map[string]kops.EtcdClusterSpec)

--- a/pkg/apis/kops/validation/cluster_test.go
+++ b/pkg/apis/kops/validation/cluster_test.go
@@ -24,6 +24,20 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 )
 
+func TestValidateClusterUpdate_NilOldCluster(t *testing.T) {
+	newCluster := &kops.Cluster{
+		Spec: kops.ClusterSpec{
+			EtcdClusters: []kops.EtcdClusterSpec{},
+		},
+	}
+
+	errs := ValidateClusterUpdate(newCluster, nil, nil, nil)
+
+	if errs == nil {
+		t.Fatalf("expected non-nil error list")
+	}
+}
+
 func TestValidEtcdChanges(t *testing.T) {
 	grid := []struct {
 		OldSpec kops.EtcdClusterSpec


### PR DESCRIPTION
Fix nil pointer dereference in ValidateClusterUpdate when old cluster is nil

ValidateClusterUpdate currently assumes that the old cluster is non-nil and
dereferences old.Spec.EtcdClusters without a guard, which can lead to a panic
when old is nil.

This scenario can occur during validation flows where an old cluster object
is not provided (e.g., certain initialization or fuzz testing paths).

This change adds a nil check for the old cluster and safely returns the
validation results for the new cluster when old is nil. This prevents the
panic while preserving existing validation behavior.

A unit test has been added to ensure that ValidateClusterUpdate handles a
nil old cluster without panicking.

Fixes #18097

/release-note
Fix a nil pointer dereference in ValidateClusterUpdate when old cluster is nil, preventing a potential panic during cluster validation.