### PR TITLE
nodeup: stream verified image bytes into ctr import

### DIFF
--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -23,12 +23,14 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/util/pkg/hashing"
 )
+
+const downloadTimeout = 3 * time.Minute
 
 // DownloadURL will download the file at the given url and store it as dest.
 // If hash is non-nil, it will also verify that it matches the hash of the downloaded file.
@@ -43,47 +45,103 @@ func DownloadURL(url string, dest string, hash *hashing.Hash) (*hashing.Hash, er
 		}
 	}
 
-	dirMode := os.FileMode(0o755)
-	err := downloadURLAlways(url, dest, dirMode)
+	return downloadURLToFile(url, dest, hash)
+}
+
+func downloadURLToFile(url string, destPath string, hash *hashing.Hash) (*hashing.Hash, error) {
+	dir := filepath.Dir(destPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("error creating directories for destination file %q: %v", destPath, err)
+	}
+
+	output, err := os.CreateTemp(dir, "."+filepath.Base(destPath)+".tmp")
+	if err != nil {
+		return nil, fmt.Errorf("error creating temporary file for download %q: %v", destPath, err)
+	}
+	tempPath := output.Name()
+	defer os.Remove(tempPath)
+
+	actual, err := downloadURLToWriter(url, output, hash)
+	if closeErr := output.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
 	if err != nil {
 		return nil, err
 	}
-
-	if hash != nil {
-		match, err := fileHasHash(dest, hash)
-		if err != nil {
-			return nil, err
-		}
-		if !match {
-			return nil, fmt.Errorf("downloaded from %q but hash did not match expected %q", url, hash)
-		}
-	} else {
-		hash, err = hashing.HashAlgorithmSHA256.HashFile(dest)
-		if err != nil {
-			return nil, err
-		}
+	if err := os.Chmod(tempPath, 0o644); err != nil {
+		return nil, fmt.Errorf("error setting mode on downloaded file %q: %v", tempPath, err)
 	}
-
-	return hash, nil
+	if err := os.Rename(tempPath, destPath); err != nil {
+		return nil, fmt.Errorf("error moving downloaded file %q to %q: %v", tempPath, destPath, err)
+	}
+	return actual, nil
 }
 
-func downloadURLAlways(url string, destPath string, dirMode os.FileMode) error {
-	err := os.MkdirAll(path.Dir(destPath), dirMode)
+// downloadURLToWriter streams the file at the given url to dest.
+// If hash is non-nil, it will also verify that it matches the downloaded bytes.
+func downloadURLToWriter(url string, dest io.Writer, hash *hashing.Hash) (*hashing.Hash, error) {
+	responseBody, err := OpenURL(url)
 	if err != nil {
-		return fmt.Errorf("error creating directories for destination file %q: %v", destPath, err)
+		return nil, err
 	}
+	defer responseBody.Close()
 
-	output, err := os.Create(destPath)
-	if err != nil {
-		return fmt.Errorf("error creating file for download %q: %v", destPath, err)
-	}
-	defer output.Close()
-
+	start := time.Now()
+	defer func() {
+		klog.V(2).Infof("Downloading %q took %q", url, time.Since(start))
+	}()
 	klog.V(2).Infof("Downloading %q", url)
 
-	// Create a client with custom timeouts
-	// to avoid idle downloads to hang the program
-	httpClient := &http.Client{
+	algorithm := hashing.HashAlgorithmSHA256
+	if hash != nil {
+		algorithm = hash.Algorithm
+	}
+	hasher := algorithm.NewHasher()
+	writer := io.MultiWriter(dest, hasher)
+
+	if _, err := io.Copy(writer, responseBody); err != nil {
+		return nil, fmt.Errorf("error downloading HTTP content from %q: %v", url, err)
+	}
+
+	actual := &hashing.Hash{
+		Algorithm: algorithm,
+		HashValue: hasher.Sum(nil),
+	}
+	if hash != nil && !actual.Equal(hash) {
+		return nil, fmt.Errorf("downloaded from %q but hash did not match expected %q", url, hash)
+	}
+	return actual, nil
+}
+
+// OpenURL opens a hardened HTTP GET stream for url.
+func OpenURL(url string) (io.ReadCloser, error) {
+	httpClient := newDownloadHTTPClient()
+
+	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("cannot create request: %v", err)
+	}
+
+	response, err := httpClient.Do(req)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("error doing HTTP fetch of %q: %v", url, err)
+	}
+
+	// http.Client follows 3xx automatically, so anything outside 2xx that reaches us is a bug or a missing Location.
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		response.Body.Close()
+		cancel()
+		return nil, fmt.Errorf("unexpected response from %q: HTTP %s", url, response.Status)
+	}
+
+	return &cancelOnCloseReadCloser{ReadCloser: response.Body, cancel: cancel}, nil
+}
+
+func newDownloadHTTPClient() *http.Client {
+	return &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
@@ -95,35 +153,15 @@ func downloadURLAlways(url string, destPath string, dirMode os.FileMode) error {
 			IdleConnTimeout:       30 * time.Second,
 		},
 	}
