### PR TITLE
Expose NFTables support in Flannel

### DIFF
--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -173,6 +173,8 @@ type FlannelNetworkingSpec struct {
 	Backend string `json:"backend,omitempty"`
 	// IptablesResyncSeconds sets resync period for iptables rules, in seconds
 	IptablesResyncSeconds *int32 `json:"iptablesResyncSeconds,omitempty"`
+	// EnableNFTables makes flannel use nftables instead of iptables.
+	EnableNFTables bool `json:"enableNFTables,omitempty"`
 }
 
 // CalicoNetworkingSpec declares that we want Calico networking

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -128,6 +128,8 @@ type FlannelNetworkingSpec struct {
 	DisableTxChecksumOffloading bool `json:"disableTxChecksumOffloading,omitempty"`
 	// IptablesResyncSeconds sets resync period for iptables rules, in seconds
 	IptablesResyncSeconds *int32 `json:"iptablesResyncSeconds,omitempty"`
+	// EnableNFTables makes flannel use nftables instead of iptables.
+	EnableNFTables bool `json:"enableNFTables,omitempty"`
 }
 
 // CalicoNetworkingSpec declares that we want Calico networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4023,6 +4023,7 @@ func autoConvert_v1alpha2_FlannelNetworkingSpec_To_kops_FlannelNetworkingSpec(in
 	out.Backend = in.Backend
 	// INFO: in.DisableTxChecksumOffloading opted out of conversion generation
 	out.IptablesResyncSeconds = in.IptablesResyncSeconds
+	out.EnableNFTables = in.EnableNFTables
 	return nil
 }
 
