### PR TITLE
Automated cherry pick of #18302: dns-controller: default Provider when ExternalDNS is partially set

### DIFF
--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -285,9 +285,10 @@ func (c *populateClusterSpec) run(ctx context.Context, clientset simple.Clientse
 			cluster.Spec.API.PublicName = "api." + cluster.Name
 		}
 		if cluster.Spec.ExternalDNS == nil {
-			cluster.Spec.ExternalDNS = &kopsapi.ExternalDNSConfig{
-				Provider: kopsapi.ExternalDNSProviderDNSController,
-			}
+			cluster.Spec.ExternalDNS = &kopsapi.ExternalDNSConfig{}
+		}
+		if cluster.Spec.ExternalDNS.Provider == "" {
+			cluster.Spec.ExternalDNS.Provider = kopsapi.ExternalDNSProviderDNSController
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #18302 on release-1.34.

#18302: dns-controller: default Provider when ExternalDNS is partially set

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDFbieppSkZmEhwD6TFbXg)_