### PR TITLE
gce: expose kops-controller on internal LB for gossip clusters

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -969,6 +969,19 @@ func (c *Cluster) UsesNoneDNS() bool {
 	return false
 }
 
+// UsesLoadBalancerForKopsController returns true when worker nodes reach kops-controller
+// via the cluster API load balancer instead of via gossip-populated /etc/hosts. True for
+// None-DNS clusters across all clouds, plus GCE gossip clusters with an API load balancer.
+func (c *Cluster) UsesLoadBalancerForKopsController() bool {
+	if c.UsesNoneDNS() {
+		return true
+	}
+	if c.UsesLegacyGossip() && c.GetCloudProvider() == CloudProviderGCE && c.Spec.API.LoadBalancer != nil {
+		return true
+	}
+	return false
+}
+
 func (c *Cluster) InstallCNIAssets() bool {
 	return c.Spec.Networking.AmazonVPC == nil &&
 		c.Spec.Networking.Calico == nil &&

--- a/pkg/apis/kops/model/features.go
+++ b/pkg/apis/kops/model/features.go
@@ -41,9 +41,10 @@ func UseChallengeCallback(cloudProvider kops.CloudProviderID) bool {
 // UseKopsControllerForNodeConfig checks if nodeup should use kops-controller to get nodeup.Config.
 func UseKopsControllerForNodeConfig(cluster *kops.Cluster) bool {
 	if cluster.UsesLegacyGossip() {
+		if cluster.UsesLoadBalancerForKopsController() {
+			return true
+		}
 		switch cluster.GetCloudProvider() {
-		case kops.CloudProviderGCE:
-			// We can use cloud-discovery here.
 		case kops.CloudProviderHetzner, kops.CloudProviderScaleway, kops.CloudProviderDO:
 			// We don't have a cloud-discovery mechanism implemented in nodeup for many clouds,
 			// but we assume that we're using a load balancer with a fixed IP address

--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -119,7 +119,7 @@ func (b *APILoadBalancerBuilder) addFirewallRules(c *fi.CloudupModelBuilderConte
 			})
 		}
 
-		if b.Cluster.UsesNoneDNS() {
+		if b.Cluster.UsesLoadBalancerForKopsController() {
 			b.AddFirewallRulesTasks(c, "kops-controller", &gcetasks.FirewallRule{
 				Lifecycle:    b.Lifecycle,
 				Network:      network,
@@ -256,7 +256,7 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 				"name":           "api-" + sn.Name,
 			},
 		})
-		if b.Cluster.UsesNoneDNS() {
+		if b.Cluster.UsesLoadBalancerForKopsController() {
 			ipAddress.WellKnownServices = append(ipAddress.WellKnownServices, wellknownservices.KopsController)
 
 			fr := &gcetasks.ForwardingRule{

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -379,7 +379,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 		controlPlaneIPs = append(controlPlaneIPs, wellKnownAddresses[wellknownservices.KubeAPIServer]...)
 	}
 
-	if cluster.UsesNoneDNS() {
+	if cluster.UsesLoadBalancerForKopsController() {
 		bootConfig.APIServerIPs = controlPlaneIPs
 	} else {
 		// If we do have a fixed IP, we use it (on some clouds, initially)

--- a/tests/integration/update_cluster/gossip-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-gce/kubernetes.tf
@@ -229,6 +229,30 @@ resource "google_compute_firewall" "https-api-ipv6-gossip-k8s-local" {
   target_tags   = ["gossip-k8s-local-k8s-io-role-control-plane"]
 }
 
+resource "google_compute_firewall" "kops-controller-gossip-k8s-local" {
+  allow {
+    ports    = ["3988"]
+    protocol = "tcp"
+  }
+  disabled      = false
+  name          = "kops-controller-gossip-k8s-local"
+  network       = google_compute_network.gossip-k8s-local.name
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["gossip-k8s-local-k8s-io-role-control-plane"]
+}
+
+resource "google_compute_firewall" "kops-controller-ipv6-gossip-k8s-local" {
+  allow {
+    ports    = ["3988"]
+    protocol = "tcp"
+  }
+  disabled      = false
+  name          = "kops-controller-ipv6-gossip-k8s-local"
+  network       = google_compute_network.gossip-k8s-local.name
+  source_ranges = ["::/0"]
+  target_tags   = ["gossip-k8s-local-k8s-io-role-control-plane"]
+}
+
 resource "google_compute_firewall" "lb-health-checks-gossip-k8s-local" {
   allow {
     protocol = "tcp"
@@ -459,6 +483,21 @@ resource "google_compute_forwarding_rule" "api-us-test1-gossip-k8s-local" {
   name                  = "api-us-test1-gossip-k8s-local"
   network               = google_compute_network.gossip-k8s-local.name
   ports                 = ["443"]
+  subnetwork            = google_compute_subnetwork.us-test1-gossip-k8s-local.name
+}
+
+resource "google_compute_forwarding_rule" "kops-controller-us-test1-gossip-k8s-local" {
+  backend_service = google_compute_region_backend_service.api-gossip-k8s-local.id
+  ip_address      = google_compute_address.api-us-test1-gossip-k8s-local.address
+  ip_protocol     = "TCP"
+  labels = {
+    "k8s-io-cluster-name" = "gossip-k8s-local"
+    "name"                = "kops-controller-us-test1"
+  }
+  load_balancing_scheme = "INTERNAL"
+  name                  = "kops-controller-us-test1-gossip-k8s-local"
+  network               = google_compute_network.gossip-k8s-local.name
+  ports                 = ["3988"]
   subnetwork            = google_compute_subnetwork.us-test1-gossip-k8s-local.name
 }
 


### PR DESCRIPTION
Enable workers to reach kops-controller via the internal API load balancer instead of resolving kops-controller.internal via gossip DNS, which broke when the gcediscovery resolver was removed in #15121.

/cc @ameukam @rifelpet 