### PR TITLE
test: Set E2E --node-os-arch=arm64 for Rocky10

### DIFF
--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -395,7 +395,7 @@ func (t *Tester) addNodeOSArchFlag() error {
 		return err
 	}
 	for _, ig := range igs {
-		if strings.Contains(ig.Spec.Image, "arm64") {
+		if strings.Contains(ig.Spec.Image, "arm64") || strings.Contains(ig.Spec.Image, "aarch64") {
 			klog.Info("Setting --node-os-arch=arm64")
 			t.TestArgs += " --node-os-arch=arm64"
 			break


### PR DESCRIPTION
Rocky10 uses AMI names like:

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-aws-distro-rocky10arm64/2043683550045147136/artifacts/instancegroups.yaml

```yaml
spec:
  image: 792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64
```

which wasn't matching the arm64 check. Without this flag we werent skipping tests that are expected to fail on arm64:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-distro-rocky10arm64/2043683550045147136

`Kubernetes e2e suite: [It] [sig-cli] Kubectl client Simple pod should return command exit codes should handle in-cluster config`

https://github.com/kubernetes/kubernetes/blob/eb51fbf7c6de0e361504729feabdadd178cd2b7b/test/e2e/kubectl/kubectl.go#L600-L603