### PR TITLE
azure: Fix disk deletion loop during cluster teardown

### DIFF
--- a/pkg/resources/azure/azure.go
+++ b/pkg/resources/azure/azure.go
@@ -19,6 +19,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	authz "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
@@ -80,11 +81,14 @@ func (g *resourceGetter) listResourcesAzure() (map[string]*resources.Resource, e
 	}
 
 	// Convert a slice of resources to a map of resources keyed by type and ID.
+	// Normalize IDs to lowercase since Azure resource IDs are case-insensitive
+	// but different Azure APIs may return different casing for the same resource.
 	resources := make(map[string]*resources.Resource)
 	for _, r := range rs {
 		if r.Done {
 			continue
 		}
+		r.ID = strings.ToLower(r.ID)
 		resources[toKey(r.Type, r.ID)] = r
 	}
 	return resources, nil
@@ -780,5 +784,5 @@ func (g *resourceGetter) isOwnedByCluster(tags map[string]*string) bool {
 }
 
 func toKey(rtype, id string) string {
-	return rtype + ":" + id
+	return rtype + ":" + strings.ToLower(id)
 }

--- a/upup/pkg/fi/cloudup/azure/disk.go
+++ b/upup/pkg/fi/cloudup/azure/disk.go
@@ -51,7 +51,7 @@ func (c *disksClientImpl) CreateOrUpdate(ctx context.Context, resourceGroupName,
 
 func (c *disksClientImpl) List(ctx context.Context, resourceGroupName string) ([]*compute.Disk, error) {
 	var l []*compute.Disk
-	pager := c.c.NewListPager(nil)
+	pager := c.c.NewListByResourceGroupPager(resourceGroupName, nil)
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)
 		if err != nil {


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-kops-e2e-azure-cni-cilium/2043766863736868864
```
Not all resources deleted; waiting before reattempting deletion
	Disk:/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/E2E-PR18183.PULL-KOPS-E2E-AZURE-CNI-CILIUM/providers/Microsoft.Compute/disks/etcd-1.etcd-events.e2e-pr18183.pull-kops-e2e-azure-cni-cilium
	Disk:/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/E2E-PR18183.PULL-KOPS-E2E-AZURE-CNI-CILIUM/providers/Microsoft.Compute/disks/etcd-1.etcd-main.e2e-pr18183.pull-kops-e2e-azure-cni-cilium
	ResourceGroup:/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/e2e-pr18183.pull-kops-e2e-azure-cni-cilium
Not all resources deleted; waiting before reattempting deletion
	Disk:/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/E2E-PR18183.PULL-KOPS-E2E-AZURE-CNI-CILIUM/providers/Microsoft.Compute/disks/etcd-1.etcd-main.e2e-pr18183.pull-kops-e2e-azure-cni-cilium
	ResourceGroup:/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/e2e-pr18183.pull-kops-e2e-azure-cni-cilium
	Disk:/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/E2E-PR18183.PULL-KOPS-E2E-AZURE-CNI-CILIUM/providers/Microsoft.Compute/disks/etcd-1.etcd-events.e2e-pr18183.pull-kops-e2e-azure-cni-cilium
Not all resources deleted; waiting before reattempting deletion
...
```

/cc @rifelpet 