### PR TITLE
gce: Disallow role=apiserver with dns=none

### DIFF
--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -242,7 +242,7 @@ func CrossValidateInstanceGroup(g *kops.InstanceGroup, cluster *kops.Cluster, cl
 		if cluster.GetCloudProvider() != kops.CloudProviderAWS && cluster.GetCloudProvider() != kops.CloudProviderGCE {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "role"), "APIServer role only supported on AWS and GCE"))
 		}
-		if cluster.UsesNoneDNS() && cluster.GetCloudProvider() != kops.CloudProviderGCE {
+		if cluster.UsesNoneDNS() {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "role"), "APIServer cannot be used with topology.dns.type=None"))
 		}
 	}

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -541,7 +541,7 @@ func TestCrossValidateAPIServerRole(t *testing.T) {
 			ExpectedErrors: 0,
 		},
 		{
-			Description: "APIServer role allowed on GCE with dns=None",
+			Description: "APIServer role forbidden on GCE with dns=None",
 			Cluster: &kops.Cluster{
 				Spec: kops.ClusterSpec{
 					CloudProvider: kops.CloudProviderSpec{
@@ -550,7 +550,7 @@ func TestCrossValidateAPIServerRole(t *testing.T) {
 					Networking: kops.NetworkingSpec{Topology: noneDNSTopology},
 				},
 			},
-			ExpectedErrors: 0,
+			ExpectedErrors: 1,
 		},
 		{
 			Description: "APIServer role forbidden on AWS with dns=None",


### PR DESCRIPTION
We tried allowing this in https://github.com/kubernetes/kops/pull/18162 but it will require too many changes to be viable for the moment.