### PR TITLE
aws: skip node S3 permissions when kops-controller serves node config

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -467,7 +467,7 @@ func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 
 	b.addNodeupPermissions(p, r.enableLifecycleHookPermissions)
 
-	if !b.Cluster.UsesNoneDNS() {
+	if !model.UseKopsControllerForNodeConfig(b.Cluster) {
 		if err := b.AddS3Permissions(p); err != nil {
 			return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
 		}

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::kops-tests"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::kops-tests"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_nodes.additionalobjects.example.com_policy
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_nodes.additionalobjects.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_nodes.cas-priority-expander-custom.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_nodes.cas-priority-expander-custom.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_nodes.cas-priority-expander.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_nodes.cas-priority-expander.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_nodes.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_nodes.containerd.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_nodes.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_nodes.containerd.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_nodes.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_nodes.123.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:CreateTags"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:CreateTags"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.many-addons.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:CreateTags"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_nodes.minimal-aws.example.com_policy
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_nodes.minimal-aws.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_nodes.minimal-etcd.example.com_policy
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_nodes.minimal-etcd.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_nodes.this.is.truly.a.really.really.really.really.really.-d86ibl_policy
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_nodes.this.is.truly.a.really.really.really.really.really.-d86ibl_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "autoscaling:DescribeLifecycleHooks",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_nodes.privatekindnet.example.com_policy
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_nodes.privatekindnet.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",


### PR DESCRIPTION
Nodes only needed S3 read access to fetch their nodeup config from the state store. When kops-controller is used for node config, nodes obtain it from kops-controller instead, so the S3 grants are unnecessary.

/cc @rifelpet @ameukam 