+}
 
-	// this will stop slow downloads after 3 minutes
-	// and interrupt reading of the Response.Body
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-	defer cancel()
+type cancelOnCloseReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return fmt.Errorf("Cannot create request: %v", err)
-	}
-
-	response, err := httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("error doing HTTP fetch of %q: %v", url, err)
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode >= 400 {
-		return fmt.Errorf("error response from %q: HTTP %v", url, response.StatusCode)
-	}
-
-	start := time.Now()
-	defer func() {
-		klog.V(2).Infof("Copying %q to %q took %q", url, destPath, time.Since(start))
-	}()
-
-	_, err = io.Copy(output, response.Body)
-	if err != nil {
-		return fmt.Errorf("error downloading HTTP content from %q: %v", url, err)
-	}
-	return nil
+func (r *cancelOnCloseReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.cancel()
+	return err
 }

--- a/upup/pkg/fi/http_test.go
+++ b/upup/pkg/fi/http_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fi
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/kops/util/pkg/hashing"
+)
+
+func TestDownloadURLRejectsNon2xxAndPreservesDestination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusFound)
+		_, _ = w.Write([]byte("redirect body"))
+	}))
+	defer server.Close()
+
+	dest := filepath.Join(t.TempDir(), "download")
+	if err := os.WriteFile(dest, []byte("original"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if _, err := DownloadURL(server.URL, dest, nil); err == nil {
+		t.Fatalf("DownloadURL() expected error")
+	}
+
+	actual, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(actual) != "original" {
+		t.Fatalf("download destination = %q, expected original contents", actual)
+	}
+}
+
+func TestDownloadURLToWriterVerifiesHash(t *testing.T) {
+	body := []byte("payload")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	expectedHash, err := hashing.HashAlgorithmSHA256.Hash(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("Hash() error = %v", err)
+	}
+
+	var output bytes.Buffer
+	actualHash, err := downloadURLToWriter(server.URL, &output, expectedHash)
+	if err != nil {
+		t.Fatalf("downloadURLToWriter() error = %v", err)
+	}
+	if !actualHash.Equal(expectedHash) {
+		t.Fatalf("downloadURLToWriter() hash = %v, expected %v", actualHash, expectedHash)
+	}
+	if !bytes.Equal(output.Bytes(), body) {
+		t.Fatalf("downloadURLToWriter() body = %q, expected %q", output.Bytes(), body)
+	}
+}
+
+func TestDownloadURLToWriterRejectsHashMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer server.Close()
+
+	wrongHash, err := hashing.HashAlgorithmSHA256.Hash(bytes.NewReader([]byte("different")))
+	if err != nil {
+		t.Fatalf("Hash() error = %v", err)
+	}
+
+	var output bytes.Buffer
+	if _, err := downloadURLToWriter(server.URL, &output, wrongHash); err == nil {
+		t.Fatalf("downloadURLToWriter() expected hash mismatch error")
+	}
+}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -343,13 +344,23 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 		return fmt.Errorf("error building loader: %v", err)
 	}
 
