### PR TITLE
gossip: introduce hybrid worker bootstrap for gossip clusters    

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -44,8 +44,10 @@ var _ fi.NodeupModelBuilder = &ProtokubeBuilder{}
 
 // Build is responsible for generating the options for protokube
 func (t *ProtokubeBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	// check is not a master and we are not using gossip (https://github.com/kubernetes/kops/pull/3091)
-	if !t.IsMaster && !t.UsesLegacyGossip() {
+	// Skip protokube on workers when it isn't needed: either the cluster doesn't use gossip,
+	// or this worker bootstraps via kops-controller NLB (hybrid mode, signalled by APIServerIPs
+	// populated on the boot config). Gossip stays alive on control-plane nodes.
+	if !t.IsMaster && (!t.UsesLegacyGossip() || len(t.BootConfig.APIServerIPs) > 0) {
 		klog.V(2).Infof("skipping the provisioning of protokube on the nodes")
 		return nil
 	}

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -952,6 +952,10 @@ func (c *Cluster) UsesLegacyGossip() bool {
 }
 
 func (c *Cluster) UsesPublicDNS() bool {
+	if c.UsesLegacyGossip() {
+		// Gossip clusters have public/private DNS topology set
+		return false
+	}
 	if c.Spec.Networking.Topology == nil || c.Spec.Networking.Topology.DNS == "" || c.Spec.Networking.Topology.DNS == DNSTypePublic {
 		return true
 	}
@@ -959,6 +963,10 @@ func (c *Cluster) UsesPublicDNS() bool {
 }
 
 func (c *Cluster) UsesPrivateDNS() bool {
+	if c.UsesLegacyGossip() {
+		// Gossip clusters have public/private DNS topology set
+		return false
+	}
 	if c.Spec.Networking.Topology != nil && c.Spec.Networking.Topology.DNS == DNSTypePrivate {
 		return true
 	}
@@ -973,16 +981,22 @@ func (c *Cluster) UsesNoneDNS() bool {
 }
 
 // UsesLoadBalancerForKopsController returns true when worker nodes reach kops-controller
-// via the cluster API load balancer instead of via gossip-populated /etc/hosts. True for
-// None-DNS clusters across all clouds, plus GCE gossip clusters with an API load balancer.
+// via the cluster load balancer rather than via gossip-populated /etc/hosts. True for all
+// None-DNS clusters, and for gossip clusters whose API load balancer can host the
+// kops-controller listener.
 func (c *Cluster) UsesLoadBalancerForKopsController() bool {
 	if c.UsesNoneDNS() {
+		// Clusters with none DNS topology may not have c.Spec.API.LoadBalancer set (see Hetzner)
 		return true
 	}
-	if c.UsesLegacyGossip() && c.GetCloudProvider() == CloudProviderGCE && c.Spec.API.LoadBalancer != nil {
-		return true
+	if c.UsesPublicDNS() || c.UsesPrivateDNS() || c.Spec.API.LoadBalancer == nil {
+		return false
 	}
-	return false
+	if c.GetCloudProvider() == CloudProviderAWS {
+		// NLB-only, the kops-controller target group requires a Network Load Balancer.
+		return c.Spec.API.LoadBalancer.Class == LoadBalancerClassNetwork
+	}
+	return true
 }
 
 func (c *Cluster) InstallCNIAssets() bool {

--- a/pkg/apis/kops/model/features.go
+++ b/pkg/apis/kops/model/features.go
@@ -39,20 +39,10 @@ func UseChallengeCallback(cloudProvider kops.CloudProviderID) bool {
 }
 
 // UseKopsControllerForNodeConfig checks if nodeup should use kops-controller to get nodeup.Config.
+// Gossip and None-DNS clusters need a fixed kops-controller endpoint baked into worker boot config,
+// which is exactly what UsesLoadBalancerForKopsController offers.
 func UseKopsControllerForNodeConfig(cluster *kops.Cluster) bool {
-	if cluster.UsesLegacyGossip() {
-		if cluster.UsesLoadBalancerForKopsController() {
-			return true
-		}
-		switch cluster.GetCloudProvider() {
-		case kops.CloudProviderHetzner, kops.CloudProviderScaleway, kops.CloudProviderDO:
-			// We don't have a cloud-discovery mechanism implemented in nodeup for many clouds,
-			// but we assume that we're using a load balancer with a fixed IP address
-		default:
-			return false
-		}
-	}
-	return true
+	return !cluster.UsesLegacyGossip() || cluster.UsesLoadBalancerForKopsController()
 }
 
 // UseCiliumEtcd is true if we are using the Cilium etcd cluster.

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -174,7 +174,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			nlbListeners = append(nlbListeners, listener443)
 		}
 
-		if b.Cluster.UsesNoneDNS() {
+		if b.Cluster.UsesLoadBalancerForKopsController() {
 			{
 				nlbListener := &awstasks.NetworkLoadBalancerListener{
 					Name:                fi.PtrTo(b.NLBListenerName("api", wellknownports.KopsControllerPort)),
@@ -225,9 +225,10 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			Type:              elbv2types.LoadBalancerTypeEnumNetwork,
 		}
 
-		// Wait for all load balancer components to be created (including network interfaces needed for NoneDNS).
-		// Limiting this to clusters using NoneDNS because load balancer creation is quite slow.
-		if b.Cluster.UsesNoneDNS() {
+		// Wait for all load balancer components to be created (including network interfaces needed to
+		// bake NLB ENI IPs into worker nodeup configs). Limiting this to clusters that actually need
+		// those IPs because load balancer creation is quite slow.
+		if b.Cluster.UsesLoadBalancerForKopsController() {
 			nlb.SetWaitForLoadBalancerReady(true)
 		}
 
@@ -264,7 +265,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KubeAPIServer},
 		}
 
-		if b.Cluster.UsesNoneDNS() {
+		if b.Cluster.UsesLoadBalancerForKopsController() {
 			lbSpec.CrossZoneLoadBalancing = fi.PtrTo(true)
 		} else if lbSpec.CrossZoneLoadBalancing == nil {
 			lbSpec.CrossZoneLoadBalancing = fi.PtrTo(false)
@@ -341,7 +342,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				c.AddTask(tg)
 			}
 
-			if b.Cluster.UsesNoneDNS() {
+			if b.Cluster.UsesLoadBalancerForKopsController() {
 				{
 					groupName := b.NLBTargetGroupName("kops-controller")
 					groupTags := b.CloudTags(groupName, false)
@@ -534,7 +535,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		}
 	}
 
-	if b.Cluster.UsesNoneDNS() {
+	if b.Cluster.UsesLoadBalancerForKopsController() {
 		nodeGroups, err := b.GetSecurityGroups(kops.InstanceGroupRoleNode)
 		if err != nil {
 			return err
@@ -620,7 +621,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				SourceGroup:   masterGroup.Task,
 				ToPort:        fi.PtrTo(int32(4)),
 			})
-			if b.Cluster.UsesNoneDNS() {
+			if b.Cluster.UsesLoadBalancerForKopsController() {
 				{
 					nlb.WellKnownServices = append(nlb.WellKnownServices, wellknownservices.KopsController)
 					clb.WellKnownServices = append(clb.WellKnownServices, wellknownservices.KopsController)

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -493,7 +493,7 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.CloudupMo
 		if b.UseLoadBalancerForAPI() && ig.HasAPIServer() {
 			if b.UseNetworkLoadBalancer() {
 				t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("tcp"))
-				if b.Cluster.UsesNoneDNS() && ig.IsControlPlane() {
+				if b.Cluster.UsesLoadBalancerForKopsController() && ig.IsControlPlane() {
 					t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("kops-controller"))
 					if b.Cluster.Spec.Networking.Cilium != nil && b.Cluster.Spec.Networking.Cilium.EtcdManaged {
 						t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("etcd-cilium"))

--- a/pkg/model/azuremodel/api_loadbalancer.go
+++ b/pkg/model/azuremodel/api_loadbalancer.go
@@ -104,7 +104,7 @@ func (b *APILoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) er
 		return fmt.Errorf("unknown load balancer Type: %q", lbSpec.Type)
 	}
 
-	if b.Cluster.UsesLegacyGossip() || b.Cluster.UsesNoneDNS() {
+	if b.Cluster.UsesLoadBalancerForKopsController() {
 		lb.WellKnownServices = append(lb.WellKnownServices, wellknownservices.KopsController)
 
 		// kops-controller probe: HTTPS on 3988 with /healthz

--- a/pkg/model/azuremodel/network.go
+++ b/pkg/model/azuremodel/network.go
@@ -236,7 +236,7 @@ func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		DestinationApplicationSecurityGroupNames: []*string{fi.PtrTo(b.NameForApplicationSecurityGroupControlPlane())},
 		DestinationPortRange:                     fi.PtrTo("*"),
 	})
-	if b.Cluster.UsesNoneDNS() && b.Cluster.Spec.API.LoadBalancer != nil && b.Cluster.Spec.API.LoadBalancer.Type == kops.LoadBalancerTypePublic {
+	if b.Cluster.UsesLoadBalancerForKopsController() && b.Cluster.Spec.API.LoadBalancer != nil && b.Cluster.Spec.API.LoadBalancer.Type == kops.LoadBalancerTypePublic {
 		// TODO: Limit access to necessary source address prefixes instead of "0.0.0.0/0" and "::/0"
 		nsgTask.SecurityRules = append(nsgTask.SecurityRules, &azuretasks.NetworkSecurityRule{
 			Name:                                     fi.PtrTo("AllowNodesToKubernetesAPI"),

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -200,7 +200,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.CloudupModelBuilderContex
 		}
 		c.AddTask(portTask)
 
-		if b.Cluster.UsesNoneDNS() && ig.Spec.Role == kops.InstanceGroupRoleControlPlane {
+		if b.Cluster.UsesLoadBalancerForKopsController() && ig.Spec.Role == kops.InstanceGroupRoleControlPlane {
 			portTask.WellKnownServices = append(portTask.WellKnownServices, wellknownservices.KubeAPIServer)
 		}
 

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -379,12 +379,14 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 		controlPlaneIPs = append(controlPlaneIPs, wellKnownAddresses[wellknownservices.KubeAPIServer]...)
 	}
 
-	if cluster.UsesLoadBalancerForKopsController() {
+	// Bake control-plane IPs into /etc/hosts (for api.internal and kops-controller.internal):
+	//   - non-CP roles in any cluster that exposes kops-controller on the API LB,
+	//   - any role on clouds without DNS-based kops-controller discovery.
+	// CP nodes get api.internal=127.0.0.1 from etc_hosts.go's IsMaster branch and don't
+	// connect to kops-controller.internal externally, so they don't need APIServerIPs.
+	if cluster.UsesLoadBalancerForKopsController() && !ig.HasAPIServer() {
 		bootConfig.APIServerIPs = controlPlaneIPs
 	} else {
-		// If we do have a fixed IP, we use it (on some clouds, initially)
-		// This covers the clouds in UseKopsControllerForNodeConfig which use kops-controller for node config,
-		// but don't have a specialized discovery mechanism for finding kops-controller etc.
 		switch cluster.GetCloudProvider() {
 		case kops.CloudProviderHetzner, kops.CloudProviderScaleway, kops.CloudProviderDO, kops.CloudProviderMetal:
 			bootConfig.APIServerIPs = controlPlaneIPs

--- a/tests/integration/update_cluster/gossip-aws/data/aws_iam_role_policy_nodes.gossip.k8s.local_policy
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_iam_role_policy_nodes.gossip.k8s.local_policy
@@ -2,28 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:Get*"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket/tests/gossip.k8s.local/cluster-completed.spec",
-        "arn:aws-test:s3:::placeholder-read-bucket/tests/gossip.k8s.local/igconfig/node/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/gossip-aws/data/aws_launch_template_nodes.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_launch_template_nodes.gossip.k8s.local_user_data
@@ -123,10 +123,33 @@ ensure-install-dir
 cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: aws
 ClusterName: gossip.k8s.local
-ConfigBase: memfs://tests/gossip.k8s.local
+ConfigServer:
+  CACertificates: |
+    -----BEGIN CERTIFICATE-----
+    MIIBbjCCARigAwIBAgIMFpANqBD8NSD82AUSMA0GCSqGSIb3DQEBCwUAMBgxFjAU
+    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwODAwWhcNMzEwNzA3MDcw
+    ODAwWjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
+    SwAwSAJBANFI3zr0Tk8krsW8vwjfMpzJOlWQ8616vG3YPa2qAgI7V4oKwfV0yIg1
+    jt+H6f4P/wkPAPTPTfRp9Iy8oHEEFw0CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
+    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFNG3zVjTcLlJwDsJ4/K9DV7KohUA
+    MA0GCSqGSIb3DQEBCwUAA0EAB8d03fY2w7WKpfO29qI295pu2C4ca9AiVGOpgSc8
+    tmQsq6rcxt3T+rb589PVtz0mw/cKTxOk6gH2CCC+yHfy2w==
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    MIIBbjCCARigAwIBAgIMFpANvmSa0OAlYmXKMA0GCSqGSIb3DQEBCwUAMBgxFjAU
+    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwOTM2WhcNMzEwNzA3MDcw
+    OTM2WjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
+    SwAwSAJBAMF6F4aZdpe0RUpyykaBpWwZCnwbffhYGOw+fs6RdLuUq7QCNmJm/Eq7
+    WWOziMYDiI9SbclpD+6QiJ0N3EqppVUCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
+    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLImp6ARjPDAH6nhI+scWVt3Q9bn
+    MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
+    9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
+    -----END CERTIFICATE-----
+  servers:
+  - https://kops-controller.internal.gossip.k8s.local:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: n/rKtAyAAO6tknrf2LGSDgoD/GNY2gJUDvx8CHp2i7E=
+NodeupConfigHash: 4pK9aRKK+peUykRrpjE5uI4ms+BHch2SFkbvBIRGRE4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_nodeupconfig-nodes_content
@@ -17,28 +17,7 @@ Assets:
   - d6dcab36d1b6af1b72c7f0662e5fcf446a291271ba6006532b95c4144e19d428@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
   - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
-CAs:
-  kubernetes-ca: |
-    -----BEGIN CERTIFICATE-----
-    MIIBbjCCARigAwIBAgIMFpANqBD8NSD82AUSMA0GCSqGSIb3DQEBCwUAMBgxFjAU
-    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwODAwWhcNMzEwNzA3MDcw
-    ODAwWjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
-    SwAwSAJBANFI3zr0Tk8krsW8vwjfMpzJOlWQ8616vG3YPa2qAgI7V4oKwfV0yIg1
-    jt+H6f4P/wkPAPTPTfRp9Iy8oHEEFw0CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
-    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFNG3zVjTcLlJwDsJ4/K9DV7KohUA
-    MA0GCSqGSIb3DQEBCwUAA0EAB8d03fY2w7WKpfO29qI295pu2C4ca9AiVGOpgSc8
-    tmQsq6rcxt3T+rb589PVtz0mw/cKTxOk6gH2CCC+yHfy2w==
-    -----END CERTIFICATE-----
-    -----BEGIN CERTIFICATE-----
-    MIIBbjCCARigAwIBAgIMFpANvmSa0OAlYmXKMA0GCSqGSIb3DQEBCwUAMBgxFjAU
-    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwOTM2WhcNMzEwNzA3MDcw
-    OTM2WjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
-    SwAwSAJBAMF6F4aZdpe0RUpyykaBpWwZCnwbffhYGOw+fs6RdLuUq7QCNmJm/Eq7
-    WWOziMYDiI9SbclpD+6QiJ0N3EqppVUCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
-    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLImp6ARjPDAH6nhI+scWVt3Q9bn
-    MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
-    9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
-    -----END CERTIFICATE-----
+CAs: {}
 ClusterName: gossip.k8s.local
 Hooks:
 - null
@@ -75,9 +54,6 @@ Networking:
 UpdatePolicy: automatic
 channels:
 - memfs://tests/gossip.k8s.local/addons/bootstrap-channel.yaml
-configStore:
-  keypairs: memfs://tests/gossip.k8s.local/pki
-  secrets: memfs://tests/gossip.k8s.local/secrets
 containerdConfig:
   logLevel: info
   runc:

--- a/tests/integration/update_cluster/gossip-aws/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-aws/kubernetes.tf
@@ -157,7 +157,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-gossip-k8s-local" {
     propagate_at_launch = true
     value               = "owned"
   }
-  target_group_arns   = [aws_lb_target_group.tcp-gossip-k8s-local-k2q54l.id]
+  target_group_arns   = [aws_lb_target_group.kops-controller-gossip-k8-53agdi.id, aws_lb_target_group.tcp-gossip-k8s-local-k2q54l.id]
   vpc_zone_identifier = [aws_subnet.us-test-1a-gossip-k8s-local.id]
 }
 
@@ -579,7 +579,7 @@ resource "aws_launch_template" "nodes-gossip-k8s-local" {
 }
 
 resource "aws_lb" "api-gossip-k8s-local" {
-  enable_cross_zone_load_balancing = false
+  enable_cross_zone_load_balancing = true
   internal                         = false
   load_balancer_type               = "network"
   name                             = "api-gossip-k8s-local-t08tb7"
@@ -594,6 +594,16 @@ resource "aws_lb" "api-gossip-k8s-local" {
   }
 }
 
+resource "aws_lb_listener" "api-gossip-k8s-local-3988" {
+  default_action {
+    target_group_arn = aws_lb_target_group.kops-controller-gossip-k8-53agdi.id
+    type             = "forward"
+  }
+  load_balancer_arn = aws_lb.api-gossip-k8s-local.id
+  port              = 3988
+  protocol          = "TCP"
+}
+
 resource "aws_lb_listener" "api-gossip-k8s-local-443" {
   default_action {
     target_group_arn = aws_lb_target_group.tcp-gossip-k8s-local-k2q54l.id
@@ -602,6 +612,27 @@ resource "aws_lb_listener" "api-gossip-k8s-local-443" {
   load_balancer_arn = aws_lb.api-gossip-k8s-local.id
   port              = 443
   protocol          = "TCP"
+}
+
+resource "aws_lb_target_group" "kops-controller-gossip-k8-53agdi" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
+  health_check {
+    healthy_threshold   = 2
+    interval            = 10
+    path                = "/healthz"
+    protocol            = "HTTPS"
+    unhealthy_threshold = 2
+  }
+  name     = "kops-controller-gossip-k8-53agdi"
+  port     = 3988
+  protocol = "TCP"
+  tags = {
+    "KubernetesCluster"                      = "gossip.k8s.local"
+    "Name"                                   = "kops-controller-gossip-k8-53agdi"
+    "kubernetes.io/cluster/gossip.k8s.local" = "owned"
+  }
+  vpc_id = aws_vpc.gossip-k8s-local.id
 }
 
 resource "aws_lb_target_group" "tcp-gossip-k8s-local-k2q54l" {
@@ -1050,6 +1081,24 @@ resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   security_group_id = aws_security_group.api-elb-gossip-k8s-local.id
   to_port           = -1
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "kops-controller-elb-to-cp" {
+  from_port                = 3988
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-gossip-k8s-local.id
+  source_security_group_id = aws_security_group.api-elb-gossip-k8s-local.id
+  to_port                  = 3988
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "node-to-elb" {
+  from_port                = 0
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.api-elb-gossip-k8s-local.id
+  source_security_group_id = aws_security_group.nodes-gossip-k8s-local.id
+  to_port                  = 0
+  type                     = "ingress"
 }
 
 resource "aws_sqs_queue" "gossip-k8s-local-nth" {

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_nodes-eastus-1.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_nodes-eastus-1.gossip.k8s.local_user_data
@@ -122,10 +122,33 @@ ensure-install-dir
 cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: azure
 ClusterName: gossip.k8s.local
-ConfigBase: memfs://tests/gossip.k8s.local
+ConfigServer:
+  CACertificates: |
+    -----BEGIN CERTIFICATE-----
+    MIIBbjCCARigAwIBAgIMFpANqBD8NSD82AUSMA0GCSqGSIb3DQEBCwUAMBgxFjAU
+    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwODAwWhcNMzEwNzA3MDcw
+    ODAwWjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
+    SwAwSAJBANFI3zr0Tk8krsW8vwjfMpzJOlWQ8616vG3YPa2qAgI7V4oKwfV0yIg1
+    jt+H6f4P/wkPAPTPTfRp9Iy8oHEEFw0CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
+    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFNG3zVjTcLlJwDsJ4/K9DV7KohUA
+    MA0GCSqGSIb3DQEBCwUAA0EAB8d03fY2w7WKpfO29qI295pu2C4ca9AiVGOpgSc8
+    tmQsq6rcxt3T+rb589PVtz0mw/cKTxOk6gH2CCC+yHfy2w==
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    MIIBbjCCARigAwIBAgIMFpANvmSa0OAlYmXKMA0GCSqGSIb3DQEBCwUAMBgxFjAU
+    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwOTM2WhcNMzEwNzA3MDcw
+    OTM2WjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
+    SwAwSAJBAMF6F4aZdpe0RUpyykaBpWwZCnwbffhYGOw+fs6RdLuUq7QCNmJm/Eq7
+    WWOziMYDiI9SbclpD+6QiJ0N3EqppVUCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
+    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLImp6ARjPDAH6nhI+scWVt3Q9bn
+    MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
+    9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
+    -----END CERTIFICATE-----
+  servers:
+  - https://kops-controller.internal.gossip.k8s.local:3988/
 InstanceGroupName: nodes-eastus-1
 InstanceGroupRole: Node
-NodeupConfigHash: fX5WLvjzmSE+ecKdEQf3gG9RrwrCbFgrgpIhATEso+g=
+NodeupConfigHash: GB2MAxzWLpOE3N+f3bV3f24FarOTjnbltOxLPxEI4wg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-nodes-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-nodes-eastus-1_source
@@ -16,28 +16,7 @@ Assets:
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
   - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 AzureAdminUser: kops
-CAs:
-  kubernetes-ca: |
-    -----BEGIN CERTIFICATE-----
-    MIIBbjCCARigAwIBAgIMFpANqBD8NSD82AUSMA0GCSqGSIb3DQEBCwUAMBgxFjAU
-    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwODAwWhcNMzEwNzA3MDcw
-    ODAwWjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
-    SwAwSAJBANFI3zr0Tk8krsW8vwjfMpzJOlWQ8616vG3YPa2qAgI7V4oKwfV0yIg1
-    jt+H6f4P/wkPAPTPTfRp9Iy8oHEEFw0CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
-    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFNG3zVjTcLlJwDsJ4/K9DV7KohUA
-    MA0GCSqGSIb3DQEBCwUAA0EAB8d03fY2w7WKpfO29qI295pu2C4ca9AiVGOpgSc8
-    tmQsq6rcxt3T+rb589PVtz0mw/cKTxOk6gH2CCC+yHfy2w==
-    -----END CERTIFICATE-----
-    -----BEGIN CERTIFICATE-----
-    MIIBbjCCARigAwIBAgIMFpANvmSa0OAlYmXKMA0GCSqGSIb3DQEBCwUAMBgxFjAU
-    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwOTM2WhcNMzEwNzA3MDcw
-    OTM2WjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
-    SwAwSAJBAMF6F4aZdpe0RUpyykaBpWwZCnwbffhYGOw+fs6RdLuUq7QCNmJm/Eq7
-    WWOziMYDiI9SbclpD+6QiJ0N3EqppVUCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
-    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLImp6ARjPDAH6nhI+scWVt3Q9bn
-    MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
-    9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
-    -----END CERTIFICATE-----
+CAs: {}
 ClusterName: gossip.k8s.local
 Hooks:
 - null
@@ -74,9 +53,6 @@ Networking:
 UpdatePolicy: automatic
 channels:
 - memfs://tests/gossip.k8s.local/addons/bootstrap-channel.yaml
-configStore:
-  keypairs: memfs://tests/gossip.k8s.local/pki
-  secrets: memfs://tests/gossip.k8s.local/secrets
 containerdConfig:
   logLevel: info
   runc:

--- a/tests/integration/update_cluster/gossip-azure/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-azure/kubernetes.tf
@@ -378,6 +378,28 @@ resource "azurerm_network_security_group" "gossip-k8s-local" {
     source_port_range                          = "*"
   }
   security_rule {
+    access                                     = "Allow"
+    destination_application_security_group_ids = [azurerm_application_security_group.control-plane-gossip-k8s-local.id]
+    destination_port_range                     = "443"
+    direction                                  = "Inbound"
+    name                                       = "AllowNodesToKubernetesAPI"
+    priority                                   = 2000
+    protocol                                   = "Tcp"
+    source_address_prefix                      = "*"
+    source_port_range                          = "*"
+  }
+  security_rule {
+    access                                     = "Allow"
+    destination_application_security_group_ids = [azurerm_application_security_group.control-plane-gossip-k8s-local.id]
+    destination_port_range                     = "3988"
+    direction                                  = "Inbound"
+    name                                       = "AllowNodesToKopsController"
+    priority                                   = 2001
+    protocol                                   = "Tcp"
+    source_address_prefix                      = "*"
+    source_port_range                          = "*"
+  }
+  security_rule {
     access                     = "Allow"
     destination_address_prefix = "VirtualNetwork"
     destination_port_range     = "*"

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -371,7 +371,7 @@ func (e *NetworkLoadBalancer) FindAddresses(c *fi.CloudupContext) ([]string, err
 				addresses = append(addresses, fi.ValueOf(lb.LoadBalancer.DNSName))
 			}
 
-			if cluster.UsesNoneDNS() {
+			if cluster.UsesLoadBalancerForKopsController() {
 				nis, err := cloud.FindELBV2NetworkInterfacesByName(fi.ValueOf(e.VPC.ID), aws.ToString(lb.LoadBalancer.LoadBalancerName))
 				if err != nil {
 					return nil, fmt.Errorf("failed to find network interfaces matching %q: %w", aws.ToString(lb.LoadBalancer.LoadBalancerName), err)


### PR DESCRIPTION
Implements the hybrid mode from #18240. Workers in gossip clusters bootstrap via the cluster load balancer (or control-plane IPs) instead of via protokube. Control plane keeps gossip and dns-controller.

This gives operators a single `kops reconcile` path to remove protokube off worker nodes and with it the unmaintained `weaveworks/mesh` / `memberlistmesh` dependencies and the over-broad worker permissions they require.

Activates for gossip clusters with an API load balancer:
- AWS (NLB)
- GCE, Azure, OpenStack, Scaleway, DigitalOcean, Hetzner

/cc @justinsb @rifelpet @ameukam