### PR TITLE
fix: use KOPS_BASE_URL image version when side-loading

### DIFF
--- a/pkg/commands/toolbox_enroll.go
+++ b/pkg/commands/toolbox_enroll.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/resources"
 	"k8s.io/kops/pkg/nodemodel"
+	"k8s.io/kops/pkg/nodemodel/wellknownassets"
 	"k8s.io/kops/pkg/wellknownservices"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
@@ -94,6 +95,12 @@ func RunToolboxEnroll(ctx context.Context, f commandutils.Factory, out io.Writer
 	if options.Host == "" {
 		// Technically we could build the host resource without the PKI, but this isn't the case we are targeting right now.
 		return fmt.Errorf("host is required")
+	}
+
+	// Resolve KOPS_BASE_URL early so that kops.Version is overridden
+	// before the version downgrade check in ApplyClusterCmd.Run.
+	if _, err := wellknownassets.BaseURL(); err != nil {
+		return err
 	}
 
 	clientset, err := f.KopsClient()

--- a/pkg/nodemodel/wellknownassets/kopsassets.go
+++ b/pkg/nodemodel/wellknownassets/kopsassets.go
@@ -67,6 +67,13 @@ func BaseURL() (*url.URL, error) {
 			return nil, fmt.Errorf("unable to parse env var KOPS_BASE_URL %q as a url: %v", baseURLString, err)
 		}
 		klog.Warningf("Using base url from env var: KOPS_BASE_URL=%q", baseURLString)
+
+		// The last path component of KOPS_BASE_URL is the artifact version.
+		// Override kops.Version so image tags in manifests match the sideloaded images.
+		if v := path.Base(kopsBaseURL.Path); v != "" && v != "." && v != "/" && v != kops.Version {
+			klog.Infof("Overriding kops version from KOPS_BASE_URL: %q -> %q", kops.Version, v)
+			kops.Version = v
+		}
 	}
 
 	return copyBaseURL(kopsBaseURL)

--- a/pkg/nodemodel/wellknownassets/kopsassets_test.go
+++ b/pkg/nodemodel/wellknownassets/kopsassets_test.go
@@ -27,6 +27,66 @@ import (
 	"k8s.io/kops/util/pkg/hashing"
 )
 
+func TestBaseURL_OverridesVersionFromKopsBaseURL(t *testing.T) {
+	origVersion := kops.Version
+	t.Cleanup(func() {
+		kops.Version = origVersion
+		kopsBaseURL = nil
+	})
+
+	tests := []struct {
+		name            string
+		kopsBaseURL     string
+		expectedVersion string
+	}{
+		{
+			name:            "postsubmit URL",
+			kopsBaseURL:     "https://storage.googleapis.com/k8s-staging-kops/kops/releases/1.35.0-beta.2+v1.35.0-beta.1-384-gf369c3ab16",
+			expectedVersion: "1.35.0-beta.2+v1.35.0-beta.1-384-gf369c3ab16",
+		},
+		{
+			name:            "postsubmit URL with trailing slash",
+			kopsBaseURL:     "https://storage.googleapis.com/k8s-staging-kops/kops/releases/1.35.0-beta.2+v1.35.0-beta.1-384-gf369c3ab16/",
+			expectedVersion: "1.35.0-beta.2+v1.35.0-beta.1-384-gf369c3ab16",
+		},
+		{
+			name:            "CI URL",
+			kopsBaseURL:     "https://storage.googleapis.com/k8s-staging-kops/kops/ci/1.35.0-beta.2+abc123",
+			expectedVersion: "1.35.0-beta.2+abc123",
+		},
+		{
+			name:            "CI URL with trailing slash",
+			kopsBaseURL:     "https://storage.googleapis.com/k8s-staging-kops/kops/ci/1.35.0-beta.2+abc123/",
+			expectedVersion: "1.35.0-beta.2+abc123",
+		},
+		{
+			name:            "release URL",
+			kopsBaseURL:     "https://artifacts.k8s.io/binaries/kops/1.35.0",
+			expectedVersion: "1.35.0",
+		},
+		{
+			name:            "same version as binary does not override",
+			kopsBaseURL:     fmt.Sprintf("https://example.com/kops/%s", origVersion),
+			expectedVersion: origVersion,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kops.Version = origVersion
+			kopsBaseURL = nil
+			t.Setenv("KOPS_BASE_URL", tc.kopsBaseURL)
+
+			_, err := BaseURL()
+			if err != nil {
+				t.Fatalf("BaseURL() error: %v", err)
+			}
+			if kops.Version != tc.expectedVersion {
+				t.Errorf("kops.Version = %q, want %q", kops.Version, tc.expectedVersion)
+			}
+		})
+	}
+}
+
 func Test_BuildMirroredAsset(t *testing.T) {
 	tests := []struct {
 		url      string


### PR DESCRIPTION
Using KOPS_BASE_URL doesn't side-load images when running locally.
After the fix:
```
% echo $KOPS_BASE_URL                                                                                                     
https://storage.googleapis.com/k8s-staging-kops/kops/releases/1.35.0-beta.2+v1.35.0-beta.1-384-gf369c3ab16
% kubectl get pods -A -o yaml | grep image: | grep gf369c3ab16 | uniq
      image: registry.k8s.io/kops/kops-controller:1.35.0-beta.2-v1.35.0-beta.1-384-gf369c3ab16
      image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.35.0-beta.2-v1.35.0-beta.1-384-gf369c3ab16
```

Assisted by Claude Opus 4.6

/cc @rifelpet @ameukam 