### PR TITLE
Automated cherry pick of #18268: Cherrypick VPC CNI fixes

### DIFF
--- a/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
+++ b/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
@@ -19,8 +19,6 @@ package networking
 import (
 	"k8s.io/kops/nodeup/pkg/model"
 	"k8s.io/kops/upup/pkg/fi"
-	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
-	"k8s.io/kops/util/pkg/distributions"
 )
 
 // AmazonVPCRoutedENIBuilder writes the Amazon VPC CNI configuration
@@ -36,99 +34,11 @@ func (b *AmazonVPCRoutedENIBuilder) Build(c *fi.NodeupModelBuilderContext) error
 		return nil
 	}
 
-	if b.Distribution == distributions.DistributionAmazonLinux2023 {
-		// Mask udev triggers installed by amazon-ec2-net-utils package
-		// Create an empty file 99-vpc-policy-routes.rules
-		c.AddTask(&nodetasks.File{
-			Path:     "/etc/udev/rules.d/99-vpc-policy-routes.rules",
-			Contents: fi.NewStringResource(""),
-			Type:     nodetasks.FileType_File,
-			OnChangeExecute: [][]string{
-				{"udevadm", "control", "--reload-rules"},
-				{"udevadm", "trigger"},
-			},
-		})
-	}
-
-	if (b.Distribution.IsUbuntu() && b.Distribution.Version() >= 22.04) ||
-		b.Distribution == distributions.DistributionAmazonLinux2023 {
-		// Make systemd-networkd ignore foreign settings, else it may
-		// unexpectedly delete IP rules and routes added by CNI
-		contents := `
-# Do not clobber any routes or rules added by CNI.
-[Network]
-ManageForeignRoutes=no
-ManageForeignRoutingPolicyRules=no
-`
-		c.AddTask(&nodetasks.File{
-			Path:            "/usr/lib/systemd/networkd.conf.d/80-release.conf",
-			Contents:        fi.NewStringResource(contents),
-			Type:            nodetasks.FileType_File,
-			OnChangeExecute: [][]string{{"systemctl", "restart", "systemd-networkd"}},
-		})
-	}
-
-	// Running Amazon VPC CNI on Ubuntu 22.04+ and AL2023 requires
-	// setting MACAddressPolicy to `none` (ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/2103
-	// & https://github.com/aws/amazon-vpc-cni-k8s/issues/2839
-	// & https://github.com/kubernetes/kops/issues/16255)
-	if b.Distribution.IsUbuntu() && b.Distribution.Version() >= 22.04 || b.Distribution == distributions.DistributionAmazonLinux2023 {
-		contents := `
-[Match]
-OriginalName=*
-[Link]
-NamePolicy=keep kernel database onboard slot path
-AlternativeNamesPolicy=database onboard slot path
-MACAddressPolicy=none
-`
-
-		// Copy all the relevant entries and replace the one that contains MACAddressPolicy= with MACAddressPolicy=none
-		c.AddTask(&nodetasks.File{
-			Path:            "/etc/systemd/network/99-default.link",
-			Contents:        fi.NewStringResource(contents),
-			Type:            nodetasks.FileType_File,
-			OnChangeExecute: [][]string{{"systemctl", "restart", "systemd-networkd"}},
-		})
-
-	}
-
-	// Running Amazon VPC CNI on al2023 requires setting Unmanaged to `yes`
-	// ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/3524
-	if b.Distribution == distributions.DistributionAmazonLinux2023 {
-		contents := `
-[Match]
-Name=ens[6-9]* ens[1-9][0-9]*
-
-[Link]
-Unmanaged=yes
-`
-
-		c.AddTask(&nodetasks.File{
-			Path:            "/etc/systemd/network/10-vpc-cni-secondary.network",
-			Contents:        fi.NewStringResource(contents),
-			Type:            nodetasks.FileType_File,
-			OnChangeExecute: [][]string{{"systemctl", "restart", "systemd-networkd"}},
-		})
-
-	}
-
-	// On Ubuntu 24.04+, cloud-init network hotplug is enabled by default
-	// (https://github.com/canonical/cloud-init/pull/4799). This causes cloud-init to reconfigure netplan
-	// when Amazon VPC CNI attaches ENIs, breaking network functionality.
-	// See: https://github.com/kubernetes/kops/issues/17881
-	if b.Distribution.IsUbuntu() && b.Distribution.Version() >= 24.04 {
-		contents := `# Disable cloud-init network hotplug to prevent interference with Amazon VPC CNI ENI management.
-# See: https://github.com/kubernetes/kops/issues/17881
-updates:
-  network:
-    when: [boot-new-instance]
-`
-		c.AddTask(&nodetasks.File{
-			Path:     "/etc/cloud/cloud.cfg.d/99-disable-network-hotplug.cfg",
-			Contents: fi.NewStringResource(contents),
-			Type:     nodetasks.FileType_File,
-		})
-	}
+	maskEC2NetUtilsUdevRules(c, b.Distribution)
+	disableManageForeignRoutes(c, b.Distribution)
+	setMACAddressPolicyNone(c, b.Distribution)
+	markSecondaryENIsUnmanaged(c, b.Distribution)
+	disableCloudInitNetworkHotplug(c, b.Distribution)
 
 	return nil
 }

