### PR TITLE
aws: Use HTTPS for kops-controller TG health check

### DIFF
--- a/cloudmock/aws/mockelbv2/targetgroups.go
+++ b/cloudmock/aws/mockelbv2/targetgroups.go
@@ -90,6 +90,7 @@ func (m *MockELBV2) CreateTargetGroup(ctx context.Context, request *elbv2.Create
 		VpcId:                   request.VpcId,
 		HealthyThresholdCount:   request.HealthyThresholdCount,
 		UnhealthyThresholdCount: request.UnhealthyThresholdCount,
+		HealthCheckProtocol:     request.HealthCheckProtocol,
 	}
 
 	m.tgCount++

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -406,7 +406,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 					Lifecycle:           b.Lifecycle,
 					VPC:                 b.LinkToVPC(),
 					Tags:                tlsGroupTags,
-					Protocol:            elbv2types.ProtocolEnumTls,
+					Protocol:            elbv2types.ProtocolEnumHttps,
 					Port:                fi.PtrTo(int32(443)),
 					Attributes:          groupAttrs,
 					Interval:            fi.PtrTo(int32(10)),

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -324,17 +324,18 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				groupTags["Name"] = groupName
 
 				tg := &awstasks.TargetGroup{
-					Name:               fi.PtrTo(groupName),
-					Lifecycle:          b.Lifecycle,
-					VPC:                b.LinkToVPC(),
-					Tags:               groupTags,
-					Protocol:           elbv2types.ProtocolEnumTcp,
-					Port:               fi.PtrTo(int32(443)),
-					Attributes:         groupAttrs,
-					Interval:           fi.PtrTo(int32(10)),
-					HealthyThreshold:   fi.PtrTo(int32(2)),
-					UnhealthyThreshold: fi.PtrTo(int32(2)),
-					Shared:             fi.PtrTo(false),
+					Name:                fi.PtrTo(groupName),
+					Lifecycle:           b.Lifecycle,
+					VPC:                 b.LinkToVPC(),
+					Tags:                groupTags,
+					Protocol:            elbv2types.ProtocolEnumTcp,
+					Port:                fi.PtrTo(int32(443)),
+					Attributes:          groupAttrs,
+					Interval:            fi.PtrTo(int32(10)),
+					HealthyThreshold:    fi.PtrTo(int32(2)),
+					UnhealthyThreshold:  fi.PtrTo(int32(2)),
+					HealthCheckProtocol: elbv2types.ProtocolEnumTcp,
+					Shared:              fi.PtrTo(false),
 				}
 				tg.CreateNewRevisionsWith(nlb)
 				c.AddTask(tg)
@@ -349,17 +350,18 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 					groupTags["Name"] = groupName
 
 					tg := &awstasks.TargetGroup{
-						Name:               fi.PtrTo(groupName),
-						Lifecycle:          b.Lifecycle,
-						VPC:                b.LinkToVPC(),
-						Tags:               groupTags,
-						Protocol:           elbv2types.ProtocolEnumTcp,
-						Port:               fi.PtrTo(int32(wellknownports.KopsControllerPort)),
-						Attributes:         groupAttrs,
-						Interval:           fi.PtrTo(int32(10)),
-						HealthyThreshold:   fi.PtrTo(int32(2)),
-						UnhealthyThreshold: fi.PtrTo(int32(2)),
-						Shared:             fi.PtrTo(false),
+						Name:                fi.PtrTo(groupName),
+						Lifecycle:           b.Lifecycle,
+						VPC:                 b.LinkToVPC(),
+						Tags:                groupTags,
+						Protocol:            elbv2types.ProtocolEnumTcp,
+						Port:                fi.PtrTo(int32(wellknownports.KopsControllerPort)),
+						Attributes:          groupAttrs,
+						Interval:            fi.PtrTo(int32(10)),
+						HealthyThreshold:    fi.PtrTo(int32(2)),
+						UnhealthyThreshold:  fi.PtrTo(int32(2)),
+						HealthCheckProtocol: elbv2types.ProtocolEnumTls,
+						Shared:              fi.PtrTo(false),
 					}
 					tg.CreateNewRevisionsWith(nlb)
 
