### PR TITLE
Setup CNI with nft when necessary

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -386,7 +386,24 @@ func (b *ContainerdBuilder) buildIPMasqueradeRules(c *fi.NodeupModelBuilderConte
 	// On GCE custom routes are at the network level, on AWS they are at the route-table / subnet level.
 	// We cannot generally assume that because something is in the private network space, that it can reach us.
 	// If we adopt "native" pod IPs (GCP ip-alias, AWS VPC CNI, etc) we can likely move to rules closer to the upstream ones.
-	script := `#!/bin/bash
+
+	var script string
+	var serviceName string
+	if b.Distribution.ForceNftables() {
+		// On distributions where iptables is not functional (e.g. RHEL 10+, Rocky 10+),
+		// use native nftables rules for pod masquerading.
+		script = `#!/bin/bash
+# Built by kOps - do not edit
+
+nft add table ip kops-cni-nat
+nft add chain ip kops-cni-nat postrouting '{ type nat hook postrouting priority srcnat; policy accept; }'
+nft add rule ip kops-cni-nat postrouting ip daddr {{.NonMasqueradeCIDR}} counter return comment \"ip-masq: pod cidr is not subject to MASQUERADE\"
+nft add rule ip kops-cni-nat postrouting fib daddr type local counter return comment \"ip-masq: local traffic is not subject to MASQUERADE\"
+nft add rule ip kops-cni-nat postrouting counter masquerade random comment \"ip-masq: outbound traffic is subject to MASQUERADE\"
+`
+		serviceName = "cni-nftables-setup"
+	} else {
+		script = `#!/bin/bash
 # Built by kOps - do not edit
 
 iptables -w -t nat -N IP-MASQ
@@ -394,30 +411,32 @@ iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POST
 iptables -w -t nat -A IP-MASQ -d {{.NonMasqueradeCIDR}} -m comment --comment "ip-masq: pod cidr is not subject to MASQUERADE" -j RETURN
 iptables -w -t nat -A IP-MASQ -m comment --comment "ip-masq: outbound traffic is subject to MASQUERADE (must be last in chain)" -j MASQUERADE
 `
+		serviceName = "cni-iptables-setup"
+	}
 
 	script = strings.ReplaceAll(script, "{{.NonMasqueradeCIDR}}", b.NodeupConfig.Networking.NonMasqueradeCIDR)
 
 	c.AddTask(&nodetasks.File{
-		Path:     "/opt/kops/bin/cni-iptables-setup",
+		Path:     "/opt/kops/bin/" + serviceName,
 		Contents: fi.NewStringResource(script),
 		Type:     nodetasks.FileType_File,
 		Mode:     s("0755"),
 	})
 
 	manifest := &systemd.Manifest{}
-	manifest.Set("Unit", "Description", "Configure iptables for kubernetes CNI")
+	manifest.Set("Unit", "Description", "Configure masquerade rules for kubernetes CNI")
 	manifest.Set("Unit", "Documentation", "https://github.com/kubernetes/kops")
 	manifest.Set("Unit", "Before", "network.target")
 	manifest.Set("Service", "Type", "oneshot")
 	manifest.Set("Service", "RemainAfterExit", "yes")
-	manifest.Set("Service", "ExecStart", "/opt/kops/bin/cni-iptables-setup")
+	manifest.Set("Service", "ExecStart", "/opt/kops/bin/"+serviceName)
 	manifest.Set("Install", "WantedBy", "basic.target")
 
 	manifestString := manifest.Render()
-	klog.V(8).Infof("Built service manifest %q\n%s", "cni-iptables-setup", manifestString)
+	klog.V(8).Infof("Built service manifest %q\n%s", serviceName, manifestString)
 
 	service := &nodetasks.Service{
-		Name:       "cni-iptables-setup.service",
+		Name:       serviceName + ".service",
 		Definition: s(manifestString),
 	}
 	service.InitDefaults()

--- a/nodeup/pkg/model/containerd_test.go
+++ b/nodeup/pkg/model/containerd_test.go
@@ -48,6 +48,10 @@ func TestContainerdBuilder_Complex(t *testing.T) {
 	runContainerdBuilderTest(t, "complex", distributions.DistributionUbuntu2604)
 }
 
+func TestContainerdBuilder_Nftables(t *testing.T) {
+	runContainerdBuilderTest(t, "nftables", distributions.DistributionRocky10)
+}
+
 func TestContainerdBuilder_BuildFlags(t *testing.T) {
 	grid := []struct {
 		config   kops.ContainerdConfig

--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
@@ -79,7 +79,7 @@ type: file
 Name: cni-iptables-setup.service
 definition: |
   [Unit]
-  Description=Configure iptables for kubernetes CNI
+  Description=Configure masquerade rules for kubernetes CNI
   Documentation=https://github.com/kubernetes/kops
   Before=network.target
 

--- a/nodeup/pkg/model/tests/containerdbuilder/nftables/cluster.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/nftables/cluster.yaml
@@ -1,0 +1,37 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+    - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  containerRuntime: containerd
+  containerd:
+    version: 1.4.4
+  etcdClusters:
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: main
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: events
+  iam:
+    legacy: false
+  kubernetesVersion: v1.21.0
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  subnets:
+    - cidr: 172.20.32.0/19
+      name: us-test-1a
+      type: Public
+      zone: us-test-1a

--- a/nodeup/pkg/model/tests/containerdbuilder/nftables/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/nftables/tasks.yaml
@@ -41,13 +41,6 @@ contents: |
 
             [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
               SystemdCgroup = true
-
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
-            test_bool_false = false
-            test_bool_true = true
-            test_int = 1
-            test_intstr = "1"
-            test_str = "test"
 path: /etc/containerd/config.toml
 type: file
 ---
@@ -65,12 +58,13 @@ contents: |
   #!/bin/bash
   # Built by kOps - do not edit
 
-  iptables -w -t nat -N IP-MASQ
-  iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
-  iptables -w -t nat -A IP-MASQ -d 100.64.0.0/10 -m comment --comment "ip-masq: pod cidr is not subject to MASQUERADE" -j RETURN
-  iptables -w -t nat -A IP-MASQ -m comment --comment "ip-masq: outbound traffic is subject to MASQUERADE (must be last in chain)" -j MASQUERADE
+  nft add table ip kops-cni-nat
+  nft add chain ip kops-cni-nat postrouting '{ type nat hook postrouting priority srcnat; policy accept; }'
+  nft add rule ip kops-cni-nat postrouting ip daddr 100.64.0.0/10 counter return comment \"ip-masq: pod cidr is not subject to MASQUERADE\"
+  nft add rule ip kops-cni-nat postrouting fib daddr type local counter return comment \"ip-masq: local traffic is not subject to MASQUERADE\"
+  nft add rule ip kops-cni-nat postrouting counter masquerade random comment \"ip-masq: outbound traffic is subject to MASQUERADE\"
 mode: "0755"
-path: /opt/kops/bin/cni-iptables-setup
+path: /opt/kops/bin/cni-nftables-setup
 type: file
 ---
 contents:
@@ -324,7 +318,7 @@ contents: |2-
 path: /usr/share/doc/containerd/apache.txt
 type: file
 ---
-Name: cni-iptables-setup.service
+Name: cni-nftables-setup.service
 definition: |
   [Unit]
   Description=Configure masquerade rules for kubernetes CNI
@@ -334,7 +328,7 @@ definition: |
   [Service]
   Type=oneshot
   RemainAfterExit=yes
-  ExecStart=/opt/kops/bin/cni-iptables-setup
+  ExecStart=/opt/kops/bin/cni-nftables-setup
 
   [Install]
   WantedBy=basic.target

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -320,7 +320,7 @@ type: file
 Name: cni-iptables-setup.service
 definition: |
   [Unit]
-  Description=Configure iptables for kubernetes CNI
+  Description=Configure masquerade rules for kubernetes CNI
   Documentation=https://github.com/kubernetes/kops
   Before=network.target
 

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -41,7 +41,7 @@ func (d *deployer) DumpClusterLogs() error {
 		"--name", d.ClusterName,
 		"--dir", d.ArtifactsDir,
 		"--private-key", d.SSHPrivateKeyPath,
-		"--ssh-user", d.SSHUser,
+		"--ssh-user", "ec2-user",
 	}
 
 	if d.MaxNodesToDump != "" {

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -513,7 +513,11 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 				}
 			}
 		}
+		g.Spec.Image = "309956199498/RHEL-10.1.0_HVM-20260331-arm64-0-Hourly2-GP3"
 
+		if cluster.GetCloudProvider() == api.CloudProviderAWS {
+			g.Spec.MachineType = "m6g.large"
+		}
 		// TODO: Clean up
 		if g.IsControlPlane() {
 			if g.Spec.MachineType == "" {


### PR DESCRIPTION
The `cni-iptables-setup` systemd service uses iptables which isn't available on certain distros.

This PR adds an equivalent `cni-nftables-setup` in that case.