--- a/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
+++ b/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
@@ -40,6 +40,7 @@ func (b *AmazonVPCRoutedENIBuilder) Build(c *fi.NodeupModelBuilderContext) error
 	markSecondaryENIsUnmanaged(c, b.Distribution)
 	disableCloudInitNetworkHotplug(c, b.Distribution)
 	narrowCloudIfupdownHelperRule(c, b.Distribution)
+	disableNMCloudSetup(c, b.Distribution)
 
 	return nil
 }

--- a/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
+++ b/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
@@ -39,6 +39,7 @@ func (b *AmazonVPCRoutedENIBuilder) Build(c *fi.NodeupModelBuilderContext) error
 	setMACAddressPolicyNone(c, b.Distribution)
 	markSecondaryENIsUnmanaged(c, b.Distribution)
 	disableCloudInitNetworkHotplug(c, b.Distribution)
+	narrowCloudIfupdownHelperRule(c, b.Distribution)
 
 	return nil
 }

--- a/nodeup/pkg/model/networking/eni_networking.go
+++ b/nodeup/pkg/model/networking/eni_networking.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
+	"k8s.io/kops/util/pkg/distributions"
+)
+
+// maskEC2NetUtilsUdevRules creates an empty /etc/udev/rules.d/99-vpc-policy-routes.rules
+// to shadow the system udev rules, preventing policy-routes@ services from running.
+// The policy-routes@ service adds secondary IPs (including CNI-allocated pod IPs) as
+// /32 addresses on the host interface, populating the kernel's local routing table
+// and breaking pod networking.
+//
+// Masking the udev rules alone is not sufficient: by the time nodeup runs,
+// policy-routes@ens5.service is already active (started at boot for the primary ENI)
+// and its refresh-policy-routes@ timer re-creates ec2net_alias.conf drop-ins every
+// ~60 seconds with fresh secondary IPs from IMDS. We must also stop the running
+// services, disable the timers, remove the drop-in files that add pod IPs as /32
+// addresses, and restart systemd-networkd to flush the stale address assignments.
+//
+// AL2023 only.
+func maskEC2NetUtilsUdevRules(c *fi.NodeupModelBuilderContext, dist distributions.Distribution) {
+	if dist != distributions.DistributionAmazonLinux2023 {
+		return
+	}
+
+	c.AddTask(&nodetasks.File{
+		Path:     "/etc/udev/rules.d/99-vpc-policy-routes.rules",
+		Contents: fi.NewStringResource(""),
+		Type:     nodetasks.FileType_File,
+		OnChangeExecute: [][]string{
+			// Reload udev rules so the empty mask file takes effect for future ENI attach events.
+			{"udevadm", "control", "--reload-rules"},
+			{"udevadm", "trigger"},
+			// Stop already-running policy-routes services and their refresh timers.
+			// These were started at boot (before nodeup) by the system udev rules for
+			// the primary ENI and would otherwise continue adding pod IPs to interfaces.
+			{"bash", "-c", "systemctl stop 'policy-routes@*.service' 'refresh-policy-routes@*.service' 'refresh-policy-routes@*.timer' 2>/dev/null; true"},
+			{"bash", "-c", "systemctl disable 'policy-routes@*.service' 'refresh-policy-routes@*.timer' 2>/dev/null; true"},
+			// Remove ec2net_alias.conf drop-ins that added secondary IPs (pod IPs) as
+			// /32 addresses on host interfaces, which populated the kernel's local routing
+			// table and caused local delivery instead of forwarding through lxc veths.
+			{"bash", "-c", "rm -f /run/systemd/network/*/ec2net_alias.conf"},
+			// Restart systemd-networkd to flush the /32 address assignments and local
+			// routing table entries that were applied from the now-removed drop-ins.
+			{"systemctl", "restart", "systemd-networkd"},
+		},
+	})
+}
+
+// disableManageForeignRoutes configures systemd-networkd to not remove foreign routes/rules
+// added by CNI. Without this, systemd-networkd may unexpectedly delete IP rules and routes.
+// AL2023 and Ubuntu 22.04+.
+func disableManageForeignRoutes(c *fi.NodeupModelBuilderContext, dist distributions.Distribution) {
+	if !((dist.IsUbuntu() && dist.Version() >= 22.04) ||
+		dist == distributions.DistributionAmazonLinux2023) {
+		return
+	}
+
+	contents := `
+# Do not clobber any routes or rules added by CNI.
+[Network]
+ManageForeignRoutes=no
+ManageForeignRoutingPolicyRules=no
+`
+	c.AddTask(&nodetasks.File{
+		Path:            "/usr/lib/systemd/networkd.conf.d/40-disable-manage-foreign-routes.conf",
+		Contents:        fi.NewStringResource(contents),
+		Type:            nodetasks.FileType_File,
+		OnChangeExecute: [][]string{{"systemctl", "restart", "systemd-networkd"}},
+	})
+}
+
+// setMACAddressPolicyNone prevents systemd-networkd from assigning predictable MAC-based
+// names to ENIs, which can interfere with CNI interface management.
+// AL2023 and Ubuntu 22.04+.
+// ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/2103
+// ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/2839
+// ref: https://github.com/kubernetes/kops/issues/16255
+func setMACAddressPolicyNone(c *fi.NodeupModelBuilderContext, dist distributions.Distribution) {
+	if !((dist.IsUbuntu() && dist.Version() >= 22.04) ||
+		dist == distributions.DistributionAmazonLinux2023) {
+		return
+	}
+
+	contents := `
+[Match]
+OriginalName=*
+[Link]
+NamePolicy=keep kernel database onboard slot path
+AlternativeNamesPolicy=database onboard slot path
+MACAddressPolicy=none
+`
+	c.AddTask(&nodetasks.File{
+		Path:            "/etc/systemd/network/99-default.link",
+		Contents:        fi.NewStringResource(contents),
+		Type:            nodetasks.FileType_File,
+		OnChangeExecute: [][]string{{"systemctl", "restart", "systemd-networkd"}},
+	})
+}
+
+// markSecondaryENIsUnmanaged tells systemd-networkd to ignore secondary ENIs (ens6+).
+// Without this, systemd-networkd fully manages secondary ENIs via DHCP, creating
+// competing routes that interfere with CNI networking.
+// AL2023 only.
+// ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/3524
+func markSecondaryENIsUnmanaged(c *fi.NodeupModelBuilderContext, dist distributions.Distribution) {
+	if dist != distributions.DistributionAmazonLinux2023 {
+		return
+	}
+
+	contents := `
+[Match]
+Name=ens[6-9]* ens[1-9][0-9]*
+
+[Link]
+Unmanaged=yes
+`
+	c.AddTask(&nodetasks.File{
+		Path:            "/etc/systemd/network/10-eni-secondary.network",
+		Contents:        fi.NewStringResource(contents),
+		Type:            nodetasks.FileType_File,
+		OnChangeExecute: [][]string{{"systemctl", "restart", "systemd-networkd"}},
+	})
+}
+
+// disableCloudInitNetworkHotplug prevents cloud-init from reconfiguring the network
+// when ENIs are attached, which breaks CNI networking.
+// Ubuntu 24.04+.
+// ref: https://github.com/kubernetes/kops/issues/17881
+func disableCloudInitNetworkHotplug(c *fi.NodeupModelBuilderContext, dist distributions.Distribution) {
+	if !(dist.IsUbuntu() && dist.Version() >= 24.04) {
+		return
+	}
+
+	contents := `# Disable cloud-init network hotplug to prevent interference with CNI ENI management.
+# See: https://github.com/kubernetes/kops/issues/17881
+updates:
+  network:
+    when: [boot-new-instance]
+`
+	c.AddTask(&nodetasks.File{
+		Path:     "/etc/cloud/cloud.cfg.d/99-disable-network-hotplug.cfg",
+		Contents: fi.NewStringResource(contents),
+		Type:     nodetasks.FileType_File,
+	})
+}

