### PR TITLE
Automated cherry pick of #18319: azure: list VMSS NICs in protokube gossip seed discovery

### DIFF
--- a/protokube/pkg/gossip/azure/client.go
+++ b/protokube/pkg/gossip/azure/client.go
@@ -146,7 +146,7 @@ func (c *Client) ListVMScaleSets(ctx context.Context) ([]*compute.VirtualMachine
 // ListVMSSNetworkInterfaces returns the interfaces that the specified VM ScaleSet has.
 func (c *Client) ListVMSSNetworkInterfaces(ctx context.Context, vmScaleSetName string) ([]*network.Interface, error) {
 	var l []*network.Interface
-	pager := c.interfacesClient.NewListPager(c.resourceGroupName(), nil)
+	pager := c.interfacesClient.NewListVirtualMachineScaleSetNetworkInterfacesPager(c.resourceGroupName(), vmScaleSetName, nil)
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #18319 on release-1.34.

#18319: azure: list VMSS NICs in protokube gossip seed discovery

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```