### PR TITLE
Deprecreate Debian 10 and Ubuntu 20.04 in kops 1.35

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -42,7 +42,7 @@ The following table provides the support status for various distros with regards
 | CoreOS                                  |          1.6 |    1.9 |       1.17 |    1.18 |
 | Debian 8                                |            - |    1.5 |       1.17 |    1.18 |
 | Debian 9                                |          1.8 |   1.10 |       1.21 |    1.23 |
-| [Debian 10](#debian-10-buster)          |         1.13 |   1.17 |          - |       - |
+| [Debian 10](#debian-10-buster)          |         1.13 |   1.17 |       1.35 |    1.36 |
 | [Debian 11](#debian-11-bullseye)        |       1.21.1 |      - |          - |       - |
 | [Debian 12](#debian-12-bookworm)        |       1.26.3 |      - |          - |       - |
 | [Debian 13](#debian-13-trixie)          |         1.34 |      - |          - |       - |
@@ -57,7 +57,7 @@ The following table provides the support status for various distros with regards
 | [Rocky 10](#rocky-10)                   |         1.35 |      - |          - |       - |
 | Ubuntu 16.04                            |          1.5 |   1.10 |       1.17 |    1.20 |
 | Ubuntu 18.04                            |         1.10 |   1.16 |       1.26 |    1.28 |
-| [Ubuntu 20.04](#ubuntu-2004-focal)      |       1.16.2 |   1.18 |          - |       - |
+| [Ubuntu 20.04](#ubuntu-2004-focal)      |       1.16.2 |   1.18 |       1.35 |    1.36 |
 | [Ubuntu 22.04](#ubuntu-2204-jammy)      |         1.23 |   1.24 |          - |       - |
 | [Ubuntu 24.04](#ubuntu-2404-noble)      |         1.29 |   1.31 |          - |       - |
 | [Ubuntu 26.04](#ubuntu-2604-resolute)   |         1.36 |      - |          - |       - |

--- a/docs/releases/1.35-NOTES.md
+++ b/docs/releases/1.35-NOTES.md
@@ -1,7 +1,5 @@
 ## Release notes for kOps 1.35 series
 
-**&#9888; kOps 1.35 has not been released yet! &#9888;**
-
 This is a document to gather the release notes prior to the release.
 
 # Significant changes

--- a/docs/releases/1.35-NOTES.md
+++ b/docs/releases/1.35-NOTES.md
@@ -41,3 +41,7 @@ This is a document to gather the release notes prior to the release.
 * Support for Kubernetes version 1.30 is deprecated and will be removed in kOps 1.36.
 
 * Support for Amazon Linux 2 is deprecated and will be removed in kOps 1.36
+
+* Support for Ubuntu 20.04 is deprecated and will be removed in kOps 1.36
+
+* Support for Debian 10 is deprecated and will be removed in kOps 1.36

--- a/docs/releases/1.36-NOTES.md
+++ b/docs/releases/1.36-NOTES.md
@@ -1,0 +1,43 @@
+## Release notes for kOps 1.36 series
+
+**&#9888; kOps 1.36 has not been released yet! &#9888;**
+
+This is a document to gather the release notes prior to the release.
+
+# Significant changes
+
+* TODO
+
+## Some Feature
+
+* TODO
+
+## AWS
+
+## GCP
+
+* TODO
+
+## Openstack
+
+* TODO
+
+# Other changes of note
+
+* TODO
+
+# Breaking changes
+
+## Other breaking changes
+
+# Known Issues
+
+* TODO
+
+# Deprecations
+
+* Support for Kubernetes version 1.30 is removed in kOps 1.36.
+
+* Support for Debian 10 is removed in kOps 1.36.
+
+* Support for Ubuntu 20.04 is removed in kOps 1.38.


### PR DESCRIPTION
Both of these lost standard LTS last year. 

https://www.debian.org/releases/

https://ubuntu.com/20-04

A followup PR will remove support in 1.36.

/cc @hakman