### PR TITLE
Fix nil panic during GCE deletion

### DIFF
--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -1097,7 +1097,7 @@ func (d *clusterDiscoveryGCE) listBackendServices() ([]*resources.Resource, erro
 					op, err := c.Compute().RegionBackendServices().Delete(c.Project(), c.Region(), svc.Name)
 					if err != nil {
 						if gce.IsNotFound(err) {
-							klog.Infof("BackendService not found, assuming deleted: %q", op.SelfLink)
+							klog.Infof("BackendService not found, assuming deleted: %q", r.Name)
 							return nil
 						}
 						return err
@@ -1141,7 +1141,7 @@ func (d *clusterDiscoveryGCE) listHealthchecks() ([]*resources.Resource, error) 
 				op, err := c.Compute().RegionHealthChecks().Delete(c.Project(), c.Region(), gce.LastComponent(hc))
 				if err != nil {
 					if gce.IsNotFound(err) {
-						klog.Infof("Healthcheck not found, assuming deleted: %q", op.SelfLink)
+						klog.Infof("Healthcheck not found, assuming deleted: %q", r.Name)
 						return nil
 					}
 					return err


### PR DESCRIPTION
While this bug was introduced in https://github.com/kubernetes/kops/pull/17692, it was only uncovered in https://github.com/kubernetes/kops/pull/18169 which introduced a second health check which shares the same deletion path, and has a higher chance of hitting the IsNotFound path.

Ref: https://github.com/kubernetes-sigs/kube-network-policies/pull/338#issuecomment-4243403727

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xd8 pc=0x655cd99]
goroutine 430 [running]:
k8s.io/kops/pkg/resources/gce.(*clusterDiscoveryGCE).listHealthchecks.func1({0x7525d40?, 0x81a1a21?}, 0xc0008f82d0?)
	k8s.io/kops/pkg/resources/gce/gce.go:1144 +0x199
k8s.io/kops/pkg/resources/ops.DeleteResources.func1({0xc0003c2088, 0x1, 0x1})
	k8s.io/kops/pkg/resources/ops/delete.go:129 +0x37f
created by k8s.io/kops/pkg/resources/ops.DeleteResources in goroutine 1
	k8s.io/kops/pkg/resources/ops/delete.go:110 +0xc4f
Error: exit status 2
```