@@ -374,17 +376,18 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 					groupTags["Name"] = groupName
 
 					tg := &awstasks.TargetGroup{
-						Name:               fi.PtrTo(groupName),
-						Lifecycle:          b.Lifecycle,
-						VPC:                b.LinkToVPC(),
-						Tags:               groupTags,
-						Protocol:           elbv2types.ProtocolEnumTcp,
-						Port:               fi.PtrTo(int32(wellknownports.EtcdCiliumClientPort)),
-						Attributes:         groupAttrs,
-						Interval:           fi.PtrTo(int32(10)),
-						HealthyThreshold:   fi.PtrTo(int32(2)),
-						UnhealthyThreshold: fi.PtrTo(int32(2)),
-						Shared:             fi.PtrTo(false),
+						Name:                fi.PtrTo(groupName),
+						Lifecycle:           b.Lifecycle,
+						VPC:                 b.LinkToVPC(),
+						Tags:                groupTags,
+						Protocol:            elbv2types.ProtocolEnumTcp,
+						Port:                fi.PtrTo(int32(wellknownports.EtcdCiliumClientPort)),
+						Attributes:          groupAttrs,
+						Interval:            fi.PtrTo(int32(10)),
+						HealthyThreshold:    fi.PtrTo(int32(2)),
+						UnhealthyThreshold:  fi.PtrTo(int32(2)),
+						HealthCheckProtocol: elbv2types.ProtocolEnumTcp,
+						Shared:              fi.PtrTo(false),
 					}
 					tg.CreateNewRevisionsWith(nlb)
 
@@ -399,17 +402,18 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				// Override the returned name to be the expected NLB TG name
 				tlsGroupTags["Name"] = tlsGroupName
 				secondaryTG := &awstasks.TargetGroup{
-					Name:               fi.PtrTo(tlsGroupName),
-					Lifecycle:          b.Lifecycle,
-					VPC:                b.LinkToVPC(),
-					Tags:               tlsGroupTags,
-					Protocol:           elbv2types.ProtocolEnumTls,
-					Port:               fi.PtrTo(int32(443)),
-					Attributes:         groupAttrs,
-					Interval:           fi.PtrTo(int32(10)),
-					HealthyThreshold:   fi.PtrTo(int32(2)),
-					UnhealthyThreshold: fi.PtrTo(int32(2)),
-					Shared:             fi.PtrTo(false),
+					Name:                fi.PtrTo(tlsGroupName),
+					Lifecycle:           b.Lifecycle,
+					VPC:                 b.LinkToVPC(),
+					Tags:                tlsGroupTags,
+					Protocol:            elbv2types.ProtocolEnumTls,
+					Port:                fi.PtrTo(int32(443)),
+					Attributes:          groupAttrs,
+					Interval:            fi.PtrTo(int32(10)),
+					HealthyThreshold:    fi.PtrTo(int32(2)),
+					UnhealthyThreshold:  fi.PtrTo(int32(2)),
+					HealthCheckProtocol: elbv2types.ProtocolEnumTcp,
+					Shared:              fi.PtrTo(false),
 				}
 				secondaryTG.CreateNewRevisionsWith(nlb)
 				c.AddTask(secondaryTG)

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -360,7 +360,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 						Interval:            fi.PtrTo(int32(10)),
 						HealthyThreshold:    fi.PtrTo(int32(2)),
 						UnhealthyThreshold:  fi.PtrTo(int32(2)),
-						HealthCheckProtocol: elbv2types.ProtocolEnumTls,
+						HealthCheckProtocol: elbv2types.ProtocolEnumHttps,
 						Shared:              fi.PtrTo(false),
 					}
 					tg.CreateNewRevisionsWith(nlb)
@@ -406,7 +406,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 					Lifecycle:           b.Lifecycle,
 					VPC:                 b.LinkToVPC(),
 					Tags:                tlsGroupTags,
-					Protocol:            elbv2types.ProtocolEnumHttps,
+					Protocol:            elbv2types.ProtocolEnumTls,
 					Port:                fi.PtrTo(int32(443)),
 					Attributes:          groupAttrs,
 					Interval:            fi.PtrTo(int32(10)),

--- a/pkg/model/awsmodel/bastion.go
+++ b/pkg/model/awsmodel/bastion.go
@@ -377,17 +377,18 @@ func (b *BastionModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		}
 
 		tg := &awstasks.TargetGroup{
-			Name:               fi.PtrTo(sshGroupName),
-			Lifecycle:          b.Lifecycle,
-			VPC:                b.LinkToVPC(),
-			Tags:               sshGroupTags,
-			Protocol:           elbv2types.ProtocolEnumTcp,
-			Port:               fi.PtrTo(int32(22)),
-			Attributes:         groupAttrs,
-			Interval:           fi.PtrTo(int32(10)),
-			HealthyThreshold:   fi.PtrTo(int32(2)),
-			UnhealthyThreshold: fi.PtrTo(int32(2)),
-			Shared:             fi.PtrTo(false),
+			Name:                fi.PtrTo(sshGroupName),
+			Lifecycle:           b.Lifecycle,
+			VPC:                 b.LinkToVPC(),
+			Tags:                sshGroupTags,
+			Protocol:            elbv2types.ProtocolEnumTcp,
+			Port:                fi.PtrTo(int32(22)),
+			Attributes:          groupAttrs,
+			Interval:            fi.PtrTo(int32(10)),
+			HealthyThreshold:    fi.PtrTo(int32(2)),
+			UnhealthyThreshold:  fi.PtrTo(int32(2)),
+			HealthCheckProtocol: elbv2types.ProtocolEnumTcp,
+			Shared:              fi.PtrTo(false),
 		}
 		tg.CreateNewRevisionsWith(nlb)
 

