### PR TITLE
aws: bypass LBC mservice webhook for kube-system

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1428,6 +1428,12 @@ webhooks:
       path: /mutate-v1-service
   failurePolicy: Fail
   name: mservice.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -145,7 +145,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: b295d8da3d0e86937fd8a0a86c93db40bbeac296fb723849a65575b2adf9021f
+    manifestHash: c9cd61a845d4630bc607ec79ed6fc6a43b40f34af0aa5845df746edcd7be4ae8
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1428,6 +1428,12 @@ webhooks:
       path: /mutate-v1-service
   failurePolicy: Fail
   name: mservice.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -160,7 +160,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: e054822df9ed81a9df63f9e5a3f6dede0e026175dca15fcd59a82673148ba5b7
+    manifestHash: 4e9d8fde70fd87318509cad2921da995fa76da85209c441bf532dfe97cf86cf3
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1434,6 +1434,12 @@ webhooks:
       path: /mutate-v1-service
   failurePolicy: Fail
   name: mservice.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -160,7 +160,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 1c4899c133afc4e24dbc8f4fa4242f72b6fe7aabdcdfa9a04c809baa4bd1bbb4
+    manifestHash: 14060d604cddeae91ae5dc9205895eb47dc7ce6c05d107bbeccc64a72e8f4cf8
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1434,6 +1434,12 @@ webhooks:
       path: /mutate-v1-service
   failurePolicy: Fail
   name: mservice.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -209,7 +209,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 31590854ee9be19cb9e7f42acfc438c0d552d7bef013169ad9036b9ec9988b31
+    manifestHash: c4f450feacca2e5c31276123eac26a416592ca7cb505c9b348aa9392bfd4b15a
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
@@ -1383,6 +1383,12 @@ webhooks:
       path: /mutate-v1-service
   failurePolicy: Fail
   name: mservice.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name


### PR DESCRIPTION
The mservice MutatingWebhook has failurePolicy=Fail and no namespaceSelector, so any kube-system Service CREATE causes race condition failures during cluster creation until the LBC pod is Ready.
Exclude kube-system to match the v3.2.2 chart default (https://github.com/kubernetes/kops/pull/18221).

/cc @rifelpet 