### PR TITLE
e2e: Pass prow job name to kops cloud labels

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -199,6 +199,9 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		// Ensure https://github.com/Azure/rg-cleanup deletes removes resources
 		tags = append(tags, "creationTimestamp="+time.Now().Format(time.RFC3339))
 	}
+	if label, ok := prowJobLabel(d.CloudProvider, os.Getenv("JOB_NAME")); ok {
+		tags = append(tags, label)
+	}
 	args = appendIfUnset(args, "--cloud-labels", strings.Join(tags, ","))
 
 	isArm := false
@@ -432,6 +435,45 @@ func (d *deployer) getZones() ([]string, error) {
 		return do.RandomZones(1)
 	}
 	return nil, fmt.Errorf("unsupported CloudProvider: %v", d.CloudProvider)
+}
+
+// prowJobLabel returns a "key=value" cloud-label fragment recording the prow
+// JOB_NAME, sanitized for the target cloud provider. Returns ok=false when
+// jobName is empty or the cloud provider does not surface kops cloudLabels.
+func prowJobLabel(cloudProvider, jobName string) (string, bool) {
+	if jobName == "" {
+		return "", false
+	}
+	switch cloudProvider {
+	case "aws":
+		// AWS tags allow '/' and '.' in keys, values up to 256 chars.
+		return "prow.k8s.io/job=" + jobName, true
+	case "azure":
+		// Azure tag names cannot contain '<>%&\?/'.
+		return "prow.k8s.io_job=" + jobName, true
+	case "gce":
+		// GCE labels: keys/values must be lowercase, <=63 chars,
+		// match [a-z0-9_-], and keys must start with a letter.
+		return "prow_k8s_io_job=" + sanitizeGCELabelValue(jobName), true
+	default:
+		// digitalocean: kops does not pass cloudLabels to DO resources, and DO
+		// tags are flat single words rather than key=value pairs.
+		return "", false
+	}
+}
+
+func sanitizeGCELabelValue(v string) string {
+	v = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		}
+		return '-'
+	}, strings.ToLower(v))
+	if len(v) > 63 {
+		v = v[:63]
+	}
+	return v
 }
 
 // appendIfUnset will append an argument and its value to args if the arg is not already present

--- a/tests/e2e/kubetest2-kops/deployer/up_test.go
+++ b/tests/e2e/kubetest2-kops/deployer/up_test.go
@@ -82,3 +82,73 @@ func TestAppendIfUnset(t *testing.T) {
 		})
 	}
 }
+
+func TestProwJobLabel(t *testing.T) {
+	cases := []struct {
+		name          string
+		cloudProvider string
+		jobName       string
+		expected      string
+		expectedOK    bool
+	}{
+		{
+			name:          "empty job name omits label",
+			cloudProvider: "aws",
+			jobName:       "",
+			expectedOK:    false,
+		},
+		{
+			name:          "aws preserves slash and dots",
+			cloudProvider: "aws",
+			jobName:       "pull-kops-e2e-k8s-aws",
+			expected:      "prow.k8s.io/job=pull-kops-e2e-k8s-aws",
+			expectedOK:    true,
+		},
+		{
+			name:          "azure replaces slash with underscore",
+			cloudProvider: "azure",
+			jobName:       "pull-kops-e2e-k8s-azure",
+			expected:      "prow.k8s.io_job=pull-kops-e2e-k8s-azure",
+			expectedOK:    true,
+		},
+		{
+			name:          "gce normalizes key and value",
+			cloudProvider: "gce",
+			jobName:       "Pull-Kops-E2E-K8s-GCE",
+			expected:      "prow_k8s_io_job=pull-kops-e2e-k8s-gce",
+			expectedOK:    true,
+		},
+		{
+			name:          "gce truncates value to 63 chars",
+			cloudProvider: "gce",
+			jobName:       "pull-kops-e2e-kubernetes-aws-canary-very-long-suffix-that-exceeds-the-gce-label-limit",
+			expected:      "prow_k8s_io_job=" + "pull-kops-e2e-kubernetes-aws-canary-very-long-suffix-that-excee",
+			expectedOK:    true,
+		},
+		{
+			name:          "gce replaces invalid chars with dash",
+			cloudProvider: "gce",
+			jobName:       "job.name/with:invalid",
+			expected:      "prow_k8s_io_job=job-name-with-invalid",
+			expectedOK:    true,
+		},
+		{
+			name:          "digitalocean omits label",
+			cloudProvider: "digitalocean",
+			jobName:       "pull-kops-e2e-k8s-do",
+			expectedOK:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, ok := prowJobLabel(tc.cloudProvider, tc.jobName)
+			if ok != tc.expectedOK {
+				t.Errorf("ok mismatch: got %v, want %v", ok, tc.expectedOK)
+			}
+			if actual != tc.expected {
+				t.Errorf("label mismatch: got %q, want %q", actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This provides cost allocation for kops clusters created in prow jobs.

Written with assistance from Opus 4.7.