### PR TITLE
Automated cherry pick of #18285: cilium: allow setting arbitrary cilium-config entries

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5611,6 +5611,13 @@ spec:
                           The cluster is operated by cilium-etcd-operator.
                           Default: false
                         type: boolean
+                      extraConfig:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ExtraConfig is appended to the cilium-config ConfigMap. Keys here override any value
+                          rendered by kops. All values must be strings (e.g. "true", not true).
+                        type: object
                       gatewayAPI:
                         description: GatewayAPI specifies the configuration for Cilium
                           Gateway API settings.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -528,6 +528,10 @@ type CiliumNetworkingSpec struct {
 
 	// GatewayAPI specifies the configuration for Cilium Gateway API settings.
 	GatewayAPI *CiliumGatewayAPISpec `json:"gatewayAPI,omitempty"`
+
+	// ExtraConfig is appended to the cilium-config ConfigMap. Keys here override any value
+	// rendered by kops. All values must be strings (e.g. "true", not true).
+	ExtraConfig map[string]string `json:"extraConfig,omitempty"`
 }
 
 // CiliumIngressSpec configures Cilium Ingress settings.

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -645,6 +645,10 @@ type CiliumNetworkingSpec struct {
 
 	// GatewayAPI specifies the configuration for Cilium Gateway API settings.
 	GatewayAPI *CiliumGatewayAPISpec `json:"gatewayAPI,omitempty"`
+
+	// ExtraConfig is appended to the cilium-config ConfigMap. Keys here override any value
+	// rendered by kops. All values must be strings (e.g. "true", not true).
+	ExtraConfig map[string]string `json:"extraConfig,omitempty"`
 }
 
 // CiliumIngressSpec configures Cilium Ingress settings.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2177,6 +2177,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	} else {
 		out.GatewayAPI = nil
 	}
+	out.ExtraConfig = in.ExtraConfig
 	return nil
 }
 
@@ -2259,6 +2260,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	} else {
 		out.GatewayAPI = nil
 	}
+	out.ExtraConfig = in.ExtraConfig
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -720,6 +720,13 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(CiliumGatewayAPISpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExtraConfig != nil {
+		in, out := &in.ExtraConfig, &out.ExtraConfig
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -476,6 +476,10 @@ type CiliumNetworkingSpec struct {
 
 	// GatewayAPI specifies the configuration for Cilium Gateway API settings.
 	GatewayAPI *CiliumGatewayAPISpec `json:"gatewayAPI,omitempty"`
+
+	// ExtraConfig is appended to the cilium-config ConfigMap. Keys here override any value
+	// rendered by kops. All values must be strings (e.g. "true", not true).
+	ExtraConfig map[string]string `json:"extraConfig,omitempty"`
 }
 
 // CiliumIngressSpec configures Cilium Ingress settings.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2308,6 +2308,7 @@ func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	} else {
 		out.GatewayAPI = nil
 	}
+	out.ExtraConfig = in.ExtraConfig
 	return nil
 }
 
@@ -2395,6 +2396,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *
 	} else {
 		out.GatewayAPI = nil
 	}
+	out.ExtraConfig = in.ExtraConfig
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -747,6 +747,13 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(CiliumGatewayAPISpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExtraConfig != nil {
+		in, out := &in.ExtraConfig, &out.ExtraConfig
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -828,6 +828,13 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(CiliumGatewayAPISpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExtraConfig != nil {
+		in, out := &in.ExtraConfig, &out.ExtraConfig
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -473,8 +473,11 @@ data:
   enable-non-default-deny-policies: "true"
   enable-source-ip-verification: "true"
 
-# Extra config allows adding arbitrary properties to the cilium config.
-# By putting it at the end of the ConfigMap, it's also possible to override existing properties.
+  # Extra config allows adding arbitrary properties to the cilium config.
+  # By putting it at the end of the ConfigMap, it's also possible to override existing properties.
+  {{- range $k, $v := .ExtraConfig }}
+  {{ $k }}: {{ printf "%q" $v }}
+  {{- end }}
 
 {{ if WithDefaultBool .Hubble.Enabled false }}
 ---


### PR DESCRIPTION
Cherry pick of #18285 on release-1.34.

#18285: cilium: allow setting arbitrary cilium-config entries

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```