### PR TITLE
Cherrypick GCE resource dump fixes to 1.35

### DIFF
--- a/pkg/resources/gce/dump.go
+++ b/pkg/resources/gce/dump.go
@@ -62,18 +62,19 @@ func DumpManagedInstance(op *resources.DumpOperation, r *resources.Resource) err
 	instanceDetails := instanceMap[u.Name]
 	if instanceDetails == nil {
 		klog.Warningf("instance %q not found", instance.Instance)
-	} else {
-		for _, ni := range instanceDetails.NetworkInterfaces {
-			if ni.NetworkIP != "" {
-				i.PrivateAddresses = append(i.PrivateAddresses, ni.NetworkIP)
-			}
-			if ni.Ipv6Address != "" {
-				i.PrivateAddresses = append(i.PrivateAddresses, ni.Ipv6Address)
-			}
-			for _, ac := range ni.AccessConfigs {
-				if ac.NatIP != "" {
-					i.PublicAddresses = append(i.PublicAddresses, ac.NatIP)
-				}
+		return nil
+	}
+
+	for _, ni := range instanceDetails.NetworkInterfaces {
+		if ni.NetworkIP != "" {
+			i.PrivateAddresses = append(i.PrivateAddresses, ni.NetworkIP)
+		}
+		if ni.Ipv6Address != "" {
+			i.PrivateAddresses = append(i.PrivateAddresses, ni.Ipv6Address)
+		}
+		for _, ac := range ni.AccessConfigs {
+			if ac.NatIP != "" {
+				i.PublicAddresses = append(i.PublicAddresses, ac.NatIP)
 			}
 		}
 	}

--- a/pkg/resources/gce/dump.go
+++ b/pkg/resources/gce/dump.go
@@ -61,7 +61,14 @@ func DumpManagedInstance(op *resources.DumpOperation, r *resources.Resource) err
 
 	instanceDetails := instanceMap[u.Name]
 	if instanceDetails == nil {
-		klog.Warningf("instance %q not found", instance.Instance)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "instance %q not found (currentAction=%q instanceStatus=%q)", instance.Instance, instance.CurrentAction, instance.InstanceStatus)
+		if instance.LastAttempt != nil && instance.LastAttempt.Errors != nil {
+			for _, e := range instance.LastAttempt.Errors.Errors {
+				fmt.Fprintf(&sb, "; lastAttempt.error code=%q location=%q message=%q", e.Code, e.Location, e.Message)
+			}
+		}
+		klog.Warning(sb.String())
 		return nil
 	}
 


### PR DESCRIPTION
Manual cherrypick because I can't find these older PRs in github.

this cherrypicks these two commits from master:

https://github.com/kubernetes/kops/commit/86169eb90b23daa558bc7796fb723f83d7afc0ab

https://github.com/kubernetes/kops/commit/d11f26a65846463816b0ca862e6f7b096781c5f6

helps troubleshoot this new job that is failing: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kubenet-cosdevarm64-k32-ko35/2052387888376582144