### PR TITLE
Automated cherry pick of #18232: Initial support for Ubuntu 26.04

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -60,6 +60,7 @@ The following table provides the support status for various distros with regards
 | [Ubuntu 20.04](#ubuntu-2004-focal)      |       1.16.2 |   1.18 |          - |       - |
 | [Ubuntu 22.04](#ubuntu-2204-jammy)      |         1.23 |   1.24 |          - |       - |
 | [Ubuntu 24.04](#ubuntu-2404-noble)      |         1.29 |   1.31 |          - |       - |
+| [Ubuntu 26.04](#ubuntu-2604-resolute)   |         1.36 |      - |          - |       - |
 
 ## Supported Distros
 
@@ -347,7 +348,7 @@ aws ec2 describe-images --region us-east-1 --output table \
   --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-*-*"
 
 # Google Cloud Platform (GCP)
-gcloud compute images list --filter ubuntu-2204-jammy-v \
+gcloud compute images list --filter ubuntu-2204-jammy \
   --project ubuntu-os-cloud
 
 # Microsoft Azure
@@ -369,12 +370,34 @@ aws ec2 describe-images --region us-east-1 --output table \
   --filters "Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-*-*"
 
 # Google Cloud Platform (GCP)
-gcloud compute images list --filter ubuntu-2204-jammy-v \
+gcloud compute images list --filter ubuntu-2404-noble \
   --project ubuntu-os-cloud
 
 # Microsoft Azure
 az vm image list --all --output table \
   --publisher Canonical --offer 0001-com-ubuntu-server-jammy --sku 22_04-lts-gen2
+```
+
+### Ubuntu 26.04 (Resolute)
+
+Support for Ubuntu 26.04 is based on Kernel version **7.0**.
+
+Available images can be listed using:
+
+```bash
+# Amazon Web Services (AWS)
+aws ec2 describe-images --region us-east-1 --output table \
+  --owners 099720109477 \
+  --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
+  --filters "Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-*-*"
+
+# Google Cloud Platform (GCP)
+gcloud compute images list --filter ubuntu-2604-resolute-v \
+  --project ubuntu-os-cloud
+
+# Microsoft Azure
+az vm image list --all --output table \
+  --publisher Canonical --offer 0001-com-ubuntu-server-resolute --sku 26_04-lts-gen2
 ```
 
 ## Owner aliases

--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -49,6 +49,7 @@ var (
 	DistributionUbuntu2204 = Distribution{packageFormat: "deb", project: "ubuntu", id: "jammy", version: 22.04}
 	DistributionUbuntu2404 = Distribution{packageFormat: "deb", project: "ubuntu", id: "noble", version: 24.04}
 	DistributionUbuntu2510 = Distribution{packageFormat: "deb", project: "ubuntu", id: "questing", version: 25.10}
+	DistributionUbuntu2604 = Distribution{packageFormat: "deb", project: "ubuntu", id: "resolute", version: 26.04}
 
 	// Redhat-family distros
 	DistributionRhel8           = Distribution{packageFormat: "rpm", project: "rhel", id: "rhel8", version: 8}

--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -76,6 +76,8 @@ func FindDistribution(rootfs string) (Distribution, error) {
 		return DistributionUbuntu2404, nil
 	case "ubuntu-25.10":
 		return DistributionUbuntu2510, nil
+	case "ubuntu-26.04":
+		return DistributionUbuntu2604, nil
 	}
 
 	// Some distros have a more verbose VERSION_ID

--- a/util/pkg/distributions/identify_test.go
+++ b/util/pkg/distributions/identify_test.go
@@ -144,6 +144,11 @@ func TestFindDistribution(t *testing.T) {
 			expected: DistributionUbuntu2510,
 		},
 		{
+			rootfs:   "ubuntu2604",
+			err:      nil,
+			expected: DistributionUbuntu2604,
+		},
+		{
 			rootfs:   "notfound",
 			err:      fmt.Errorf("reading /etc/os-release: open tests/notfound/etc/os-release: no such file or directory"),
 			expected: Distribution{},

--- a/util/pkg/distributions/tests/ubuntu2604/etc/os-release
+++ b/util/pkg/distributions/tests/ubuntu2604/etc/os-release
@@ -1,0 +1,13 @@
+PRETTY_NAME="Ubuntu 26.04 LTS"
+NAME="Ubuntu"
+VERSION_ID="26.04"
+VERSION="26.04 (Resolute Raccoon)"
+VERSION_CODENAME=resolute
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=resolute
+LOGO=ubuntu-logo


### PR DESCRIPTION
Cherry pick of #18232 on release-1.35.

#18232: Initial support for Ubuntu 26.04

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```