### PR TITLE
WIP etcd-manager: scope AWS volume discovery to the owning instance group

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -537,6 +537,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 				fmt.Sprintf("kubernetes.io/cluster/%s=owned", b.Cluster.Name),
 				awsup.TagNameEtcdClusterPrefix + etcdCluster.Name,
 				awsup.TagNameRolePrefix + "control-plane=1",
+				fmt.Sprintf("%s=%s", awsup.TagNameKopsInstanceGroup, instanceGroupName),
 			}
 			config.VolumeNameTag = awsup.TagNameEtcdClusterPrefix + etcdCluster.Name
 

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -83,8 +83,8 @@ Contents: |
         --discovery-poll-interval=1m15s --dns-suffix=.internal.minimal.example.com --grpc-port=3997
         --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-        --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-        > /tmp/pipe 2>&1
+        --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
       image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260227
       name: etcd-manager
       resources:
@@ -256,8 +256,8 @@ Contents: |
         --discovery-poll-interval=1m15s --dns-suffix=.internal.minimal.example.com --grpc-port=3996
         --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-        --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-        > /tmp/pipe 2>&1
+        --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
       image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260227
       name: etcd-manager
       resources:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -83,7 +83,8 @@ Contents: |
         --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
         --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
         --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+        --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+        > /tmp/pipe 2>&1
       image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260227
       name: etcd-manager
       resources:
@@ -248,7 +249,8 @@ Contents: |
         --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
         --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
         --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+        --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+        > /tmp/pipe 2>&1
       image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260227
       name: etcd-manager
       resources:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -83,7 +83,8 @@ Contents: |
         --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
         --quarantine-client-urls=https://__name__:3995 --v=3 --volume-name-tag=k8s.io/etcd/events
         --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+        --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+        > /tmp/pipe 2>&1
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
@@ -258,7 +259,8 @@ Contents: |
         --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
         --quarantine-client-urls=https://__name__:3994 --v=3 --volume-name-tag=k8s.io/etcd/main
         --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+        --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+        > /tmp/pipe 2>&1
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -83,7 +83,8 @@ Contents: |
         --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
         --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
         --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+        --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+        > /tmp/pipe 2>&1
       env:
       - name: NO_PROXY
         value: noproxy.example.com
@@ -264,7 +265,8 @@ Contents: |
         --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
         --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
         --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+        --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+        > /tmp/pipe 2>&1
       env:
       - name: NO_PROXY
         value: noproxy.example.com

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -176,6 +176,9 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.CloudupModelBuilderContext, nam
 	// This says "only mount on a control plane node"
 	tags[awsup.TagNameRolePrefix+"control-plane"] = "1"
 	tags[awsup.TagNameRolePrefix+"master"] = "1"
+	// Identifies the instance group that owns this volume, so that an etcd-manager
+	// in the same AZ as another control-plane instance group will only attach its own volume.
+	tags[awsup.TagNameKopsInstanceGroup] = fi.ValueOf(m.InstanceGroup)
 
 	// We always add an owned tags (these can't be shared)
 	tags["kubernetes.io/cluster/"+b.Cluster.ObjectMeta.Name] = "owned"

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.additionalobjects.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.additionalobjects.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/additionalobjects/kubernetes.tf
+++ b/tests/integration/update_cluster/additionalobjects/kubernetes.tf
@@ -307,6 +307,7 @@ resource "aws_ebs_volume" "a-etcd-events-additionalobjects-example-com" {
     "k8s.io/etcd/events"                                  = "a/a"
     "k8s.io/role/control-plane"                           = "1"
     "k8s.io/role/master"                                  = "1"
+    "kops.k8s.io/instancegroup"                           = "master-us-test-1a"
     "kubernetes.io/cluster/additionalobjects.example.com" = "owned"
   }
   throughput = 125
