### PR TITLE
Load nf_tables module and install iptables-nft on RHEL10+

### DIFF
--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -60,6 +60,9 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 			c.AddTask(&nodetasks.Package{Name: "iptables"})
 		default:
 			c.AddTask(&nodetasks.Package{Name: "nftables"})
+			// Also install iptables-nft so that CNI plugins that shell
+			// out to the iptables binary get the nf_tables backend
+			c.AddTask(&nodetasks.Package{Name: "iptables-nft"})
 		}
 		c.AddTask(&nodetasks.Package{Name: "libseccomp"})
 		if b.NodeupConfig.KubeProxy != nil && fi.ValueOf(b.NodeupConfig.KubeProxy.Enabled) && b.NodeupConfig.KubeProxy.ProxyMode == "nftables" {

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -583,14 +583,24 @@ func loadKernelModules(context *model.NodeupModelContext, distribution distribut
 			klog.Warningf("error loading br_netfilter module: %v", err)
 		}
 	}
-	switch distribution {
-	case distributions.DistributionRocky9:
-		// Rocky 9 doesn't load nf_conntrack by default, and it's required for kube-proxy:
-		// "Error running ProxyServer" err="open /proc/sys/net/netfilter/nf_conntrack_max: no such file or directory"
-		// "command failed" err="open /proc/sys/net/netfilter/nf_conntrack_max: no such file or directory"
-		err := modprobe("nf_conntrack")
-		if err != nil {
-			klog.Warningf("error loading nf_conntrack module: %v", err)
+	if distribution.ForceNftables() {
+		// Distributions like RHEL10+ use nftables exclusively
+		// Load nf_tables and nf_conntrack to fix CNI plugins that use iptables-nft
+		for _, mod := range []string{"nf_tables", "nf_conntrack"} {
+			if err := modprobe(mod); err != nil {
+				klog.Warningf("error loading %s module: %v", mod, err)
+			}
+		}
+	} else {
+		switch distribution {
+		case distributions.DistributionRocky9:
+			// Rocky 9 doesn't load nf_conntrack by default, and it's required for kube-proxy:
+			// "Error running ProxyServer" err="open /proc/sys/net/netfilter/nf_conntrack_max: no such file or directory"
+			// "command failed" err="open /proc/sys/net/netfilter/nf_conntrack_max: no such file or directory"
+			err := modprobe("nf_conntrack")
+			if err != nil {
+				klog.Warningf("error loading nf_conntrack module: %v", err)
+			}
 		}
 	}
 	// TODO: Add to /etc/modules-load.d/ ?


### PR DESCRIPTION
RHEL10 removed legacy iptables kernel modules and uses nftables exclusively. CNI plugins that shell out to the iptables binary need the nf_tables backend modules loaded and the iptables-nft package installed.


Example RHEL10 E2E failures:

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-grid-kubenet-rocky10arm64-k33/2042208977168633856/artifacts/i-05604d542db372bec/journal.log

```
Apr 09 12:02:24.668192 i-05604d542db372bec.eu-west-1.compute.internal systemd[1]: Starting kubernetes-iptables-setup.service - Configure iptables for kubernetes...
Apr 09 12:02:24.675374 i-05604d542db372bec.eu-west-1.compute.internal iptables-setup[5914]: /opt/kops/bin/iptables-setup: line 6: iptables: command not found
Apr 09 12:02:24.675991 i-05604d542db372bec.eu-west-1.compute.internal cni-iptables-setup[5913]: /opt/kops/bin/cni-iptables-setup: line 4: iptables: command not found
Apr 09 12:02:24.676921 i-05604d542db372bec.eu-west-1.compute.internal cni-iptables-setup[5916]: /opt/kops/bin/cni-iptables-setup: line 5: iptables: command not found
Apr 09 12:02:24.677532 i-05604d542db372bec.eu-west-1.compute.internal cni-iptables-setup[5917]: /opt/kops/bin/cni-iptables-setup: line 6: iptables: command not found
Apr 09 12:02:24.678272 i-05604d542db372bec.eu-west-1.compute.internal cni-iptables-setup[5918]: /opt/kops/bin/cni-iptables-setup: line 7: iptables: command not found
Apr 09 12:02:24.682059 i-05604d542db372bec.eu-west-1.compute.internal iptables-setup[5919]: /opt/kops/bin/iptables-setup: line 12: iptables: command not found
Apr 09 12:02:24.708533 i-05604d542db372bec.eu-west-1.compute.internal systemd[1]: cni-iptables-setup.service: Main process exited, code=exited, status=127/n/a
Apr 09 12:02:24.708697 i-05604d542db372bec.eu-west-1.compute.internal systemd[1]: cni-iptables-setup.service: Failed with result 'exit-code'.
```


https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-grid-cilium-etcd-rhel10arm64-k33/2041976442706726912/artifacts/cluster-info/kube-system/cilium-k2tn2/cilium-agent.log

`time=2026-04-08T20:54:47.241804421Z level=error msg="iptables rules full reconciliation failed, will retry another one later" module=agent.datapath.iptables error="failed to install rules: cannot install static proxy rules: unable to run 'iptables -t raw -A CILIUM_PRE_raw -m mark --mark 0x00000200/0x00000f00 -m comment --comment cilium: NOTRACK for proxy traffic -j CT --notrack' iptables command: exit status 4 stderr=\"Warning: Extension mark revision 0 not supported, missing kernel module?\\nWarning: Extension comment revision 0 not supported, missing kernel module?\\nWarning: Extension CT revision 0 not supported, missing kernel module?\\niptables v1.8.8 (nf_tables):  RULE_APPEND failed (No such file or directory): rule in chain CILIUM_PRE_raw\\n\""`

Written with assistance from Opus 4.6