### PR TITLE
aws: bypass LBC mservice webhook for kube-system

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1428,6 +1428,12 @@ webhooks:
       path: /mutate-v1-service
   failurePolicy: Fail
   name: mservice.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -147,7 +147,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 31b8c4c35d39dcf65bc87a36c73e5e960ff093d3c5265051350918e8ecdc0b35
+    manifestHash: 7ae4c7850d660897881de802402520f9cb03deadae8b933ed75b552626d6a6d3
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1428,6 +1428,12 @@ webhooks:
       path: /mutate-v1-service
   failurePolicy: Fail
   name: mservice.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -162,7 +162,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 5a2ea3288223bc10b52c2d85163b0d5a26096db4284e8d9cb2b4f36642b679b9
+    manifestHash: 6106b961ca8781e93bd60b858bfed4f2606f687fe311c49aab9db9e1cfc3dd58
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1434,6 +1434,12 @@ webhooks:
       path: /mutate-v1-service
   failurePolicy: Fail
   name: mservice.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -162,7 +162,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 4f2c23ad955a40439df2564479299a5cb78dcd7f68ee4096ee9122912acfcbea
+    manifestHash: 5305522da656f93e319efa2c2bb19ce85ec88264479a09ea4ada5753a2ceeb0c
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1434,6 +1434,12 @@ webhooks:
       path: /mutate-v1-service
   failurePolicy: Fail
   name: mservice.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -211,7 +211,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: aae9daba9c9ddadef1d7a1256698ab867b67f94441d5ff143ef88b0cc1106ead
+    manifestHash: 6d242b4ef9701832ac3592c399922ccbb765e5df64ba359fd5629ccb4f4ae89a
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
@@ -1383,6 +1383,12 @@ webhooks:
       path: /mutate-v1-service
   failurePolicy: Fail
   name: mservice.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name


### PR DESCRIPTION
The mservice MutatingWebhook has failurePolicy=Fail and no namespaceSelector, so any kube-system Service CREATE causes race condition failures during cluster creation until the LBC pod is Ready.
Exclude kube-system to match the v3.2.2 chart default (https://github.com/kubernetes/kops/pull/18221).

/cc @rifelpet 