### PR TITLE
feat: verify config server IPs with DNS name

### DIFF
--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -185,6 +185,8 @@ type BootConfig struct {
 type ConfigServerOptions struct {
 	// Servers are the addresses of the configuration servers to use (kops-controller)
 	Servers []string `json:"servers,omitempty"`
+	// TLSServerName is the server name to use for TLS verification when connecting to Servers.
+	TLSServerName string `json:"tlsServerName,omitempty"`
 	// CACertificates are the certificates to trust for fi.CertificateIDCA.
 	CACertificates string
 }

--- a/pkg/kopscontrollerclient/client.go
+++ b/pkg/kopscontrollerclient/client.go
@@ -52,6 +52,10 @@ type Client struct {
 }
 
 func New(authenticator bootstrap.Authenticator, cas []byte, baseURL url.URL) *Client {
+	return NewWithTLSServerName(authenticator, cas, baseURL, "")
+}
+
+func NewWithTLSServerName(authenticator bootstrap.Authenticator, cas []byte, baseURL url.URL, tlsServerName string) *Client {
 	client := &Client{
 		Authenticator: authenticator,
 		CAs:           cas,
@@ -60,11 +64,15 @@ func New(authenticator bootstrap.Authenticator, cas []byte, baseURL url.URL) *Cl
 
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(cas)
+	tlsConfig := &tls.Config{
+		RootCAs:    certPool,
+		MinVersion: tls.VersionTLS12,
+	}
+	if tlsServerName != "" {
+		tlsConfig.ServerName = tlsServerName
+	}
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			RootCAs:    certPool,
-			MinVersion: tls.VersionTLS12,
-		},
+		TLSClientConfig: tlsConfig,
 	}
 	client.httpClient = &http.Client{
 		Timeout:   time.Duration(15) * time.Second,

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -393,23 +393,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 
 	useConfigServer := kopsmodel.UseKopsControllerForNodeConfig(cluster) && !ig.HasAPIServer()
 	if useConfigServer {
-		hosts := []string{"kops-controller.internal." + cluster.ObjectMeta.Name}
-		if len(bootConfig.APIServerIPs) > 0 {
-			hosts = bootConfig.APIServerIPs
-		}
-
-		configServer := &nodeup.ConfigServerOptions{
-			CACertificates: config.CAs[fi.CertificateIDCA],
-		}
-		for _, host := range hosts {
-			baseURL := url.URL{
-				Scheme: "https",
-				Host:   net.JoinHostPort(host, strconv.Itoa(wellknownports.KopsControllerPort)),
-				Path:   "/",
-			}
-			configServer.Servers = append(configServer.Servers, baseURL.String())
-		}
-		bootConfig.ConfigServer = configServer
+		bootConfig.ConfigServer = buildConfigServerOptions(cluster.ObjectMeta.Name, config.CAs[fi.CertificateIDCA], bootConfig.APIServerIPs)
 		delete(config.CAs, fi.CertificateIDCA)
 	} else {
 		bootConfig.ConfigBase = fi.PtrTo(n.configBase.Path())
@@ -463,6 +447,30 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 	config.Packages = append(config.Packages, ig.Spec.Packages...)
 
 	return config, bootConfig, nil
+}
+
+func buildConfigServerOptions(clusterName string, caCertificates string, apiserverIPs []string) *nodeup.ConfigServerOptions {
+	kopsControllerName := "kops-controller.internal." + clusterName
+	hosts := []string{kopsControllerName}
+
+	configServer := &nodeup.ConfigServerOptions{
+		CACertificates: caCertificates,
+	}
+	if len(apiserverIPs) > 0 {
+		hosts = apiserverIPs
+		configServer.TLSServerName = kopsControllerName
+	}
+
+	for _, host := range hosts {
+		baseURL := url.URL{
+			Scheme: "https",
+			Host:   net.JoinHostPort(host, strconv.Itoa(wellknownports.KopsControllerPort)),
+			Path:   "/",
+		}
+		configServer.Servers = append(configServer.Servers, baseURL.String())
+	}
+
+	return configServer
 }
 
 func loadCertificates(keysets map[string]*fi.Keyset, name string, config *nodeup.Config, includeKeypairID bool) error {

--- a/pkg/nodemodel/nodeupconfigbuilder_test.go
+++ b/pkg/nodemodel/nodeupconfigbuilder_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodemodel
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildConfigServerOptionsUsesTLSServerNameForIPServers(t *testing.T) {
+	options := buildConfigServerOptions("cluster.k8s.local", "ca-data", []string{"10.0.1.2"})
+
+	if got, want := options.TLSServerName, "kops-controller.internal.cluster.k8s.local"; got != want {
+		t.Fatalf("TLSServerName = %q, want %q", got, want)
+	}
+	if got, want := options.Servers, []string{"https://10.0.1.2:3988/"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Servers = %v, want %v", got, want)
+	}
+}
+
+func TestBuildConfigServerOptionsUsesDNSNameByDefault(t *testing.T) {
+	options := buildConfigServerOptions("cluster.k8s.local", "ca-data", nil)
+
+	if options.TLSServerName != "" {
+		t.Fatalf("TLSServerName = %q, want empty", options.TLSServerName)
+	}
+	if got, want := options.Servers, []string{"https://kops-controller.internal.cluster.k8s.local:3988/"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Servers = %v, want %v", got, want)
+	}
+}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -738,7 +738,7 @@ func getNodeConfigFromServers(ctx context.Context, bootConfig *nodeup.BootConfig
 	}
 
 	// Note: The url is overridden in every iteration of the loop below.
-	client := kopscontrollerclient.New(authenticator, []byte(bootConfig.ConfigServer.CACertificates), url.URL{})
+	client := kopscontrollerclient.NewWithTLSServerName(authenticator, []byte(bootConfig.ConfigServer.CACertificates), url.URL{}, bootConfig.ConfigServer.TLSServerName)
 	defer client.Close()
 
 	var merr error


### PR DESCRIPTION
Allow nodeup to connect to IP-based kops-controller config-server endpoints while verifying TLS against `kops-controller.internal.<cluster_name>`.

/cc @rifelpet 