### PR TITLE
build: strip release binaries by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,23 +81,18 @@ DISCOVERY_SERVER_TAG=$(IMAGE_TAG)
 
 CGO_ENABLED=0
 export CGO_ENABLED
-BUILDFLAGS="-trimpath"
+BUILDFLAGS=-trimpath -buildvcs=false
 
 
 # Go exports:
 LDFLAGS := -ldflags=all=
-
-ifdef STATIC_BUILD
-  CGO_ENABLED=0
-  export CGO_ENABLED
-  EXTRA_BUILDFLAGS=-installsuffix cgo
-  EXTRA_LDFLAGS=-s -w
-endif
+EXTRA_LDFLAGS?=-s -w
 
 
 # Set compiler flags to allow binary debugging
 ifdef DEBUGGABLE
   GCFLAGS=-gcflags "all=-N -l"
+  EXTRA_LDFLAGS=
 endif
 
 .PHONY: kops-install # Install kops to local $GOPATH/bin
@@ -300,7 +295,7 @@ push-aws-run-amd64 push-aws-run-arm64: push-aws-run-%: push-%
 
 .PHONY: ${NODEUP}
 ${NODEUP}:
-	go build ${GCFLAGS} ${EXTRA_BUILDFLAGS} ${LDFLAGS}"${EXTRA_LDFLAGS} -X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA}" -o $@ k8s.io/kops/cmd/nodeup
+	go build ${GCFLAGS} ${BUILDFLAGS} ${EXTRA_BUILDFLAGS} ${LDFLAGS}"${EXTRA_LDFLAGS} -X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA}" -o $@ k8s.io/kops/cmd/nodeup
 
 .PHONY: dns-controller-push
 dns-controller-push: ko-dns-controller-push


### PR DESCRIPTION
Binary | Arch | Before | After | Saved | Reduction
-- | -- | -- | -- | -- | --
kops | amd64 | 261.9 MiB | 196.0 MiB | 65.9 MiB | 25.2%
kops | arm64 | 239.8 MiB | 175.3 MiB | 64.5 MiB | 26.9%
nodeup | amd64 | 215.5 MiB | 162.2 MiB | 53.3 MiB | 24.7%
nodeup | arm64 | 195.9 MiB | 143.8 MiB | 52.1 MiB | 26.6%
protokube | amd64 | 182.1 MiB | 135.6 MiB | 46.5 MiB | 25.5%
protokube | arm64 | 166.9 MiB | 121.4 MiB | 45.5 MiB | 27.3%
channels | amd64 | 94.2 MiB | 67.0 MiB | 27.3 MiB | 28.9%
channels | arm64 | 88.4 MiB | 62.1 MiB | 26.3 MiB | 29.8%

> -buildvcs
	Whether to stamp binaries with version control information
	("true", "false", or "auto"). By default ("auto"), version control
	information is stamped into a binary if the main package, the main module
	containing it, and the current directory are all in the same repository.
	Use -buildvcs=false to always omit version control information, or
	-buildvcs=true to error out if version control information is available but
	cannot be included due to a missing tool or ambiguous directory structure.

/cc @rifelpet @ameukam 