--- a/nodeup/pkg/model/networking/eni_networking.go
+++ b/nodeup/pkg/model/networking/eni_networking.go
@@ -194,3 +194,38 @@ updates:
 		Type:     nodetasks.FileType_File,
 	})
 }
+
+// disableNMCloudSetup masks NetworkManager's nm-cloud-setup service and timer.
+// nm-cloud-setup polls IMDS, sees the secondary IPs assigned to ENIs (the pod
+// IPs), and tells NetworkManager to install per-IP source-routing rules in
+// reserved tables 30200/30201/30400/30401 with priority 30200-30401. Those
+// priorities are lower (= higher precedence) than the AWS VPC CNI rules at
+// 32765, so pod traffic is routed through tables that don't have the routes
+// the CNI needs for the service CIDR or IMDS — pods can't reach 100.64.0.1
+// or 169.254.169.254 and cluster validation fails.
+// ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/troubleshooting.md
+// RHEL 9 only.
+func disableNMCloudSetup(c *fi.NodeupModelBuilderContext, dist distributions.Distribution) {
+	if dist != distributions.DistributionRhel9 {
+		return
+	}
+
+	// Use a marker file so we run the disable steps once and idempotently. The
+	// File task triggers OnChangeExecute the first time we land it.
+	c.AddTask(&nodetasks.File{
+		Path:     "/etc/kops/nm-cloud-setup-disabled",
+		Contents: fi.NewStringResource("# Marker: nm-cloud-setup disabled by kops to avoid breaking AWS VPC CNI pod routing.\n"),
+		Type:     nodetasks.FileType_File,
+		OnChangeExecute: [][]string{
+			// Stop and disable the unit + timer so they can't run again.
+			{"bash", "-c", "systemctl disable --now nm-cloud-setup.service nm-cloud-setup.timer 2>/dev/null; true"},
+			// Mask so future package updates / preset re-enables can't bring them back.
+			{"systemctl", "mask", "nm-cloud-setup.service", "nm-cloud-setup.timer"},
+			// Drop any rules/routes nm-cloud-setup already installed before we
+			// got here. NetworkManager owns these via "device-reapply" with
+			// proto=static; tearing the connections down and back up clears the
+			// per-IP rules in tables 30200/30201/30400/30401.
+			{"bash", "-c", "for c in $(nmcli -t -f NAME connection show --active 2>/dev/null); do nmcli connection down \"$c\" 2>/dev/null; nmcli connection up \"$c\" 2>/dev/null; done; true"},
+		},
+	})
+}