@@ -324,6 +325,7 @@ resource "aws_ebs_volume" "a-etcd-main-additionalobjects-example-com" {
     "k8s.io/etcd/main"                                    = "a/a"
     "k8s.io/role/control-plane"                           = "1"
     "k8s.io/role/master"                                  = "1"
+    "kops.k8s.io/instancegroup"                           = "master-us-test-1a"
     "kubernetes.io/cluster/additionalobjects.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,8 +18,8 @@ spec:
       --containerized=true --dns-suffix=.internal.minimal.example.com --grpc-port=3997
       --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,8 +18,8 @@ spec:
       --containerized=true --dns-suffix=.internal.minimal.example.com --grpc-port=3996
       --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/apiservernodes/kubernetes.tf
+++ b/tests/integration/update_cluster/apiservernodes/kubernetes.tf
@@ -380,6 +380,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -397,6 +398,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -357,6 +357,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -374,6 +375,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.bastionuserdata.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.bastionuserdata.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-bastionuserdata-example-com" {
     "k8s.io/etcd/events"                                = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                         = "1"
     "k8s.io/role/master"                                = "1"
+    "kops.k8s.io/instancegroup"                         = "master-us-test-1a"
     "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-bastionuserdata-example-com" {
     "k8s.io/etcd/main"                                  = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                         = "1"
     "k8s.io/role/master"                                = "1"
+    "kops.k8s.io/instancegroup"                         = "master-us-test-1a"
     "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.cas-priority-expander-custom.example.com --grpc-port=3997
       --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.cas-priority-expander-custom.example.com --grpc-port=3996
       --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/kubernetes.tf
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/kubernetes.tf
@@ -413,6 +413,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-cas-priority-expander-custom-e
     "k8s.io/etcd/events"                                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                                      = "1"
     "k8s.io/role/master"                                             = "1"
+    "kops.k8s.io/instancegroup"                                      = "master-us-test-1a"
     "kubernetes.io/cluster/cas-priority-expander-custom.example.com" = "owned"
   }
   throughput = 125
@@ -430,6 +431,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-cas-priority-expander-custom-exa
     "k8s.io/etcd/main"                                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                                      = "1"
     "k8s.io/role/master"                                             = "1"
+    "kops.k8s.io/instancegroup"                                      = "master-us-test-1a"
     "kubernetes.io/cluster/cas-priority-expander-custom.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.cas-priority-expander.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned >
-      /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.cas-priority-expander.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned >
-      /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/kubernetes.tf
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/kubernetes.tf
@@ -413,6 +413,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-cas-priority-expander-example-
     "k8s.io/etcd/events"                                      = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                               = "1"
     "k8s.io/role/master"                                      = "1"
+    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
     "kubernetes.io/cluster/cas-priority-expander.example.com" = "owned"
   }
   throughput = 125
@@ -430,6 +431,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-cas-priority-expander-example-co
     "k8s.io/etcd/main"                                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                               = "1"
     "k8s.io/role/master"                                      = "1"
+    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
     "kubernetes.io/cluster/cas-priority-expander.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.complex.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/complex.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.complex.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/complex.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -338,6 +338,7 @@ resource "aws_ebs_volume" "a-etcd-events-complex-example-com" {
     "k8s.io/etcd/events"                        = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
   throughput = 125
