### PR TITLE
Automated cherry pick of #18110: Update Cluster Autoscaler to 1.35.0

### DIFF
--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -50,13 +50,13 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 			case 31:
 				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.31.5"
 			case 32:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7"
 			case 33:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.2"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.4"
 			case 34:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.1"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.3"
 			default:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.1"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0"
 			}
 		}
 		cas.Image = fi.PtrTo(image)

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 5691088ab49d3a07d67faaab475bb63c2f793eaba83943cd71a2fd59d4515626
+    manifestHash: bdf9835482d45714cb5956eebe65e5379ac02287a87452319e4521eb8f6e2274
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -365,7 +365,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -38,7 +38,7 @@ spec:
     enabled: true
     expander: priority
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: b9b8c15ff0323c3e3c1975ddb0b09936b7d885e118d12851f6ee85a34e81fe26
+    manifestHash: e0c88cf0dcd2f9c28c92102572cb4cd35427a8e417da796a56629ea2c10335e5
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -365,7 +365,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
     enabled: true
     expander: priority
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -38,7 +38,7 @@ spec:
     enabled: true
     expander: random
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 8c5912d44dcd25d8ffc9164bd2c3bcc981be1f974cb5a4599d44bfa51e94809d
+    manifestHash: 80c60c8e636d4a920cb61c55c29046eb4c896a7c923d41fd9b8b35e8e3465d52
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -339,7 +339,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/cluster-autoscaler.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     enabled: true
     expander: random
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 998c15df9e43958c8f34cc909eff4a21167c266f365b8c055f8cd657ccee4a84
+    manifestHash: 9437f12061bb0bfbfbfadebc8bfe0cf7ba1bc54833e3f0b60a7c37d9f8095325
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -341,7 +341,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -37,7 +37,7 @@ spec:
     enabled: true
     expander: random
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 6966e358ff554797a53d2bdffc071dd0ac7487ab751814bb8a3c96a248bc6eed
+    manifestHash: 53dcdfcbb3d0b47e39a403e3ba1a9b270512193f37e5c1519848b9bc0497753f
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -337,7 +337,7 @@ spec:
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -35,7 +35,7 @@ spec:
     enabled: true
     expander: random
     ignoreDaemonSetsUtilization: false
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     podAnnotations:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 5154923b1c213a5b6230b6f0702de29718527b2c6e1a6c7d7eada88b8e856b7e
+    manifestHash: 8a3e69977e604a723aae52f8f6c7cd424d58e8dd4d75bdc31156aa8a8edae8af
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -342,7 +342,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.4
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
Cherry pick of #18110 on release-1.35.

#18110: Update Cluster Autoscaler to 1.35.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```