### PR TITLE
Reapply "gce: Use SSL health check for kops-controller"

### DIFF
--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -197,6 +197,7 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 		controlPlaneHC := &gcetasks.HealthCheck{
 			Name:      s(b.NameForHealthCheck("kops-controller")),
 			Port:      wellknownports.KopsControllerPort,
+			Protocol:  gcetasks.HealthCheckProtocolSSL,
 			Lifecycle: b.Lifecycle,
 		}
 		c.AddTask(controlPlaneHC)

--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -152,6 +152,7 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 	hc := &gcetasks.HealthCheck{
 		Name:      s(b.NameForHealthCheck("api")),
 		Port:      wellknownports.KubeAPIServer,
+		Protocol:  gcetasks.HealthCheckProtocolTCP,
 		Lifecycle: b.Lifecycle,
 	}
 	c.AddTask(hc)

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
@@ -729,7 +729,7 @@ resource "google_compute_region_health_check" "api-minimal-gce-plb-apiserver-exa
 
 resource "google_compute_region_health_check" "kops-controller-minimal-gce-plb-apiserver-example-com" {
   name = "kops-controller-minimal-gce-plb-apiserver-example-com"
-  tcp_health_check {
+  ssl_health_check {
     port = 3988
   }
 }

--- a/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
@@ -27,6 +27,14 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
+// HealthCheckProtocol is the protocol used for a health check.
+type HealthCheckProtocol string
+
+const (
+	HealthCheckProtocolTCP HealthCheckProtocol = "TCP"
+	HealthCheckProtocolSSL HealthCheckProtocol = "SSL"
+)
+
 // +kops:fitask
 // HealthCheck represents a GCE "healthcheck" type - this is the
 // non-deprecated new-style HC, which combines the deprecated HTTPHealthCheck
@@ -35,6 +43,7 @@ import (
 type HealthCheck struct {
 	Name      *string
 	Port      int64
+	Protocol  HealthCheckProtocol
 	Lifecycle fi.Lifecycle
 }
 
@@ -42,6 +51,14 @@ var _ fi.CompareWithID = (*HealthCheck)(nil)
 
 func (e *HealthCheck) CompareWithID() *string {
 	return e.Name
+}
+
+// protocol returns the effective protocol, defaulting to TCP.
+func (e *HealthCheck) protocol() HealthCheckProtocol {
+	if e.Protocol == "" {
+		return HealthCheckProtocolTCP
+	}
+	return e.Protocol
 }
 
 func (e *HealthCheck) Find(c *fi.CloudupContext) (*HealthCheck, error) {
@@ -72,8 +89,17 @@ func (e *HealthCheck) find(cloud gce.GCECloud) (*HealthCheck, error) {
 
 	actual := &HealthCheck{}
 	actual.Name = &r.Name
-	if r.TcpHealthCheck != nil {
-		actual.Port = r.TcpHealthCheck.Port
+	switch r.Type {
+	case "SSL":
+		actual.Protocol = HealthCheckProtocolSSL
+		if r.SslHealthCheck != nil {
+			actual.Port = r.SslHealthCheck.Port
+		}
+	default:
+		actual.Protocol = HealthCheckProtocolTCP
+		if r.TcpHealthCheck != nil {
+			actual.Port = r.TcpHealthCheck.Port
+		}
 	}
 
 	return actual, nil
@@ -91,6 +117,9 @@ func (_ *HealthCheck) CheckChanges(a, e, changes *HealthCheck) error {
 		if e.Port != a.Port {
 			return fi.CannotChangeField("Port")
 		}
+		if e.protocol() != a.protocol() {
+			return fi.CannotChangeField("Protocol")
+		}
 	}
 	return nil
 }
@@ -98,13 +127,21 @@ func (_ *HealthCheck) CheckChanges(a, e, changes *HealthCheck) error {
 func (_ *HealthCheck) RenderGCE(t *gce.GCEAPITarget, a, e, changes *HealthCheck) error {
 	cloud := t.Cloud
 	hc := &compute.HealthCheck{
-		Name: *e.Name,
-		TcpHealthCheck: &compute.TCPHealthCheck{
-			Port: e.Port,
-		},
-		Type: "TCP",
-
+		Name:   *e.Name,
 		Region: cloud.Region(),
+	}
+
+	switch e.protocol() {
+	case HealthCheckProtocolSSL:
+		hc.Type = "SSL"
+		hc.SslHealthCheck = &compute.SSLHealthCheck{
+			Port: e.Port,
+		}
+	default:
+		hc.Type = "TCP"
+		hc.TcpHealthCheck = &compute.TCPHealthCheck{
+			Port: e.Port,
+		}
 	}
 
 	if a == nil {
@@ -125,22 +162,28 @@ func (_ *HealthCheck) RenderGCE(t *gce.GCEAPITarget, a, e, changes *HealthCheck)
 	return nil
 }
 
-type terraformTCPBlock struct {
+type terraformHealthCheckBlock struct {
 	Port int64 `cty:"port"`
 }
 
 type terraformHealthCheck struct {
-	Name           string            `cty:"name"`
-	TCPHealthCheck terraformTCPBlock `cty:"tcp_health_check"`
+	Name           string                     `cty:"name"`
+	TCPHealthCheck *terraformHealthCheckBlock `cty:"tcp_health_check"`
+	SSLHealthCheck *terraformHealthCheckBlock `cty:"ssl_health_check"`
 }
 
 func (_ *HealthCheck) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *HealthCheck) error {
 	tf := &terraformHealthCheck{
 		Name: *e.Name,
-		TCPHealthCheck: terraformTCPBlock{
-			Port: e.Port,
-		},
 	}
+
+	switch e.protocol() {
+	case HealthCheckProtocolSSL:
+		tf.SSLHealthCheck = &terraformHealthCheckBlock{Port: e.Port}
+	default:
+		tf.TCPHealthCheck = &terraformHealthCheckBlock{Port: e.Port}
+	}
+
 	return t.RenderResource("google_compute_region_health_check", *e.Name, tf)
 }
 


### PR DESCRIPTION
This reverts commit ac17825.

This issue https://github.com/kubernetes/kops/pull/18171#issuecomment-4212754005 was because the Find method was updated to default the new protocol field to TCP. This resulted in a spurious change of "TCP -> unset" and triggering the unsupported "update" code path. We now set the new protocol field on the original API healthcheck task to TCP so that the new Find logic will result in a no-op.