### PR TITLE
etcd-manager: Bump etcd patches and drop 3.4 support

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -29,8 +29,8 @@ type EtcdOptionsBuilder struct {
 var _ loader.ClusterOptionsBuilder = &EtcdOptionsBuilder{}
 
 const (
-	DefaultEtcd3Version_1_22 = "3.5.25"
-	DefaultEtcd3Version_1_34 = "3.6.6"
+	DefaultEtcd3Version_1_22 = "3.5.30"
+	DefaultEtcd3Version_1_34 = "3.6.11"
 )
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -94,8 +94,8 @@ type etcdVersion struct {
 // supported minor. All earlier patch versions within the same minor are
 // generated as SymlinkToVersion entries by etcdSupportedVersions.
 var etcdLatestImages = []etcdVersion{
-	{Version: "3.5.25", Image: "registry.k8s.io/etcd:v3.5.25"},
-	{Version: "3.6.6", Image: "registry.k8s.io/etcd:v3.6.6"},
+	{Version: "3.5.30", Image: "registry.k8s.io/etcd:v3.5.30"},
+	{Version: "3.6.11", Image: "registry.k8s.io/etcd:v3.6.11"},
 }
 
 func etcdSupportedVersions() []etcdVersion {

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
@@ -89,36 +90,36 @@ type etcdVersion struct {
 	SymlinkToVersion string
 }
 
-var etcdSupportedImages = []etcdVersion{
-	{Version: "3.4.3", SymlinkToVersion: "3.4.13"},
+// etcdLatestImages lists the latest etcd patch image bundled by kops for each
+// supported minor. All earlier patch versions within the same minor are
+// generated as SymlinkToVersion entries by etcdSupportedVersions.
+var etcdLatestImages = []etcdVersion{
 	{Version: "3.4.13", Image: "registry.k8s.io/etcd:v3.4.13"},
-	{Version: "3.5.0", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.1", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.3", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.4", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.6", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.7", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.9", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.13", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.17", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.21", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.23", SymlinkToVersion: "3.5.25"},
-	{Version: "3.5.24", SymlinkToVersion: "3.5.25"},
 	{Version: "3.5.25", Image: "registry.k8s.io/etcd:v3.5.25"},
-	{Version: "3.6.5", SymlinkToVersion: "3.6.6"},
 	{Version: "3.6.6", Image: "registry.k8s.io/etcd:v3.6.6"},
 }
 
 func etcdSupportedVersions() []etcdVersion {
 	var versions []etcdVersion
-	versions = append(versions, etcdSupportedImages...)
-	sort.Slice(versions, func(i, j int) bool { return versions[i].Version < versions[j].Version })
+	for _, latest := range etcdLatestImages {
+		sv := semver.MustParse(latest.Version)
+		versions = append(versions, latest)
+		for patch := uint64(0); patch < sv.Patch; patch++ {
+			versions = append(versions, etcdVersion{
+				Version:          fmt.Sprintf("%d.%d.%d", sv.Major, sv.Minor, patch),
+				SymlinkToVersion: latest.Version,
+			})
+		}
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		return semver.MustParse(versions[i].Version).LT(semver.MustParse(versions[j].Version))
+	})
 	return versions
 }
 
 func etcdVersionIsSupported(version string) bool {
 	version = strings.TrimPrefix(version, "v")
-	for _, etcdVersion := range etcdSupportedImages {
+	for _, etcdVersion := range etcdSupportedVersions() {
 		if etcdVersion.Version == version {
 			return true
 		}

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -94,7 +94,6 @@ type etcdVersion struct {
 // supported minor. All earlier patch versions within the same minor are
 // generated as SymlinkToVersion entries by etcdSupportedVersions.
 var etcdLatestImages = []etcdVersion{
-	{Version: "3.4.13", Image: "registry.k8s.io/etcd:v3.4.13"},
 	{Version: "3.5.25", Image: "registry.k8s.io/etcd:v3.5.25"},
 	{Version: "3.6.6", Image: "registry.k8s.io/etcd:v3.6.6"},
 }

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -119,50 +119,25 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.5.30
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.4.13
-      name: init-etcd-3-4-13
+      image: registry.k8s.io/etcd:v3.5.30
+      name: init-etcd-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.6.11
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.5.25
-      name: init-etcd-3-5-25
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --target-dir=/opt/etcd-v3.6.6
-      - --src=/usr/local/bin/etcd
-      - --src=/usr/local/bin/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.6.6
-      name: init-etcd-3-6-6
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --symlink
-      - --target-dir=/opt/etcd-v3.4.3
-      - --src=/opt/etcd-v3.4.13/etcd
-      - --src=/opt/etcd-v3.4.13/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-4-13
+      image: registry.k8s.io/etcd:v3.6.11
+      name: init-etcd-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -171,35 +146,63 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.10
+      - --target-dir=/opt/etcd-v3.5.11
+      - --target-dir=/opt/etcd-v3.5.12
       - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.14
+      - --target-dir=/opt/etcd-v3.5.15
+      - --target-dir=/opt/etcd-v3.5.16
       - --target-dir=/opt/etcd-v3.5.17
+      - --target-dir=/opt/etcd-v3.5.18
+      - --target-dir=/opt/etcd-v3.5.19
+      - --target-dir=/opt/etcd-v3.5.2
+      - --target-dir=/opt/etcd-v3.5.20
       - --target-dir=/opt/etcd-v3.5.21
+      - --target-dir=/opt/etcd-v3.5.22
       - --target-dir=/opt/etcd-v3.5.23
       - --target-dir=/opt/etcd-v3.5.24
+      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.5.26
+      - --target-dir=/opt/etcd-v3.5.27
+      - --target-dir=/opt/etcd-v3.5.28
+      - --target-dir=/opt/etcd-v3.5.29
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.5
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.8
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.25/etcd
-      - --src=/opt/etcd-v3.5.25/etcdctl
+      - --src=/opt/etcd-v3.5.30/etcd
+      - --src=/opt/etcd-v3.5.30/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-5-25
+      name: init-etcd-symlinks-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
       - --symlink
+      - --target-dir=/opt/etcd-v3.6.0
+      - --target-dir=/opt/etcd-v3.6.1
+      - --target-dir=/opt/etcd-v3.6.10
+      - --target-dir=/opt/etcd-v3.6.2
+      - --target-dir=/opt/etcd-v3.6.3
+      - --target-dir=/opt/etcd-v3.6.4
       - --target-dir=/opt/etcd-v3.6.5
-      - --src=/opt/etcd-v3.6.6/etcd
-      - --src=/opt/etcd-v3.6.6/etcdctl
+      - --target-dir=/opt/etcd-v3.6.6
+      - --target-dir=/opt/etcd-v3.6.7
+      - --target-dir=/opt/etcd-v3.6.8
+      - --target-dir=/opt/etcd-v3.6.9
+      - --src=/opt/etcd-v3.6.11/etcd
+      - --src=/opt/etcd-v3.6.11/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-6-6
+      name: init-etcd-symlinks-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -289,50 +292,25 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.5.30
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.4.13
-      name: init-etcd-3-4-13
+      image: registry.k8s.io/etcd:v3.5.30
+      name: init-etcd-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.6.11
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.5.25
-      name: init-etcd-3-5-25
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --target-dir=/opt/etcd-v3.6.6
-      - --src=/usr/local/bin/etcd
-      - --src=/usr/local/bin/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.6.6
-      name: init-etcd-3-6-6
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --symlink
-      - --target-dir=/opt/etcd-v3.4.3
-      - --src=/opt/etcd-v3.4.13/etcd
-      - --src=/opt/etcd-v3.4.13/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-4-13
+      image: registry.k8s.io/etcd:v3.6.11
+      name: init-etcd-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -341,35 +319,63 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.10
+      - --target-dir=/opt/etcd-v3.5.11
+      - --target-dir=/opt/etcd-v3.5.12
       - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.14
+      - --target-dir=/opt/etcd-v3.5.15
+      - --target-dir=/opt/etcd-v3.5.16
       - --target-dir=/opt/etcd-v3.5.17
+      - --target-dir=/opt/etcd-v3.5.18
+      - --target-dir=/opt/etcd-v3.5.19
+      - --target-dir=/opt/etcd-v3.5.2
+      - --target-dir=/opt/etcd-v3.5.20
       - --target-dir=/opt/etcd-v3.5.21
+      - --target-dir=/opt/etcd-v3.5.22
       - --target-dir=/opt/etcd-v3.5.23
       - --target-dir=/opt/etcd-v3.5.24
+      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.5.26
+      - --target-dir=/opt/etcd-v3.5.27
+      - --target-dir=/opt/etcd-v3.5.28
+      - --target-dir=/opt/etcd-v3.5.29
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.5
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.8
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.25/etcd
-      - --src=/opt/etcd-v3.5.25/etcdctl
+      - --src=/opt/etcd-v3.5.30/etcd
+      - --src=/opt/etcd-v3.5.30/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-5-25
+      name: init-etcd-symlinks-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
       - --symlink
+      - --target-dir=/opt/etcd-v3.6.0
+      - --target-dir=/opt/etcd-v3.6.1
+      - --target-dir=/opt/etcd-v3.6.10
+      - --target-dir=/opt/etcd-v3.6.2
+      - --target-dir=/opt/etcd-v3.6.3
+      - --target-dir=/opt/etcd-v3.6.4
       - --target-dir=/opt/etcd-v3.6.5
-      - --src=/opt/etcd-v3.6.6/etcd
-      - --src=/opt/etcd-v3.6.6/etcdctl
+      - --target-dir=/opt/etcd-v3.6.6
+      - --target-dir=/opt/etcd-v3.6.7
+      - --target-dir=/opt/etcd-v3.6.8
+      - --target-dir=/opt/etcd-v3.6.9
+      - --src=/opt/etcd-v3.6.11/etcd
+      - --src=/opt/etcd-v3.6.11/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-6-6
+      name: init-etcd-symlinks-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -101,40 +101,92 @@ Contents: |
         name: pki
       - mountPath: /opt
         name: opt
-      - mountPath: /opt/etcd-v3.4.13
-        name: etcd-v3-4-13
-      - mountPath: /opt/etcd-v3.4.3
-        name: etcd-v3-4-13
       - mountPath: /opt/etcd-v3.5.0
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.1
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.13
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.17
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.21
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.23
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.24
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.25
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.2
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.3
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.4
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.5
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.6
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.7
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.8
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.9
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.10
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.11
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.12
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.13
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.14
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.15
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.16
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.17
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.18
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.19
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.20
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.21
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.22
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.23
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.24
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.25
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.26
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.27
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.28
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.29
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.30
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.6.0
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.1
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.2
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.3
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.4
+        name: etcd-v3-6-11
       - mountPath: /opt/etcd-v3.6.5
-        name: etcd-v3-6-6
+        name: etcd-v3-6-11
       - mountPath: /opt/etcd-v3.6.6
-        name: etcd-v3-6-6
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.7
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.8
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.9
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.10
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.11
+        name: etcd-v3-6-11
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
@@ -160,16 +212,12 @@ Contents: |
       name: opt
     - image:
         pullPolicy: IfNotPresent
-        reference: registry.k8s.io/etcd:v3.4.13
-      name: etcd-v3-4-13
+        reference: registry.k8s.io/etcd:v3.5.30
+      name: etcd-v3-5-30
     - image:
         pullPolicy: IfNotPresent
-        reference: registry.k8s.io/etcd:v3.5.25
-      name: etcd-v3-5-25
-    - image:
-        pullPolicy: IfNotPresent
-        reference: registry.k8s.io/etcd:v3.6.6
-      name: etcd-v3-6-6
+        reference: registry.k8s.io/etcd:v3.6.11
+      name: etcd-v3-6-11
     - hostPath:
         path: /var/log/etcd-events.log
         type: FileOrCreate
@@ -218,40 +266,92 @@ Contents: |
         name: pki
       - mountPath: /opt
         name: opt
-      - mountPath: /opt/etcd-v3.4.13
-        name: etcd-v3-4-13
-      - mountPath: /opt/etcd-v3.4.3
-        name: etcd-v3-4-13
       - mountPath: /opt/etcd-v3.5.0
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.1
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.13
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.17
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.21
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.23
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.24
-        name: etcd-v3-5-25
-      - mountPath: /opt/etcd-v3.5.25
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.2
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.3
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.4
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.5
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.6
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.7
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.8
+        name: etcd-v3-5-30
       - mountPath: /opt/etcd-v3.5.9
-        name: etcd-v3-5-25
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.10
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.11
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.12
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.13
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.14
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.15
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.16
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.17
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.18
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.19
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.20
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.21
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.22
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.23
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.24
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.25
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.26
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.27
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.28
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.29
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.5.30
+        name: etcd-v3-5-30
+      - mountPath: /opt/etcd-v3.6.0
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.1
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.2
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.3
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.4
+        name: etcd-v3-6-11
       - mountPath: /opt/etcd-v3.6.5
-        name: etcd-v3-6-6
+        name: etcd-v3-6-11
       - mountPath: /opt/etcd-v3.6.6
-        name: etcd-v3-6-6
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.7
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.8
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.9
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.10
+        name: etcd-v3-6-11
+      - mountPath: /opt/etcd-v3.6.11
+        name: etcd-v3-6-11
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
@@ -277,16 +377,12 @@ Contents: |
       name: opt
     - image:
         pullPolicy: IfNotPresent
-        reference: registry.k8s.io/etcd:v3.4.13
-      name: etcd-v3-4-13
+        reference: registry.k8s.io/etcd:v3.5.30
+      name: etcd-v3-5-30
     - image:
         pullPolicy: IfNotPresent
-        reference: registry.k8s.io/etcd:v3.5.25
-      name: etcd-v3-5-25
-    - image:
-        pullPolicy: IfNotPresent
-        reference: registry.k8s.io/etcd:v3.6.6
-      name: etcd-v3-6-6
+        reference: registry.k8s.io/etcd:v3.6.11
+      name: etcd-v3-6-11
     - hostPath:
         path: /var/log/etcd.log
         type: FileOrCreate

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -121,50 +121,25 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.5.30
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.4.13
-      name: init-etcd-3-4-13
+      image: registry.k8s.io/etcd:v3.5.30
+      name: init-etcd-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.6.11
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.5.25
-      name: init-etcd-3-5-25
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --target-dir=/opt/etcd-v3.6.6
-      - --src=/usr/local/bin/etcd
-      - --src=/usr/local/bin/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.6.6
-      name: init-etcd-3-6-6
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --symlink
-      - --target-dir=/opt/etcd-v3.4.3
-      - --src=/opt/etcd-v3.4.13/etcd
-      - --src=/opt/etcd-v3.4.13/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-4-13
+      image: registry.k8s.io/etcd:v3.6.11
+      name: init-etcd-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -173,35 +148,63 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.10
+      - --target-dir=/opt/etcd-v3.5.11
+      - --target-dir=/opt/etcd-v3.5.12
       - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.14
+      - --target-dir=/opt/etcd-v3.5.15
+      - --target-dir=/opt/etcd-v3.5.16
       - --target-dir=/opt/etcd-v3.5.17
+      - --target-dir=/opt/etcd-v3.5.18
+      - --target-dir=/opt/etcd-v3.5.19
+      - --target-dir=/opt/etcd-v3.5.2
+      - --target-dir=/opt/etcd-v3.5.20
       - --target-dir=/opt/etcd-v3.5.21
+      - --target-dir=/opt/etcd-v3.5.22
       - --target-dir=/opt/etcd-v3.5.23
       - --target-dir=/opt/etcd-v3.5.24
+      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.5.26
+      - --target-dir=/opt/etcd-v3.5.27
+      - --target-dir=/opt/etcd-v3.5.28
+      - --target-dir=/opt/etcd-v3.5.29
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.5
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.8
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.25/etcd
-      - --src=/opt/etcd-v3.5.25/etcdctl
+      - --src=/opt/etcd-v3.5.30/etcd
+      - --src=/opt/etcd-v3.5.30/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-5-25
+      name: init-etcd-symlinks-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
       - --symlink
+      - --target-dir=/opt/etcd-v3.6.0
+      - --target-dir=/opt/etcd-v3.6.1
+      - --target-dir=/opt/etcd-v3.6.10
+      - --target-dir=/opt/etcd-v3.6.2
+      - --target-dir=/opt/etcd-v3.6.3
+      - --target-dir=/opt/etcd-v3.6.4
       - --target-dir=/opt/etcd-v3.6.5
-      - --src=/opt/etcd-v3.6.6/etcd
-      - --src=/opt/etcd-v3.6.6/etcdctl
+      - --target-dir=/opt/etcd-v3.6.6
+      - --target-dir=/opt/etcd-v3.6.7
+      - --target-dir=/opt/etcd-v3.6.8
+      - --target-dir=/opt/etcd-v3.6.9
+      - --src=/opt/etcd-v3.6.11/etcd
+      - --src=/opt/etcd-v3.6.11/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-6-6
+      name: init-etcd-symlinks-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -293,50 +296,25 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.5.30
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.4.13
-      name: init-etcd-3-4-13
+      image: registry.k8s.io/etcd:v3.5.30
+      name: init-etcd-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.6.11
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.5.25
-      name: init-etcd-3-5-25
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --target-dir=/opt/etcd-v3.6.6
-      - --src=/usr/local/bin/etcd
-      - --src=/usr/local/bin/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.6.6
-      name: init-etcd-3-6-6
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --symlink
-      - --target-dir=/opt/etcd-v3.4.3
-      - --src=/opt/etcd-v3.4.13/etcd
-      - --src=/opt/etcd-v3.4.13/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-4-13
+      image: registry.k8s.io/etcd:v3.6.11
+      name: init-etcd-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -345,35 +323,63 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.10
+      - --target-dir=/opt/etcd-v3.5.11
+      - --target-dir=/opt/etcd-v3.5.12
       - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.14
+      - --target-dir=/opt/etcd-v3.5.15
+      - --target-dir=/opt/etcd-v3.5.16
       - --target-dir=/opt/etcd-v3.5.17
+      - --target-dir=/opt/etcd-v3.5.18
+      - --target-dir=/opt/etcd-v3.5.19
+      - --target-dir=/opt/etcd-v3.5.2
+      - --target-dir=/opt/etcd-v3.5.20
       - --target-dir=/opt/etcd-v3.5.21
+      - --target-dir=/opt/etcd-v3.5.22
       - --target-dir=/opt/etcd-v3.5.23
       - --target-dir=/opt/etcd-v3.5.24
+      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.5.26
+      - --target-dir=/opt/etcd-v3.5.27
+      - --target-dir=/opt/etcd-v3.5.28
+      - --target-dir=/opt/etcd-v3.5.29
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.5
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.8
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.25/etcd
-      - --src=/opt/etcd-v3.5.25/etcdctl
+      - --src=/opt/etcd-v3.5.30/etcd
+      - --src=/opt/etcd-v3.5.30/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-5-25
+      name: init-etcd-symlinks-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
       - --symlink
+      - --target-dir=/opt/etcd-v3.6.0
+      - --target-dir=/opt/etcd-v3.6.1
+      - --target-dir=/opt/etcd-v3.6.10
+      - --target-dir=/opt/etcd-v3.6.2
+      - --target-dir=/opt/etcd-v3.6.3
+      - --target-dir=/opt/etcd-v3.6.4
       - --target-dir=/opt/etcd-v3.6.5
-      - --src=/opt/etcd-v3.6.6/etcd
-      - --src=/opt/etcd-v3.6.6/etcdctl
+      - --target-dir=/opt/etcd-v3.6.6
+      - --target-dir=/opt/etcd-v3.6.7
+      - --target-dir=/opt/etcd-v3.6.8
+      - --target-dir=/opt/etcd-v3.6.9
+      - --src=/opt/etcd-v3.6.11/etcd
+      - --src=/opt/etcd-v3.6.11/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-6-6
+      name: init-etcd-symlinks-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -127,50 +127,25 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.5.30
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.4.13
-      name: init-etcd-3-4-13
+      image: registry.k8s.io/etcd:v3.5.30
+      name: init-etcd-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.6.11
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.5.25
-      name: init-etcd-3-5-25
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --target-dir=/opt/etcd-v3.6.6
-      - --src=/usr/local/bin/etcd
-      - --src=/usr/local/bin/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.6.6
-      name: init-etcd-3-6-6
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --symlink
-      - --target-dir=/opt/etcd-v3.4.3
-      - --src=/opt/etcd-v3.4.13/etcd
-      - --src=/opt/etcd-v3.4.13/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-4-13
+      image: registry.k8s.io/etcd:v3.6.11
+      name: init-etcd-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -179,35 +154,63 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.10
+      - --target-dir=/opt/etcd-v3.5.11
+      - --target-dir=/opt/etcd-v3.5.12
       - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.14
+      - --target-dir=/opt/etcd-v3.5.15
+      - --target-dir=/opt/etcd-v3.5.16
       - --target-dir=/opt/etcd-v3.5.17
+      - --target-dir=/opt/etcd-v3.5.18
+      - --target-dir=/opt/etcd-v3.5.19
+      - --target-dir=/opt/etcd-v3.5.2
+      - --target-dir=/opt/etcd-v3.5.20
       - --target-dir=/opt/etcd-v3.5.21
+      - --target-dir=/opt/etcd-v3.5.22
       - --target-dir=/opt/etcd-v3.5.23
       - --target-dir=/opt/etcd-v3.5.24
+      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.5.26
+      - --target-dir=/opt/etcd-v3.5.27
+      - --target-dir=/opt/etcd-v3.5.28
+      - --target-dir=/opt/etcd-v3.5.29
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.5
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.8
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.25/etcd
-      - --src=/opt/etcd-v3.5.25/etcdctl
+      - --src=/opt/etcd-v3.5.30/etcd
+      - --src=/opt/etcd-v3.5.30/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-5-25
+      name: init-etcd-symlinks-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
       - --symlink
+      - --target-dir=/opt/etcd-v3.6.0
+      - --target-dir=/opt/etcd-v3.6.1
+      - --target-dir=/opt/etcd-v3.6.10
+      - --target-dir=/opt/etcd-v3.6.2
+      - --target-dir=/opt/etcd-v3.6.3
+      - --target-dir=/opt/etcd-v3.6.4
       - --target-dir=/opt/etcd-v3.6.5
-      - --src=/opt/etcd-v3.6.6/etcd
-      - --src=/opt/etcd-v3.6.6/etcdctl
+      - --target-dir=/opt/etcd-v3.6.6
+      - --target-dir=/opt/etcd-v3.6.7
+      - --target-dir=/opt/etcd-v3.6.8
+      - --target-dir=/opt/etcd-v3.6.9
+      - --src=/opt/etcd-v3.6.11/etcd
+      - --src=/opt/etcd-v3.6.11/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-6-6
+      name: init-etcd-symlinks-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -305,50 +308,25 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.5.30
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.4.13
-      name: init-etcd-3-4-13
+      image: registry.k8s.io/etcd:v3.5.30
+      name: init-etcd-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
-      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.6.11
       - --src=/usr/local/bin/etcd
       - --src=/usr/local/bin/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.5.25
-      name: init-etcd-3-5-25
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --target-dir=/opt/etcd-v3.6.6
-      - --src=/usr/local/bin/etcd
-      - --src=/usr/local/bin/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/etcd:v3.6.6
-      name: init-etcd-3-6-6
-      resources: {}
-      volumeMounts:
-      - mountPath: /opt
-        name: opt
-    - args:
-      - --symlink
-      - --target-dir=/opt/etcd-v3.4.3
-      - --src=/opt/etcd-v3.4.13/etcd
-      - --src=/opt/etcd-v3.4.13/etcdctl
-      command:
-      - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-4-13
+      image: registry.k8s.io/etcd:v3.6.11
+      name: init-etcd-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -357,35 +335,63 @@ Contents: |
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.10
+      - --target-dir=/opt/etcd-v3.5.11
+      - --target-dir=/opt/etcd-v3.5.12
       - --target-dir=/opt/etcd-v3.5.13
+      - --target-dir=/opt/etcd-v3.5.14
+      - --target-dir=/opt/etcd-v3.5.15
+      - --target-dir=/opt/etcd-v3.5.16
       - --target-dir=/opt/etcd-v3.5.17
+      - --target-dir=/opt/etcd-v3.5.18
+      - --target-dir=/opt/etcd-v3.5.19
+      - --target-dir=/opt/etcd-v3.5.2
+      - --target-dir=/opt/etcd-v3.5.20
       - --target-dir=/opt/etcd-v3.5.21
+      - --target-dir=/opt/etcd-v3.5.22
       - --target-dir=/opt/etcd-v3.5.23
       - --target-dir=/opt/etcd-v3.5.24
+      - --target-dir=/opt/etcd-v3.5.25
+      - --target-dir=/opt/etcd-v3.5.26
+      - --target-dir=/opt/etcd-v3.5.27
+      - --target-dir=/opt/etcd-v3.5.28
+      - --target-dir=/opt/etcd-v3.5.29
       - --target-dir=/opt/etcd-v3.5.3
       - --target-dir=/opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.5
       - --target-dir=/opt/etcd-v3.5.6
       - --target-dir=/opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.8
       - --target-dir=/opt/etcd-v3.5.9
-      - --src=/opt/etcd-v3.5.25/etcd
-      - --src=/opt/etcd-v3.5.25/etcdctl
+      - --src=/opt/etcd-v3.5.30/etcd
+      - --src=/opt/etcd-v3.5.30/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-5-25
+      name: init-etcd-symlinks-3-5-30
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
       - --symlink
+      - --target-dir=/opt/etcd-v3.6.0
+      - --target-dir=/opt/etcd-v3.6.1
+      - --target-dir=/opt/etcd-v3.6.10
+      - --target-dir=/opt/etcd-v3.6.2
+      - --target-dir=/opt/etcd-v3.6.3
+      - --target-dir=/opt/etcd-v3.6.4
       - --target-dir=/opt/etcd-v3.6.5
-      - --src=/opt/etcd-v3.6.6/etcd
-      - --src=/opt/etcd-v3.6.6/etcdctl
+      - --target-dir=/opt/etcd-v3.6.6
+      - --target-dir=/opt/etcd-v3.6.7
+      - --target-dir=/opt/etcd-v3.6.8
+      - --target-dir=/opt/etcd-v3.6.9
+      - --src=/opt/etcd-v3.6.11/etcd
+      - --src=/opt/etcd-v3.6.11/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-      name: init-etcd-symlinks-3-6-6
+      name: init-etcd-symlinks-3-6-11
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://tests/additionalobjects.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -38,40 +38,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -97,16 +149,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -38,40 +38,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -97,16 +149,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -40,40 +40,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -99,16 +151,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -40,40 +40,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -99,16 +151,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/bastionuserdata.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -66,7 +66,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/cas-priority-expander-custom.example.com/backups/etcd/events
     etcdMembers:
@@ -75,7 +75,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/cas-priority-expander-custom.example.com/pki

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
@@ -59,7 +59,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/cas-priority-expander.example.com/backups/etcd/events
     etcdMembers:
@@ -68,7 +68,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/cas-priority-expander.example.com/pki

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -62,7 +62,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/complex.example.com/backups/etcd/events
     etcdMembers:
@@ -71,7 +71,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/compress.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/containerd.example.com/backups/etcd/events
     etcdMembers:
@@ -59,7 +59,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd/assets.yaml
+++ b/tests/integration/update_cluster/containerd/assets.yaml
@@ -44,12 +44,10 @@ images:
   download: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
 - canonical: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260227
   download: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260227
-- canonical: registry.k8s.io/etcd:v3.4.13
-  download: registry.k8s.io/etcd:v3.4.13
-- canonical: registry.k8s.io/etcd:v3.5.25
-  download: registry.k8s.io/etcd:v3.5.25
-- canonical: registry.k8s.io/etcd:v3.6.6
-  download: registry.k8s.io/etcd:v3.6.6
+- canonical: registry.k8s.io/etcd:v3.5.30
+  download: registry.k8s.io/etcd:v3.5.30
+- canonical: registry.k8s.io/etcd:v3.6.11
+  download: registry.k8s.io/etcd:v3.6.11
 - canonical: registry.k8s.io/kops/dns-controller:1.34.0-beta.1
   download: registry.k8s.io/kops/dns-controller:1.34.0-beta.1
 - canonical: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/containerd.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/123.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/existing-iam.example.com/backups/etcd/events
     etcdMembers:
@@ -57,7 +57,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
@@ -47,7 +47,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
     etcdMembers:
@@ -60,7 +60,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: external-dns
   iam:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: external-dns
   iam:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/externallb.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/externalpolicies.example.com/backups/etcd/events
     etcdMembers:
@@ -57,7 +57,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   externalPolicies:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://tests/gossip.k8s.local/backups/etcd/events
     cpuRequest: 100m
@@ -56,7 +56,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_cluster-completed.spec_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_cluster-completed.spec_source
@@ -44,7 +44,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://tests/gossip.k8s.local/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_etcd-cluster-spec-events_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_etcd-cluster-spec-events_source
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_etcd-cluster-spec-main_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_etcd-cluster-spec-main_source
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -48,7 +48,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://tests/gossip.k8s.local/backups/etcd/events
     cpuRequest: 100m
@@ -59,7 +59,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://tests/gossip.k8s.local/backups/etcd/events
     cpuRequest: 100m
@@ -52,7 +52,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -39,40 +39,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -98,16 +150,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -39,40 +39,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -98,16 +150,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/ha.example.com/backups/etcd/events
     etcdMembers:
@@ -57,7 +57,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -53,7 +53,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/ha-gce.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -68,7 +68,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -66,7 +66,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -75,7 +75,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -67,7 +67,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -76,7 +76,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -67,7 +67,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -78,7 +78,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -65,7 +65,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/many-addons.example.com/backups/etcd/events
     etcdMembers:
@@ -74,7 +74,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://clusters.example.com/minimal-aws.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/minimal-aws.example.com/pki

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -38,40 +38,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -97,16 +149,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -38,40 +38,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -97,16 +149,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -56,7 +56,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   iam:
     allowContainerRegistry: true
     legacy: false

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
@@ -43,7 +43,7 @@ spec:
       image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc
       logLevel: 10
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal-etcd.example.com/backups/etcd/events
     etcdMembers:
@@ -57,7 +57,7 @@ spec:
         value: 1d
       image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -57,50 +57,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -109,35 +84,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -55,7 +55,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   keyStore: memfs://clusters.example.com/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com/pki

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal-warmpool.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: kops.k8s.io/remapped-image/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: kops.k8s.io/remapped-image/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: kops.k8s.io/remapped-image/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: kops.k8s.io/remapped-image/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_cluster-completed.spec_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_cluster-completed.spec_source
@@ -46,7 +46,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://tests/minimal-azure.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -58,7 +58,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.6.6
+    version: 3.6.11
   iam:
     legacy: false
   keyStore: memfs://tests/minimal-azure.example.com/pki

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_etcd-cluster-spec-events_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_etcd-cluster-spec-events_source
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_etcd-cluster-spec-main_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_etcd-cluster-spec-main_source
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
@@ -37,40 +37,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -96,16 +148,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -49,7 +49,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal-gce.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -60,7 +60,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -51,7 +51,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal-gce.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -62,7 +62,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   iam:
     legacy: false
   keyStore: memfs://tests/minimal-gce.example.com/pki

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
@@ -53,7 +53,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal-gce-ilb.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -64,7 +64,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_cluster-completed.spec_content
@@ -53,7 +53,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal-gce-ilb-cilium-etcd.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -64,7 +64,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal-gce-ilb-cilium-etcd.example.com/backups/etcd/cilium
     etcdMembers:
@@ -73,7 +73,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: cilium
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_etcd-cluster-spec-cilium_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_etcd-cluster-spec-cilium_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -53,7 +53,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -64,7 +64,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -61,7 +61,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
@@ -53,7 +53,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal-gce-plb.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -64,7 +64,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_cluster-completed.spec_content
@@ -53,7 +53,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal-gce-plb-apiserver.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -64,7 +64,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,50 +57,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -109,35 +84,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,50 +57,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -109,35 +84,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
@@ -49,7 +49,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal-gce-private.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -60,7 +60,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -39,7 +39,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
     etcdMembers:
@@ -48,7 +48,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -41,7 +41,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -52,7 +52,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   iam:
     allowContainerRegistry: true
     legacy: false

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -56,50 +56,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -108,35 +83,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -56,50 +56,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -108,35 +83,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -32,7 +32,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://tests/scw-minimal.k8s.local/backups/etcd/events
     cpuRequest: 100m
@@ -43,7 +43,7 @@ spec:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -58,50 +58,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -110,35 +85,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -58,50 +58,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -110,35 +85,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
     etcdMembers:
@@ -57,7 +57,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
     etcdMembers:
@@ -57,7 +57,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 3,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-ip.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-subnet.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/privatecalico.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium
     etcdMembers:
@@ -60,7 +60,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: cilium
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-cilium_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-cilium_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
@@ -45,7 +45,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://clusters.example.com/privatedns1.example.com/backups/etcd/events
     etcdMembers:
@@ -54,7 +54,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -38,40 +38,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -97,16 +149,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -38,40 +38,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -97,16 +149,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/privatedns2.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.6.6
+    version: 3.6.11
   - backups:
       backupStore: memfs://clusters.example.com/privateflannel.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.6.6
+    version: 3.6.11
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.6.6"
+  "etcdVersion": "3.6.11"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -38,40 +38,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -97,16 +149,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -38,40 +38,92 @@ spec:
       name: pki
     - mountPath: /opt
       name: opt
-    - mountPath: /opt/etcd-v3.4.13
-      name: etcd-v3-4-13
-    - mountPath: /opt/etcd-v3.4.3
-      name: etcd-v3-4-13
     - mountPath: /opt/etcd-v3.5.0
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.1
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.13
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.17
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.21
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.23
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.24
-      name: etcd-v3-5-25
-    - mountPath: /opt/etcd-v3.5.25
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.2
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.3
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.4
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.5
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.6
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.7
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.8
+      name: etcd-v3-5-30
     - mountPath: /opt/etcd-v3.5.9
-      name: etcd-v3-5-25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.10
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.11
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.12
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.13
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.14
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.15
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.16
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.17
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.18
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.19
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.20
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.21
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.22
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.23
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.24
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.25
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.26
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.27
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.28
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.29
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.5.30
+      name: etcd-v3-5-30
+    - mountPath: /opt/etcd-v3.6.0
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.1
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.2
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.3
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.4
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.5
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
     - mountPath: /opt/etcd-v3.6.6
-      name: etcd-v3-6-6
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.7
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.8
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.9
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.10
+      name: etcd-v3-6-11
+    - mountPath: /opt/etcd-v3.6.11
+      name: etcd-v3-6-11
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -97,16 +149,12 @@ spec:
     name: opt
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.4.13
-    name: etcd-v3-4-13
+      reference: registry.k8s.io/etcd:v3.5.30
+    name: etcd-v3-5-30
   - image:
       pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.5.25
-    name: etcd-v3-5-25
-  - image:
-      pullPolicy: IfNotPresent
-      reference: registry.k8s.io/etcd:v3.6.6
-    name: etcd-v3-6-6
+      reference: registry.k8s.io/etcd:v3.6.11
+    name: etcd-v3-6-11
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/privatekindnet.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/privatekopeio.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/sharedsubnet.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/sharedvpc.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
@@ -53,7 +53,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -55,50 +55,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -107,35 +82,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/unmanaged.example.com/backups/etcd/events
     etcdMembers:
@@ -51,7 +51,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
@@ -40,7 +40,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: main
-    version: 3.5.25
+    version: 3.5.30
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
@@ -49,7 +49,7 @@ spec:
     manager:
       backupRetentionDays: 90
     name: events
-    version: 3.5.25
+    version: 3.5.30
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.25"
+  "etcdVersion": "3.5.30"
 }

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -54,50 +54,25 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.5.30
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.4.13
-    name: init-etcd-3-4-13
+    image: registry.k8s.io/etcd:v3.5.30
+    name: init-etcd-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
-    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.6.11
     - --src=/usr/local/bin/etcd
     - --src=/usr/local/bin/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.5.25
-    name: init-etcd-3-5-25
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --target-dir=/opt/etcd-v3.6.6
-    - --src=/usr/local/bin/etcd
-    - --src=/usr/local/bin/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/etcd:v3.6.6
-    name: init-etcd-3-6-6
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
-  - args:
-    - --symlink
-    - --target-dir=/opt/etcd-v3.4.3
-    - --src=/opt/etcd-v3.4.13/etcd
-    - --src=/opt/etcd-v3.4.13/etcdctl
-    command:
-    - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-4-13
+    image: registry.k8s.io/etcd:v3.6.11
+    name: init-etcd-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt
@@ -106,35 +81,63 @@ spec:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.10
+    - --target-dir=/opt/etcd-v3.5.11
+    - --target-dir=/opt/etcd-v3.5.12
     - --target-dir=/opt/etcd-v3.5.13
+    - --target-dir=/opt/etcd-v3.5.14
+    - --target-dir=/opt/etcd-v3.5.15
+    - --target-dir=/opt/etcd-v3.5.16
     - --target-dir=/opt/etcd-v3.5.17
+    - --target-dir=/opt/etcd-v3.5.18
+    - --target-dir=/opt/etcd-v3.5.19
+    - --target-dir=/opt/etcd-v3.5.2
+    - --target-dir=/opt/etcd-v3.5.20
     - --target-dir=/opt/etcd-v3.5.21
+    - --target-dir=/opt/etcd-v3.5.22
     - --target-dir=/opt/etcd-v3.5.23
     - --target-dir=/opt/etcd-v3.5.24
+    - --target-dir=/opt/etcd-v3.5.25
+    - --target-dir=/opt/etcd-v3.5.26
+    - --target-dir=/opt/etcd-v3.5.27
+    - --target-dir=/opt/etcd-v3.5.28
+    - --target-dir=/opt/etcd-v3.5.29
     - --target-dir=/opt/etcd-v3.5.3
     - --target-dir=/opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.5
     - --target-dir=/opt/etcd-v3.5.6
     - --target-dir=/opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.8
     - --target-dir=/opt/etcd-v3.5.9
-    - --src=/opt/etcd-v3.5.25/etcd
-    - --src=/opt/etcd-v3.5.25/etcdctl
+    - --src=/opt/etcd-v3.5.30/etcd
+    - --src=/opt/etcd-v3.5.30/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-5-25
+    name: init-etcd-symlinks-3-5-30
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
     - --symlink
+    - --target-dir=/opt/etcd-v3.6.0
+    - --target-dir=/opt/etcd-v3.6.1
+    - --target-dir=/opt/etcd-v3.6.10
+    - --target-dir=/opt/etcd-v3.6.2
+    - --target-dir=/opt/etcd-v3.6.3
+    - --target-dir=/opt/etcd-v3.6.4
     - --target-dir=/opt/etcd-v3.6.5
-    - --src=/opt/etcd-v3.6.6/etcd
-    - --src=/opt/etcd-v3.6.6/etcdctl
+    - --target-dir=/opt/etcd-v3.6.6
+    - --target-dir=/opt/etcd-v3.6.7
+    - --target-dir=/opt/etcd-v3.6.8
+    - --target-dir=/opt/etcd-v3.6.9
+    - --src=/opt/etcd-v3.6.11/etcd
+    - --src=/opt/etcd-v3.6.11/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.35.0-beta.1
-    name: init-etcd-symlinks-3-6-6
+    name: init-etcd-symlinks-3-6-11
     resources: {}
     volumeMounts:
     - mountPath: /opt


### PR DESCRIPTION
- Bump etcd to the latest patches per minor: v3.5.30 and v3.6.11.
- Drop the 3.4 support — hasn't shipped it as a default for years and no current Kubernetes default uses it.
- Refactor `etcdSupportedImages` into `etcdLatestImages` (one entry per minor); older-patch `SymlinkToVersion` entries are now generated dynamically, so future bumps are a one-line change.

/cc @rifelpet @ameukam 