### PR TITLE
azure: drop unused UsesPrivateDNS clause from API LB

### DIFF
--- a/pkg/model/azuremodel/api_loadbalancer.go
+++ b/pkg/model/azuremodel/api_loadbalancer.go
@@ -104,7 +104,7 @@ func (b *APILoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) er
 		return fmt.Errorf("unknown load balancer Type: %q", lbSpec.Type)
 	}
 
-	if b.Cluster.UsesLegacyGossip() || b.Cluster.UsesPrivateDNS() || b.Cluster.UsesNoneDNS() {
+	if b.Cluster.UsesLegacyGossip() || b.Cluster.UsesNoneDNS() {
 		lb.WellKnownServices = append(lb.WellKnownServices, wellknownservices.KopsController)
 
 		// kops-controller probe: HTTPS on 3988 with /healthz


### PR DESCRIPTION
The Azure model has no DNSTypePrivate handling, so this branch never fires. Setting topology.dns=Private on Azure does not wire up a private DNS zone the way it does on AWS via Route53.

/cc @rifelpet @ameukam 