### PR TITLE
Automated cherry pick of #18114: Pin upload-artifacts GHA to commit sha

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Archive production artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: tests-e2e-scenarios-bare-metal
           path: /tmp/artifacts/
@@ -85,7 +85,7 @@ jobs:
           ARTIFACTS: /tmp/artifacts
       - name: Archive production artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: tests-e2e-scenarios-bare-metal-ipv6
           path: /tmp/artifacts/


### PR DESCRIPTION
Cherry pick of #18114 on release-1.34.

#18114: Pin upload-artifacts GHA to commit sha

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```