### PR TITLE
Automated cherry pick of #18237: cilium: require k8s-connectivity in liveness probe

### DIFF
--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: beb0496ec99d2bfb237f088d6033dd59501bb18fd8763b0f9a0c5c504b03e1b8
+    manifestHash: 3250c972b52b57cd23a58d3f5962aa372215d17e5581f868d605213faaaf6384
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -700,7 +700,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 6bd890997541788cd00972513c7e5fd5a561d053e95baa5411b654537ba6031a
+    manifestHash: 7480ed4fef9226f0ac8f67b10bab414f5902c19a27566aba11f026cf7b602932
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -703,7 +703,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 93caa103d778466ed15999c0e1d9e3e896585992f4ff62b0502944dd67905e3b
+    manifestHash: 3ab75bd474f37dbab884191a90e5d7732041be44b1be29be75efb250edddfced
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
@@ -703,7 +703,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 67b3ea6813bb591b4543524fbdc4cc6c909ece2330bbfece99b511a52d22ca7e
+    manifestHash: de10b714bc23b418243ee8557b516893fbe391d2389ee014872044e3ce4d3b6f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -728,7 +728,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: a1bb43c838b23644106822792781eced953f3326cf049799c2c63f0cba38d0e1
+    manifestHash: d0f05fc0dbd97d949f198186b2f4ed274cadcaeba5ae06523f56b630bfed0424
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -706,7 +706,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -154,7 +154,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 9b451283987f83208a50a19117ff1ad246dd95225c17aa56947d2a8f09688266
+    manifestHash: 85ea52dd26ad82530959c12f10b60d0a82ab4fc5f6bf272a9aceadb075097479
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -990,7 +990,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 28144cae2e4a7f0b6c6287894415ef330cde18f76a7ad06f66ff7c3878a45df7
+    manifestHash: 395d067af92a3a5cdc2817eefc2d328b8f9cdf3c24244547ee526fdad96ca0ba
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -737,7 +737,7 @@ spec:
             - name: brief
               value: "true"
             - name: require-k8s-connectivity
-              value: "false"
+              value: "true"
             path: /healthz
             port: 9879
             scheme: HTTP

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -1408,7 +1408,7 @@ spec:
             - name: "brief"
               value: "true"
             - name: "require-k8s-connectivity"
-              value: "false"
+              value: "true"
           periodSeconds: 30
           successThreshold: 1
           failureThreshold: 10

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: f1c91987ced18d3459a733919130699dd565c0122d90f029e40d4de76cf1840d
+    manifestHash: dd3d4fa2e2b698c20678ef546e31dc574480a478da2e2f1d1f4b1491b31cb24f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: f1c91987ced18d3459a733919130699dd565c0122d90f029e40d4de76cf1840d
+    manifestHash: dd3d4fa2e2b698c20678ef546e31dc574480a478da2e2f1d1f4b1491b31cb24f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -162,7 +162,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: f1c91987ced18d3459a733919130699dd565c0122d90f029e40d4de76cf1840d
+    manifestHash: dd3d4fa2e2b698c20678ef546e31dc574480a478da2e2f1d1f4b1491b31cb24f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #18237 on release-1.34.

#18237: cilium: require k8s-connectivity in liveness probe

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```