@@ -357,6 +358,7 @@ resource "aws_ebs_volume" "a-etcd-main-complex-example-com" {
     "k8s.io/etcd/main"                          = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/complex.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.compress.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/compress.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.compress.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/compress.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-compress-example-com" {
     "k8s.io/etcd/events"                         = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                  = "1"
     "k8s.io/role/master"                         = "1"
+    "kops.k8s.io/instancegroup"                  = "master-us-test-1a"
     "kubernetes.io/cluster/compress.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-compress-example-com" {
     "k8s.io/etcd/main"                           = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                  = "1"
     "k8s.io/role/master"                         = "1"
+    "kops.k8s.io/instancegroup"                  = "master-us-test-1a"
     "kubernetes.io/cluster/compress.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.containerd.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/containerd.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.containerd.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/containerd.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/containerd-custom/kubernetes.tf
+++ b/tests/integration/update_cluster/containerd-custom/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-containerd-example-com" {
     "k8s.io/etcd/events"                           = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
     "kubernetes.io/cluster/containerd.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-containerd-example-com" {
     "k8s.io/etcd/main"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
     "kubernetes.io/cluster/containerd.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.containerd.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/containerd.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.containerd.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/containerd.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/containerd/kubernetes.tf
+++ b/tests/integration/update_cluster/containerd/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-containerd-example-com" {
     "k8s.io/etcd/events"                           = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
     "kubernetes.io/cluster/containerd.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-containerd-example-com" {
     "k8s.io/etcd/main"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
     "kubernetes.io/cluster/containerd.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.123.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/123.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.123.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/123.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/digit/kubernetes.tf
+++ b/tests/integration/update_cluster/digit/kubernetes.tf
@@ -327,6 +327,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-123-example-com" {
     "k8s.io/etcd/events"                    = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"             = "1"
     "k8s.io/role/master"                    = "1"
+    "kops.k8s.io/instancegroup"             = "master-us-test-1a"
     "kubernetes.io/cluster/123.example.com" = "owned"
   }
   throughput = 125
@@ -344,6 +345,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-123-example-com" {
     "k8s.io/etcd/main"                      = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"             = "1"
     "k8s.io/role/master"                    = "1"
+    "kops.k8s.io/instancegroup"             = "master-us-test-1a"
     "kubernetes.io/cluster/123.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,9 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.existing-iam.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned > /tmp/pipe
+      2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -15,8 +15,9 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.existing-iam.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1b
+      --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned > /tmp/pipe
+      2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -15,8 +15,9 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.existing-iam.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1c
+      --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned > /tmp/pipe
+      2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,9 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.existing-iam.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned > /tmp/pipe
+      2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -15,8 +15,9 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.existing-iam.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1b
+      --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned > /tmp/pipe
+      2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -15,8 +15,9 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.existing-iam.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1c
+      --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned > /tmp/pipe
+      2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -433,6 +433,7 @@ resource "aws_ebs_volume" "a-etcd-events-existing-iam-example-com" {
     "k8s.io/etcd/events"                             = "a/a,b,c"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
   throughput = 125
@@ -450,6 +451,7 @@ resource "aws_ebs_volume" "a-etcd-main-existing-iam-example-com" {
     "k8s.io/etcd/main"                               = "a/a,b,c"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
   throughput = 125
@@ -467,6 +469,7 @@ resource "aws_ebs_volume" "b-etcd-events-existing-iam-example-com" {
     "k8s.io/etcd/events"                             = "b/a,b,c"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1b"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
   throughput = 125
@@ -484,6 +487,7 @@ resource "aws_ebs_volume" "b-etcd-main-existing-iam-example-com" {
     "k8s.io/etcd/main"                               = "b/a,b,c"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1b"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
   throughput = 125
@@ -501,6 +505,7 @@ resource "aws_ebs_volume" "c-etcd-events-existing-iam-example-com" {
     "k8s.io/etcd/events"                             = "c/a,b,c"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1c"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
   throughput = 125
@@ -518,6 +523,7 @@ resource "aws_ebs_volume" "c-etcd-main-existing-iam-example-com" {
     "k8s.io/etcd/main"                               = "c/a,b,c"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1c"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.existingsg.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.existingsg.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1b --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.existingsg.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1c --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.existingsg.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.existingsg.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1b --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.existingsg.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1c --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -456,6 +456,7 @@ resource "aws_ebs_volume" "a-etcd-events-existingsg-example-com" {
     "k8s.io/etcd/events"                           = "a/a,b,c"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
   throughput = 125
@@ -473,6 +474,7 @@ resource "aws_ebs_volume" "a-etcd-main-existingsg-example-com" {
     "k8s.io/etcd/main"                             = "a/a,b,c"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
   throughput = 125
@@ -490,6 +492,7 @@ resource "aws_ebs_volume" "b-etcd-events-existingsg-example-com" {
     "k8s.io/etcd/events"                           = "b/a,b,c"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1b"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
   throughput = 125
@@ -507,6 +510,7 @@ resource "aws_ebs_volume" "b-etcd-main-existingsg-example-com" {
     "k8s.io/etcd/main"                             = "b/a,b,c"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1b"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
   throughput = 125
@@ -524,6 +528,7 @@ resource "aws_ebs_volume" "c-etcd-events-existingsg-example-com" {
     "k8s.io/etcd/events"                           = "c/a,b,c"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1c"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
   throughput = 125
@@ -541,6 +546,7 @@ resource "aws_ebs_volume" "c-etcd-main-existingsg-example-com" {
     "k8s.io/etcd/main"                             = "c/a,b,c"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1c"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/external_dns/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
@@ -347,6 +347,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -364,6 +365,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.externallb.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/externallb.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.externallb.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/externallb.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -301,6 +301,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-externallb-example-com" {
     "k8s.io/etcd/events"                           = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
     "kubernetes.io/cluster/externallb.example.com" = "owned"
   }
   throughput = 125
@@ -318,6 +319,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-externallb-example-com" {
     "k8s.io/etcd/main"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                    = "1"
     "k8s.io/role/master"                           = "1"
+    "kops.k8s.io/instancegroup"                    = "master-us-test-1a"
     "kubernetes.io/cluster/externallb.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.externalpolicies.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.externalpolicies.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -329,6 +329,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-externalpolicies-example-com" 
     "k8s.io/etcd/events"                                 = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                          = "1"
     "k8s.io/role/master"                                 = "1"
+    "kops.k8s.io/instancegroup"                          = "master-us-test-1a"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
   throughput = 125
@@ -348,6 +349,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-externalpolicies-example-com" {
     "k8s.io/etcd/main"                                   = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                          = "1"
     "k8s.io/role/master"                                 = "1"
+    "kops.k8s.io/instancegroup"                          = "master-us-test-1a"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.gossip.k8s.local
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/gossip.k8s.local=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/gossip.k8s.local=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.gossip.k8s.local
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/gossip.k8s.local=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/gossip.k8s.local=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/gossip-aws/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-aws/kubernetes.tf
@@ -298,6 +298,7 @@ resource "aws_ebs_volume" "a-etcd-events-gossip-k8s-local" {
     "k8s.io/etcd/events"                     = "a/a"
     "k8s.io/role/control-plane"              = "1"
     "k8s.io/role/master"                     = "1"
+    "kops.k8s.io/instancegroup"              = "master-us-test-1a"
     "kubernetes.io/cluster/gossip.k8s.local" = "owned"
   }
   throughput = 125
@@ -315,6 +316,7 @@ resource "aws_ebs_volume" "a-etcd-main-gossip-k8s-local" {
     "k8s.io/etcd/main"                       = "a/a"
     "k8s.io/role/control-plane"              = "1"
     "k8s.io/role/master"                     = "1"
+    "kops.k8s.io/instancegroup"              = "master-us-test-1a"
     "kubernetes.io/cluster/gossip.k8s.local" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.ha.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/ha.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.ha.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1b
+      --volume-tag=kubernetes.io/cluster/ha.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.ha.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1c
+      --volume-tag=kubernetes.io/cluster/ha.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.ha.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/ha.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.ha.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1b
+      --volume-tag=kubernetes.io/cluster/ha.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.ha.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1c
+      --volume-tag=kubernetes.io/cluster/ha.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -453,6 +453,7 @@ resource "aws_ebs_volume" "a-etcd-events-ha-example-com" {
     "k8s.io/etcd/events"                   = "a/a,b,c"
     "k8s.io/role/control-plane"            = "1"
     "k8s.io/role/master"                   = "1"
+    "kops.k8s.io/instancegroup"            = "master-us-test-1a"
     "kubernetes.io/cluster/ha.example.com" = "owned"
   }
   throughput = 125
@@ -470,6 +471,7 @@ resource "aws_ebs_volume" "a-etcd-main-ha-example-com" {
     "k8s.io/etcd/main"                     = "a/a,b,c"
     "k8s.io/role/control-plane"            = "1"
     "k8s.io/role/master"                   = "1"
+    "kops.k8s.io/instancegroup"            = "master-us-test-1a"
     "kubernetes.io/cluster/ha.example.com" = "owned"
   }
   throughput = 125
@@ -487,6 +489,7 @@ resource "aws_ebs_volume" "b-etcd-events-ha-example-com" {
     "k8s.io/etcd/events"                   = "b/a,b,c"
     "k8s.io/role/control-plane"            = "1"
     "k8s.io/role/master"                   = "1"
+    "kops.k8s.io/instancegroup"            = "master-us-test-1b"
     "kubernetes.io/cluster/ha.example.com" = "owned"
   }
   throughput = 125
@@ -504,6 +507,7 @@ resource "aws_ebs_volume" "b-etcd-main-ha-example-com" {
     "k8s.io/etcd/main"                     = "b/a,b,c"
     "k8s.io/role/control-plane"            = "1"
     "k8s.io/role/master"                   = "1"
+    "kops.k8s.io/instancegroup"            = "master-us-test-1b"
     "kubernetes.io/cluster/ha.example.com" = "owned"
   }
   throughput = 125
@@ -521,6 +525,7 @@ resource "aws_ebs_volume" "c-etcd-events-ha-example-com" {
     "k8s.io/etcd/events"                   = "c/a,b,c"
     "k8s.io/role/control-plane"            = "1"
     "k8s.io/role/master"                   = "1"
+    "kops.k8s.io/instancegroup"            = "master-us-test-1c"
     "kubernetes.io/cluster/ha.example.com" = "owned"
   }
   throughput = 125
@@ -538,6 +543,7 @@ resource "aws_ebs_volume" "c-etcd-main-ha-example-com" {
     "k8s.io/etcd/main"                     = "c/a,b,c"
     "k8s.io/role/control-plane"            = "1"
     "k8s.io/role/master"                   = "1"
+    "kops.k8s.io/instancegroup"            = "master-us-test-1c"
     "kubernetes.io/cluster/ha.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -337,6 +337,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -354,6 +355,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/karpenter/kubernetes.tf
+++ b/tests/integration/update_cluster/karpenter/kubernetes.tf
@@ -261,6 +261,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -278,6 +279,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
@@ -367,6 +367,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -384,6 +385,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
@@ -312,6 +312,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -329,6 +330,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,9 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.many-addons.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/many-addons.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/many-addons.example.com=owned > /tmp/pipe
+      2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,9 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.many-addons.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/many-addons.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/many-addons.example.com=owned > /tmp/pipe
+      2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/many-addons/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-many-addons-example-com" {
     "k8s.io/etcd/events"                            = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                     = "1"
     "k8s.io/role/master"                            = "1"
+    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
     "kubernetes.io/cluster/many-addons.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-many-addons-example-com" {
     "k8s.io/etcd/main"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                     = "1"
     "k8s.io/role/master"                            = "1"
+    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
     "kubernetes.io/cluster/many-addons.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.31/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.31/kubernetes.tf
@@ -307,6 +307,7 @@ resource "aws_ebs_volume" "a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -324,6 +325,7 @@ resource "aws_ebs_volume" "a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.32/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.32/kubernetes.tf
@@ -307,6 +307,7 @@ resource "aws_ebs_volume" "a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -324,6 +325,7 @@ resource "aws_ebs_volume" "a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.33/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.33/kubernetes.tf
@@ -307,6 +307,7 @@ resource "aws_ebs_volume" "a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -324,6 +325,7 @@ resource "aws_ebs_volume" "a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.34/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.34/kubernetes.tf
@@ -307,6 +307,7 @@ resource "aws_ebs_volume" "a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -324,6 +325,7 @@ resource "aws_ebs_volume" "a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.35/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.35/kubernetes.tf
@@ -307,6 +307,7 @@ resource "aws_ebs_volume" "a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -324,6 +325,7 @@ resource "aws_ebs_volume" "a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-1.36/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.36/kubernetes.tf
@@ -307,6 +307,7 @@ resource "aws_ebs_volume" "a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -324,6 +325,7 @@ resource "aws_ebs_volume" "a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-aws.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-aws.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-aws.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-aws.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-aws.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-aws.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-aws/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-aws/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-aws-example-com" {
     "k8s.io/etcd/events"                            = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                     = "1"
     "k8s.io/role/master"                            = "1"
+    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-aws.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-aws-example-com" {
     "k8s.io/etcd/main"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                     = "1"
     "k8s.io/role/master"                            = "1"
+    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-aws.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -15,8 +15,8 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
@@ -308,6 +308,7 @@ resource "aws_ebs_volume" "a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -325,6 +326,7 @@ resource "aws_ebs_volume" "a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "a/a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-etcd.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-etcd.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-etcd.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 30d

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-etcd.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=10 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-etcd.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-etcd.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-etcd/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-etcd/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-etcd-example-com" {
     "k8s.io/etcd/events"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-etcd.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-etcd-example-com" {
     "k8s.io/etcd/main"                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-etcd.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
@@ -333,6 +333,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-ipv6-example-com" {
     "k8s.io/etcd/events"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125
@@ -350,6 +351,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-ipv6-example-com" {
     "k8s.io/etcd/main"                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
@@ -333,6 +333,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-ipv6-example-com" {
     "k8s.io/etcd/events"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125
@@ -350,6 +351,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-ipv6-example-com" {
     "k8s.io/etcd/main"                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/kubernetes.tf
@@ -333,6 +333,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-ipv6-example-com" {
     "k8s.io/etcd/events"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125
@@ -350,6 +351,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-ipv6-example-com" {
     "k8s.io/etcd/main"                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
@@ -333,6 +333,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-ipv6-example-com" {
     "k8s.io/etcd/events"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125
@@ -350,6 +351,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-ipv6-example-com" {
     "k8s.io/etcd/main"                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -333,6 +333,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-ipv6-example-com" {
     "k8s.io/etcd/events"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125
@@ -350,6 +351,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-ipv6-example-com" {
     "k8s.io/etcd/main"                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com=owned
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com=owned
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/minimal-longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-longclustername/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-this-is-truly-a-really-really-
     "k8s.io/etcd/events"                                                                                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                                                                                      = "1"
     "k8s.io/role/master"                                                                                             = "1"
+    "kops.k8s.io/instancegroup"                                                                                      = "master-us-test-1a"
     "kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-this-is-truly-a-really-really-re
     "k8s.io/etcd/main"                                                                                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                                                                                      = "1"
     "k8s.io/role/master"                                                                                             = "1"
+    "kops.k8s.io/instancegroup"                                                                                      = "master-us-test-1a"
     "kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-warmpool.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-warmpool.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -309,6 +309,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-warmpool-example-com" 
     "k8s.io/etcd/events"                                 = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                          = "1"
     "k8s.io/role/master"                                 = "1"
+    "kops.k8s.io/instancegroup"                          = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-warmpool.example.com" = "owned"
   }
   throughput = 125
@@ -326,6 +327,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-warmpool-example-com" {
     "k8s.io/etcd/main"                                   = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                          = "1"
     "k8s.io/role/master"                                 = "1"
+    "kops.k8s.io/instancegroup"                          = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-warmpool.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.k8s.local --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.k8s.local --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-k8s-local" {
     "k8s.io/etcd/events"                      = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"               = "1"
     "k8s.io/role/master"                      = "1"
+    "kops.k8s.io/instancegroup"               = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.k8s.local" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-k8s-local" {
     "k8s.io/etcd/main"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"               = "1"
     "k8s.io/role/master"                      = "1"
+    "kops.k8s.io/instancegroup"               = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.k8s.local" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.k8s.local --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.k8s.local --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/minimal_gossip_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/kubernetes.tf
@@ -337,6 +337,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-k8s-local" {
     "k8s.io/etcd/events"                      = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"               = "1"
     "k8s.io/role/master"                      = "1"
+    "kops.k8s.io/instancegroup"               = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.k8s.local" = "owned"
   }
   throughput = 125
@@ -354,6 +355,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-k8s-local" {
     "k8s.io/etcd/main"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"               = "1"
     "k8s.io/role/master"                      = "1"
+    "kops.k8s.io/instancegroup"               = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.k8s.local" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1b --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1c --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1b --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1c --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -471,6 +471,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-mixedinstances-example-com" {
     "k8s.io/etcd/events"                               = "us-test-1a/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125
@@ -488,6 +489,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-mixedinstances-example-com" {
     "k8s.io/etcd/main"                                 = "us-test-1a/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125
@@ -505,6 +507,7 @@ resource "aws_ebs_volume" "us-test-1b-etcd-events-mixedinstances-example-com" {
     "k8s.io/etcd/events"                               = "us-test-1b/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125
@@ -522,6 +525,7 @@ resource "aws_ebs_volume" "us-test-1b-etcd-main-mixedinstances-example-com" {
     "k8s.io/etcd/main"                                 = "us-test-1b/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125
@@ -539,6 +543,7 @@ resource "aws_ebs_volume" "us-test-1c-etcd-events-mixedinstances-example-com" {
     "k8s.io/etcd/events"                               = "us-test-1c/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125
@@ -556,6 +561,7 @@ resource "aws_ebs_volume" "us-test-1c-etcd-main-mixedinstances-example-com" {
     "k8s.io/etcd/main"                                 = "us-test-1c/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1b --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1c --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1b --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1c --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -471,6 +471,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-mixedinstances-example-com" {
     "k8s.io/etcd/events"                               = "us-test-1a/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125
@@ -488,6 +489,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-mixedinstances-example-com" {
     "k8s.io/etcd/main"                                 = "us-test-1a/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125
@@ -505,6 +507,7 @@ resource "aws_ebs_volume" "us-test-1b-etcd-events-mixedinstances-example-com" {
     "k8s.io/etcd/events"                               = "us-test-1b/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125
@@ -522,6 +525,7 @@ resource "aws_ebs_volume" "us-test-1b-etcd-main-mixedinstances-example-com" {
     "k8s.io/etcd/main"                                 = "us-test-1b/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1b"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125
@@ -539,6 +543,7 @@ resource "aws_ebs_volume" "us-test-1c-etcd-events-mixedinstances-example-com" {
     "k8s.io/etcd/events"                               = "us-test-1c/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125
@@ -556,6 +561,7 @@ resource "aws_ebs_volume" "us-test-1c-etcd-main-mixedinstances-example-com" {
     "k8s.io/etcd/main"                                 = "us-test-1c/us-test-1a,us-test-1b,us-test-1c"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1c"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com --grpc-port=3997
       --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com --grpc-port=3996
       --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/kubernetes.tf
@@ -261,6 +261,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-nthimdsprocessor-longclusterna
     "k8s.io/etcd/events"                                                 = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                                          = "1"
     "k8s.io/role/master"                                                 = "1"
+    "kops.k8s.io/instancegroup"                                          = "master-us-test-1a"
     "kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com" = "owned"
   }
   throughput = 125
@@ -278,6 +279,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-nthimdsprocessor-longclustername
     "k8s.io/etcd/main"                                                   = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                                          = "1"
     "k8s.io/role/master"                                                 = "1"
+    "kops.k8s.io/instancegroup"                                          = "master-us-test-1a"
     "kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com --grpc-port=3997
       --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com --grpc-port=3996
       --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/nth-imds-processor/kubernetes.tf
+++ b/tests/integration/update_cluster/nth-imds-processor/kubernetes.tf
@@ -211,6 +211,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-nthimdsprocessor-longclusterna
     "k8s.io/etcd/events"                                                 = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                                          = "1"
     "k8s.io/role/master"                                                 = "1"
+    "kops.k8s.io/instancegroup"                                          = "master-us-test-1a"
     "kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com" = "owned"
   }
   throughput = 125
@@ -228,6 +229,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-nthimdsprocessor-longclustername
     "k8s.io/etcd/main"                                                   = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                                          = "1"
     "k8s.io/role/master"                                                 = "1"
+    "kops.k8s.io/instancegroup"                                          = "master-us-test-1a"
     "kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/nvidia/kubernetes.tf
+++ b/tests/integration/update_cluster/nvidia/kubernetes.tf
@@ -302,6 +302,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -319,6 +320,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.private-shared-ip.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.private-shared-ip.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-private-shared-ip-example-com"
     "k8s.io/etcd/events"                                  = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                           = "1"
     "k8s.io/role/master"                                  = "1"
+    "kops.k8s.io/instancegroup"                           = "master-us-test-1a"
     "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-private-shared-ip-example-com" {
     "k8s.io/etcd/main"                                    = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                           = "1"
     "k8s.io/role/master"                                  = "1"
+    "kops.k8s.io/instancegroup"                           = "master-us-test-1a"
     "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.private-shared-subnet.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
-      /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.private-shared-subnet.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
-      /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -377,6 +377,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-private-shared-subnet-example-
     "k8s.io/etcd/events"                                      = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                               = "1"
     "k8s.io/role/master"                                      = "1"
+    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
     "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
   }
   throughput = 125
@@ -394,6 +395,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-private-shared-subnet-example-co
     "k8s.io/etcd/main"                                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                               = "1"
     "k8s.io/role/master"                                      = "1"
+    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
     "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatecalico.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatecalico.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatecalico-example-com" {
     "k8s.io/etcd/events"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                       = "1"
     "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatecalico-example-com" {
     "k8s.io/etcd/main"                                = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                       = "1"
     "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatecilium.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatecilium.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatecilium-example-com" {
     "k8s.io/etcd/events"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                       = "1"
     "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatecilium-example-com" {
     "k8s.io/etcd/main"                                = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                       = "1"
     "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatecilium.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatecilium.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatecilium-example-com" {
     "k8s.io/etcd/events"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                       = "1"
     "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatecilium-example-com" {
     "k8s.io/etcd/main"                                = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                       = "1"
     "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatecilium.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatecilium.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatecilium-example-com" {
     "k8s.io/etcd/events"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                       = "1"
     "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatecilium-example-com" {
     "k8s.io/etcd/main"                                = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                       = "1"
     "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -16,8 +16,9 @@ spec:
       --containerized=true --dns-suffix=.internal.privateciliumadvanced.example.com
       --grpc-port=3991 --peer-urls=https://__name__:2382 --quarantine-client-urls=https://__name__:3992
       --v=6 --volume-name-tag=k8s.io/etcd/cilium --volume-provider=aws --volume-tag=k8s.io/etcd/cilium
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
-      > /tmp/pipe 2>&1
+      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a
+      --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
+      /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privateciliumadvanced.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
-      /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privateciliumadvanced.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
-      /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-cilium-privateciliumadvanced-example-
     "k8s.io/etcd/cilium"                                      = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                               = "1"
     "k8s.io/role/master"                                      = "1"
+    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
     "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privateciliumadvanced-example-
     "k8s.io/etcd/events"                                      = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                               = "1"
     "k8s.io/role/master"                                      = "1"
+    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
     "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
   }
   throughput = 125
@@ -416,6 +418,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privateciliumadvanced-example-co
     "k8s.io/etcd/main"                                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                               = "1"
     "k8s.io/role/master"                                      = "1"
+    "kops.k8s.io/instancegroup"                               = "master-us-test-1a"
     "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatedns1.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatedns1.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -422,6 +422,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatedns1-example-com" {
     "k8s.io/etcd/events"                            = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                     = "1"
     "k8s.io/role/master"                            = "1"
+    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
   throughput = 125
@@ -441,6 +442,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatedns1-example-com" {
     "k8s.io/etcd/main"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                     = "1"
     "k8s.io/role/master"                            = "1"
+    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatedns2.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatedns2.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatedns2-example-com" {
     "k8s.io/etcd/events"                            = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                     = "1"
     "k8s.io/role/master"                            = "1"
+    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
     "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatedns2-example-com" {
     "k8s.io/etcd/main"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                     = "1"
     "k8s.io/role/master"                            = "1"
+    "kops.k8s.io/instancegroup"                     = "master-us-test-1a"
     "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privateflannel.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privateflannel.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privateflannel-example-com" {
     "k8s.io/etcd/events"                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privateflannel-example-com" {
     "k8s.io/etcd/main"                                 = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatekindnet.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatekindnet.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatekindnet.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatekindnet.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatekindnet.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatekindnet.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatekindnet/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekindnet/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatekindnet-example-com" {
     "k8s.io/etcd/events"                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/privatekindnet.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatekindnet-example-com" {
     "k8s.io/etcd/main"                                 = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                        = "1"
     "k8s.io/role/master"                               = "1"
+    "kops.k8s.io/instancegroup"                        = "master-us-test-1a"
     "kubernetes.io/cluster/privatekindnet.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatekopeio.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.privatekopeio.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -397,6 +397,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-privatekopeio-example-com" {
     "k8s.io/etcd/events"                              = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                       = "1"
     "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
   throughput = 125
@@ -414,6 +415,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatekopeio-example-com" {
     "k8s.io/etcd/main"                                = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                       = "1"
     "k8s.io/role/master"                              = "1"
+    "kops.k8s.io/instancegroup"                       = "master-us-test-1a"
     "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -347,6 +347,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -364,6 +365,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.sharedsubnet.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.sharedsubnet.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-sharedsubnet-example-com" {
     "k8s.io/etcd/events"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-sharedsubnet-example-com" {
     "k8s.io/etcd/main"                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.sharedvpc.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.sharedvpc.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -297,6 +297,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-sharedvpc-example-com" {
     "k8s.io/etcd/events"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                   = "1"
     "k8s.io/role/master"                          = "1"
+    "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
     "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
   }
   throughput = 125
@@ -314,6 +315,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-sharedvpc-example-com" {
     "k8s.io/etcd/main"                            = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                   = "1"
     "k8s.io/role/master"                          = "1"
+    "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
     "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,8 +16,8 @@ spec:
       --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
@@ -333,6 +333,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-ipv6-example-com" {
     "k8s.io/etcd/events"                             = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125
@@ -350,6 +351,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-ipv6-example-com" {
     "k8s.io/etcd/main"                               = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                      = "1"
     "k8s.io/role/master"                             = "1"
+    "kops.k8s.io/instancegroup"                      = "master-us-test-1a"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.unmanaged.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.unmanaged.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -382,6 +382,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-unmanaged-example-com" {
     "k8s.io/etcd/events"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                   = "1"
     "k8s.io/role/master"                          = "1"
+    "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
     "kubernetes.io/cluster/unmanaged.example.com" = "owned"
   }
   throughput = 125
@@ -399,6 +400,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-unmanaged-example-com" {
     "k8s.io/etcd/main"                            = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                   = "1"
     "k8s.io/role/master"                          = "1"
+    "kops.k8s.io/instancegroup"                   = "master-us-test-1a"
     "kubernetes.io/cluster/unmanaged.example.com" = "owned"
   }
   throughput = 125

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -16,7 +16,8 @@ spec:
       --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      --volume-tag=kops.k8s.io/instancegroup=master-us-test-1a --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -307,6 +307,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
     "k8s.io/etcd/events"                        = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125
@@ -324,6 +325,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
     "k8s.io/etcd/main"                          = "us-test-1a/us-test-1a"
     "k8s.io/role/control-plane"                 = "1"
     "k8s.io/role/master"                        = "1"
+    "kops.k8s.io/instancegroup"                 = "master-us-test-1a"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
   throughput = 125

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -99,6 +99,9 @@ const TagRoleMaster = "master"
 // TagNameKopsRole is the AWS tag used to identify the role an object plays for a cluster
 const TagNameKopsRole = "kubernetes.io/kops/role"
 
+// TagNameKopsInstanceGroup is the AWS tag used to identify the kOps instance group an object belongs to.
+const TagNameKopsInstanceGroup = "kops.k8s.io/instancegroup"
+
 // TagNameClusterOwnershipPrefix is the AWS tag used for ownership
 const TagNameClusterOwnershipPrefix = "kubernetes.io/cluster/"
 


### PR DESCRIPTION
Tag etcd EBS volumes with kops.k8s.io/instancegroup and add a matching `--volume-tag` filter to the per-IG manifest, so control-plane nodes sharing an AZ can no longer claim other IG's volume.

/cc @rifelpet 

Fixes #14560