### PR TITLE
gce: Include MIG scaling errors when instances are not found

### DIFF
--- a/pkg/resources/gce/dump.go
+++ b/pkg/resources/gce/dump.go
@@ -61,7 +61,14 @@ func DumpManagedInstance(op *resources.DumpOperation, r *resources.Resource) err
 
 	instanceDetails := instanceMap[u.Name]
 	if instanceDetails == nil {
-		klog.Warningf("instance %q not found", instance.Instance)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "instance %q not found (currentAction=%q instanceStatus=%q)", instance.Instance, instance.CurrentAction, instance.InstanceStatus)
+		if instance.LastAttempt != nil && instance.LastAttempt.Errors != nil {
+			for _, e := range instance.LastAttempt.Errors.Errors {
+				fmt.Fprintf(&sb, "; lastAttempt.error code=%q location=%q message=%q", e.Code, e.Location, e.Message)
+			}
+		}
+		klog.Warning(sb.String())
 		return nil
 	}
 


### PR DESCRIPTION
This only occurs when MIG can't create the instance. This log should reveal why that is happening.

Example job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kubenet-rhel10-k35/2048108168793296896

```
I0425 18:58:09.422864   14330 gce.go:97] Scanning zones: [us-west2-a us-west2-b us-west2-c]
W0425 18:58:14.258389   14330 dump.go:64] instance "https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-132/zones/us-west2-a/instances/nodes-us-west2-a-x6r9" not found
W0425 18:58:14.258419   14330 dump.go:64] instance "https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-132/zones/us-west2-a/instances/nodes-us-west2-a-wkjv" not found
W0425 18:58:14.258426   14330 dump.go:64] instance "https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-132/zones/us-west2-a/instances/control-plane-us-west2-a-3dg5" not found
W0425 18:58:14.258431   14330 dump.go:64] instance "https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-132/zones/us-west2-a/instances/nodes-us-west2-a-bvb5" not found
W0425 18:58:14.258434   14330 dump.go:64] instance "https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-132/zones/us-west2-a/instances/nodes-us-west2-a-jn5n" not found
W0425 18:58:44.263451   14330 toolbox_dump.go:188] error listing nodes in cluster: Get "https://34.102.113.37/api/v1/nodes": dial tcp 34.102.113.37:443: i/o timeout
I0425 18:58:44.263468   14330 toolbox_dump.go:204] will SSH using username "prow"
I0425 18:58:44.263472   14330 toolbox_dump.go:205] ssh auth methods [0x6877fe0]
I0425 18:58:44.263499   14330 dumper.go:157] starting to dump 0 control plane nodes fetched through the Kubernetes APIs
```