### PR TITLE
Continue skipping networking tests in k8s 1.37

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -86,9 +86,9 @@ func (t *Tester) setSkipRegexFlag() error {
 		// https://github.com/kubernetes/kubernetes/blob/418ae605ec1b788d43bff7ac44af66d8b669b833/test/e2e/network/networking.go#L135
 		skipRegex += "|should.check.kube-proxy.urls"
 
-		if k8sVersion.Minor < 37 {
+		if k8sVersion.Minor < 38 {
 			// This seems to be specific to the kube-proxy replacement
-			// < 36 so we look at this again
+			// < 38 so we look at this again
 			skipRegex += "|Services.should.support.externalTrafficPolicy.Local.for.type.NodePort"
 			// https://github.com/kubernetes/kubernetes/issues/129221
 		}
@@ -137,8 +137,8 @@ func (t *Tester) setSkipRegexFlag() error {
 	// ref: https://github.com/kubernetes/kubernetes/issues/123255
 	// ref: https://github.com/kubernetes/kubernetes/issues/121018
 	// ref: https://github.com/kubernetes/kubernetes/pull/126896
-	// < 37 so we look at this again
-	if k8sVersion.Minor < 37 {
+	// < 38 so we look at this again
+	if k8sVersion.Minor < 38 {
 		skipRegex += "|Services.should.function.for.service.endpoints.using.hostNetwork"
 		skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
 	}


### PR DESCRIPTION
These are still failing in k8s 1.37 alpha CI builds: https://testgrid.k8s.io/kops-network-plugins#kops-aws-cni-cilium-k8s-ci