### PR TITLE
Automated cherry pick of #18307: gce: expose kops-controller on internal LB for gossip clusters

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -955,6 +955,19 @@ func (c *Cluster) UsesNoneDNS() bool {
 	return false
 }
 
+// UsesLoadBalancerForKopsController returns true when worker nodes reach kops-controller
+// via the cluster API load balancer instead of via gossip-populated /etc/hosts. True for
+// None-DNS clusters across all clouds, plus GCE gossip clusters with an API load balancer.
+func (c *Cluster) UsesLoadBalancerForKopsController() bool {
+	if c.UsesNoneDNS() {
+		return true
+	}
+	if c.UsesLegacyGossip() && c.GetCloudProvider() == CloudProviderGCE && c.Spec.API.LoadBalancer != nil {
+		return true
+	}
+	return false
+}
+
 func (c *Cluster) InstallCNIAssets() bool {
 	return c.Spec.Networking.AmazonVPC == nil &&
 		c.Spec.Networking.Calico == nil &&

--- a/pkg/apis/kops/model/features.go
+++ b/pkg/apis/kops/model/features.go
@@ -39,9 +39,10 @@ func UseChallengeCallback(cloudProvider kops.CloudProviderID) bool {
 // UseKopsControllerForNodeConfig checks if nodeup should use kops-controller to get nodeup.Config.
 func UseKopsControllerForNodeConfig(cluster *kops.Cluster) bool {
 	if cluster.UsesLegacyGossip() {
+		if cluster.UsesLoadBalancerForKopsController() {
+			return true
+		}
 		switch cluster.GetCloudProvider() {
-		case kops.CloudProviderGCE:
-			// We can use cloud-discovery here.
 		case kops.CloudProviderHetzner, kops.CloudProviderScaleway, kops.CloudProviderDO:
 			// We don't have a cloud-discovery mechanism implemented in nodeup for many clouds,
 			// but we assume that we're using a load balancer with a fixed IP address

--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -118,7 +118,7 @@ func (b *APILoadBalancerBuilder) addFirewallRules(c *fi.CloudupModelBuilderConte
 			})
 		}
 
-		if b.Cluster.UsesNoneDNS() {
+		if b.Cluster.UsesLoadBalancerForKopsController() {
 			b.AddFirewallRulesTasks(c, "kops-controller", &gcetasks.FirewallRule{
 				Lifecycle:    b.Lifecycle,
 				Network:      network,
@@ -211,7 +211,7 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 				"name":           "api-" + sn.Name,
 			},
 		})
-		if b.Cluster.UsesNoneDNS() {
+		if b.Cluster.UsesLoadBalancerForKopsController() {
 			ipAddress.WellKnownServices = append(ipAddress.WellKnownServices, wellknownservices.KopsController)
 
 			fr := &gcetasks.ForwardingRule{

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -379,7 +379,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 		controlPlaneIPs = append(controlPlaneIPs, wellKnownAddresses[wellknownservices.KubeAPIServer]...)
 	}
 
-	if cluster.UsesNoneDNS() {
+	if cluster.UsesLoadBalancerForKopsController() {
 		bootConfig.APIServerIPs = controlPlaneIPs
 	} else {
 		// If we do have a fixed IP, we use it (on some clouds, initially)


### PR DESCRIPTION
Cherry pick of #18307 on release-1.35.

#18307: gce: expose kops-controller on internal LB for gossip clusters

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```