### PR TITLE
hetzner: Upgrade hcloud-cloud-controller-manager to v1.30.1

### DIFF
--- a/pkg/model/components/hetznercloudcontrollermanager.go
+++ b/pkg/model/components/hetznercloudcontrollermanager.go
@@ -55,7 +55,7 @@ func (b *HetznerCloudControllerManagerOptionsBuilder) BuildOptions(cluster *kops
 	eccm.ConfigureCloudRoutes = fi.PtrTo(false)
 
 	if eccm.Image == "" {
-		eccm.Image = "hetznercloud/hcloud-cloud-controller-manager:v1.27.0"
+		eccm.Image = "hetznercloud/hcloud-cloud-controller-manager:v1.30.1"
 	}
 
 	return nil

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     cloudProvider: hcloud
     clusterCIDR: 100.96.0.0/11
     configureCloudRoutes: false
-    image: hetznercloud/hcloud-cloud-controller-manager:v1.27.0
+    image: hetznercloud/hcloud-cloud-controller-manager:v1.30.1
     leaderElection:
       leaderElect: false
   cloudProvider: hetzner

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
@@ -35,7 +35,7 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.22
     manifest: hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml
-    manifestHash: f041aa2c24c2d70086b168573271a9f119333347de170182ee00f1a03bd7414f
+    manifestHash: 7b4c356af05c309d3c6b7a926023160809170b5ad49c98b738d281c53469705f
     name: hcloud-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: hcloud-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_gossip.k8s.local-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_gossip.k8s.local-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
@@ -87,7 +87,7 @@ spec:
             secretKeyRef:
               key: network
               name: hcloud
-        image: hetznercloud/hcloud-cloud-controller-manager:v1.27.0
+        image: hetznercloud/hcloud-cloud-controller-manager:v1.30.1
         name: hcloud-cloud-controller-manager
         ports:
         - containerPort: 8233

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     cloudProvider: hcloud
     clusterCIDR: 100.96.0.0/11
     configureCloudRoutes: false
-    image: hetznercloud/hcloud-cloud-controller-manager:v1.27.0
+    image: hetznercloud/hcloud-cloud-controller-manager:v1.30.1
     leaderElection:
       leaderElect: false
   cloudProvider: hetzner

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -29,7 +29,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.22
     manifest: hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml
-    manifestHash: 7e28838077cb18a39ba60134fbcbc3459c5b95fd7a3aa83999a8032adb47941d
+    manifestHash: 690f7824bc9b626dd7a2412fa894a73afe6b6160147b6bf57a2d11821c1caa62
     name: hcloud-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: hcloud-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
@@ -87,7 +87,7 @@ spec:
             secretKeyRef:
               key: network
               name: hcloud
-        image: hetznercloud/hcloud-cloud-controller-manager:v1.27.0
+        image: hetznercloud/hcloud-cloud-controller-manager:v1.30.1
         name: hcloud-cloud-controller-manager
         ports:
         - containerPort: 8233


### PR DESCRIPTION
Required upgrade 2026-06-01. See https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/tag/v1.30.1.