-	for i, image := range nodeupConfig.Images[architecture] {
-		taskMap["LoadImage."+strconv.Itoa(i)] = &nodetasks.LoadImageTask{
+	for _, image := range nodeupConfig.Images[architecture] {
+		if len(image.Sources) == 0 {
+			return fmt.Errorf("image has no sources: %v", image)
+		}
+		u, err := url.Parse(image.Sources[0])
+		if err != nil {
+			return fmt.Errorf("invalid image source URL %q: %w", image.Sources[0], err)
+		}
+		key := "SideloadImage/" + path.Base(u.Path)
+		if _, ok := taskMap[key]; ok {
+			return fmt.Errorf("duplicate image task %q", key)
+		}
+		taskMap[key] = &nodetasks.LoadImageTask{
 			Sources: image.Sources,
 			Hash:    image.Hash,
 		}
 	}
-	// Protokube load image task is in ProtokubeBuilder
 
 	var target fi.NodeupTarget
 

--- a/upup/pkg/fi/nodeup/nodetasks/compression.go
+++ b/upup/pkg/fi/nodeup/nodetasks/compression.go
@@ -14,34 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package nodetasks
 
 import (
+	"bufio"
+	"bytes"
 	"compress/gzip"
 	"io"
-	"os"
 )
 
-// UngzipFile extracts a .gzip file
-func UngzipFile(gzipPath string, destPath string) error {
-	reader, err := os.Open(gzipPath)
-	if err != nil {
-		return err
-	}
-	defer reader.Close()
+var gzipMagic = []byte{0x1f, 0x8b}
 
-	writer, err := os.Create(destPath)
-	if err != nil {
-		return err
+func maybeGzipReader(r io.Reader) (io.ReadCloser, error) {
+	buffered := bufio.NewReader(r)
+	header, err := buffered.Peek(len(gzipMagic))
+	if err != nil && err != io.EOF {
+		return nil, err
 	}
-	defer writer.Close()
-
-	archive, err := gzip.NewReader(reader)
-	if err != nil {
-		return err
+	if len(header) == len(gzipMagic) && bytes.Equal(header, gzipMagic) {
+		return gzip.NewReader(buffered)
 	}
-	defer archive.Close()
-
-	_, err = io.Copy(writer, archive)
-	return err
+	return io.NopCloser(buffered), nil
 }

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -17,12 +17,16 @@ limitations under the License.
 package nodetasks
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/backoff"
@@ -31,6 +35,11 @@ import (
 	"k8s.io/kops/upup/pkg/fi/utils"
 	"k8s.io/kops/util/pkg/hashing"
 )
+
+// errCtrImport tags failures returned by the ctr import command, so the
+// caller can skip DoGlobalBackoff — that backoff is meant to throttle
+// repeated downloads, not failures inside containerd.
+var errCtrImport = errors.New("ctr import failed")
 
 // LoadImageTask is responsible for downloading a docker image
 type LoadImageTask struct {
@@ -95,62 +104,68 @@ func (_ *LoadImageTask) RenderLocal(t *local.LocalTarget, a, e, changes *LoadIma
 
 	urls := e.Sources
 	if len(urls) == 0 {
-		return fmt.Errorf("no sources specified: %v", err)
+		return fmt.Errorf("no sources specified")
 	}
 
-	// We assume the first url is the "main" url, and download to a local file based on that _name_, wherever we get it from
-	primaryURL := urls[0]
-	key := path.Base(primaryURL)
-	localFile := filepath.Join(t.CacheDir, hash.String()+"_"+utils.SanitizeString(key))
+	if !isContainerdReady() {
+		return fi.NewTryAgainLaterError("waiting for containerd to be ready")
+	}
 
 	for _, url := range urls {
-		_, err = fi.DownloadURL(url, localFile, hash)
-		if err != nil {
-			klog.Warningf("error downloading url %q: %v", url, err)
-			continue
-		} else {
-			break
+		err = importContainerImage(url, hash, t.CacheDir)
+		if err == nil {
+			return nil
+		}
+		klog.Warningf("error importing image from url %q: %v", url, err)
+		if errors.Is(err, errCtrImport) {
+			return err
 		}
 	}
-	if err != nil {
-		// Hack to try to avoid failed downloads causing massive bandwidth bills
-		backoff.DoGlobalBackoff(fmt.Errorf("failed to download image %s: %v", primaryURL, err))
+
+	// All sources failed at download. Throttle to avoid runaway bandwidth costs.
+	backoff.DoGlobalBackoff(err)
+	return err
+}
+
+func isContainerdReady() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ctr", "version")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run() == nil
+}
+
+func importContainerImage(url string, expectedHash *hashing.Hash, cacheDir string) error {
+	// Phase 1: fetch (or reuse cached) verified bytes. fi.DownloadURL writes via a
+	// temp-file + atomic rename and short-circuits if cacheFile already matches the hash,
+	// so a re-run of nodeup that already populated the cache skips the network round-trip.
+	cacheFile := filepath.Join(cacheDir, expectedHash.Hex()+"_"+utils.SanitizeString(path.Base(url)))
+	if _, err := fi.DownloadURL(url, cacheFile, expectedHash); err != nil {
 		return err
 	}
 
-	// containerd can't import gzipped container images, if the image is gzipped extract it to tmp dir
-	// TODO: Improve the naive gzip format detection by checking the content type bytes "\x1F\x8B\x08"
-	var tarFile string
-	if strings.HasSuffix(localFile, "gz") {
-		tmpDir, err := os.MkdirTemp("", "loadimage")
-		if err != nil {
-			return fmt.Errorf("error creating temp dir: %v", err)
-		}
-		defer func() {
-			if err := os.RemoveAll(tmpDir); err != nil {
-				klog.Warningf("error deleting temp dir %q: %v", tmpDir, err)
-			}
-		}()
-		tarFile = path.Join(tmpDir, utils.SanitizeString(primaryURL))
-		err = utils.UngzipFile(localFile, tarFile)
-		if err != nil {
-			return fmt.Errorf("error ungzipping container image: %v", err)
-		}
-	} else {
-		// Assume container image is tar file alerady
-		tarFile = localFile
+	// Phase 2: stream verified bytes (transparently gunzipped) to ctr.
+	file, err := os.Open(cacheFile)
+	if err != nil {
+		return fmt.Errorf("error opening verified image file: %v", err)
 	}
+	defer file.Close()
 
-	// Load the container image
-	args := []string{"ctr", "--namespace", "k8s.io", "images", "import", tarFile}
+	reader, err := maybeGzipReader(file)
+	if err != nil {
+		return fmt.Errorf("error decoding image archive from %q: %v", url, err)
+	}
+	defer reader.Close()
+
+	args := []string{"ctr", "--namespace", "k8s.io", "images", "import", "-"}
 	human := strings.Join(args, " ")
 
 	klog.Infof("running command %s", human)
 	cmd := exec.Command(args[0], args[1:]...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("error loading docker image with '%s': %v: %s", human, err, string(output))
+	cmd.Stdin = reader
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%w: error loading docker image with '%s': %v: %s", errCtrImport, human, err, string(output))
 	}
-
 	return nil
 }

--- a/upup/pkg/fi/nodeup/nodetasks/loadimage_test.go
+++ b/upup/pkg/fi/nodeup/nodetasks/loadimage_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package nodetasks
 
 import (
+	"bytes"
+	"compress/gzip"
+	"io"
 	"reflect"
 	"testing"
 
@@ -36,5 +39,47 @@ func TestLoadImageTask_Deps(t *testing.T) {
 	expected := []fi.NodeupTask{tasks["ServiceDocker"]}
 	if !reflect.DeepEqual(expected, deps) {
 		t.Fatalf("unexpected deps.  expected=%v, actual=%v", expected, deps)
+	}
+}
+
+func TestMaybeGzipReaderRejectsCorruptGzip(t *testing.T) {
+	// Bytes start with the gzip magic but don't form a valid header.
+	corrupt := bytes.NewReader([]byte{0x1f, 0x8b, 0x08, 0x00})
+	if _, err := maybeGzipReader(corrupt); err == nil {
+		t.Fatalf("maybeGzipReader() expected error for truncated gzip header")
+	}
+}
+
+func TestMaybeGzipReaderPassesThroughUncompressed(t *testing.T) {
+	body := []byte("plain tar bytes")
+	r, err := maybeGzipReader(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("maybeGzipReader() error = %v", err)
+	}
+	defer r.Close()
+	got := make([]byte, len(body))
+	if _, err := r.Read(got); err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("maybeGzipReader() body = %q, expected %q", got, body)
+	}
+
+	// Sanity: round-trip through gzip works too.
+	var compressed bytes.Buffer
+	gw := gzip.NewWriter(&compressed)
+	_, _ = gw.Write(body)
+	_ = gw.Close()
+	r2, err := maybeGzipReader(bytes.NewReader(compressed.Bytes()))
+	if err != nil {
+		t.Fatalf("maybeGzipReader(gzip) error = %v", err)
+	}
+	defer r2.Close()
+	got2, err := io.ReadAll(r2)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if !bytes.Equal(got2, body) {
+		t.Fatalf("maybeGzipReader(gzip) body = %q, expected %q", got2, body)
 	}
 }


### PR DESCRIPTION
Replace the download → ungzip-to-disk → reference-by-path flow with a single streaming pipeline: download to a hash-named cache file with inline hash verification, then re-open and stream (transparently gunzipping via magic-byte detection) straight into ctr images import over stdin. This avoids materializing an extracted tar on disk and prevents hash-mismatched bytes from ever reaching containerd's image store, since ctr atomically commits image references from the archive's manifest at import time.

fi.DownloadURL now streams through a MultiWriter hasher with atomic rename, and a new fi.OpenURL helper exposes the hardened HTTP GET stream that the image import path reuses.
- Reject non-2xx HTTP responses
- Wait for containerd readiness via TryAgainLaterError, bounded by a 5s probe
- Skip the global download backoff for ctr-side failures
- Detect gzip by magic bytes rather than file suffix
- Key LoadImageTask by source filename and reject sources-less images at config load

Assisted by Claude Opus

/cc @ameukam @rifelpet 