### PR TITLE
Fix support for VPC CNI + Debian 11

### DIFF
--- a/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
+++ b/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
@@ -39,6 +39,7 @@ func (b *AmazonVPCRoutedENIBuilder) Build(c *fi.NodeupModelBuilderContext) error
 	setMACAddressPolicyNone(c, b.Distribution)
 	markSecondaryENIsUnmanaged(c, b.Distribution)
 	disableCloudInitNetworkHotplug(c, b.Distribution)
+	narrowCloudIfupdownHelperRule(c, b.Distribution)
 
 	return nil
 }

--- a/nodeup/pkg/model/networking/eni_networking.go
+++ b/nodeup/pkg/model/networking/eni_networking.go
@@ -144,6 +144,38 @@ Unmanaged=yes
 	})
 }
 
+// narrowCloudIfupdownHelperRule rewrites Debian 11's
+// /etc/udev/rules.d/75-cloud-ifupdown.rules to exclude AWS VPC CNI veths.
+// The package-shipped rule matches ENV{INTERFACE}=="eth*|en*", which catches
+// real ENIs (ens*) and CNI veths (eni*) alike. For each new netdev,
+// /etc/network/cloud-ifupdown-helper generates a DHCP ifupdown stanza and
+// starts ifup@$IFACE.service. On CNI veths DHCP times out, ifdown then takes
+// the veth DOWN, and pod networking is broken.
+//
+// The rule and helper are written by cloud-init at first boot and are not
+// owned by any dpkg package, so overwriting the file is safe.
+//
+// Debian 11 only.
+func narrowCloudIfupdownHelperRule(c *fi.NodeupModelBuilderContext, dist distributions.Distribution) {
+	if dist != distributions.DistributionDebian11 {
+		return
+	}
+
+	contents := `# Handle allow-hotplug interfaces.
+# kops: ENV{INTERFACE} narrowed from "eth*|en*" to "eth*|ens*" so AWS VPC CNI
+# veths (eni*) are not hijacked by cloud-ifupdown-helper.
+SUBSYSTEM=="net", ACTION=="add", ENV{INTERFACE}=="eth*|ens*", RUN+="/etc/network/cloud-ifupdown-helper"
+`
+	c.AddTask(&nodetasks.File{
+		Path:     "/etc/udev/rules.d/75-cloud-ifupdown.rules",
+		Contents: fi.NewStringResource(contents),
+		Type:     nodetasks.FileType_File,
+		OnChangeExecute: [][]string{
+			{"udevadm", "control", "--reload-rules"},
+		},
+	})
+}
+
 // disableCloudInitNetworkHotplug prevents cloud-init from reconfiguring the network
 // when ENIs are attached, which breaks CNI networking.
 // Ubuntu 24.04+ and Debian 12+.

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -154,6 +154,9 @@ func (t *Tester) setSkipRegexFlag() error {
 			// https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#implementations-supplementalgroupspolicy
 			// https://github.com/kubernetes/test-infra/blob/0fa3c1f53ee2b715469380f9e50200d6b7612dff/config/jobs/kubernetes/kops/helpers.py#L107-L109
 			skipMap["SupplementalGroupsPolicy"] = nil
+			// ImageVolume requires containerd v2.1
+			// ref: https://github.com/containerd/containerd/releases/tag/v2.1.0
+			skipMap["ImageVolume"] = nil
 		}
 		if matchesAnySubstrings(ig.Spec.Image, []string{
 			"rocky-9", "rocky-10", "rhel-9", "rhel-10", // aws


### PR DESCRIPTION
We dont have a presubmit job for VPC CNI + Debian 11 so we can't test this pre-merge

The periodics will also need https://github.com/kubernetes/test-infra/pull/36935 to pass.

[This e2e job](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/18261/pull-kops-aws-distro-debian11/2050559170322632704) includes this fix plus temporary overrides to use vpc cni + debian 11 + the instance types we force for ENI CNIs. The only failure is now being skipped in this PR.

Written with assistance from Opus 4.7