--- a/nodeup/pkg/model/networking/eni_networking.go
+++ b/nodeup/pkg/model/networking/eni_networking.go
@@ -141,6 +141,38 @@ Unmanaged=yes
 	})
 }
 
+// narrowCloudIfupdownHelperRule rewrites Debian 11's
+// /etc/udev/rules.d/75-cloud-ifupdown.rules to exclude AWS VPC CNI veths.
+// The package-shipped rule matches ENV{INTERFACE}=="eth*|en*", which catches
+// real ENIs (ens*) and CNI veths (eni*) alike. For each new netdev,
+// /etc/network/cloud-ifupdown-helper generates a DHCP ifupdown stanza and
+// starts ifup@$IFACE.service. On CNI veths DHCP times out, ifdown then takes
+// the veth DOWN, and pod networking is broken.
+//
+// The rule and helper are written by cloud-init at first boot and are not
+// owned by any dpkg package, so overwriting the file is safe.
+//
+// Debian 11 only.
+func narrowCloudIfupdownHelperRule(c *fi.NodeupModelBuilderContext, dist distributions.Distribution) {
+	if dist != distributions.DistributionDebian11 {
+		return
+	}
+
+	contents := `# Handle allow-hotplug interfaces.
+# kops: ENV{INTERFACE} narrowed from "eth*|en*" to "eth*|ens*" so AWS VPC CNI
+# veths (eni*) are not hijacked by cloud-ifupdown-helper.
+SUBSYSTEM=="net", ACTION=="add", ENV{INTERFACE}=="eth*|ens*", RUN+="/etc/network/cloud-ifupdown-helper"
+`
+	c.AddTask(&nodetasks.File{
+		Path:     "/etc/udev/rules.d/75-cloud-ifupdown.rules",
+		Contents: fi.NewStringResource(contents),
+		Type:     nodetasks.FileType_File,
+		OnChangeExecute: [][]string{
+			{"udevadm", "control", "--reload-rules"},
+		},
+	})
+}
+
 // disableCloudInitNetworkHotplug prevents cloud-init from reconfiguring the network
 // when ENIs are attached, which breaks CNI networking.
 // Ubuntu 24.04+.

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -18,6 +18,7 @@ package tester
 
 import (
 	"regexp"
+	"strings"
 
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/apis/kops/v1alpha2"
@@ -182,6 +183,40 @@ func (t *Tester) setSkipRegexFlag() error {
 			skipRegex += "|SSH.should.SSH.to.all.nodes.and.run.commands"
 			break
 		}
+	}
+
+	igs, err := t.getKopsInstanceGroups()
+	if err != nil {
+		return err
+	}
+
+	skipMap := make(map[string]any)
+	for _, ig := range igs {
+		if ig.Spec.Role != "Node" {
+			continue
+		}
+		if strings.Contains(ig.Spec.Image, "debian-11") {
+			// SupplementalGroupsPolicy requires containerd v2 but we're pinning these distros to container v1.7:
+			// https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#implementations-supplementalgroupspolicy
+			// https://github.com/kubernetes/test-infra/blob/0fa3c1f53ee2b715469380f9e50200d6b7612dff/config/jobs/kubernetes/kops/helpers.py#L107-L109
+			// amazonlinux2 isn't included here because we pin it to K8s 1.34 which doesn't include these tests:
+			// https://github.com/kubernetes/test-infra/blob/0fa3c1f53ee2b715469380f9e50200d6b7612dff/config/jobs/kubernetes/kops/build_jobs.py#L1355-L1357
+			skipMap["SupplementalGroupsPolicy"] = nil
+			// ImageVolume requires containerd v2.1
+			// ref: https://github.com/containerd/containerd/releases/tag/v2.1.0
+			skipMap["ImageVolume"] = nil
+		}
+		if matchesAnySubstrings(ig.Spec.Image, []string{
+			"rocky-9", "rocky-10", "rhel-9", "rhel-10", // aws
+			"rocky-linux-10", // gce
+		}) {
+			// This metric requires the nfacct sub-system, not present in these distros
+			// https://github.com/cri-o/cri-o/issues/8270
+			skipMap["KubeProxy.should.update.metric.for.tracking.accepted.packets.destined.for.localhost.nodeports"] = nil
+		}
+	}
+	for k := range skipMap {
+		skipRegex += "|" + k
 	}
 
 	// Ensure it is valid regex

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -226,3 +226,13 @@ func (t *Tester) setSkipRegexFlag() error {
 	t.SkipRegex = skipRegex
 	return nil
 }
+
+func matchesAnySubstrings(s string, substrings []string) bool {
+	s = strings.ToLower(s)
+	for _, substr := range substrings {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Cherry pick of #18268 on release-1.34.

#18268: Cherrypick VPC CNI fixes to 1.35

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```