### PR TITLE
kops toolbox dump fixes

### DIFF
--- a/pkg/dump/dumper.go
+++ b/pkg/dump/dumper.go
@@ -440,7 +440,7 @@ func (n *logDumperNode) findFiles(ctx context.Context, dir string) ([]string, er
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	err := n.client.ExecPiped(ctx, "sudo find "+dir+" -print0", &stdout, &stderr)
+	err := n.client.ExecPiped(ctx, "sudo find "+dir+" -type f -print0", &stdout, &stderr)
 	if err != nil {
 		return nil, fmt.Errorf("error listing %q: %v", dir, err)
 	}

--- a/pkg/dump/podlogs.go
+++ b/pkg/dump/podlogs.go
@@ -82,23 +82,21 @@ func (d *podLogDumper) DumpLogs(ctx context.Context) error {
 	for i := 0; i < len(allPods.Items); i++ {
 		result := <-results
 		if result.err != nil {
-			errors.Join(dumpErr, result.err)
+			dumpErr = errors.Join(dumpErr, result.err)
 		}
 	}
-	close(results)
 	return dumpErr
 }
 
 func (d *podLogDumper) getPodLogs(ctx context.Context, pods chan v1.Pod, results chan podLogDumpResult) {
 	for pod := range pods {
+		var podErr error
 		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 			resPath := path.Join(d.artifactsDir, "cluster-info", pod.Namespace, pod.Name, container.Name)
 
 			err := os.MkdirAll(path.Dir(resPath), 0755)
 			if err != nil {
-				results <- podLogDumpResult{
-					err: fmt.Errorf("creating directory %q: %w", resPath, err),
-				}
+				podErr = errors.Join(podErr, fmt.Errorf("creating directory %q: %w", resPath, err))
 				continue
 			}
 
@@ -107,16 +105,12 @@ func (d *podLogDumper) getPodLogs(ctx context.Context, pods chan v1.Pod, results
 				var statusErr *k8sErrors.StatusError
 				if errors.As(err, &statusErr) {
 					if statusErr.ErrStatus.Code != 400 {
-						results <- podLogDumpResult{
-							err: fmt.Errorf("getting pod logs for the previous instance of %v/%v: %w", pod.Namespace, pod.Name, err),
-						}
+						podErr = errors.Join(podErr, fmt.Errorf("getting pod logs for the previous instance of %v/%v: %w", pod.Namespace, pod.Name, err))
 					}
 				} else {
 					err := writeContainerLogs(resPath+".previous.log", resp)
 					if err != nil {
-						results <- podLogDumpResult{
-							err: err,
-						}
+						podErr = errors.Join(podErr, err)
 					}
 				}
 			}
@@ -126,23 +120,19 @@ func (d *podLogDumper) getPodLogs(ctx context.Context, pods chan v1.Pod, results
 				var statusErr *k8sErrors.StatusError
 				if errors.As(err, &statusErr) {
 					if statusErr.ErrStatus.Code != 400 {
-						results <- podLogDumpResult{
-							err: fmt.Errorf("getting pod logs for the current instance of %v/%v: %w", pod.Namespace, pod.Name, err),
-						}
+						podErr = errors.Join(podErr, fmt.Errorf("getting pod logs for the current instance of %v/%v: %w", pod.Namespace, pod.Name, err))
 						continue
 					}
 				} else {
 					err := writeContainerLogs(resPath+".log", resp)
 					if err != nil {
-						results <- podLogDumpResult{
-							err: err,
-						}
+						podErr = errors.Join(podErr, err)
 					}
 				}
 			}
 		}
 
-		results <- podLogDumpResult{}
+		results <- podLogDumpResult{err: podErr}
 	}
 }
 


### PR DESCRIPTION
* Fix getPodLogs panic: 
  getPodLogs could send multiple results per pod (one per container error plus a completion signal), but DumpLogs only drained len(pods) results before closing the channel, causing workers to panic when sending remaining errors. Accumulate errors per-pod with errors.Join and send exactly one result per pod. Also fix a dropped errors.Join return value when aggregating worker results.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-calico-deb12arm64-k34-ko35/2054298708597542912

```
 I0512 20:57:01.717835   13080 podlogs.go:61] Dumping k8s pod logs
panic: send on closed channel
goroutine 885 [running]:
k8s.io/kops/pkg/dump.(*podLogDumper).getPodLogs(0xc001157620, {0x90a1a78, 0xc0005ce000}, 0xc0003f53b0, 0xc0003f5420)
	k8s.io/kops/pkg/dump/podlogs.go:129 +0x96b
created by k8s.io/kops/pkg/dump.(*podLogDumper).DumpLogs in goroutine 1
	k8s.io/kops/pkg/dump/podlogs.go:72 +0x19e
```

* Skip symlinks when enumerating files to dump

  `findFiles` is used to list files under /var/log and /etc/containerd
  for `kops toolbox dump`. Without `-type f`, a symlink in either
  directory would be followed by the subsequent `sudo cat`, exposing
  the target file (potentially something outside the intended scope)
  in the dump artifacts.


Written with assistance from Opus 4.7