### PR TITLE
Automated cherry pick of #18298: dns-controller: make priorityClassName configurable

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1461,6 +1461,11 @@ spec:
                     description: Disable indicates we do not wish to run the dns-controller
                       addon
                     type: boolean
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName overrides the priorityClassName on the dns-controller pod.
+                      Defaults to "system-cluster-critical" when unset.
+                    type: string
                   provider:
                     description: |-
                       Provider determines which implementation of ExternalDNS to use.

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -648,6 +648,9 @@ type ExternalDNSConfig struct {
 	// 'dns-controller' will use kOps DNS Controller.
 	// 'external-dns' will use kubernetes-sigs/external-dns.
 	Provider ExternalDNSProvider `json:"provider,omitempty"`
+	// PriorityClassName overrides the priorityClassName on the dns-controller pod.
+	// Defaults to "system-cluster-critical" when unset.
+	PriorityClassName *string `json:"priorityClassName,omitempty"`
 }
 
 // EtcdProviderType describes etcd cluster provisioning types (Standalone, Manager)

--- a/pkg/apis/kops/fieldmap.go
+++ b/pkg/apis/kops/fieldmap.go
@@ -82,4 +82,5 @@ var clusterFieldMappings = []struct {
 	{V1Alpha2: "spec.masterPublicName", V1Alpha3: "spec.api.publicName"},
 	{V1Alpha2: "spec.topology.dns.type", V1Alpha3: "spec.networking.topology.dns"},
 	{V1Alpha2: "spec.externalDns.provider", V1Alpha3: "spec.externalDNS.provider"},
+	{V1Alpha2: "spec.externalDns.priorityClassName", V1Alpha3: "spec.externalDNS.priorityClassName"},
 }

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -628,6 +628,9 @@ type ExternalDNSConfig struct {
 	// 'dns-controller' will use kOps DNS Controller.
 	// 'external-dns' will use kubernetes-sigs/external-dns.
 	Provider ExternalDNSProvider `json:"provider,omitempty"`
+	// PriorityClassName overrides the priorityClassName on the dns-controller pod.
+	// Defaults to "system-cluster-critical" when unset.
+	PriorityClassName *string `json:"priorityClassName,omitempty"`
 }
 
 // EtcdProviderType describes etcd cluster provisioning types (Standalone, Manager)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3911,6 +3911,7 @@ func autoConvert_v1alpha2_ExternalDNSConfig_To_kops_ExternalDNSConfig(in *Extern
 	out.WatchIngress = in.WatchIngress
 	out.WatchNamespace = in.WatchNamespace
 	out.Provider = kops.ExternalDNSProvider(in.Provider)
+	out.PriorityClassName = in.PriorityClassName
 	return nil
 }
 
@@ -3918,6 +3919,7 @@ func autoConvert_kops_ExternalDNSConfig_To_v1alpha2_ExternalDNSConfig(in *kops.E
 	out.WatchIngress = in.WatchIngress
 	out.WatchNamespace = in.WatchNamespace
 	out.Provider = ExternalDNSProvider(in.Provider)
+	out.PriorityClassName = in.PriorityClassName
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2161,6 +2161,11 @@ func (in *ExternalDNSConfig) DeepCopyInto(out *ExternalDNSConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PriorityClassName != nil {
+		in, out := &in.PriorityClassName, &out.PriorityClassName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -611,6 +611,9 @@ type ExternalDNSConfig struct {
 	// 'dns-controller' will use kOps DNS Controller.
 	// 'external-dns' will use kubernetes-sigs/external-dns.
 	Provider ExternalDNSProvider `json:"provider,omitempty"`
+	// PriorityClassName overrides the priorityClassName on the dns-controller pod.
+	// Defaults to "system-cluster-critical" when unset.
+	PriorityClassName *string `json:"priorityClassName,omitempty"`
 }
 
 // EtcdClusterSpec is the etcd cluster specification

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -4171,6 +4171,7 @@ func autoConvert_v1alpha3_ExternalDNSConfig_To_kops_ExternalDNSConfig(in *Extern
 	out.WatchIngress = in.WatchIngress
 	out.WatchNamespace = in.WatchNamespace
 	out.Provider = kops.ExternalDNSProvider(in.Provider)
+	out.PriorityClassName = in.PriorityClassName
 	return nil
 }
 
@@ -4183,6 +4184,7 @@ func autoConvert_kops_ExternalDNSConfig_To_v1alpha3_ExternalDNSConfig(in *kops.E
 	out.WatchIngress = in.WatchIngress
 	out.WatchNamespace = in.WatchNamespace
 	out.Provider = ExternalDNSProvider(in.Provider)
+	out.PriorityClassName = in.PriorityClassName
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -2067,6 +2067,11 @@ func (in *ExternalDNSConfig) DeepCopyInto(out *ExternalDNSConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PriorityClassName != nil {
+		in, out := &in.PriorityClassName, &out.PriorityClassName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2230,6 +2230,11 @@ func (in *ExternalDNSConfig) DeepCopyInto(out *ExternalDNSConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PriorityClassName != nil {
+		in, out := &in.PriorityClassName, &out.PriorityClassName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -21,7 +21,7 @@ spec:
         k8s-app: dns-controller
         version: v{{ KopsVersion }}
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: {{ DNSControllerPriorityClassName }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -173,6 +173,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["OpenStackCCMTag"] = tf.OpenStackCCMTag
 	dest["OpenStackCSITag"] = tf.OpenStackCSITag
 	dest["DNSControllerEnvs"] = tf.DNSControllerEnvs
+	dest["DNSControllerPriorityClassName"] = tf.DNSControllerPriorityClassName
 	dest["ProxyEnv"] = tf.ProxyEnv
 
 	dest["KopsControllerEnv"] = tf.KopsControllerEnv
@@ -849,6 +850,15 @@ func (tf *TemplateFunctions) ExternalDNSArgv() ([]string, error) {
 	}
 
 	return argv, nil
+}
+
+// DNSControllerPriorityClassName returns the priorityClassName for the dns-controller pod,
+// defaulting to "system-cluster-critical" when the spec leaves it unset.
+func (tf *TemplateFunctions) DNSControllerPriorityClassName() string {
+	if tf.Cluster.Spec.ExternalDNS != nil && tf.Cluster.Spec.ExternalDNS.PriorityClassName != nil {
+		return *tf.Cluster.Spec.ExternalDNS.PriorityClassName
+	}
+	return "system-cluster-critical"
 }
 
 func (tf *TemplateFunctions) DNSControllerEnvs() map[string]string {


### PR DESCRIPTION
Cherry pick of #18298 on release-1.34.

#18298: dns-controller: make priorityClassName configurable

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```