--- a/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
@@ -638,7 +638,7 @@ resource "aws_lb_target_group" "kops-controller-minimal-e-uvauf3" {
   health_check {
     healthy_threshold   = 2
     interval            = 10
-    protocol            = "TLS"
+    protocol            = "HTTPS"
     unhealthy_threshold = 2
   }
   name     = "kops-controller-minimal-e-uvauf3"

--- a/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
@@ -638,7 +638,7 @@ resource "aws_lb_target_group" "kops-controller-minimal-e-uvauf3" {
   health_check {
     healthy_threshold   = 2
     interval            = 10
-    protocol            = "TCP"
+    protocol            = "TLS"
     unhealthy_threshold = 2
   }
   name     = "kops-controller-minimal-e-uvauf3"

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -64,9 +64,10 @@ type TargetGroup struct {
 
 	Attributes map[string]string
 
-	Interval           *int32
-	HealthyThreshold   *int32
-	UnhealthyThreshold *int32
+	Interval            *int32
+	HealthyThreshold    *int32
+	UnhealthyThreshold  *int32
+	HealthCheckProtocol elbv2types.ProtocolEnum
 
 	info     *awsup.TargetGroupInfo
 	revision string
@@ -237,14 +238,15 @@ func (e *TargetGroup) Find(c *fi.CloudupContext) (*TargetGroup, error) {
 	tg := targetGroupInfo.TargetGroup
 
 	actual := &TargetGroup{
-		Name:               tg.TargetGroupName,
-		Port:               tg.Port,
-		Protocol:           tg.Protocol,
-		ARN:                tg.TargetGroupArn,
-		Interval:           tg.HealthCheckIntervalSeconds,
-		HealthyThreshold:   tg.HealthyThresholdCount,
-		UnhealthyThreshold: tg.UnhealthyThresholdCount,
-		VPC:                &VPC{ID: tg.VpcId},
+		Name:                tg.TargetGroupName,
+		Port:                tg.Port,
+		Protocol:            tg.Protocol,
+		ARN:                 tg.TargetGroupArn,
+		Interval:            tg.HealthCheckIntervalSeconds,
+		HealthyThreshold:    tg.HealthyThresholdCount,
+		UnhealthyThreshold:  tg.UnhealthyThresholdCount,
+		HealthCheckProtocol: tg.HealthCheckProtocol,
+		VPC:                 &VPC{ID: tg.VpcId},
 	}
 	actual.info = targetGroupInfo
 	e.info = targetGroupInfo
@@ -361,6 +363,7 @@ func (_ *TargetGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *TargetGrou
 			HealthCheckIntervalSeconds: e.Interval,
 			HealthyThresholdCount:      e.HealthyThreshold,
 			UnhealthyThresholdCount:    e.UnhealthyThreshold,
+			HealthCheckProtocol:        e.HealthCheckProtocol,
 			Tags:                       awsup.ELBv2Tags(tags),
 		}
 
@@ -456,7 +459,7 @@ func (_ *TargetGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 			Interval:           *e.Interval,
 			HealthyThreshold:   *e.HealthyThreshold,
 			UnhealthyThreshold: *e.UnhealthyThreshold,
-			Protocol:           elbv2types.ProtocolEnumTcp,
+			Protocol:           e.HealthCheckProtocol,
 		},
 	}
 


### PR DESCRIPTION
The original tcp health check results in [spurious EOF log noise in kops-controller:](https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-aws-karpenter/2042999787455778816/artifacts/cluster-info/kube-system/kops-controller-z4z46/kops-controller.log)

`2026/04/11 16:52:57 http: TLS handshake error from 172.20.191.10:5917: EOF`

In GCE https://github.com/kubernetes/kops/pull/18174 we saw that updating the health check to TLS silences those EOF logs: [before](https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-gce-apiserver-nodes/2042003370356510720/artifacts/cluster-info/kube-system/kops-controller-gzssh/kops-controller.log) and [after](https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-gce-apiserver-nodes/2043090637447761920/artifacts/cluster-info/kube-system/kops-controller-45wqq/kops-controller.log).

This updates the AWS target group health check to match GCE.

