### PR TITLE
cilium: require k8s-connectivity in liveness probe

### DIFF
--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 7335e2809e2a81c8dcd187e711fb0f9574e418658ba111cc39ccf58446435994
+    manifestHash: a9b061d4905cb9a3e115de8a01b5df9d5294e8dd1ec6cf17d031de5458736515
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -701,7 +701,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: cec5cca64c5eb654d337873c3063cbc2c10d842f0a8797390d8efbfef9a462da
+    manifestHash: 0765c584a3c6f62995c90a5de8000e83473c28c3f74a007579d33b0c9f20f3c0
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -704,7 +704,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-bootstrap_content
@@ -107,7 +107,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 92a1c4753375e1793d586ef95c1c012e7c1b88363777f85e4a0cc0aba08e4a0a
+    manifestHash: e48bb1f2ad182b52ed3fdf7a7b4db49eac69e795d2e975334e1f1775eb552339
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -713,7 +713,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: b261b51229036f83708ef48385ba3cd1830fc3c0e911eae18b99901d0e21b355
+    manifestHash: 662bc706e53a3260abcf1379e33f3b60d5ce03b0915613ac9b5477e2b036dc4b
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
@@ -704,7 +704,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 8b76832914b569c0c766dd20e8e9f3a04796eee204e75d831251386dad00a526
+    manifestHash: f9d09ea860b7c3f12ffdacd3c9968b525377ca56a60ac7d4e1a65f8f628b3466
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -729,7 +729,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 592b7e4bd38b9580005e7ee6558e8a79acbc77bc5abf64dd8932c88aa263de48
+    manifestHash: 95f58708f238f7b42affb64cac18ada7ea42478ce7f7af3241d725984df7aa27
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -707,7 +707,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -152,7 +152,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 0c3bdf6e0fe9adc81aa309d99d855ba4c6b528b50457251c52c89ac9a61169fe
+    manifestHash: 39a64e65b83b84530b04fb33830495fd83aa9df13b43f2cfebb8a54c5d99442e
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -991,7 +991,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 221074197f8815b2d6d3cb5948b64ca617bb8f9a7b18c5ab51b41d004f853f94
+    manifestHash: 5e2a504a37a17409202366d613de2c8185eda734ecc7412bb903af9ca5432e13
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -738,7 +738,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -1409,7 +1409,7 @@ spec:
             - name: "brief"
               value: "true"
             - name: "require-k8s-connectivity"
-              value: "false"
+              value: "true"
           periodSeconds: 30
           successThreshold: 1
           failureThreshold: 10

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 3ec5ea5f49fb1aa4deb2086db7438856bc11ef5ea75255cc540a15bd0dbfbe17
+    manifestHash: de116903c9a962c8d599ab44a67d9132f2fa89bcc06c0fa8ff68c1758a75b545
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 3ec5ea5f49fb1aa4deb2086db7438856bc11ef5ea75255cc540a15bd0dbfbe17
+    manifestHash: de116903c9a962c8d599ab44a67d9132f2fa89bcc06c0fa8ff68c1758a75b545
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -160,7 +160,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 3ec5ea5f49fb1aa4deb2086db7438856bc11ef5ea75255cc540a15bd0dbfbe17
+    manifestHash: de116903c9a962c8d599ab44a67d9132f2fa89bcc06c0fa8ff68c1758a75b545
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
This is a regression that blocks refresh of control-plane address for the agents. This was introduced during the last major update and is present in kOps v1.34 and v1.35.

The Q would, do we want to remove this "feature" or we may want to ignore cilium agents during cluster validation?

https://docs.cilium.io/en/stable/api/
> GET /healthz returns health and status information of the Cilium daemon and related components such as the local container runtime, connected datastore, Kubernetes integration and Hubble. It accepts the request header "brief" which returns a brief representation of the Cilium status, and "require-k8s-connectivity" which, if set to true, causes failure of the agent to connect to the Kubernetes control plane to also fail the agent's health status.

https://github.com/cilium/cilium/pull/32724
> The community discussed the issue in the APAC community meeting and concluded that killing the whole Cilium agent on k8s disconnection is too aggressive — if the kube-apiserver goes down, that would force every cilium-agent instance in the cluster to also go down. Similar to how the dataplane should continue without the local control plane, it makes sense for the local control plane to continue without the central control plane.

/cc @rifelpet @ameukam 