### PR TITLE
Migrate deprecated kubelet flags to config file

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -24,18 +24,23 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	logsapi "k8s.io/component-base/logs/api/v1"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
+	kopsutil "k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/rbac"
 	"k8s.io/kops/pkg/systemd"
@@ -55,6 +60,37 @@ const (
 	kubeletConfigFilePath            = "/var/lib/kubelet/kubelet.conf"
 	credentialProviderConfigFilePath = "/var/lib/kubelet/credential-provider.conf"
 )
+
+// Scheme registration is shared across all calls in this file because the
+// schemes are stateless after AddToScheme runs. Constructing them per-call
+// allocates a populated scheme map and walks the scheme registry on every
+// nodeup invocation.
+var (
+	kubeletV1Beta1Encoder runtime.Encoder
+	kubeletV1Encoder      runtime.Encoder
+)
+
+func init() {
+	v1beta1Scheme := runtime.NewScheme()
+	utilruntime.Must(kubelet.AddToScheme(v1beta1Scheme))
+	kubeletV1Beta1Encoder = mustYAMLEncoder(v1beta1Scheme, kubelet.SchemeGroupVersion)
+
+	v1Scheme := runtime.NewScheme()
+	utilruntime.Must(kubeletv1.AddToScheme(v1Scheme))
+	kubeletV1Encoder = mustYAMLEncoder(v1Scheme, kubeletv1.SchemeGroupVersion)
+}
+
+// mustYAMLEncoder returns a YAML encoder for the given scheme + GV, panicking
+// if the scheme has no YAML serializer registered (which would be a programmer
+// error since the kubelet types we register always have one).
+func mustYAMLEncoder(scheme *runtime.Scheme, gv runtime.GroupVersioner) runtime.Encoder {
+	codecFactory := serializer.NewCodecFactory(scheme)
+	info, ok := runtime.SerializerInfoForMediaType(codecFactory.SupportedMediaTypes(), "application/yaml")
+	if !ok {
+		panic(fmt.Sprintf("no YAML serializer registered for kubelet scheme %v", gv))
+	}
+	return codecFactory.EncoderForVersion(info.Serializer, gv)
+}
 
 // KubeletBuilder installs kubelet
 type KubeletBuilder struct {
@@ -98,7 +134,7 @@ func (b *KubeletBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 			providerID = "azure://" + metadata.ResourceID
 		}
 
-		t, err := buildKubeletComponentConfig(kubeletConfig, providerID)
+		t, err := b.buildKubeletComponentConfig(kubeletConfig, providerID)
 		if err != nil {
 			return err
 		}
@@ -237,58 +273,149 @@ func (b *KubeletBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	return nil
 }
 
-func buildKubeletComponentConfig(kubeletConfig *kops.KubeletConfigSpec, providerID string) (*nodetasks.File, error) {
-	componentConfig := kubelet.KubeletConfiguration{}
-	if providerID != "" {
-		componentConfig.ProviderID = providerID
-	}
-	if kubeletConfig.CrashLoopBackOffMaxContainerRestartPeriod != nil {
-		componentConfig.CrashLoopBackOff.MaxContainerRestartPeriod = kubeletConfig.CrashLoopBackOffMaxContainerRestartPeriod
-	}
-	if kubeletConfig.ShutdownGracePeriod != nil {
-		componentConfig.ShutdownGracePeriod = *kubeletConfig.ShutdownGracePeriod
-	}
-	if kubeletConfig.ShutdownGracePeriodCriticalPods != nil {
-		componentConfig.ShutdownGracePeriodCriticalPods = *kubeletConfig.ShutdownGracePeriodCriticalPods
-	}
-	if kubeletConfig.ImageMaximumGCAge != nil {
-		componentConfig.ImageMaximumGCAge = *kubeletConfig.ImageMaximumGCAge
-	}
-	if kubeletConfig.ImageMinimumGCAge != nil {
-		componentConfig.ImageMinimumGCAge = *kubeletConfig.ImageMinimumGCAge
-	}
-	componentConfig.MaxParallelImagePulls = kubeletConfig.MaxParallelImagePulls
-	componentConfig.MemorySwap.SwapBehavior = kubeletConfig.MemorySwapBehavior
-	componentConfig.EventRecordQPS = kubeletConfig.EventRecordQPS
-	if kubeletConfig.NodeLeaseDurationSeconds != nil {
-		componentConfig.NodeLeaseDurationSeconds = *kubeletConfig.NodeLeaseDurationSeconds
-	}
-
-	s := runtime.NewScheme()
-	if err := kubelet.AddToScheme(s); err != nil {
+func (b *KubeletBuilder) buildKubeletComponentConfig(kubeletConfig *kops.KubeletConfigSpec, providerID string) (*nodetasks.File, error) {
+	componentConfig, err := b.kubeletConfiguration(kubeletConfig, providerID)
+	if err != nil {
 		return nil, err
 	}
 
-	gv := kubelet.SchemeGroupVersion
-	codecFactory := serializer.NewCodecFactory(s)
-	info, ok := runtime.SerializerInfoForMediaType(codecFactory.SupportedMediaTypes(), "application/yaml")
-	if !ok {
-		return nil, fmt.Errorf("failed to find serializer")
-	}
-	encoder := codecFactory.EncoderForVersion(info.Serializer, gv)
-	var w bytes.Buffer
-	if err := encoder.Encode(&componentConfig, &w); err != nil {
-		return nil, err
+	var buf bytes.Buffer
+	if err := kubeletV1Beta1Encoder.Encode(componentConfig, &buf); err != nil {
+		return nil, fmt.Errorf("encoding kubelet component config: %w", err)
 	}
 
-	t := &nodetasks.File{
-		Path:           "/var/lib/kubelet/kubelet.conf",
-		Contents:       fi.NewBytesResource(w.Bytes()),
+	return &nodetasks.File{
+		Path:           kubeletConfigFilePath,
+		Contents:       fi.NewBytesResource(buf.Bytes()),
 		Type:           nodetasks.FileType_File,
 		BeforeServices: []string{kubeletService},
+	}, nil
+}
+
+// kubeletConfiguration translates a kops.KubeletConfigSpec into the upstream
+// kubelet.KubeletConfiguration written to /var/lib/kubelet/kubelet.conf.
+// Most kubelet CLI flags are deprecated upstream in favor of this config
+// file; fields that have flag:"-" in the kops API land here.
+func (b *KubeletBuilder) kubeletConfiguration(kubeletConfig *kops.KubeletConfigSpec, providerID string) (*kubelet.KubeletConfiguration, error) {
+	cc := &kubelet.KubeletConfiguration{
+		CgroupDriver:                     kubeletConfig.CgroupDriver,
+		CgroupRoot:                       kubeletConfig.CgroupRoot,
+		TLSCertFile:                      filepath.Join(b.PathSrvKubernetes(), "kubelet-server.crt"),
+		TLSPrivateKeyFile:                filepath.Join(b.PathSrvKubernetes(), "kubelet-server.key"),
+		TLSCipherSuites:                  kubeletConfig.TLSCipherSuites,
+		TLSMinVersion:                    kubeletConfig.TLSMinVersion,
+		ClusterDNS:                       []string{kubeletConfig.ClusterDNS},
+		ClusterDomain:                    kubeletConfig.ClusterDomain,
+		EnableDebuggingHandlers:          kubeletConfig.EnableDebuggingHandlers,
+		HairpinMode:                      kubeletConfig.HairpinMode,
+		StaticPodPath:                    kubeletConfig.PodManifestPath,
+		VolumePluginDir:                  kubeletConfig.VolumePluginDirectory,
+		ProviderID:                       providerID,
+		KubeletCgroups:                   kubeletConfig.KubeletCgroups,
+		SystemCgroups:                    kubeletConfig.SystemCgroups,
+		PodCIDR:                          kubeletConfig.PodCIDR,
+		ResolverConfig:                   kubeletConfig.ResolverConfig,
+		SerializeImagePulls:              kubeletConfig.SerializeImagePulls,
+		MaxParallelImagePulls:            kubeletConfig.MaxParallelImagePulls,
+		AllowedUnsafeSysctls:             kubeletConfig.AllowedUnsafeSysctls,
+		CPUCFSQuota:                      kubeletConfig.CPUCFSQuota,
+		CPUCFSQuotaPeriod:                kubeletConfig.CPUCFSQuotaPeriod,
+		CPUManagerPolicy:                 kubeletConfig.CpuManagerPolicy,
+		RegistryPullQPS:                  kubeletConfig.RegistryPullQPS,
+		TopologyManagerPolicy:            kubeletConfig.TopologyManagerPolicy,
+		RotateCertificates:               fi.ValueOf(kubeletConfig.RotateCertificates),
+		ContainerLogMaxSize:              kubeletConfig.ContainerLogMaxSize,
+		ContainerLogMaxFiles:             kubeletConfig.ContainerLogMaxFiles,
+		PodPidsLimit:                     kubeletConfig.PodPidsLimit,
+		ImageGCHighThresholdPercent:      kubeletConfig.ImageGCHighThresholdPercent,
+		ImageGCLowThresholdPercent:       kubeletConfig.ImageGCLowThresholdPercent,
+		ImageMaximumGCAge:                fi.ValueOf(kubeletConfig.ImageMaximumGCAge),
+		NodeStatusUpdateFrequency:        fi.ValueOf(kubeletConfig.NodeStatusUpdateFrequency),
+		NodeLeaseDurationSeconds:         fi.ValueOf(kubeletConfig.NodeLeaseDurationSeconds),
+		SeccompDefault:                   kubeletConfig.SeccompDefault,
+		KubeReserved:                     kubeletConfig.KubeReserved,
+		KubeReservedCgroup:               kubeletConfig.KubeReservedCgroup,
+		SystemReserved:                   kubeletConfig.SystemReserved,
+		SystemReservedCgroup:             kubeletConfig.SystemReservedCgroup,
+		FailSwapOn:                       kubeletConfig.FailSwapOn,
+		EvictionPressureTransitionPeriod: fi.ValueOf(kubeletConfig.EvictionPressureTransitionPeriod),
+		EvictionMaxPodGracePeriod:        kubeletConfig.EvictionMaxPodGracePeriod,
+		EventRecordQPS:                   kubeletConfig.EventRecordQPS,
+		ProtectKernelDefaults:            fi.ValueOf(kubeletConfig.ProtectKernelDefaults),
+		KernelMemcgNotification:          fi.ValueOf(kubeletConfig.KernelMemcgNotification),
+		MaxPods:                          fi.ValueOf(kubeletConfig.MaxPods),
+		ReadOnlyPort:                     fi.ValueOf(kubeletConfig.ReadOnlyPort),
+		MemorySwap:                       kubelet.MemorySwapConfiguration{SwapBehavior: kubeletConfig.MemorySwapBehavior},
+		Logging:                          logsapi.LoggingConfiguration{Format: kubeletConfig.LogFormat},
+		CrashLoopBackOff:                 kubelet.CrashLoopBackOffConfig{MaxContainerRestartPeriod: kubeletConfig.CrashLoopBackOffMaxContainerRestartPeriod},
+		ShutdownGracePeriod:              fi.ValueOf(kubeletConfig.ShutdownGracePeriod),
+		ShutdownGracePeriodCriticalPods:  fi.ValueOf(kubeletConfig.ShutdownGracePeriodCriticalPods),
 	}
 
-	return t, nil
+	cc.Authentication.Anonymous.Enabled = kubeletConfig.AnonymousAuth
+	cc.Authentication.Webhook.Enabled = kubeletConfig.AuthenticationTokenWebhook
+	if kubeletConfig.ClientCAFile != "" {
+		cc.Authentication.X509.ClientCAFile = kubeletConfig.ClientCAFile
+	}
+	if kubeletConfig.AuthorizationMode != "" {
+		cc.Authorization.Mode = kubelet.KubeletAuthorizationMode(kubeletConfig.AuthorizationMode)
+	}
+
+	// EventQPS is the legacy kops field; EventRecordQPS is the newer alias
+	// matching the kubelet config field name. Preserve historical precedence
+	// where EventQPS overrides EventRecordQPS when both are set.
+	if kubeletConfig.EventQPS != nil {
+		cc.EventRecordQPS = kubeletConfig.EventQPS
+	}
+
+	if b.NodeupConfig.ContainerdConfig.Address == nil {
+		cc.ContainerRuntimeEndpoint = "unix:///run/containerd/containerd.sock"
+	} else {
+		cc.ContainerRuntimeEndpoint = "unix://" + fi.ValueOf(b.NodeupConfig.ContainerdConfig.Address)
+	}
+
+	if kubeletConfig.EvictionHard != nil {
+		evictionHard, err := parseKeyValueList(*kubeletConfig.EvictionHard, "<")
+		if err != nil {
+			return nil, fmt.Errorf("evictionHard: %w", err)
+		}
+		cc.EvictionHard = evictionHard
+	}
+	evictionSoft, err := parseKeyValueList(kubeletConfig.EvictionSoft, "<")
+	if err != nil {
+		return nil, fmt.Errorf("evictionSoft: %w", err)
+	}
+	cc.EvictionSoft = evictionSoft
+	evictionSoftGracePeriod, err := parseKeyValueList(kubeletConfig.EvictionSoftGracePeriod, "=")
+	if err != nil {
+		return nil, fmt.Errorf("evictionSoftGracePeriod: %w", err)
+	}
+	cc.EvictionSoftGracePeriod = evictionSoftGracePeriod
+	evictionMinimumReclaim, err := parseKeyValueList(kubeletConfig.EvictionMinimumReclaim, "=")
+	if err != nil {
+		return nil, fmt.Errorf("evictionMinimumReclaim: %w", err)
+	}
+	cc.EvictionMinimumReclaim = evictionMinimumReclaim
+
+	featureGates, err := parseFeatureGates(kubeletConfig.FeatureGates)
+	if err != nil {
+		return nil, fmt.Errorf("featureGates: %w", err)
+	}
+	cc.FeatureGates = featureGates
+
+	if kubeletConfig.EnforceNodeAllocatable != "" {
+		cc.EnforceNodeAllocatable = strings.Split(kubeletConfig.EnforceNodeAllocatable, ",")
+	}
+
+	for _, t := range kubeletConfig.Taints {
+		taint, err := parseTaint(t)
+		if err != nil {
+			return nil, fmt.Errorf("taints: %w", err)
+		}
+		cc.RegisterWithTaints = append(cc.RegisterWithTaints, taint)
+	}
+
+	return cc, nil
 }
 
 func (b *KubeletBuilder) binaryPath() string {
@@ -355,17 +482,6 @@ func (b *KubeletBuilder) buildSystemdEnvironmentFile(ctx context.Context, kubele
 		}
 	}
 
-	// Add container runtime spcific flags
-	flags += " --runtime-request-timeout=15m"
-	if b.NodeupConfig.ContainerdConfig.Address == nil {
-		flags += " --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
-	} else {
-		flags += " --container-runtime-endpoint=unix://" + fi.ValueOf(b.NodeupConfig.ContainerdConfig.Address)
-	}
-
-	flags += " --tls-cert-file=" + b.PathSrvKubernetes() + "/kubelet-server.crt"
-	flags += " --tls-private-key-file=" + b.PathSrvKubernetes() + "/kubelet-server.key"
-
 	if b.IsIPv6Only() {
 		flags += " --node-ip=::"
 	}
@@ -388,6 +504,66 @@ func (b *KubeletBuilder) buildSystemdEnvironmentFile(ctx context.Context, kubele
 	}
 
 	return t, nil
+}
+
+// parseKeyValueList parses a comma-separated list of key/value pairs
+// separated by sep (for example "memory.available<100Mi" with sep="<").
+// Whitespace around keys and values is trimmed. An empty input returns
+// (nil, nil) so callers can leave the corresponding kubelet config field
+// unset. Returns an error if any entry is missing the separator.
+//
+// The kops API uses these CSV strings for fields that kubelet represents
+// as map[string]string: eviction-hard / eviction-soft use "<", while
+// eviction-soft-grace-period and eviction-minimum-reclaim use "=".
+func parseKeyValueList(in string, sep string) (map[string]string, error) {
+	if in == "" {
+		return nil, nil
+	}
+	result := make(map[string]string, strings.Count(in, ",")+1)
+	for kv := range strings.SplitSeq(in, ",") {
+		k, v, ok := strings.Cut(kv, sep)
+		if !ok {
+			return nil, fmt.Errorf("invalid key/value pair %q (expected separator %q)", kv, sep)
+		}
+		result[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	return result, nil
+}
+
+// parseTaint converts the kops "key=value:Effect" taint string (the form
+// historically passed to --register-with-taints) into a v1.Taint, the type
+// the kubelet config field RegisterWithTaints requires.
+func parseTaint(s string) (v1.Taint, error) {
+	parsed, err := kopsutil.ParseTaint(s)
+	if err != nil {
+		return v1.Taint{}, err
+	}
+	return v1.Taint{
+		Key:    parsed["key"],
+		Value:  parsed["value"],
+		Effect: v1.TaintEffect(parsed["effect"]),
+	}, nil
+}
+
+// parseFeatureGates converts the kops map[string]string feature-gate
+// representation into the map[string]bool that the kubelet config schema
+// requires. Values are parsed with strconv.ParseBool, so "true"/"false",
+// "1"/"0", "t"/"f" etc. are all accepted. An empty or nil input returns
+// (nil, nil); an unparseable value returns an error naming the offending
+// gate.
+func parseFeatureGates(gates map[string]string) (map[string]bool, error) {
+	if len(gates) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]bool, len(gates))
+	for name, raw := range gates {
+		parsed, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid feature gate value %q=%q: %w", name, raw, err)
+		}
+		out[name] = parsed
+	}
+	return out, nil
 }
 
 // buildSystemdService is responsible for generating the kubelet systemd unit
@@ -498,30 +674,17 @@ func (b *KubeletBuilder) addECRCredentialProvider(c *fi.NodeupModelBuilderContex
 			},
 		}
 
-		sch := runtime.NewScheme()
-		if err := kubeletv1.AddToScheme(sch); err != nil {
-			return err
+		var buf bytes.Buffer
+		if err := kubeletV1Encoder.Encode(providerConfig, &buf); err != nil {
+			return fmt.Errorf("encoding ECR credential provider config: %w", err)
 		}
 
-		gv := kubeletv1.SchemeGroupVersion
-		codecFactory := serializer.NewCodecFactory(sch)
-		info, ok := runtime.SerializerInfoForMediaType(codecFactory.SupportedMediaTypes(), "application/yaml")
-		if !ok {
-			return fmt.Errorf("failed to find serializer")
-		}
-		encoder := codecFactory.EncoderForVersion(info.Serializer, gv)
-		var w bytes.Buffer
-		if err := encoder.Encode(providerConfig, &w); err != nil {
-			return err
-		}
-
-		t := &nodetasks.File{
+		c.AddTask(&nodetasks.File{
 			Path:     credentialProviderConfigFilePath,
-			Contents: fi.NewBytesResource(w.Bytes()),
+			Contents: fi.NewBytesResource(buf.Bytes()),
 			Type:     nodetasks.FileType_File,
 			Mode:     s("0644"),
-		}
-		c.AddTask(t)
+		})
 	}
 	return nil
 }
@@ -592,6 +755,13 @@ func (b *KubeletBuilder) buildKubeletConfigSpec(ctx context.Context) (*kops.Kube
 	c := b.NodeupConfig.KubeletConfig
 
 	c.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
+
+	// Preserve the historical 15m default that used to be hard-coded into the
+	// kubelet env file. Stays as a CLI flag because the upstream config field
+	// is non-pointer with omitempty and would drop a zero value.
+	if c.RuntimeRequestTimeout == nil {
+		c.RuntimeRequestTimeout = &metav1.Duration{Duration: 15 * time.Minute}
+	}
 
 	// Wait less for pods to restart, especially during the bootstrap sequence
 	if b.IsKubernetesGTE("1.35") && b.IsMaster {
@@ -707,28 +877,12 @@ func (b *KubeletBuilder) buildKubeletServingCertificate(c *fi.NodeupModelBuilder
 		return err
 	}
 
+	var cert, key fi.Resource
 	if !b.HasAPIServer {
-		cert, key, err := b.GetBootstrapCert(name, fi.CertificateIDCA)
+		cert, key, err = b.GetBootstrapCert(name, fi.CertificateIDCA)
 		if err != nil {
 			return err
 		}
-
-		c.AddTask(&nodetasks.File{
-			Path:           filepath.Join(dir, name+".crt"),
-			Contents:       cert,
-			Type:           nodetasks.FileType_File,
-			Mode:           fi.PtrTo("0644"),
-			BeforeServices: []string{"kubelet.service"},
-		})
-
-		c.AddTask(&nodetasks.File{
-			Path:           filepath.Join(dir, name+".key"),
-			Contents:       key,
-			Type:           nodetasks.FileType_File,
-			Mode:           fi.PtrTo("0400"),
-			BeforeServices: []string{"kubelet.service"},
-		})
-
 	} else {
 		issueCert := &nodetasks.IssueCert{
 			Name:      name,
@@ -741,8 +895,30 @@ func (b *KubeletBuilder) buildKubeletServingCertificate(c *fi.NodeupModelBuilder
 			AlternateNames: names,
 		}
 		c.AddTask(issueCert)
-		return issueCert.AddFileTasks(c, dir, name, "", nil)
+		cert, key, _ = issueCert.GetResources()
+		c.EnsureTask(&nodetasks.File{
+			Path: dir,
+			Type: nodetasks.FileType_Directory,
+			Mode: fi.PtrTo("0755"),
+		})
 	}
+
+	c.AddTask(&nodetasks.File{
+		Path:           filepath.Join(dir, name+".crt"),
+		Contents:       cert,
+		Type:           nodetasks.FileType_File,
+		Mode:           fi.PtrTo("0644"),
+		BeforeServices: []string{kubeletService},
+	})
+
+	c.AddTask(&nodetasks.File{
+		Path:           filepath.Join(dir, name+".key"),
+		Contents:       key,
+		Type:           nodetasks.FileType_File,
+		Mode:           fi.PtrTo("0400"),
+		BeforeServices: []string{kubeletService},
+	})
+
 	return nil
 }
 

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -196,7 +198,7 @@ func runKubeletBuilder(t *testing.T, context *fi.NodeupModelBuilderContext, node
 		return
 	}
 	{
-		fileTask, err := buildKubeletComponentConfig(kubeletConfig, "")
+		fileTask, err := builder.buildKubeletComponentConfig(kubeletConfig, "")
 		if err != nil {
 			t.Fatalf("error from KubeletBuilder buildKubeletComponentConfig: %v", err)
 			return
@@ -405,39 +407,103 @@ func Test_BuildComponentConfigFile(t *testing.T) {
 		MaxParallelImagePulls:           fi.PtrTo(int32(5)),
 	}
 
-	_, err := buildKubeletComponentConfig(&componentConfig, "")
+	builder := &KubeletBuilder{NodeupModelContext: &NodeupModelContext{
+		NodeupConfig: &nodeup.Config{
+			ContainerdConfig: &kops.ContainerdConfig{},
+		},
+	}}
+
+	_, err := builder.buildKubeletComponentConfig(&componentConfig, "")
 	if err != nil {
 		t.Errorf("Failed to build component config file: %v", err)
 	}
 }
 
+func TestParseKeyValueList(t *testing.T) {
+	tests := []struct {
+		name            string
+		in              string
+		sep             string
+		want            map[string]string
+		wantErrContains string
+	}{
+		{name: "empty input returns nil map", in: "", sep: "<", want: nil},
+		{name: "less-than separator", in: "memory.available<100Mi,nodefs.available<10%", sep: "<", want: map[string]string{"memory.available": "100Mi", "nodefs.available": "10%"}},
+		{name: "equals separator", in: "memory.available=30s", sep: "=", want: map[string]string{"memory.available": "30s"}},
+		{name: "trims whitespace around keys and values", in: " memory.available = 100Mi ", sep: "=", want: map[string]string{"memory.available": "100Mi"}},
+		{name: "missing separator returns error", in: "memory.available", sep: "<", wantErrContains: "expected separator"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseKeyValueList(tc.in, tc.sep)
+			if tc.wantErrContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrContains) {
+					t.Fatalf("parseKeyValueList(%q, %q) error = %v, want error containing %q", tc.in, tc.sep, err, tc.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseKeyValueList(%q, %q) unexpected error: %v", tc.in, tc.sep, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseKeyValueList(%q, %q) = %v, want %v", tc.in, tc.sep, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseFeatureGates(t *testing.T) {
+	tests := []struct {
+		name            string
+		in              map[string]string
+		want            map[string]bool
+		wantErrContains string
+	}{
+		{name: "nil input returns nil map", in: nil, want: nil},
+		{name: "valid bools", in: map[string]string{"A": "true", "B": "false"}, want: map[string]bool{"A": true, "B": false}},
+		{name: "invalid bool returns error naming the gate", in: map[string]string{"A": "yesplz"}, wantErrContains: `"A"="yesplz"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseFeatureGates(tc.in)
+			if tc.wantErrContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrContains) {
+					t.Fatalf("parseFeatureGates(%v) error = %v, want error containing %q", tc.in, err, tc.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseFeatureGates(%v) unexpected error: %v", tc.in, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseFeatureGates(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func Test_Kubelet_BuildFlags(t *testing.T) {
-	grid := []struct {
-		config   kops.KubeletConfigSpec
-		expected string
+	tests := []struct {
+		name   string
+		config kops.KubeletConfigSpec
+		want   string
 	}{
 		{
-			kops.KubeletConfigSpec{
-				ImageMaximumGCAge: &metav1.Duration{Duration: 30 * time.Hour},
-			},
-			"",
-		},
-		{
-			kops.KubeletConfigSpec{
-				ImageMinimumGCAge: &metav1.Duration{Duration: 30 * time.Minute},
-			},
-			"",
+			name:   "ImageMaximumGCAge migrated to config file",
+			config: kops.KubeletConfigSpec{ImageMaximumGCAge: &metav1.Duration{Duration: 30 * time.Hour}},
+			want:   "",
 		},
 	}
 
-	for _, g := range grid {
-		actual, err := flagbuilder.BuildFlags(&g.config)
-		if err != nil {
-			t.Errorf("error building flags for %v: %v", g.config, err)
-			continue
-		}
-		if actual != g.expected {
-			t.Errorf("flags did not match.  actual=%q expected=%q", actual, g.expected)
-		}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := flagbuilder.BuildFlags(&tc.config)
+			if err != nil {
+				t.Fatalf("BuildFlags(%+v) error = %v", tc.config, err)
+			}
+			if got != tc.want {
+				t.Errorf("BuildFlags(%+v) = %q, want %q", tc.config, got, tc.want)
+			}
+		})
 	}
 }

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --cgroup-driver=systemd --cgroup-root=/ --client-ca-file=/srv/kubernetes/ca.crt --cloud-provider=external --cluster-dns=100.64.0.10 --cluster-domain=cluster.local --enable-debugging-handlers=true --eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5% --feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --kubeconfig=/var/lib/kubelet/kubeconfig --pod-manifest-path=/etc/kubernetes/manifests --protect-kernel-defaults=true --register-schedulable=true --resolv-conf=/run/systemd/resolve/resolv.conf --v=2 --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cloud-config=/etc/kubernetes/in-tree-cloud.config --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key --config=/var/lib/kubelet/kubelet.conf --image-credential-provider-config=/var/lib/kubelet/credential-provider.conf --image-credential-provider-bin-dir=/usr/local/bin"
+  DAEMON_ARGS="--cloud-provider=external --kubeconfig=/var/lib/kubelet/kubeconfig --register-schedulable=true --runtime-request-timeout=15m0s --v=2 --cloud-config=/etc/kubernetes/in-tree-cloud.config --config=/var/lib/kubelet/kubelet.conf --image-credential-provider-config=/var/lib/kubelet/credential-provider.conf --image-credential-provider-bin-dir=/usr/local/bin"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file
@@ -16,15 +16,33 @@ contents: |
     anonymous: {}
     webhook:
       cacheTTL: 0s
-    x509: {}
+      enabled: true
+    x509:
+      clientCAFile: /srv/kubernetes/ca.crt
   authorization:
+    mode: Webhook
     webhook:
       cacheAuthorizedTTL: 0s
       cacheUnauthorizedTTL: 0s
-  containerRuntimeEndpoint: ""
+  cgroupDriver: systemd
+  cgroupRoot: /
+  clusterDNS:
+  - 100.64.0.10
+  clusterDomain: cluster.local
+  containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
   cpuManagerReconcilePeriod: 0s
   crashLoopBackOff: {}
+  enableDebuggingHandlers: true
+  evictionHard:
+    imagefs.available: 10%
+    imagefs.inodesFree: 5%
+    memory.available: 100Mi
+    nodefs.available: 10%
+    nodefs.inodesFree: 5%
   evictionPressureTransitionPeriod: 0s
+  featureGates:
+    AllowExtTrafficLocalEndpoints: false
+    ExperimentalCriticalPodAnnotation: true
   fileCheckFrequency: 0s
   httpCheckFrequency: 0s
   imageMaximumGCAge: 0s
@@ -41,11 +59,17 @@ contents: |
   memorySwap: {}
   nodeStatusReportFrequency: 0s
   nodeStatusUpdateFrequency: 0s
+  protectKernelDefaults: true
+  resolvConf: /run/systemd/resolve/resolv.conf
   runtimeRequestTimeout: 0s
   shutdownGracePeriod: 30s
   shutdownGracePeriodCriticalPods: 10s
+  staticPodPath: /etc/kubernetes/manifests
   streamingConnectionIdleTimeout: 0s
   syncFrequency: 0s
+  tlsCertFile: /srv/kubernetes/kubelet-server.crt
+  tlsPrivateKeyFile: /srv/kubernetes/kubelet-server.key
+  volumePluginDir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
   volumeStatsAggPeriod: 0s
 path: /var/lib/kubelet/kubelet.conf
 type: file

--- a/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --cgroup-driver=systemd --cgroup-root=/ --client-ca-file=/srv/kubernetes/ca.crt --cloud-provider=external --cluster-dns=100.64.0.10 --cluster-domain=cluster.local --enable-debugging-handlers=true --eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5% --kubeconfig=/var/lib/kubelet/kubeconfig --pod-manifest-path=/etc/kubernetes/manifests --protect-kernel-defaults=true --register-schedulable=true --resolv-conf=/run/systemd/resolve/resolv.conf --v=2 --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cloud-config=/etc/kubernetes/in-tree-cloud.config --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key --config=/var/lib/kubelet/kubelet.conf --image-credential-provider-config=/var/lib/kubelet/credential-provider.conf --image-credential-provider-bin-dir=/usr/local/bin"
+  DAEMON_ARGS="--cloud-provider=external --kubeconfig=/var/lib/kubelet/kubeconfig --register-schedulable=true --runtime-request-timeout=15m0s --v=2 --cloud-config=/etc/kubernetes/in-tree-cloud.config --config=/var/lib/kubelet/kubelet.conf --image-credential-provider-config=/var/lib/kubelet/credential-provider.conf --image-credential-provider-bin-dir=/usr/local/bin"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file
@@ -16,14 +16,29 @@ contents: |
     anonymous: {}
     webhook:
       cacheTTL: 0s
-    x509: {}
+      enabled: true
+    x509:
+      clientCAFile: /srv/kubernetes/ca.crt
   authorization:
+    mode: Webhook
     webhook:
       cacheAuthorizedTTL: 0s
       cacheUnauthorizedTTL: 0s
-  containerRuntimeEndpoint: ""
+  cgroupDriver: systemd
+  cgroupRoot: /
+  clusterDNS:
+  - 100.64.0.10
+  clusterDomain: cluster.local
+  containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
   cpuManagerReconcilePeriod: 0s
   crashLoopBackOff: {}
+  enableDebuggingHandlers: true
+  evictionHard:
+    imagefs.available: 10%
+    imagefs.inodesFree: 5%
+    memory.available: 100Mi
+    nodefs.available: 10%
+    nodefs.inodesFree: 5%
   evictionPressureTransitionPeriod: 0s
   fileCheckFrequency: 0s
   httpCheckFrequency: 0s
@@ -41,11 +56,17 @@ contents: |
   memorySwap: {}
   nodeStatusReportFrequency: 0s
   nodeStatusUpdateFrequency: 0s
+  protectKernelDefaults: true
+  resolvConf: /run/systemd/resolve/resolv.conf
   runtimeRequestTimeout: 0s
   shutdownGracePeriod: 30s
   shutdownGracePeriodCriticalPods: 10s
+  staticPodPath: /etc/kubernetes/manifests
   streamingConnectionIdleTimeout: 0s
   syncFrequency: 0s
+  tlsCertFile: /srv/kubernetes/kubelet-server.crt
+  tlsPrivateKeyFile: /srv/kubernetes/kubelet-server.key
+  volumePluginDir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
   volumeStatsAggPeriod: 0s
 path: /var/lib/kubelet/kubelet.conf
 type: file

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -27,21 +27,23 @@ type KubeletConfigSpec struct {
 	// APIServers is not used for clusters version 1.6 and later - flag removed
 	APIServers string `json:"apiServers,omitempty" flag:"api-servers"`
 	// AnonymousAuth permits you to control auth to the kubelet api
-	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
+	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"-"`
 	// AuthorizationMode is the authorization mode the kubelet is running in
-	AuthorizationMode string `json:"authorizationMode,omitempty" flag:"authorization-mode"`
+	AuthorizationMode string `json:"authorizationMode,omitempty" flag:"-"`
 	// BootstrapKubeconfig is the path to a kubeconfig file that will be used to get client certificate for kubelet
 	BootstrapKubeconfig string `json:"bootstrapKubeconfig,omitempty" flag:"bootstrap-kubeconfig"`
 	// ClientCAFile is the path to a CA certificate
-	ClientCAFile string `json:"clientCAFile,omitempty" flag:"client-ca-file"`
-	// TODO: Remove unused TLSCertFile
-	TLSCertFile string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
-	// TODO: Remove unused TLSPrivateKeyFile
-	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
+	ClientCAFile string `json:"clientCAFile,omitempty" flag:"-"`
+	// TLSCertFile is the path to the kubelet's serving cert. Set automatically
+	// by nodeup to a cert+CA bundle; users should not set this directly.
+	TLSCertFile string `json:"tlsCertFile,omitempty" flag:"-"`
+	// TLSPrivateKeyFile is the path to the private key for the kubelet's
+	// serving cert. Set automatically by nodeup; users should not set this directly.
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"-"`
 	// TLSCipherSuites indicates the allowed TLS cipher suite
-	TLSCipherSuites []string `json:"tlsCipherSuites,omitempty" flag:"tls-cipher-suites"`
+	TLSCipherSuites []string `json:"tlsCipherSuites,omitempty" flag:"-"`
 	// TLSMinVersion indicates the minimum TLS version allowed
-	TLSMinVersion string `json:"tlsMinVersion,omitempty" flag:"tls-min-version"`
+	TLSMinVersion string `json:"tlsMinVersion,omitempty" flag:"-"`
 	// KubeconfigPath is the path of kubeconfig for the kubelet
 	KubeconfigPath string `json:"kubeconfigPath,omitempty" flag:"kubeconfig"`
 	// RequireKubeconfig indicates a kubeconfig is required
@@ -49,49 +51,49 @@ type KubeletConfigSpec struct {
 	// LogFormat is the logging format of the kubelet.
 	// Supported values: text, json.
 	// Default: text
-	LogFormat string `json:"logFormat,omitempty" flag:"logging-format" flag-empty:"text"`
+	LogFormat string `json:"logFormat,omitempty" flag:"-"`
 	// LogLevel is the logging level of the kubelet
 	LogLevel *int32 `json:"logLevel,omitempty" flag:"v" flag-empty:"0"`
 	// config is the path to the config file or directory of files
-	PodManifestPath string `json:"podManifestPath,omitempty" flag:"pod-manifest-path"`
+	PodManifestPath string `json:"podManifestPath,omitempty" flag:"-"`
 	// HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
 	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
 	// DEPRECATED: Image garbage collector will get sandbox image information from CRI.
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty"`
 	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
-	SeccompDefault *bool `json:"seccompDefault,omitempty" flag:"seccomp-default"`
+	SeccompDefault *bool `json:"seccompDefault,omitempty" flag:"-"`
 	// SeccompProfileRoot is the directory path for seccomp profiles.
 	SeccompProfileRoot *string `json:"seccompProfileRoot,omitempty" flag:"seccomp-profile-root"`
 	// AllowPrivileged enables containers to request privileged mode (defaults to false)
 	AllowPrivileged *bool `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
 	// EnableDebuggingHandlers enables server endpoints for log collection and local running of containers and commands
-	EnableDebuggingHandlers *bool `json:"enableDebuggingHandlers,omitempty" flag:"enable-debugging-handlers"`
+	EnableDebuggingHandlers *bool `json:"enableDebuggingHandlers,omitempty" flag:"-"`
 	// RegisterNode enables automatic registration with the apiserver.
 	RegisterNode *bool `json:"registerNode,omitempty" flag:"register-node"`
 	// NodeStatusUpdateFrequency Specifies how often kubelet posts node status to master (default 10s)
 	// must work with nodeMonitorGracePeriod in KubeControllerManagerConfig.
-	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
+	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"-"`
 	// ClusterDomain is the DNS domain for this cluster
-	ClusterDomain string `json:"clusterDomain,omitempty" flag:"cluster-domain"`
+	ClusterDomain string `json:"clusterDomain,omitempty" flag:"-"`
 	// ClusterDNS is the IP address for a cluster DNS server
-	ClusterDNS string `json:"clusterDNS,omitempty" flag:"cluster-dns"`
+	ClusterDNS string `json:"clusterDNS,omitempty" flag:"-"`
 	// NetworkPluginName is the name of the network plugin to be invoked for various events in kubelet/pod lifecycle
 	NetworkPluginName *string `json:"networkPluginName,omitempty" flag:"network-plugin"`
 	// CloudProvider is the provider for cloud services.
 	CloudProvider string `json:"cloudProvider,omitempty" flag:"cloud-provider"`
 	// KubeletCgroups is the absolute name of cgroups to isolate the kubelet in.
-	KubeletCgroups string `json:"kubeletCgroups,omitempty" flag:"kubelet-cgroups"`
+	KubeletCgroups string `json:"kubeletCgroups,omitempty" flag:"-"`
 	// Cgroups that container runtime is expected to be isolated in.
 	RuntimeCgroups string `json:"runtimeCgroups,omitempty" flag:"runtime-cgroups"`
 	// ReadOnlyPort is the port used by the kubelet api for read-only access (default 10255)
-	ReadOnlyPort *int32 `json:"readOnlyPort,omitempty" flag:"read-only-port"`
+	ReadOnlyPort *int32 `json:"readOnlyPort,omitempty" flag:"-"`
 	// SystemCgroups is absolute name of cgroups in which to place
 	// all non-kernel processes that are not already in a container. Empty
 	// for no container. Rolling back the flag requires a reboot.
-	SystemCgroups string `json:"systemCgroups,omitempty" flag:"system-cgroups"`
+	SystemCgroups string `json:"systemCgroups,omitempty" flag:"-"`
 	// cgroupRoot is the root cgroup to use for pods. This is handled by the container runtime on a best effort basis.
-	CgroupRoot string `json:"cgroupRoot,omitempty" flag:"cgroup-root"`
+	CgroupRoot string `json:"cgroupRoot,omitempty" flag:"-"`
 	// configureCBR0 enables the kubelet to configure cbr0 based on Node.Spec.PodCIDR.
 	ConfigureCBR0 *bool `json:"configureCbr0,omitempty" flag:"configure-cbr0"`
 	// How should the kubelet configure the container bridge for hairpin packets.
@@ -103,25 +105,25 @@ type KubeletConfigSpec struct {
 	// Setting --configure-cbr0 to false implies that to achieve hairpin NAT
 	// one must set --hairpin-mode=veth-flag, because bridge assumes the
 	// existence of a container bridge named cbr0.
-	HairpinMode string `json:"hairpinMode,omitempty" flag:"hairpin-mode"`
+	HairpinMode string `json:"hairpinMode,omitempty" flag:"-"`
 	// The node has babysitter process monitoring docker and kubelet. Removed as of 1.7
 	BabysitDaemons *bool `json:"babysitDaemons,omitempty" flag:"babysit-daemons"`
 	// MaxPods is the number of pods that can run on this Kubelet.
-	MaxPods *int32 `json:"maxPods,omitempty" flag:"max-pods"`
+	MaxPods *int32 `json:"maxPods,omitempty" flag:"-"`
 	// NvidiaGPUs is the number of NVIDIA GPU devices on this node.
 	NvidiaGPUs int32 `json:"nvidiaGPUs,omitempty" flag:"experimental-nvidia-gpus" flag-empty:"0"`
 	// PodCIDR is the CIDR to use for pod IP addresses, only used in standalone mode.
 	// In cluster mode, this is obtained from the master.
-	PodCIDR string `json:"podCIDR,omitempty" flag:"pod-cidr"`
+	PodCIDR string `json:"podCIDR,omitempty" flag:"-"`
 	// ResolverConfig is the resolver configuration file used as the basis for the container DNS resolution configuration."), []
-	ResolverConfig *string `json:"resolvConf,omitempty" flag:"resolv-conf" flag-include-empty:"true"`
+	ResolverConfig *string `json:"resolvConf,omitempty" flag:"-"`
 	// ReconcileCIDR is Reconcile node CIDR with the CIDR specified by the
 	// API server. No-op if register-node or configure-cbr0 is false.
 	ReconcileCIDR *bool `json:"reconcileCIDR,omitempty" flag:"reconcile-cidr"`
 	// registerSchedulable tells the kubelet to register the node as schedulable. No-op if register-node is false.
 	RegisterSchedulable *bool `json:"registerSchedulable,omitempty" flag:"register-schedulable"`
 	// SerializeImagePulls when enabled, tells the Kubelet to pull images one at a time.
-	SerializeImagePulls *bool `json:"serializeImagePulls,omitempty" flag:"serialize-image-pulls"`
+	SerializeImagePulls *bool `json:"serializeImagePulls,omitempty" flag:"-"`
 	// NodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string `json:"nodeLabels,omitempty" flag:"node-labels"`
 	// NonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
@@ -133,7 +135,8 @@ type KubeletConfigSpec struct {
 	// computed (such as IPSEC).
 	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
 	// imageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: "2m"
-	ImageMinimumGCAge *metav1.Duration `json:"imageMinimumGCAge,omitempty"`
+	// Kept as a flag so explicit zero is preserved; the upstream config field is non-pointer with omitempty and would drop a zero value.
+	ImageMinimumGCAge *metav1.Duration `json:"imageMinimumGCAge,omitempty" flag:"image-minimum-gc-age"`
 	// imageMaximumGCAge is the maximum age an image can be unused before it is garbage collected.
 	// The default of this field is "0s", which disables this field--meaning images won't be garbage
 	// collected based on being unused for too long. Default: "0s" (disabled)
@@ -145,99 +148,105 @@ type KubeletConfigSpec struct {
 	MaxParallelImagePulls *int32 `json:"maxParallelImagePulls,omitempty"`
 	// ImageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.
-	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"image-gc-high-threshold"`
+	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"-"`
 	// ImageGCLowThresholdPercent is the percent of disk usage before which
 	// image garbage collection is never run. Lowest disk usage to garbage
 	// collect to.
-	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty" flag:"image-gc-low-threshold"`
+	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty" flag:"-"`
 	// ImagePullProgressDeadline is the timeout for image pulls
 	// If no pulling progress is made before this deadline, the image pulling will be cancelled. (default 1m0s)
 	ImagePullProgressDeadline *metav1.Duration `json:"imagePullProgressDeadline,omitempty" flag:"image-pull-progress-deadline"`
 	// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
-	EvictionHard *string `json:"evictionHard,omitempty" flag:"eviction-hard"`
+	EvictionHard *string `json:"evictionHard,omitempty" flag:"-"`
 	// Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.
-	EvictionSoft string `json:"evictionSoft,omitempty" flag:"eviction-soft"`
+	EvictionSoft string `json:"evictionSoft,omitempty" flag:"-"`
 	// Comma-delimited list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.
-	EvictionSoftGracePeriod string `json:"evictionSoftGracePeriod,omitempty" flag:"eviction-soft-grace-period"`
+	EvictionSoftGracePeriod string `json:"evictionSoftGracePeriod,omitempty" flag:"-"`
 	// Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
-	EvictionPressureTransitionPeriod *metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"eviction-pressure-transition-period" flag-empty:"0s"`
+	EvictionPressureTransitionPeriod *metav1.Duration `json:"evictionPressureTransitionPeriod,omitempty" flag:"-"`
 	// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
-	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"eviction-max-pod-grace-period" flag-empty:"0"`
+	EvictionMaxPodGracePeriod int32 `json:"evictionMaxPodGracePeriod,omitempty" flag:"-"`
 	// Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
-	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"eviction-minimum-reclaim"`
+	EvictionMinimumReclaim string `json:"evictionMinimumReclaim,omitempty" flag:"-"`
 	// The full path of the directory in which to search for additional third party volume plugins (this path must be writeable, dependent on your choice of OS)
-	VolumePluginDirectory string `json:"volumePluginDirectory,omitempty" flag:"volume-plugin-dir"`
+	VolumePluginDirectory string `json:"volumePluginDirectory,omitempty" flag:"-"`
 	// Taints to add when registering a node in the cluster
-	Taints []string `json:"taints,omitempty" flag:"register-with-taints"`
+	Taints []string `json:"taints,omitempty" flag:"-"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
-	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"-"`
 	// Integrate with the kernel memcg notification to determine if memory eviction thresholds are crossed rather than polling.
-	KernelMemcgNotification *bool `json:"kernelMemcgNotification,omitempty" flag:"kernel-memcg-notification"`
+	KernelMemcgNotification *bool `json:"kernelMemcgNotification,omitempty" flag:"-"`
 	// Resource reservation for kubernetes system daemons like the kubelet, container runtime, node problem detector, etc.
-	KubeReserved map[string]string `json:"kubeReserved,omitempty" flag:"kube-reserved"`
+	KubeReserved map[string]string `json:"kubeReserved,omitempty" flag:"-"`
 	// Control group for kube daemons.
-	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty" flag:"kube-reserved-cgroup"`
+	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty" flag:"-"`
 	// Capture resource reservation for OS system daemons like sshd, udev, etc.
-	SystemReserved map[string]string `json:"systemReserved,omitempty" flag:"system-reserved"`
+	SystemReserved map[string]string `json:"systemReserved,omitempty" flag:"-"`
 	// Parent control group for OS system daemons.
-	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"system-reserved-cgroup"`
+	SystemReservedCgroup string `json:"systemReservedCgroup,omitempty" flag:"-"`
 	// Enforce Allocatable across pods whenever the overall usage across all pods exceeds Allocatable.
-	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"enforce-node-allocatable"`
+	EnforceNodeAllocatable string `json:"enforceNodeAllocatable,omitempty" flag:"-"`
 	// RuntimeRequestTimeout is timeout for runtime requests on - pull, logs, exec and attach
+	// Kept as a flag so explicit zero is preserved; the upstream config field is non-pointer with omitempty and would drop a zero value.
 	RuntimeRequestTimeout *metav1.Duration `json:"runtimeRequestTimeout,omitempty" flag:"runtime-request-timeout"`
 	// VolumeStatsAggPeriod is the interval for kubelet to calculate and cache the volume disk usage for all pods and volumes
+	// Kept as a flag so explicit zero is preserved; the upstream config field is non-pointer with omitempty and would drop a zero value.
 	VolumeStatsAggPeriod *metav1.Duration `json:"volumeStatsAggPeriod,omitempty" flag:"volume-stats-agg-period"`
 	// Tells the Kubelet to fail to start if swap is enabled on the node.
-	FailSwapOn *bool `json:"failSwapOn,omitempty" flag:"fail-swap-on"`
+	FailSwapOn *bool `json:"failSwapOn,omitempty" flag:"-"`
 	// ExperimentalAllowedUnsafeSysctls are passed to the kubelet config to whitelist allowable sysctls
 	// Was promoted to beta and renamed. https://github.com/kubernetes/kubernetes/pull/63717
 	ExperimentalAllowedUnsafeSysctls []string `json:"experimentalAllowedUnsafeSysctls,omitempty" flag:"experimental-allowed-unsafe-sysctls"`
 	// AllowedUnsafeSysctls are passed to the kubelet config to whitelist allowable sysctls
-	AllowedUnsafeSysctls []string `json:"allowedUnsafeSysctls,omitempty" flag:"allowed-unsafe-sysctls"`
+	AllowedUnsafeSysctls []string `json:"allowedUnsafeSysctls,omitempty" flag:"-"`
 	// StreamingConnectionIdleTimeout is the maximum time a streaming connection can be idle before the connection is automatically closed
+	// Kept as a flag so explicit zero is preserved; the upstream config field is non-pointer with omitempty and would drop a zero value.
 	StreamingConnectionIdleTimeout *metav1.Duration `json:"streamingConnectionIdleTimeout,omitempty" flag:"streaming-connection-idle-timeout"`
 	// DockerDisableSharedPID was removed.
 	DockerDisableSharedPID *bool `json:"-"`
 	// RootDir is the directory path for managing kubelet files (volume mounts,etc)
 	RootDir string `json:"rootDir,omitempty" flag:"root-dir"`
 	// AuthenticationTokenWebhook uses the TokenReview API to determine authentication for bearer tokens.
-	AuthenticationTokenWebhook *bool `json:"authenticationTokenWebhook,omitempty" flag:"authentication-token-webhook"`
+	AuthenticationTokenWebhook *bool `json:"authenticationTokenWebhook,omitempty" flag:"-"`
 	// AuthenticationTokenWebhook sets the duration to cache responses from the webhook token authenticator. Default is 2m. (default 2m0s)
+	// Kept as a flag so explicit zero is preserved; the upstream config field is non-pointer with omitempty and would drop a zero value.
 	AuthenticationTokenWebhookCacheTTL *metav1.Duration `json:"authenticationTokenWebhookCacheTTL,omitempty" flag:"authentication-token-webhook-cache-ttl"`
 	// CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits
-	CPUCFSQuota *bool `json:"cpuCFSQuota,omitempty" flag:"cpu-cfs-quota"`
+	CPUCFSQuota *bool `json:"cpuCFSQuota,omitempty" flag:"-"`
 	// CPUCFSQuotaPeriod sets CPU CFS quota period value, cpu.cfs_period_us, defaults to Linux Kernel default
-	CPUCFSQuotaPeriod *metav1.Duration `json:"cpuCFSQuotaPeriod,omitempty" flag:"cpu-cfs-quota-period"`
+	CPUCFSQuotaPeriod *metav1.Duration `json:"cpuCFSQuotaPeriod,omitempty" flag:"-"`
 	// CpuManagerPolicy allows for changing the default policy of None to static
-	CpuManagerPolicy string `json:"cpuManagerPolicy,omitempty" flag:"cpu-manager-policy"`
+	CpuManagerPolicy string `json:"cpuManagerPolicy,omitempty" flag:"-"`
 	// RegistryPullQPS if > 0, limit registry pull QPS to this value.  If 0, unlimited. (default 5)
-	RegistryPullQPS *int32 `json:"registryPullQPS,omitempty" flag:"registry-qps"`
+	RegistryPullQPS *int32 `json:"registryPullQPS,omitempty" flag:"-"`
 	// RegistryBurst Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry-qps. Only used if --registry-qps > 0 (default 10)
+	// Kept as a flag so explicit zero is preserved; the upstream config field is non-pointer with omitempty and would drop a zero value.
 	RegistryBurst *int32 `json:"registryBurst,omitempty" flag:"registry-burst"`
 	// TopologyManagerPolicy determines the allocation policy for the topology manager.
-	TopologyManagerPolicy string `json:"topologyManagerPolicy,omitempty" flag:"topology-manager-policy"`
+	TopologyManagerPolicy string `json:"topologyManagerPolicy,omitempty" flag:"-"`
 	// rotateCertificates enables client certificate rotation.
-	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"rotate-certificates"`
+	RotateCertificates *bool `json:"rotateCertificates,omitempty" flag:"-"`
 	// Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
 	// DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag.
-	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
+	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"-"`
 	// CgroupDriver allows the explicit setting of the kubelet cgroup driver.
 	// DEPRECATED: The cgroup driver is automatically detected.
-	CgroupDriver string `json:"cgroupDriver,omitempty" flag:"cgroup-driver"`
+	CgroupDriver string `json:"cgroupDriver,omitempty" flag:"-"`
 	// HousekeepingInterval allows to specify interval between container housekeepings.
 	HousekeepingInterval *metav1.Duration `json:"housekeepingInterval,omitempty" flag:"housekeeping-interval"`
 	// EventQPS if > 0, limit event creations per second to this value.  If 0, unlimited.
-	EventQPS *int32 `json:"eventQPS,omitempty" flag:"event-qps" flag-empty:"0"`
+	EventQPS *int32 `json:"eventQPS,omitempty" flag:"-"`
 	// EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
+	// Kept as a flag so explicit zero is preserved; the upstream config field is non-pointer with omitempty and would drop a zero value.
 	EventBurst *int32 `json:"eventBurst,omitempty" flag:"event-burst"`
 	// ContainerLogMaxSize is the maximum size (e.g. 10Mi) of container log file before it is rotated.
-	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty" flag:"container-log-max-size"`
+	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty" flag:"-"`
 	// ContainerLogMaxFiles is the maximum number of container log files that can be present for a container. The number must be >= 2.
-	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty" flag:"container-log-max-files"`
+	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty" flag:"-"`
 	// EnableCadvisorJsonEndpoints enables cAdvisor json `/spec` and `/stats/*` endpoints. Defaults to False.
 	EnableCadvisorJsonEndpoints *bool `json:"enableCadvisorJsonEndpoints,omitempty" flag:"enable-cadvisor-json-endpoints"`
 	// PodPidsLimit is the maximum number of pids in any pod.
-	PodPidsLimit *int64 `json:"podPidsLimit,omitempty" flag:"pod-max-pids"`
+	PodPidsLimit *int64 `json:"podPidsLimit,omitempty" flag:"-"`
 	// ExperimentalAllocatableIgnoreEviction enables ignoring Hard Eviction Thresholds while calculating Node Allocatable
 	ExperimentalAllocatableIgnoreEviction *bool `json:"experimentalAllocatableIgnoreEviction,omitempty" flag:"experimental-allocatable-ignore-eviction"`
 

--- a/pkg/flagbuilder/buildflags_test.go
+++ b/pkg/flagbuilder/buildflags_test.go
@@ -94,12 +94,6 @@ func TestKubeletConfigSpec(t *testing.T) {
 		},
 		{
 			Config: &kops.KubeletConfigSpec{
-				EvictionPressureTransitionPeriod: &metav1.Duration{Duration: 5 * time.Second},
-			},
-			Expected: "--eviction-pressure-transition-period=5s",
-		},
-		{
-			Config: &kops.KubeletConfigSpec{
 				LogLevel: fi.PtrTo(int32(0)),
 			},
 			Expected: "",
@@ -111,41 +105,17 @@ func TestKubeletConfigSpec(t *testing.T) {
 			Expected: "--v=2",
 		},
 
-		// Test string pointers without the "flag-include-empty" tag
+		// Fields that have been migrated to the kubelet config file emit no flag.
 		{
 			Config: &kops.KubeletConfigSpec{
-				EvictionHard: fi.PtrTo("memory.available<100Mi"),
-			},
-			Expected: "--eviction-hard=memory.available<100Mi",
-		},
-		{
-			Config: &kops.KubeletConfigSpec{
-				EvictionHard: fi.PtrTo(""),
+				EvictionPressureTransitionPeriod: &metav1.Duration{Duration: 5 * time.Second},
+				EvictionHard:                     fi.PtrTo("memory.available<100Mi"),
+				ResolverConfig:                   fi.PtrTo("test"),
 			},
 			Expected: "",
 		},
-
-		// Test string pointers with the "flag-include-empty" tag
 		{
 			Config:   &kops.KubeletConfigSpec{},
-			Expected: "",
-		},
-		{
-			Config: &kops.KubeletConfigSpec{
-				ResolverConfig: fi.PtrTo("test"),
-			},
-			Expected: "--resolv-conf=test",
-		},
-		{
-			Config: &kops.KubeletConfigSpec{
-				ResolverConfig: fi.PtrTo(""),
-			},
-			Expected: "--resolv-conf=",
-		},
-		{
-			Config: &kops.KubeletConfigSpec{
-				ResolverConfig: nil,
-			},
 			Expected: "",
 		},
 	}


### PR DESCRIPTION
This populates `/var/lib/kubelet/kubelet.conf` with values that were previously emitted as CLI flags.

Written with assistance from Opus 4.7