### PR TITLE
dns-controller: default Provider when ExternalDNS is partially set

### DIFF
--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -284,9 +284,10 @@ func (c *populateClusterSpec) run(ctx context.Context, clientset simple.Clientse
 			cluster.Spec.API.PublicName = "api." + cluster.Name
 		}
 		if cluster.Spec.ExternalDNS == nil {
-			cluster.Spec.ExternalDNS = &kopsapi.ExternalDNSConfig{
-				Provider: kopsapi.ExternalDNSProviderDNSController,
-			}
+			cluster.Spec.ExternalDNS = &kopsapi.ExternalDNSConfig{}
+		}
+		if cluster.Spec.ExternalDNS.Provider == "" {
+			cluster.Spec.ExternalDNS.Provider = kopsapi.ExternalDNSProviderDNSController
 		}
 	}
 


### PR DESCRIPTION
The defaulter at `populate_cluster_spec.go` only sets `Provider=dns-controller` when `Spec.ExternalDNS` is nil. After #18298 added `PriorityClassName`, a user (or `--override=spec.externalDns.priorityClassName=`) can leave `ExternalDNS` non-nil with `Provider=""`, which silently drops the dns-controller addon from `bootstrap-channel.yaml`.

In gossip clusters this strands workers: nothing publishes the `kops-controller.internal.<cluster>` A record into the mesh, nodeup's `BootstrapClient` lookup fails for the full timeout, and no node ever joins. First observed in `pull-kops-aws-upgrade-gossip` after release-1.35 picked up the cherry-pick of #18298 — see [build 2053420008796590080](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/18296/pull-kops-aws-upgrade-gossip/2053420008796590080).

Default `Provider` to `dns-controller` whenever it is empty, regardless of whether `ExternalDNS` itself is nil.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDFbieppSkZmEhwD6TFbXg)_