### PR TITLE
chore(channels): update k8s and ubuntu jammy ami versions in alpha channel

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -66,11 +66,11 @@ spec:
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0 <1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260218
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260218
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260410
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.27.0 <1.32.0"
@@ -120,13 +120,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.35.0"
-    recommendedVersion: 1.35.3
+    recommendedVersion: 1.35.4
     requiredVersion: 1.35.0
   - range: ">=1.34.0"
-    recommendedVersion: 1.34.6
+    recommendedVersion: 1.34.7
     requiredVersion: 1.34.0
   - range: ">=1.33.0"
-    recommendedVersion: 1.33.10
+    recommendedVersion: 1.33.11
     requiredVersion: 1.33.0
   - range: ">=1.32.0"
     recommendedVersion: 1.32.13
@@ -201,15 +201,15 @@ spec:
   - range: ">=1.35.0-alpha.1"
     recommendedVersion: "1.35.0-beta.1"
     #requiredVersion: 1.35.0
-    kubernetesVersion: 1.35.3
+    kubernetesVersion: 1.35.4
   - range: ">=1.34.0-alpha.1"
     recommendedVersion: "1.34.1"
     #requiredVersion: 1.34.0
-    kubernetesVersion: 1.34.6
+    kubernetesVersion: 1.34.7
   - range: ">=1.33.0-alpha.1"
     recommendedVersion: "1.34.1"
     #requiredVersion: 1.33.0
-    kubernetesVersion: 1.33.10
+    kubernetesVersion: 1.33.11
   - range: ">=1.32.0-alpha.1"
     recommendedVersion: "1.34.1"
     #requiredVersion: 1.32.0


### PR DESCRIPTION
`noble` has `20260409` available in most regions except for `us-gov-*`, so holding off with bumping that until it's available everywhere 

Signed-off-by: Moshe Vayner <moshe@vayner.me>

<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