@@ -4034,6 +4035,7 @@ func Convert_v1alpha2_FlannelNetworkingSpec_To_kops_FlannelNetworkingSpec(in *Fl
 func autoConvert_kops_FlannelNetworkingSpec_To_v1alpha2_FlannelNetworkingSpec(in *kops.FlannelNetworkingSpec, out *FlannelNetworkingSpec, s conversion.Scope) error {
 	out.Backend = in.Backend
 	out.IptablesResyncSeconds = in.IptablesResyncSeconds
+	out.EnableNFTables = in.EnableNFTables
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -137,6 +137,8 @@ type FlannelNetworkingSpec struct {
 	Backend string `json:"backend,omitempty"`
 	// IptablesResyncSeconds sets resync period for iptables rules, in seconds
 	IptablesResyncSeconds *int32 `json:"iptablesResyncSeconds,omitempty"`
+	// EnableNFTables makes flannel use nftables instead of iptables.
+	EnableNFTables bool `json:"enableNFTables,omitempty"`
 }
 
 // CalicoNetworkingSpec declares that we want Calico networking

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -4320,6 +4320,7 @@ func Convert_kops_FileAssetSpec_To_v1alpha3_FileAssetSpec(in *kops.FileAssetSpec
 func autoConvert_v1alpha3_FlannelNetworkingSpec_To_kops_FlannelNetworkingSpec(in *FlannelNetworkingSpec, out *kops.FlannelNetworkingSpec, s conversion.Scope) error {
 	out.Backend = in.Backend
 	out.IptablesResyncSeconds = in.IptablesResyncSeconds
+	out.EnableNFTables = in.EnableNFTables
 	return nil
 }
 
@@ -4331,6 +4332,7 @@ func Convert_v1alpha3_FlannelNetworkingSpec_To_kops_FlannelNetworkingSpec(in *Fl
 func autoConvert_kops_FlannelNetworkingSpec_To_v1alpha3_FlannelNetworkingSpec(in *kops.FlannelNetworkingSpec, out *FlannelNetworkingSpec, s conversion.Scope) error {
 	out.Backend = in.Backend
 	out.IptablesResyncSeconds = in.IptablesResyncSeconds
+	out.EnableNFTables = in.EnableNFTables
 	return nil
 }
 

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -41,7 +41,7 @@ func (d *deployer) DumpClusterLogs() error {
 		"--name", d.ClusterName,
 		"--dir", d.ArtifactsDir,
 		"--private-key", d.SSHPrivateKeyPath,
-		"--ssh-user", d.SSHUser,
+		"--ssh-user", "ec2-user",
 	}
 
 	if d.MaxNodesToDump != "" {

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.25
     manifest: networking.flannel/k8s-1.25.yaml
-    manifestHash: a570d436240292d500900f0b57e54652f79830120a27fddc7dd20d4212eeaab4
+    manifestHash: 2182c4d3b22f7ee71ffbf596c2c64e177f9ed37b2e3c883f0ac2603ca2f31703
     name: networking.flannel
     prune:
       kinds:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-networking.flannel-k8s-1.25_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-networking.flannel-k8s-1.25_content
@@ -174,7 +174,7 @@ spec:
           value: "5000"
         - name: CONT_WHEN_CACHE_NOT_READY
           value: "false"
-        image: ghcr.io/flannel-io/flannel:v0.27.4
+        image: ghcr.io/flannel-io/flannel:v0.28.2
         name: kube-flannel
         resources:
           requests:
@@ -201,7 +201,7 @@ spec:
         - /opt/cni/bin/flannel
         command:
         - cp
-        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.8.0-flannel1
+        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.9.0-flannel1
         name: install-cni-plugin
         volumeMounts:
         - mountPath: /opt/cni/bin
@@ -212,7 +212,7 @@ spec:
         - /etc/cni/net.d/10-flannel.conflist
         command:
         - cp
-        image: ghcr.io/flannel-io/flannel:v0.27.4
+        image: ghcr.io/flannel-io/flannel:v0.28.2
         name: install-cni
         volumeMounts:
         - mountPath: /etc/cni/net.d

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.25.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.25.yaml.template
@@ -1,4 +1,4 @@
-# Pulled and modified from: https://raw.githubusercontent.com/coreos/flannel/v0.27.4/Documentation/kube-flannel.yml
+# Pulled and modified from: https://raw.githubusercontent.com/coreos/flannel/v0.28.2/Documentation/kube-flannel.yml
 ---
 kind: Namespace
 apiVersion: v1
@@ -135,7 +135,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni-plugin
-        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.8.0-flannel1
+        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.9.0-flannel1
         command:
         - cp
         args:
@@ -146,7 +146,7 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-        image: ghcr.io/flannel-io/flannel:v0.27.4
+        image: ghcr.io/flannel-io/flannel:v0.28.2
         command:
         - cp
         args:
@@ -160,7 +160,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: ghcr.io/flannel-io/flannel:v0.27.4
+        image: ghcr.io/flannel-io/flannel:v0.28.2
         command:
         - /opt/bin/flanneld
         args:

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.25.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.25.yaml.template
@@ -92,7 +92,7 @@ data:
   net-conf.json: |
     {
       "Network": "{{ .Networking.NonMasqueradeCIDR }}",
-      "EnableNFTables": false,
+      "EnableNFTables": {{ .Networking.Flannel.EnableNFTables }},
       "Backend": {
         "Type": "{{ FlannelBackendType }}"
       }

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -513,7 +513,11 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 				}
 			}
 		}
+		g.Spec.Image = "309956199498/RHEL-10.1.0_HVM-20260331-arm64-0-Hourly2-GP3"
 
+		if cluster.GetCloudProvider() == api.CloudProviderAWS {
+			g.Spec.MachineType = "m6g.large"
+		}
 		// TODO: Clean up
 		if g.IsControlPlane() {
 			if g.Spec.MachineType == "" {
@@ -1266,12 +1270,14 @@ func setupNetworking(opt *NewClusterOptions, cluster *api.Cluster) error {
 		cluster.Spec.Networking.Kopeio = &api.KopeioNetworkingSpec{}
 	case "flannel", "flannel-vxlan":
 		cluster.Spec.Networking.Flannel = &api.FlannelNetworkingSpec{
-			Backend: "vxlan",
+			Backend:        "vxlan",
+			EnableNFTables: true,
 		}
 	case "flannel-udp":
 		klog.Warningf("flannel UDP mode is not recommended; consider flannel-vxlan instead")
 		cluster.Spec.Networking.Flannel = &api.FlannelNetworkingSpec{
-			Backend: "udp",
+			Backend:        "udp",
+			EnableNFTables: true,
 		}
 	case "calico":
 		cluster.Spec.Networking.Calico = &api.CalicoNetworkingSpec{}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -585,8 +585,8 @@ func loadKernelModules(context *model.NodeupModelContext, distribution distribut
 	}
 	if distribution.ForceNftables() {
 		// Distributions like RHEL10+ use nftables exclusively
-		// Load nf_tables and nf_conntrack to fix CNI plugins that use iptables-nft
-		for _, mod := range []string{"nf_tables", "nf_conntrack"} {
+		// Load nft-related modules to fix CNI plugins that use iptables-nft
+		for _, mod := range []string{"nf_tables", "nf_conntrack", "nft_compat"} {
 			if err := modprobe(mod); err != nil {
 				klog.Warningf("error loading %s module: %v", mod, err)
 			}


### PR DESCRIPTION
Needed to fix jobs like this: https://testgrid.k8s.io/kops-distro-rocky10#kops-grid-flannel-rocky10arm64-k34

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-grid-flannel-rocky10arm64-k34/2043627932752023552/artifacts/cluster-info/kube-flannel/kube-flannel-ds-qtmlz/kube-flannel.log

`E0413 10:18:28.718696       1 main.go:278] Failed to check br_netfilter: stat /proc/sys/net/bridge/bridge-nf-call-iptables: no such file or directory`