### PR TITLE
aws: Update EBS CSI driver to 1.58.0

### DIFF
--- a/pkg/model/components/awsebscsidriver.go
+++ b/pkg/model/components/awsebscsidriver.go
@@ -43,7 +43,7 @@ func (b *AWSEBSCSIDriverOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 	c := aws.EBSCSIDriver
 
 	if c.Version == nil {
-		c.Version = fi.PtrTo("v1.47.0")
+		c.Version = fi.PtrTo("v1.58.0")
 	}
 
 	return nil

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -1069,28 +1069,29 @@ func AddAWSEBSCSIDriverPermissions(b *PolicyBuilder, p *Policy, appendSnapshotPe
 	addKMSIAMPolicies(p)
 
 	if appendSnapshotPermissions {
-		addSnapshotPersmissions(b, p)
+		addSnapshotPermissions(b, p)
 	}
 
 	p.unconditionalAction.Insert(
-		"ec2:DescribeAccountAttributes",    // aws.go
+		"ec2:DescribeAvailabilityZones",    // aws.go
 		"ec2:DescribeInstances",            // aws.go
+		"ec2:DescribeInstanceTypes",        // aws.go
+		"ec2:DescribeTags",                 // aws.go
 		"ec2:DescribeVolumes",              // aws.go
 		"ec2:DescribeVolumesModifications", // aws.go
-		"ec2:DescribeTags",                 // aws.go
+		"ec2:DescribeVolumeStatus",         // aws.go
 	)
 	p.clusterTaggedAction.Insert(
-		"ec2:ModifyVolume",            // aws.go
-		"ec2:ModifyInstanceAttribute", // aws.go
-		"ec2:AttachVolume",            // aws.go
-		"ec2:DeleteVolume",            // aws.go
-		"ec2:DetachVolume",            // aws.go
+		"ec2:AttachVolume", // aws.go
+		"ec2:DeleteVolume", // aws.go
+		"ec2:DetachVolume", // aws.go
+		"ec2:ModifyVolume", // aws.go
 	)
 
 	p.AddEC2CreateAction(
 		[]string{
+			"CopyVolumes",
 			"CreateVolume",
-			"CreateSnapshot",
 		},
 		[]string{
 			"volume",
@@ -1099,7 +1100,7 @@ func AddAWSEBSCSIDriverPermissions(b *PolicyBuilder, p *Policy, appendSnapshotPe
 	)
 }
 
-func addSnapshotPersmissions(b *PolicyBuilder, p *Policy) {
+func addSnapshotPermissions(b *PolicyBuilder, p *Policy) {
 	p.unconditionalAction.Insert(
 		"ec2:CreateSnapshot",
 		"ec2:DescribeAvailabilityZones",
@@ -1107,6 +1108,17 @@ func addSnapshotPersmissions(b *PolicyBuilder, p *Policy) {
 	)
 	p.clusterTaggedAction.Insert(
 		"ec2:DeleteSnapshot",
+		"ec2:EnableFastSnapshotRestores",
+	)
+
+	p.AddEC2CreateAction(
+		[]string{
+			"CreateSnapshot",
+		},
+		[]string{
+			"volume",
+			"snapshot",
+		},
 	)
 	p.Statement = append(p.Statement,
 		&Statement{

--- a/pkg/model/iam/tests/iam_builder_master_gossip.json
+++ b/pkg/model/iam/tests/iam_builder_master_gossip.json
@@ -38,8 +38,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "iam-builder-test.k8s.local",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -108,7 +108,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -120,6 +119,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -191,8 +191,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/pkg/model/iam/tests/iam_builder_master_gossip_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_gossip_ecr.json
@@ -38,8 +38,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "iam-builder-test.k8s.local",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -108,7 +108,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -120,6 +119,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -198,8 +198,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -38,8 +38,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "iam-builder-test.nonexistant",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -108,7 +108,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -120,6 +119,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -191,8 +191,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -38,8 +38,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "iam-builder-test.nonexistant",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -108,7 +108,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -120,6 +119,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -198,8 +198,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "additionalobjects.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -261,8 +261,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: fd323d85033dd1db883efd5cc546cf8ebc53a9857ad4d2607741c40b44280f1a
+    manifestHash: 89638a31a008ba432ce1b9bbefa4fedea72e02bb457aa45284e0189e8bd7c0b3
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -6,8 +6,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -38,9 +38,11 @@
     },
     {
       "Action": [
-        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
@@ -58,7 +60,6 @@
         "ec2:AttachVolume",
         "ec2:DeleteVolume",
         "ec2:DetachVolume",
-        "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
       "Condition": {
@@ -71,7 +72,7 @@
     },
     {
       "Action": [
-        "ec2:CreateSnapshot",
+        "ec2:CopyVolumes",
         "ec2:CreateVolume"
       ],
       "Condition": {

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
@@ -15,7 +15,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -892,20 +1040,26 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -951,16 +1106,24 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -972,6 +1135,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -987,6 +1151,8 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -994,9 +1160,13 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1008,6 +1178,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1025,16 +1196,24 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1225,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1054,14 +1234,20 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1071,6 +1257,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1132,9 +1319,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -167,7 +167,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6bf5621734269271c21258a8fd88f5d89da3da0539b91ab87fa0aaa233efbe33
+    manifestHash: e6f34a6f8b62081a02835fe34399f10f683048393b830f36223765d2b3348eaf
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "bastionuserdata.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 92698fd3d59a9e351e133429f28076a6d1c7f24bff4f86455cdc55c795e0c35e
+    manifestHash: 1f49688bffdc1b66a87d139dda39a677ae9fe332ebb87ffc3c998499fcb11154
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_masters.cas-priority-expander-custom.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_masters.cas-priority-expander-custom.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "cas-priority-expander-custom.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: cdcefec97ddc17bfcad9f7afe3c26ac5e622841eeda7f11fb909af0118f5df6a
+    manifestHash: 7208fc8333ccc1e99e6c536cef2fc0ecde942ca6eae6f19ca92aa30f459153b5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_masters.cas-priority-expander.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_masters.cas-priority-expander.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "cas-priority-expander.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 8096b9f0c572f1e927a8f01ba44312ad6b8a7e9a31df0bb91fac8f4b403ecaa6
+    manifestHash: cbebb9eaebe45e5c912763638b2f2addc55d4844bd6b77d26e995fa6a666cf4b
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "complex.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -29,7 +29,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0a3085de4970ea841b02f002f4aa812e9f93f96a6ac6624cc799479fe8c7c5af
+    manifestHash: bf563dc68e8ee820818f36c1ae5e0b1f4a471e83a0343ef1ed41e1847a3d1bee
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "compress.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e68b1dc63ae7bcfda9a00b82365c2a2a81e74d99531f158730235165c2168e08
+    manifestHash: ade68e19cf044b77509c0e09d9932442db6ff270c2c2df2e37abe8e7f2500e10
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "containerd.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -258,8 +258,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 886a6b2b2bb54ae447da9950c7efbebac4810ffff71214a903d0d322917b9f2a
+    manifestHash: 3cd29fda577043936a0c01bdb10679ad0857837c75217151d94dcf9336ba477e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/containerd/assets.yaml
+++ b/tests/integration/update_cluster/containerd/assets.yaml
@@ -68,17 +68,17 @@ images:
   download: registry.k8s.io/kube-scheduler:v1.32.0
 - canonical: registry.k8s.io/pause:3.10.1
   download: registry.k8s.io/pause:3.10.1
-- canonical: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
-  download: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+- canonical: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
+  download: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
 - canonical: registry.k8s.io/provider-aws/cloud-controller-manager:v1.32.5
   download: registry.k8s.io/provider-aws/cloud-controller-manager:v1.32.5
-- canonical: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
-  download: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
-- canonical: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
-  download: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
-- canonical: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
-  download: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
-- canonical: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
-  download: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
-- canonical: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
-  download: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+- canonical: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
+  download: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
+- canonical: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
+  download: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
+- canonical: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
+  download: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
+- canonical: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
+  download: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
+- canonical: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
+  download: registry.k8s.io/sig-storage/livenessprobe:v2.18.0

--- a/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "containerd.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 886a6b2b2bb54ae447da9950c7efbebac4810ffff71214a903d0d322917b9f2a
+    manifestHash: 3cd29fda577043936a0c01bdb10679ad0857837c75217151d94dcf9336ba477e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "123.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c28134017e0c0e805589f26aa61acf57726687d39e5e2299269635d73db87549
+    manifestHash: 3b364afa878f200b35602b104cf7049684326af2bdf31579c9f8dd625f3b5132
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6f1af5a104e25631406be6d5f4accca4ed2446b138bf6de3a92685294811cad3
+    manifestHash: 00ab2196c59c685f9af1ab1b4862f42e7b31b80129b27c66ea9648712ade64c8
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "existingsg.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
@@ -14,7 +14,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: f43c75918368ce7519696e108bb47b59c9bb0bda12376823469fcbdf7878cfbe
+    manifestHash: 66efa4bf4f6c8f7064ccf552cca53a403ee4e9a128dc33deea1f8466279ab72b
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -6,8 +6,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -38,9 +38,11 @@
     },
     {
       "Action": [
-        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
@@ -58,7 +60,6 @@
         "ec2:AttachVolume",
         "ec2:DeleteVolume",
         "ec2:DetachVolume",
-        "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
       "Condition": {
@@ -71,7 +72,7 @@
     },
     {
       "Action": [
-        "ec2:CreateSnapshot",
+        "ec2:CopyVolumes",
         "ec2:CreateVolume"
       ],
       "Condition": {

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -892,20 +1040,26 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -951,16 +1106,24 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -972,6 +1135,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -987,6 +1151,8 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -994,9 +1160,13 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1008,6 +1178,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1025,16 +1196,24 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1225,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1054,14 +1234,20 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1071,6 +1257,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1132,9 +1319,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6bf5621734269271c21258a8fd88f5d89da3da0539b91ab87fa0aaa233efbe33
+    manifestHash: e6f34a6f8b62081a02835fe34399f10f683048393b830f36223765d2b3348eaf
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "externallb.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1a8a472f4490de71c57d3dc0401596ac25f714c24996079c06c5044da146e427
+    manifestHash: a06b73cbc1e635336d77a3b1146b9fa076ae14a015d2aa78d921f6b839a2d7bb
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "externalpolicies.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d858a417822caf07aef4c22c4dc780e5a95d680d503ec822c6c6c3cc8d0bf1f5
+    manifestHash: 920d61dcf473f7b9facff669b55c37928c445c52837b99d85792b9b54b65e3ee
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "ha.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 93fbde908b603f5837571eba26610a82d7265783a15e879a1229fe12a2cbb819
+    manifestHash: 41fde4a937a2e4e7d32dab885f07a2b192147b07de32eb1babd0d19a82f89622
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -167,7 +167,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -6,8 +6,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -38,9 +38,11 @@
     },
     {
       "Action": [
-        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
@@ -58,7 +60,6 @@
         "ec2:AttachVolume",
         "ec2:DeleteVolume",
         "ec2:DetachVolume",
-        "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
       "Condition": {
@@ -71,7 +72,7 @@
     },
     {
       "Action": [
-        "ec2:CreateSnapshot",
+        "ec2:CopyVolumes",
         "ec2:CreateVolume"
       ],
       "Condition": {

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -892,20 +1040,26 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -951,16 +1106,24 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -972,6 +1135,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -987,6 +1151,8 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -994,9 +1160,13 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1008,6 +1178,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1025,16 +1196,24 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1225,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1054,14 +1234,20 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1071,6 +1257,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1136,9 +1323,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 35275a29e0f576db65ce0ebfb5add87e54310a5a9ce1e64578c485b10d57c0f4
+    manifestHash: b31cbdf55e1ad608ded3bd4533ad0953c15390cf61a54e9e71ea68309eec3108
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -1,6 +1,41 @@
 {
   "Statement": [
     {
+      "Action": "ec2:CreateTags",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
+          "ec2:CreateAction": [
+            "CreateSnapshot"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
+      ]
+    },
+    {
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
+        "StringEquals": {
+          "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
+      ]
+    },
+    {
       "Action": "ec2:CreateVolume",
       "Condition": {
         "StringEquals": {
@@ -18,8 +53,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -51,11 +86,12 @@
     {
       "Action": [
         "ec2:CreateSnapshot",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeSnapshots",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
@@ -74,7 +110,7 @@
         "ec2:DeleteSnapshot",
         "ec2:DeleteVolume",
         "ec2:DetachVolume",
-        "ec2:ModifyInstanceAttribute",
+        "ec2:EnableFastSnapshotRestores",
         "ec2:ModifyVolume"
       ],
       "Condition": {
@@ -87,6 +123,7 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSnapshot",
         "ec2:CreateVolume"
       ],

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -19,7 +19,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -892,20 +1040,26 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -951,16 +1106,24 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -972,6 +1135,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -987,6 +1151,8 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -994,9 +1160,13 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1008,6 +1178,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1023,6 +1194,7 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --http-endpoint=0.0.0.0:3306
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -1030,9 +1202,13 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
         imagePullPolicy: IfNotPresent
         name: csi-snapshotter
+        ports:
+        - containerPort: 3306
+          name: metrics-snap
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1044,6 +1220,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1061,16 +1238,24 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1082,6 +1267,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1090,14 +1276,20 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1107,6 +1299,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1168,9 +1361,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -190,7 +190,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 72cf98281e58f4b633760e973d10646a7c155cfc6ad31589302692dd83cd7093
+    manifestHash: de6058fb5bf25f58ce3905a9388a1e32a44e4ce16e1ca504ac2abd65ab61952f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -95,6 +95,41 @@
       ]
     },
     {
+      "Action": "ec2:CreateTags",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
+          "ec2:CreateAction": [
+            "CreateSnapshot"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
+      ]
+    },
+    {
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
+        "StringEquals": {
+          "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
+      ]
+    },
+    {
       "Action": "ec2:CreateVolume",
       "Condition": {
         "StringEquals": {
@@ -112,8 +147,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -247,6 +282,7 @@
         "ec2:DescribeSnapshots",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcPeeringConnections",
@@ -297,6 +333,7 @@
         "ec2:DeleteSnapshot",
         "ec2:DeleteVolume",
         "ec2:DetachVolume",
+        "ec2:EnableFastSnapshotRestores",
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume",
         "ec2:RevokeSecurityGroupIngress",
@@ -342,6 +379,7 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
         "ec2:CreateSnapshot",
         "ec2:CreateVolume",

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -20,7 +20,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       hostNetwork: true
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -645,7 +788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -682,6 +825,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -693,24 +837,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -720,6 +866,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -729,7 +876,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -741,6 +888,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -792,7 +940,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -815,7 +963,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -894,16 +1042,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -919,7 +1073,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -931,6 +1085,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -946,12 +1101,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -963,6 +1126,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -975,12 +1139,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -992,6 +1162,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1004,12 +1175,17 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --http-endpoint=0.0.0.0:3306
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
         imagePullPolicy: IfNotPresent
         name: csi-snapshotter
+        ports:
+        - containerPort: 3306
+          name: metrics-snap
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1021,6 +1197,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1035,12 +1212,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1052,14 +1237,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1069,6 +1261,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1116,9 +1309,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -190,7 +190,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c9b725a17bfb0b76499c0638e5b6e21d05b6b860b8edb839e88a2011beace448
+    manifestHash: 0e21c884db9347220a6ce1cc1aec569164424a678c3c17e5c4d6c6b0c5a18e2d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
@@ -95,6 +95,41 @@
       ]
     },
     {
+      "Action": "ec2:CreateTags",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "many-addons.example.com",
+          "ec2:CreateAction": [
+            "CreateSnapshot"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
+      ]
+    },
+    {
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
+        "StringEquals": {
+          "aws:ResourceTag/KubernetesCluster": "many-addons.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
+      ]
+    },
+    {
       "Action": "ec2:CreateVolume",
       "Condition": {
         "StringEquals": {
@@ -112,8 +147,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "many-addons.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -247,6 +282,7 @@
         "ec2:DescribeSnapshots",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcPeeringConnections",
@@ -297,6 +333,7 @@
         "ec2:DeleteSnapshot",
         "ec2:DeleteVolume",
         "ec2:DetachVolume",
+        "ec2:EnableFastSnapshotRestores",
         "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume",
         "ec2:RevokeSecurityGroupIngress",
@@ -342,6 +379,7 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
         "ec2:CreateSnapshot",
         "ec2:CreateVolume",

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -17,7 +17,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1006,12 +1177,17 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --http-endpoint=0.0.0.0:3306
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
         imagePullPolicy: IfNotPresent
         name: csi-snapshotter
+        ports:
+        - containerPort: 3306
+          name: metrics-snap
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1023,6 +1199,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1037,12 +1214,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1054,14 +1239,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1071,6 +1263,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1118,9 +1311,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -239,7 +239,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7e342803517549dd51beff09760efd193800cf856c3020fbcc408672df1a368d
+    manifestHash: 0d186dc69b05c85ed82db87a9efe395ca6a319253398123bb1b4898114aec5d7
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -261,8 +261,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -261,8 +261,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -261,8 +261,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -261,8 +261,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -261,8 +261,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -261,8 +261,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_masters.minimal-aws.example.com_policy
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_masters.minimal-aws.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal-aws.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb5de52c91874923aebad1feef849dbb4a57920a6d68ad9c7b2db3b739489d88
+    manifestHash: 7c25840fa1ae1efec067288711b2c7c9defba7b19855ff2a4064ee5339b14d89
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -70,8 +70,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -140,7 +140,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -152,6 +151,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -231,8 +231,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal-etcd.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7b226690d3cd6c74a750c270881ab714c8248f1f54b27d7540ab9e6bba1bc050
+    manifestHash: 2708064828499dcabe469bc97ca9eb2baf98a3db7f7ef17905562559abc64375
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -171,7 +171,6 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -184,6 +183,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -256,8 +256,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -649,7 +792,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -686,6 +829,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -697,24 +841,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -724,6 +870,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -733,7 +880,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -745,6 +892,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -796,7 +944,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -819,7 +967,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -900,16 +1048,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -925,7 +1079,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -937,6 +1091,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -952,12 +1107,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -969,6 +1132,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -981,12 +1145,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -998,6 +1168,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1012,12 +1183,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1029,14 +1208,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1232,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1093,9 +1280,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -160,7 +160,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9840743af78406c069f160fcb6ab7fe656814be7887e4fa700e6d271c8bf3f66
+    manifestHash: d84cbdeb0843159584630e1ccd494377f97d1c331db41332fb456cb58a2d518a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -171,7 +171,6 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -184,6 +183,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -256,8 +256,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -649,7 +792,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -686,6 +829,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -697,24 +841,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -724,6 +870,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -733,7 +880,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -745,6 +892,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -796,7 +944,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -819,7 +967,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -900,16 +1048,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -925,7 +1079,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -937,6 +1091,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -952,12 +1107,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -969,6 +1132,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -981,12 +1145,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -998,6 +1168,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1012,12 +1183,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1029,14 +1208,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1232,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1093,9 +1280,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9840743af78406c069f160fcb6ab7fe656814be7887e4fa700e6d271c8bf3f66
+    manifestHash: d84cbdeb0843159584630e1ccd494377f97d1c331db41332fb456cb58a2d518a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -171,7 +171,6 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -184,6 +183,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -257,8 +257,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -649,7 +792,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -686,6 +829,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -697,24 +841,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -724,6 +870,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -733,7 +880,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -745,6 +892,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -796,7 +944,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -819,7 +967,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -900,16 +1048,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -925,7 +1079,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -937,6 +1091,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -952,12 +1107,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -969,6 +1132,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -981,12 +1145,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -998,6 +1168,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1012,12 +1183,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1029,14 +1208,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1232,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1093,9 +1280,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9840743af78406c069f160fcb6ab7fe656814be7887e4fa700e6d271c8bf3f66
+    manifestHash: d84cbdeb0843159584630e1ccd494377f97d1c331db41332fb456cb58a2d518a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -171,7 +171,6 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -184,6 +183,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -256,8 +256,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -649,7 +792,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -686,6 +829,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -697,24 +841,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -724,6 +870,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -733,7 +880,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -745,6 +892,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -796,7 +944,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -819,7 +967,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -900,16 +1048,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -925,7 +1079,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -937,6 +1091,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -952,12 +1107,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -969,6 +1132,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -981,12 +1145,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -998,6 +1168,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1012,12 +1183,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1029,14 +1208,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1232,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1093,9 +1280,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9840743af78406c069f160fcb6ab7fe656814be7887e4fa700e6d271c8bf3f66
+    manifestHash: d84cbdeb0843159584630e1ccd494377f97d1c331db41332fb456cb58a2d518a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -171,7 +171,6 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -184,6 +183,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -256,8 +256,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -649,7 +792,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -686,6 +829,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -697,24 +841,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -724,6 +870,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -733,7 +880,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -745,6 +892,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -796,7 +944,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -819,7 +967,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -900,16 +1048,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -925,7 +1079,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -937,6 +1091,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -952,12 +1107,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -969,6 +1132,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -981,12 +1145,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -998,6 +1168,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1012,12 +1183,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1029,14 +1208,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1232,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1093,9 +1280,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9840743af78406c069f160fcb6ab7fe656814be7887e4fa700e6d271c8bf3f66
+    manifestHash: d84cbdeb0843159584630e1ccd494377f97d1c331db41332fb456cb58a2d518a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.really.really.reall-g6fsnu_policy
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.really.really.reall-g6fsnu_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: f80fb43f8ea88f4ff2375deefea35cb592c4d54e40e7277ec27fe7a427f2411c
+    manifestHash: c11759814519a13d980871511a726bf936c080923f9571eb11b9c814f1225d91
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal-warmpool.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -149,7 +149,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal-warmpool.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: nCNbIekY8hv8vqvDnTJXRz5Z/2sEfPP/2W7RbZYLmSw=
+NodeupConfigHash: vg6PnHeNL1n9ikgBVK85mCGN5dKCKmj8Gl/tmzRk0QE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: kops.k8s.io/remapped-image/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: kops.k8s.io/remapped-image/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: kops.k8s.io/remapped-image/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: kops.k8s.io/remapped-image/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: kops.k8s.io/remapped-image/sig-storage/livenessprobe:v2.16.0
+        image: kops.k8s.io/remapped-image/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: kops.k8s.io/remapped-image/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: kops.k8s.io/remapped-image/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: kops.k8s.io/remapped-image/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: kops.k8s.io/remapped-image/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: kops.k8s.io/remapped-image/sig-storage/csi-attacher:v4.9.0
+        image: kops.k8s.io/remapped-image/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: kops.k8s.io/remapped-image/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: kops.k8s.io/remapped-image/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: kops.k8s.io/remapped-image/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: kops.k8s.io/remapped-image/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 57e260ab0cf24646f41bb9221ebfe71165cf1d08c60fc73f8852f02d1507828a
+    manifestHash: 6ab4deffd05cc85a3c5f08206696f0d585b774861bfa4ef387e53dd27868527e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -60,7 +60,7 @@ warmPoolImages:
 - kops.k8s.io/remapped-image/cilium/cilium:v1.18.6
 - kops.k8s.io/remapped-image/cilium/operator:v1.18.6
 - kops.k8s.io/remapped-image/kube-proxy:v1.32.0
-- kops.k8s.io/remapped-image/provider-aws/aws-ebs-csi-driver:v1.47.0
+- kops.k8s.io/remapped-image/provider-aws/aws-ebs-csi-driver:v1.58.0
 - kops.k8s.io/remapped-image/provider-aws/cloud-controller-manager:v1.32.5
-- kops.k8s.io/remapped-image/sig-storage/csi-node-driver-registrar:v2.14.0
-- kops.k8s.io/remapped-image/sig-storage/livenessprobe:v2.16.0
+- kops.k8s.io/remapped-image/sig-storage/csi-node-driver-registrar:v2.16.0
+- kops.k8s.io/remapped-image/sig-storage/livenessprobe:v2.18.0

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -70,8 +70,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.k8s.local",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -140,7 +140,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -152,6 +151,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -224,8 +224,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1bd14902a3ee7b87e260027e297cee882466df6f4e756118fb049913910e6db9
+    manifestHash: 4fb44d0795712b324dffbf3e7f49d9461770b9a942e129351f93a32a58456664
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local_policy
@@ -6,8 +6,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.k8s.local",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -38,9 +38,11 @@
     },
     {
       "Action": [
-        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
@@ -58,7 +60,6 @@
         "ec2:AttachVolume",
         "ec2:DeleteVolume",
         "ec2:DetachVolume",
-        "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
       "Condition": {
@@ -71,7 +72,7 @@
     },
     {
       "Action": [
-        "ec2:CreateSnapshot",
+        "ec2:CopyVolumes",
         "ec2:CreateVolume"
       ],
       "Condition": {

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -892,20 +1040,26 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -951,16 +1106,24 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -972,6 +1135,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -987,6 +1151,8 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -994,9 +1160,13 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1008,6 +1178,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1025,16 +1196,24 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1225,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1054,14 +1234,20 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1071,6 +1257,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1132,9 +1319,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c024ad7ee18f923c12f52559d09cbf7bf9aaa4e0c29ca6ef2c24b798fa7e0df9
+    manifestHash: ca3010c949e1b4549f2a8683e8b80aa6ee727c5210956de82773059edbf2acc1
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "mixedinstances.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1708a830eb34cce8cacd98fb631c644db03d1c6bb18d5fe6343782dc162bf6ec
+    manifestHash: 31627c274b7adcd2c762988e1ec0d95f83ae69b08dc903fbc71490aab0d0bce2
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "mixedinstances.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1708a830eb34cce8cacd98fb631c644db03d1c6bb18d5fe6343782dc162bf6ec
+    manifestHash: 31627c274b7adcd2c762988e1ec0d95f83ae69b08dc903fbc71490aab0d0bce2
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l_policy
@@ -6,8 +6,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "nthimdsprocessor.longclustername.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -38,9 +38,11 @@
     },
     {
       "Action": [
-        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
@@ -58,7 +60,6 @@
         "ec2:AttachVolume",
         "ec2:DeleteVolume",
         "ec2:DetachVolume",
-        "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
       "Condition": {
@@ -71,7 +72,7 @@
     },
     {
       "Action": [
-        "ec2:CreateSnapshot",
+        "ec2:CopyVolumes",
         "ec2:CreateVolume"
       ],
       "Condition": {

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -892,20 +1040,26 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -951,16 +1106,24 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -972,6 +1135,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -987,6 +1151,8 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -994,9 +1160,13 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1008,6 +1178,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1025,16 +1196,24 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1225,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1054,14 +1234,20 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1071,6 +1257,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1132,9 +1319,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -103,7 +103,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 8649792e803f47415a55fb3c14806fc45b6f5c711f298259342bcb2df2884329
+    manifestHash: e9e626bb394f7ac400af7d6ef8e62f21a615f11017b5d07b3c86ae43bc92c52d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "nthimdsprocessor.longclustername.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -251,8 +251,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -103,7 +103,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a6a550ae7dc488e47f712cd27700b189796cddb6a22f3afaaec795aa8dc35fd6
+    manifestHash: a175f936aad529f0defd128bc7a712afb1c06c88b5ba1a9338c6d1f6fef00b8b
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "private-shared-ip.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: f61490986c7e16c5c8bd99ac35d366540a86d046fa11fe5bc4f89ca527a61367
+    manifestHash: 9c5fd79447e65592e0129e91f13ceb696eca41723e2a072cde9b6ba567505f54
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "private-shared-subnet.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: b2c5d6177240d4af5f76e3e8894d3d8de4b7ad2721905b6af5e716b661ea4110
+    manifestHash: 9345241d97bfbb00bbd8852ffda0216e16704d9fb75f7d931e42473ef7948155
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "privatecalico.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -262,8 +262,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -160,7 +160,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e52a4eb6974bfa8bab14d767e461fe046563bdd33c5b37542add0129048d919a
+    manifestHash: 31efacc6ec58da41d56f3ff2f367de6e496595af18b4c3d685e5c298cb5d06ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "privatecilium.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -175,7 +175,6 @@
         "ec2:CreateNetworkInterface",
         "ec2:CreateTags",
         "ec2:DeleteNetworkInterface",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -188,6 +187,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -262,8 +262,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2046ab9aa41511fe26999d71cea00425967a80547c5aff2ce20aa4cb32d197e4
+    manifestHash: cf922bff964b8c12bf9fad3c557a2a2a07a6898a5518a52ef26933c35530f194
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "privatecilium.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2046ab9aa41511fe26999d71cea00425967a80547c5aff2ce20aa4cb32d197e4
+    manifestHash: cf922bff964b8c12bf9fad3c557a2a2a07a6898a5518a52ef26933c35530f194
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "privatecilium.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -15,7 +15,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -168,7 +168,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2046ab9aa41511fe26999d71cea00425967a80547c5aff2ce20aa4cb32d197e4
+    manifestHash: cf922bff964b8c12bf9fad3c557a2a2a07a6898a5518a52ef26933c35530f194
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
@@ -110,8 +110,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "privateciliumadvanced.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -185,7 +185,6 @@
         "ec2:CreateNetworkInterface",
         "ec2:CreateTags",
         "ec2:DeleteNetworkInterface",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -198,6 +197,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -272,8 +272,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: aeb36b98b2f555deeb9a6ed4053bbbc24bfb2964b9106648af6540d2c1f7c2ac
+    manifestHash: 29152e9a63e45adf648d1b77b5b0c399544bae4b8d928459c4eb7ffc913ee68b
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "privatedns1.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: f83f3bca52c9bfdff6c3bef97d44bdf57bbddd52d1ad7beb9986ab79fa01f8be
+    manifestHash: 7cb85c698bb7b2aea623122258b3ccfe831e47983e19d7cfd35aaf4fd794a23c
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "privatedns2.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: f0736f35b52374a3551b56de4d0441a3e33b284655293607f7bce9bdba2d6635
+    manifestHash: f2e031aac271295b58b935fedf169963356f54798eec5519307b6223f83e7132
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "privateflannel.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -156,7 +156,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e4271a9b24f0ecbf7176a877c59c93165478c86723124a756d11d33a561a3d16
+    manifestHash: ec35a9397c1a1a79750a77ef3ccc74417e0942f1f12f3b58480b1b4e7ff229f6
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_masters.privatekindnet.example.com_policy
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_masters.privatekindnet.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "privatekindnet.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -255,8 +255,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0d0a8800b6ba2b3691b75d5920d9513870d1a1d611bf9daabacfd420e94e60f7
+    manifestHash: 35b5625b321a61bb1950f8050d9d3009dd78f0fe606e6c987905e3b9bfa6bcd7
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "privatekopeio.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -154,7 +154,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 389a45e33b14fc42b0b84f3cbf1e645babe41900d1f049a832dddf000163f5fe
+    manifestHash: 40f1cf9413d49189b432b83f4640a22363bf44f9884d0dfb7f589e565f6c60cb
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -6,8 +6,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -38,9 +38,11 @@
     },
     {
       "Action": [
-        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
@@ -58,7 +60,6 @@
         "ec2:AttachVolume",
         "ec2:DeleteVolume",
         "ec2:DetachVolume",
-        "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolume"
       ],
       "Condition": {
@@ -71,7 +72,7 @@
     },
     {
       "Action": [
-        "ec2:CreateSnapshot",
+        "ec2:CopyVolumes",
         "ec2:CreateVolume"
       ],
       "Condition": {

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -892,20 +1040,26 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -951,16 +1106,24 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -972,6 +1135,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -987,6 +1151,8 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -994,9 +1160,13 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1008,6 +1178,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1025,16 +1196,24 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1225,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1054,14 +1234,20 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1071,6 +1257,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1132,9 +1319,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6bf5621734269271c21258a8fd88f5d89da3da0539b91ab87fa0aaa233efbe33
+    manifestHash: e6f34a6f8b62081a02835fe34399f10f683048393b830f36223765d2b3348eaf
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "sharedsubnet.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7b3ced2cebd49bf8a0e55a0a4e7157d8bf488aa9812c6edeef25f64c74024205
+    manifestHash: 2c00c4c37970846f914eb3b38807c90b7355f08213b29784d131944082626f52
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "sharedvpc.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d658138c396db16054dfac82bfddb3a03a013868c521cae35a32819091fea7de
+    manifestHash: 1ff0b3dc81725880d093edc0082d78ddeef0a65ce8b9422a9a4f021f78569742
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -171,7 +171,6 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -184,6 +183,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -256,8 +256,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -649,7 +792,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -686,6 +829,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -697,24 +841,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -724,6 +870,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -733,7 +880,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -745,6 +892,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -796,7 +944,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -819,7 +967,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -900,16 +1048,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -925,7 +1079,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -937,6 +1091,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -952,12 +1107,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -969,6 +1132,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -981,12 +1145,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -998,6 +1168,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1012,12 +1183,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1029,14 +1208,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1046,6 +1232,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1093,9 +1280,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9840743af78406c069f160fcb6ab7fe656814be7887e4fa700e6d271c8bf3f66
+    manifestHash: d84cbdeb0843159584630e1ccd494377f97d1c331db41332fb456cb58a2d518a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "unmanaged.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
@@ -13,7 +13,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2da778b7c1e9110577ca78928a8628f3aeeb94408a03aefc06767ddcb99aa44d
+    manifestHash: 2435c5e41b37d376595be363c2b3ea3a0d2326f25801c13b008d4c647eeb4c79
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,8 @@
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
+            "CopyVolumes",
+            "CreateVolume"
           ]
         }
       },
@@ -170,7 +170,6 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
-        "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceTopology",
@@ -182,6 +181,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
+        "ec2:DescribeVolumeStatus",
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "ec2:DescribeVpcs",
@@ -254,8 +254,8 @@
     },
     {
       "Action": [
+        "ec2:CopyVolumes",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
@@ -11,7 +11,7 @@ spec:
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
-      version: v1.47.0
+      version: v1.58.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -64,7 +64,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -112,25 +112,30 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - patch
-  - list
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
   - list
   - watch
 - apiGroups:
@@ -151,7 +156,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -200,6 +205,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - update
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -249,7 +256,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -314,7 +321,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -336,17 +343,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - create
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -401,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -424,7 +420,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-getter-binding
 roleRef:
@@ -447,7 +443,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -470,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -493,7 +489,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -516,7 +512,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-role
   namespace: kube-system
@@ -544,7 +540,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-leases-rolebinding
   namespace: kube-system
@@ -562,6 +558,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "3301"
+    prometheus.io/scrape: "true"
   labels:
     addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
     app: ebs-csi-controller
@@ -580,6 +579,150 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3302"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-provisioner
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3302
+    targetPort: 3302
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3303"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-attacher
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3303
+    targetPort: 3303
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3304"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-resizer
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3304
+    targetPort: 3304
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3305"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-liveness-probe
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3305
+    targetPort: 3305
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3306"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-snapshotter
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "3307"
+    prometheus.io/scrape: "true"
+  labels:
+    addon.kops.k8s.io/name: aws-ebs-csi-driver.addons.k8s.io
+    app: ebs-csi-controller-volumemodifier
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: aws-ebs-csi-driver.addons.k8s.io
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 3307
+    targetPort: 3307
+  selector:
+    app: ebs-csi-controller
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -589,7 +732,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -607,7 +750,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -647,7 +790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -684,6 +827,7 @@ spec:
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/kubelet
           mountPropagation: Bidirectional
@@ -695,24 +839,26 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --http-endpoint=0.0.0.0:9809
         - --v=5
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          exec:
-            command:
-            - /csi-node-driver-registrar
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --mode=kubelet-registration-probe
+          httpGet:
+            path: /healthz
+            port: healthz-ndr
           initialDelaySeconds: 30
           periodSeconds: 90
           timeoutSeconds: 15
         name: node-driver-registrar
+        ports:
+        - containerPort: 9809
+          name: healthz-ndr
         resources:
           limits:
             memory: 256Mi
@@ -722,6 +868,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -731,7 +878,7 @@ spec:
           name: probe-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources:
@@ -743,6 +890,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
@@ -794,7 +942,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -817,7 +965,7 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.47.0
+        app.kubernetes.io/version: v1.58.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -896,16 +1044,22 @@ spec:
               key: endpoint
               name: aws-meta
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.47.0
+        - name: AWS_SAGEMAKER_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              key: sagemaker_endpoint
+              name: aws-meta
+              optional: true
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         name: ebs-plugin
         ports:
         - containerPort: 9808
@@ -921,7 +1075,7 @@ spec:
             port: healthz
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 60
         resources:
           limits:
             memory: 256Mi
@@ -933,6 +1087,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -948,12 +1103,20 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3302
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
+        ports:
+        - containerPort: 3302
+          name: metrics-prov
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -965,6 +1128,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -977,12 +1141,18 @@ spec:
         - --kube-api-burst=100
         - --worker-threads=100
         - --retry-interval-max=5m
+        - --feature-gates=MutableCSINodeAllocatableCount=true
+        - --http-endpoint=0.0.0.0:3303
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
+        ports:
+        - containerPort: 3303
+          name: metrics-attach
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -994,6 +1164,7 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -1008,12 +1179,20 @@ spec:
         - --kube-api-burst=100
         - --workers=100
         - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=false
+        - --http-endpoint=0.0.0.0:3304
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        - name: ENABLE_VAC_FALLBACK
+          value: "true"
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
+        ports:
+        - containerPort: 3304
+          name: metrics-resizer
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1025,14 +1204,21 @@ spec:
           readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        - --probe-timeout=60s
+        - --metrics-address=0.0.0.0:3305
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
+        ports:
+        - containerPort: 3305
+          name: metrics-lp
+          protocol: TCP
         resources:
           limits:
             memory: 256Mi
@@ -1042,6 +1228,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
@@ -1089,9 +1276,10 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.47.0
+    app.kubernetes.io/version: v1.58.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
   attachRequired: true
+  nodeAllocatableUpdatePeriodSeconds: 10
   podInfoOnMount: false

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d6a6feda71d9e0260346b93ebd423163d4e2552aba71a8bedca9c3ae2a71a9bf
+    manifestHash: 660cd0dabf91866052ccbc4b43d67b2709f9ab33d18dc608f0c16522b588eb13
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/helm-values.yaml
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/helm-values.yaml
@@ -1,0 +1,115 @@
+# These are used to generate the template file
+# helm repo list | grep -q aws-ebs-csi-driver || helm repo add aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+# helm repo update
+# helm template aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver -n kube-system -f helm-values.yaml --no-hooks
+image:
+  repository: registry.k8s.io/provider-aws/aws-ebs-csi-driver
+  tag: "{{ .Version }}"
+
+controller:
+  enableMetrics: true
+  logLevel: 5
+  volumeModificationFeature:
+    enabled: true
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: "topology.kubernetes.io/zone"
+      whenUnsatisfiable: ScheduleAnyway
+    - maxSkew: 1
+      topologyKey: "kubernetes.io/hostname"
+      whenUnsatisfiable: DoNotSchedule
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
+
+sidecars:
+  provisioner:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-provisioner
+    logLevel: 5
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        memory: 256Mi
+  attacher:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-attacher
+    logLevel: 5
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        memory: 256Mi
+  snapshotter:
+    forceEnable: true
+    image:
+      repository: registry.k8s.io/sig-storage/csi-snapshotter
+    logLevel: 5
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        memory: 256Mi
+  resizer:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-resizer
+    logLevel: 5
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        memory: 256Mi
+  livenessProbe:
+    image:
+      repository: registry.k8s.io/sig-storage/livenessprobe
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        memory: 256Mi
+  nodeDriverRegistrar:
+    image:
+      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
+    logLevel: 5
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        memory: 256Mi
+  volumemodifier:
+    logLevel: 5
+
+node:
+  enableWindows: false
+  logLevel: 5
+  priorityClassName: system-node-critical
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: Exists
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                  - fargate
+                  - auto
+                  - hybrid
+              - key: node.kubernetes.io/instance-type
+                operator: NotIn
+                values:
+                  - a1.medium
+                  - a1.large
+                  - a1.xlarge
+                  - a1.2xlarge
+                  - a1.4xlarge
+
+nodeAllocatableUpdatePeriodSeconds: 10

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -1,9 +1,3 @@
-#helm template aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver -n kube-system \
-#  --set controller.volumeModificationFeature.enabled=true \
-#  --set sidecars.snapshotter.forceEnable=true \
-#  --set controller.enableMetrics=true \
-#  --no-hooks | grep -vi helm
-
 {{ with .CloudProvider.AWS.EBSCSIDriver }}
 ---
 # Source: aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -89,12 +83,15 @@ metadata:
     app.kubernetes.io/version: {{ .Version }}
     app.kubernetes.io/component: csi-driver
 rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "patch", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["patch", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get"]
@@ -129,9 +126,14 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  # The "watch" and "update" verbs for volumesnapshots are optional but recommended.
+  # They enable finalizer-based protection to prevent snapshots from being deleted
+  # during provisioning. Without these permissions, the provisioner will still function
+  # but snapshot protection will be unavailable. This makes the provisioner backwards
+  # compatible with older RBAC configurations.
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
@@ -187,7 +189,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  # only required if enabling the alpha volume modify feature
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattributesclasses"]
     verbs: ["get", "list", "watch"]
@@ -219,9 +220,6 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update", "patch", "create"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -378,6 +376,9 @@ metadata:
   namespace: kube-system
   labels:
     app: ebs-csi-controller
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3301"
 spec:
   selector:
     app: ebs-csi-controller
@@ -385,6 +386,126 @@ spec:
     - name: metrics
       port: 3301
       targetPort: 3301
+  type: ClusterIP
+---
+# Source: aws-ebs-csi-driver/templates/metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ebs-csi-controller-provisioner
+  namespace: kube-system
+  labels:
+    app: ebs-csi-controller-provisioner
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3302"
+spec:
+  selector:
+    app: ebs-csi-controller
+  ports:
+    - name: metrics
+      port: 3302
+      targetPort: 3302
+  type: ClusterIP
+---
+# Source: aws-ebs-csi-driver/templates/metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ebs-csi-controller-attacher
+  namespace: kube-system
+  labels:
+    app: ebs-csi-controller-attacher
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3303"
+spec:
+  selector:
+    app: ebs-csi-controller
+  ports:
+    - name: metrics
+      port: 3303
+      targetPort: 3303
+  type: ClusterIP
+---
+# Source: aws-ebs-csi-driver/templates/metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ebs-csi-controller-resizer
+  namespace: kube-system
+  labels:
+    app: ebs-csi-controller-resizer
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3304"
+spec:
+  selector:
+    app: ebs-csi-controller
+  ports:
+    - name: metrics
+      port: 3304
+      targetPort: 3304
+  type: ClusterIP
+---
+# Source: aws-ebs-csi-driver/templates/metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ebs-csi-controller-liveness-probe
+  namespace: kube-system
+  labels:
+    app: ebs-csi-controller-liveness-probe
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3305"
+spec:
+  selector:
+    app: ebs-csi-controller
+  ports:
+    - name: metrics
+      port: 3305
+      targetPort: 3305
+  type: ClusterIP
+---
+# Source: aws-ebs-csi-driver/templates/metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ebs-csi-controller-snapshotter
+  namespace: kube-system
+  labels:
+    app: ebs-csi-controller-snapshotter
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3306"
+spec:
+  selector:
+    app: ebs-csi-controller
+  ports:
+    - name: metrics
+      port: 3306
+      targetPort: 3306
+  type: ClusterIP
+---
+# Source: aws-ebs-csi-driver/templates/metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ebs-csi-controller-volumemodifier
+  namespace: kube-system
+  labels:
+    app: ebs-csi-controller-volumemodifier
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3307"
+spec:
+  selector:
+    app: ebs-csi-controller
+  ports:
+    - name: metrics
+      port: 3307
+      targetPort: 3307
   type: ClusterIP
 ---
 # Source: aws-ebs-csi-driver/templates/node.yaml
@@ -530,24 +651,27 @@ spec:
             preStop:
               exec:
                 command: ["/bin/aws-ebs-csi-driver", "pre-stop-hook"]
+          terminationMessagePolicy: FallbackToLogsOnError
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --http-endpoint=0.0.0.0:9809
             - --v=5
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
+          ports:
+            - name: healthz-ndr
+              containerPort: 9809
           livenessProbe:
-            exec:
-              command:
-              - /csi-node-driver-registrar
-              - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-              - --mode=kubelet-registration-probe
+            httpGet:
+              path: /healthz
+              port: healthz-ndr
             initialDelaySeconds: 30
             periodSeconds: 90
             timeoutSeconds: 15
@@ -567,8 +691,9 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+          terminationMessagePolicy: FallbackToLogsOnError
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -584,6 +709,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+          terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: kubelet-dir
           hostPath:
@@ -782,6 +908,12 @@ spec:
                   name: aws-meta
                   key: endpoint
                   optional: true
+            - name: AWS_SAGEMAKER_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: aws-meta
+                  key: sagemaker_endpoint
+                  optional: true
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -797,15 +929,15 @@ spec:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 60
             periodSeconds: 10
-            failureThreshold: 5
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 60
             periodSeconds: 10
             failureThreshold: 5
           resources:
@@ -819,8 +951,9 @@ spec:
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
+          terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
           imagePullPolicy: IfNotPresent
           args:
             - --timeout=60s
@@ -834,12 +967,20 @@ spec:
             - --kube-api-burst={{ or .KubeAPIBurst "100" }}
             - --worker-threads=100
             - --retry-interval-max=30m
+            - --feature-gates=VolumeAttributesClass=false
+            - --http-endpoint=0.0.0.0:3302
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: ENABLE_VAC_FALLBACK
+              value: "true"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          ports:
+            - name: metrics-prov
+              containerPort: 3302
+              protocol: TCP
           resources:
             limits:
               memory: 256Mi
@@ -851,8 +992,9 @@ spec:
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
+          terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
           imagePullPolicy: IfNotPresent
           args:
             - --timeout=6m
@@ -863,12 +1005,18 @@ spec:
             - --kube-api-burst=100
             - --worker-threads=100
             - --retry-interval-max=5m
+            - --feature-gates=MutableCSINodeAllocatableCount=true
+            - --http-endpoint=0.0.0.0:3303
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          ports:
+            - name: metrics-attach
+              containerPort: 3303
+              protocol: TCP
           resources:
             limits:
               memory: 256Mi
@@ -880,9 +1028,10 @@ spec:
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
+          terminationMessagePolicy: FallbackToLogsOnError
         {{ if HasSnapshotController }}
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -893,12 +1042,17 @@ spec:
             - --kube-api-burst=100
             - --worker-threads=100
             - --retry-interval-max=30m
+            - --http-endpoint=0.0.0.0:3306
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          ports:
+            - name: metrics-snap
+              containerPort: 3306
+              protocol: TCP
           resources:
             limits:
               memory: 256Mi
@@ -910,46 +1064,10 @@ spec:
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
-        {{ end }}
-        {{ if IsKubernetesLT "1.31.0" }}
-        # volume-modifier-for-k8s is no longer needed starting with Kubernetes 1.31.
-        # https://github.com/awslabs/volume-modifier-for-k8s/issues/46
-        - name: volumemodifier
-          image: public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s:v0.7.0
-          imagePullPolicy: IfNotPresent
-          args:
-            - --timeout=60s
-            - --csi-address=$(ADDRESS)
-            - --v=5
-            - --leader-election=true
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-          resources:
-            limits:
-              memory: 256Mi
-            requests:
-              cpu: 10m
-              memory: 40Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            seccompProfile:
-              type: RuntimeDefault
+          terminationMessagePolicy: FallbackToLogsOnError
         {{ end }}
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
           imagePullPolicy: IfNotPresent
           args:
             - --timeout=60s
@@ -962,12 +1080,20 @@ spec:
             - --kube-api-burst=100
             - --workers=100
             - --retry-interval-max=30m
+            - --feature-gates=VolumeAttributesClass=false
+            - --http-endpoint=0.0.0.0:3304
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: ENABLE_VAC_FALLBACK
+              value: "true"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          ports:
+            - name: metrics-resizer
+              containerPort: 3304
+              protocol: TCP
           resources:
             limits:
               memory: 256Mi
@@ -979,14 +1105,21 @@ spec:
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
+          terminationMessagePolicy: FallbackToLogsOnError
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
+            - --probe-timeout=60s
+            - --metrics-address=0.0.0.0:3305
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          ports:
+            - name: metrics-lp
+              containerPort: 3305
+              protocol: TCP
           resources:
             limits:
               memory: 256Mi
@@ -996,6 +1129,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+          terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -1013,6 +1147,7 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  nodeAllocatableUpdatePeriodSeconds: 10
   # Disabled because the field is immutable and kOps doesn't have a way to delete and recreate the resource
   # fsGroupPolicy: File
 {{ if KopsFeatureEnabled "SELinuxMount" }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6d293d5146e4acdd9ab0770838e13cbfa2b824eb0f1b8ac1672bb9abd34be281
+    manifestHash: 846cf7e37c39b9199bfba467005304318dc8efa606baf8e0f1197d5ee37d30b4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6d293d5146e4acdd9ab0770838e13cbfa2b824eb0f1b8ac1672bb9abd34be281
+    manifestHash: 846cf7e37c39b9199bfba467005304318dc8efa606baf8e0f1197d5ee37d30b4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6d293d5146e4acdd9ab0770838e13cbfa2b824eb0f1b8ac1672bb9abd34be281
+    manifestHash: 846cf7e37c39b9199bfba467005304318dc8efa606baf8e0f1197d5ee37d30b4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6d293d5146e4acdd9ab0770838e13cbfa2b824eb0f1b8ac1672bb9abd34be281
+    manifestHash: 846cf7e37c39b9199bfba467005304318dc8efa606baf8e0f1197d5ee37d30b4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6d293d5146e4acdd9ab0770838e13cbfa2b824eb0f1b8ac1672bb9abd34be281
+    manifestHash: 846cf7e37c39b9199bfba467005304318dc8efa606baf8e0f1197d5ee37d30b4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6d293d5146e4acdd9ab0770838e13cbfa2b824eb0f1b8ac1672bb9abd34be281
+    manifestHash: 846cf7e37c39b9199bfba467005304318dc8efa606baf8e0f1197d5ee37d30b4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6d293d5146e4acdd9ab0770838e13cbfa2b824eb0f1b8ac1672bb9abd34be281
+    manifestHash: 846cf7e37c39b9199bfba467005304318dc8efa606baf8e0f1197d5ee37d30b4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -120,7 +120,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6d293d5146e4acdd9ab0770838e13cbfa2b824eb0f1b8ac1672bb9abd34be281
+    manifestHash: 846cf7e37c39b9199bfba467005304318dc8efa606baf8e0f1197d5ee37d30b4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -175,7 +175,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6d293d5146e4acdd9ab0770838e13cbfa2b824eb0f1b8ac1672bb9abd34be281
+    manifestHash: 846cf7e37c39b9199bfba467005304318dc8efa606baf8e0f1197d5ee37d30b4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e5904602c0f5bf0798802482c946b6962d77d015dae5d4ece7931b77c4fb7b59
+    manifestHash: d5c03373a9660fb8c48c34212cc7a3d04bc0158458de7cbc10cb3e81def28d81
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6d293d5146e4acdd9ab0770838e13cbfa2b824eb0f1b8ac1672bb9abd34be281
+    manifestHash: 846cf7e37c39b9199bfba467005304318dc8efa606baf8e0f1197d5ee37d30b4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io


### PR DESCRIPTION
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md

1.47.1 includes a fix to the driver crashing (https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2621) that I believe we're experiencing in some e2e jobs.