### PR TITLE
Surface scaling issues during cluster validation

### DIFF
--- a/cloudmock/aws/mockautoscaling/api.go
+++ b/cloudmock/aws/mockautoscaling/api.go
@@ -31,6 +31,11 @@ type MockAutoscaling struct {
 	Groups            map[string]*autoscalingtypes.AutoScalingGroup
 	WarmPoolInstances map[string][]autoscalingtypes.Instance
 	LifecycleHooks    map[string]*autoscalingtypes.LifecycleHook
+	// ScalingActivities is the canned response for DescribeScalingActivities,
+	// keyed by Auto Scaling group name.
+	ScalingActivities map[string][]autoscalingtypes.Activity
+	// DescribeScalingActivitiesCalls counts the number of paginated calls made.
+	DescribeScalingActivitiesCalls int
 }
 
 var _ awsinterfaces.AutoScalingAPI = &MockAutoscaling{}

--- a/cloudmock/aws/mockautoscaling/api.go
+++ b/cloudmock/aws/mockautoscaling/api.go
@@ -31,6 +31,25 @@ type MockAutoscaling struct {
 	Groups            map[string]*autoscalingtypes.AutoScalingGroup
 	WarmPoolInstances map[string][]autoscalingtypes.Instance
 	LifecycleHooks    map[string]*autoscalingtypes.LifecycleHook
+	// ScalingActivities is the canned response for DescribeScalingActivities,
+	// keyed by Auto Scaling group name.
+	ScalingActivities map[string][]autoscalingtypes.Activity
+	// ScalingActivityPageSize, when positive, makes DescribeScalingActivities
+	// paginate at this size regardless of the caller's MaxRecords. Callers that
+	// do not set MaxRecords are otherwise served in a single page, which leaves
+	// their pagination behaviour untestable.
+	ScalingActivityPageSize int
+
+	describeScalingActivitiesCalls int
+}
+
+// ScalingActivityCalls returns how many DescribeScalingActivities requests the
+// mock has served, including paginated continuations. Safe to call while other
+// goroutines are driving the mock.
+func (m *MockAutoscaling) ScalingActivityCalls() int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.describeScalingActivitiesCalls
 }
 
 var _ awsinterfaces.AutoScalingAPI = &MockAutoscaling{}

--- a/cloudmock/aws/mockautoscaling/scaling_activities.go
+++ b/cloudmock/aws/mockautoscaling/scaling_activities.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockautoscaling
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+)
+
+// DescribeScalingActivities returns the canned activities for the named group.
+// To exercise pagination, the mock returns one activity per page when the input
+// has MaxRecords == 1.
+func (m *MockAutoscaling) DescribeScalingActivities(ctx context.Context, input *autoscaling.DescribeScalingActivitiesInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeScalingActivitiesOutput, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.DescribeScalingActivitiesCalls++
+
+	name := aws.ToString(input.AutoScalingGroupName)
+	activities := m.ScalingActivities[name]
+
+	start := 0
+	if input.NextToken != nil {
+		s, err := strconv.Atoi(aws.ToString(input.NextToken))
+		if err != nil {
+			return nil, fmt.Errorf("invalid NextToken %q: %w", aws.ToString(input.NextToken), err)
+		}
+		start = s
+	}
+
+	pageSize := len(activities) - start
+	if input.MaxRecords != nil && int(*input.MaxRecords) > 0 && int(*input.MaxRecords) < pageSize {
+		pageSize = int(*input.MaxRecords)
+	}
+	end := start + pageSize
+	if end > len(activities) {
+		end = len(activities)
+	}
+
+	out := &autoscaling.DescribeScalingActivitiesOutput{
+		Activities: activities[start:end],
+	}
+	if end < len(activities) {
+		out.NextToken = aws.String(strconv.Itoa(end))
+	}
+	return out, nil
+}

--- a/cloudmock/aws/mockautoscaling/scaling_activities.go
+++ b/cloudmock/aws/mockautoscaling/scaling_activities.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockautoscaling
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	autoscalingtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+)
+
+// DescribeScalingActivities returns the canned activities for the named group,
+// paginating at ScalingActivityPageSize or the caller's MaxRecords, whichever
+// is smaller and positive.
+func (m *MockAutoscaling) DescribeScalingActivities(ctx context.Context, input *autoscaling.DescribeScalingActivitiesInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeScalingActivitiesOutput, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.describeScalingActivitiesCalls++
+
+	name := aws.ToString(input.AutoScalingGroupName)
+	activities := m.ScalingActivities[name]
+
+	start := 0
+	if input.NextToken != nil {
+		s, err := strconv.Atoi(aws.ToString(input.NextToken))
+		if err != nil {
+			return nil, fmt.Errorf("invalid NextToken %q: %w", aws.ToString(input.NextToken), err)
+		}
+		if s < 0 || s > len(activities) {
+			return nil, fmt.Errorf("invalid NextToken %q: out of range for %d activities", aws.ToString(input.NextToken), len(activities))
+		}
+		start = s
+	}
+
+	end := len(activities)
+	if m.ScalingActivityPageSize > 0 {
+		end = min(start+m.ScalingActivityPageSize, end)
+	}
+	if input.MaxRecords != nil && *input.MaxRecords > 0 {
+		end = min(start+int(*input.MaxRecords), end)
+	}
+
+	// Copy: the caller iterates the page without holding the mock's lock.
+	page := make([]autoscalingtypes.Activity, end-start)
+	copy(page, activities[start:end])
+
+	out := &autoscaling.DescribeScalingActivitiesOutput{
+		Activities: page,
+	}
+	if end < len(activities) {
+		out.NextToken = aws.String(strconv.Itoa(end))
+	}
+	return out, nil
+}

--- a/cloudmock/gce/mock_gce_cloud.go
+++ b/cloudmock/gce/mock_gce_cloud.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"fmt"
 
 	"cloud.google.com/go/storage"
@@ -49,7 +50,11 @@ type MockGCECloud struct {
 	cloudResourceManagerClient *cloudresourcemanager.Service
 }
 
-var _ gce.GCECloud = &MockGCECloud{}
+var (
+	_ gce.GCECloud                               = &MockGCECloud{}
+	_ cloudinstances.GroupFailureReporter        = &MockGCECloud{}
+	_ cloudinstances.GroupInstanceStatusReporter = &MockGCECloud{}
+)
 
 // InstallMockGCECloud registers a MockGCECloud implementation for the specified region & project
 func InstallMockGCECloud(region string, project string) *MockGCECloud {
@@ -66,6 +71,12 @@ func InstallMockGCECloud(region string, project string) *MockGCECloud {
 	return c
 }
 
+// ComputeClient exposes the mock compute client so tests can install canned
+// responses that are not reachable through the gce.ComputeClient interface.
+func (c *MockGCECloud) ComputeClient() *mockcompute.MockClient {
+	return c.computeClient
+}
+
 func (c *MockGCECloud) AllResources() map[string]interface{} {
 	return c.computeClient.AllResources()
 }
@@ -73,6 +84,14 @@ func (c *MockGCECloud) AllResources() map[string]interface{} {
 // GetCloudGroups is not implemented yet
 func (c *MockGCECloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	return gce.GetCloudGroups(c, cluster, instancegroups, warnUnmatched, nodes)
+}
+
+func (c *MockGCECloud) GetGroupFailures(ctx context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupFailure, error) {
+	return gce.GetGroupFailures(ctx, c, group)
+}
+
+func (c *MockGCECloud) GetGroupInstanceStatuses(ctx context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupInstanceStatus, error) {
+	return gce.GetGroupInstanceStatuses(ctx, c, group)
 }
 
 // Zones is not implemented yet

--- a/cloudmock/gce/mockcompute/api.go
+++ b/cloudmock/gce/mockcompute/api.go
@@ -173,6 +173,17 @@ func (c *MockClient) InstanceGroupManagers() gce.InstanceGroupManagerClient {
 	return c.instanceGroupManagerClient
 }
 
+// SetInstanceGroupManagerErrors installs the canned ListErrors response for one
+// managed instance group.
+func (c *MockClient) SetInstanceGroupManagerErrors(project, zone, name string, errs []*compute.InstanceManagedByIgmError) {
+	c.instanceGroupManagerClient.SetErrors(project, zone, name, errs)
+}
+
+// SetManagedInstance installs the managed instance a group reports for name.
+func (c *MockClient) SetManagedInstance(project, zone, name string, mi *compute.ManagedInstance) {
+	c.instanceGroupManagerClient.SetManagedInstance(project, zone, name, mi)
+}
+
 func (c *MockClient) TargetPools() gce.TargetPoolClient {
 	return c.targetPoolClient
 }

--- a/cloudmock/gce/mockcompute/instance_group_manager.go
+++ b/cloudmock/gce/mockcompute/instance_group_manager.go
@@ -174,6 +174,10 @@ func (c *instanceGroupManagerClient) ListManagedInstances(ctx context.Context, p
 	return l, nil
 }
 
+func (c *instanceGroupManagerClient) ListErrors(ctx context.Context, project, zone, name string) ([]*compute.InstanceManagedByIgmError, error) {
+	return nil, nil
+}
+
 func (c *instanceGroupManagerClient) RecreateInstances(project, zone, name, id string) (*compute.Operation, error) {
 	return doneOperation(), nil
 }

--- a/cloudmock/gce/mockcompute/instance_group_manager.go
+++ b/cloudmock/gce/mockcompute/instance_group_manager.go
@@ -31,6 +31,8 @@ type instanceGroupManagerClient struct {
 	instanceGroupManagers map[string]map[string]map[string]*compute.InstanceGroupManager
 	// managedInstances are managedInstances keyed by project, zone, and name.
 	managedInstances map[string]map[string]map[string]*compute.ManagedInstance
+	// igmErrors are canned ListErrors responses keyed by project, zone, and name.
+	igmErrors map[string]map[string]map[string][]*compute.InstanceManagedByIgmError
 	// instanceClient is the client for instances.
 	instanceClient gce.InstanceClient
 	sync.Mutex
@@ -42,6 +44,7 @@ func newInstanceGroupManagerClient(instanceClient gce.InstanceClient) *instanceG
 	return &instanceGroupManagerClient{
 		instanceGroupManagers: map[string]map[string]map[string]*compute.InstanceGroupManager{},
 		managedInstances:      map[string]map[string]map[string]*compute.ManagedInstance{},
+		igmErrors:             map[string]map[string]map[string][]*compute.InstanceManagedByIgmError{},
 		instanceClient:        instanceClient,
 	}
 }
@@ -172,6 +175,49 @@ func (c *instanceGroupManagerClient) ListManagedInstances(ctx context.Context, p
 		l = append(l, instance)
 	}
 	return l, nil
+}
+
+func (c *instanceGroupManagerClient) ListErrors(ctx context.Context, project, zone, name string) ([]*compute.InstanceManagedByIgmError, error) {
+	c.Lock()
+	defer c.Unlock()
+	return c.igmErrors[project][zone][name], nil
+}
+
+// SetErrors installs the canned ListErrors response for one managed instance
+// group, so tests can drive the provisioning-failure reporting path.
+func (c *instanceGroupManagerClient) SetErrors(project, zone, name string, errs []*compute.InstanceManagedByIgmError) {
+	c.Lock()
+	defer c.Unlock()
+	zones, ok := c.igmErrors[project]
+	if !ok {
+		zones = map[string]map[string][]*compute.InstanceManagedByIgmError{}
+		c.igmErrors[project] = zones
+	}
+	names, ok := zones[zone]
+	if !ok {
+		names = map[string][]*compute.InstanceManagedByIgmError{}
+		zones[zone] = names
+	}
+	names[name] = errs
+}
+
+// SetManagedInstance installs the managed instance the group reports for name,
+// including one that has no backing compute instance because creation keeps
+// failing.
+func (c *instanceGroupManagerClient) SetManagedInstance(project, zone, name string, mi *compute.ManagedInstance) {
+	c.Lock()
+	defer c.Unlock()
+	zones, ok := c.managedInstances[project]
+	if !ok {
+		zones = map[string]map[string]*compute.ManagedInstance{}
+		c.managedInstances[project] = zones
+	}
+	names, ok := zones[zone]
+	if !ok {
+		names = map[string]*compute.ManagedInstance{}
+		zones[zone] = names
+	}
+	names[name] = mi
 }
 
 func (c *instanceGroupManagerClient) RecreateInstances(project, zone, name, id string) (*compute.Operation, error) {

--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -274,6 +274,19 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 			klog.Warningf("error dumping nodes: %v", err)
 		}
 
+		igList, err := clientset.InstanceGroupsFor(cluster).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			klog.Warningf("error listing instance groups: %v", err)
+		} else {
+			var instanceGroups []*kops.InstanceGroup
+			for i := range igList.Items {
+				instanceGroups = append(instanceGroups, &igList.Items[i])
+			}
+			if err := dump.DumpCloudInstanceGroups(ctx, cloud, cluster, instanceGroups, nodes.Items, options.Dir); err != nil {
+				klog.Warningf("error dumping cloud instance groups: %v", err)
+			}
+		}
+
 		if kubeConfig != nil && options.K8sResources {
 			dumper, err := dump.NewResourceDumper(kubeConfig, options.Output, options.Dir)
 			if err != nil {

--- a/pkg/cloudinstances/cloud_instance.go
+++ b/pkg/cloudinstances/cloud_instance.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package cloudinstances
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
 
 // CloudInstanceStatusDetached means the instance needs update and has been detached.
 const CloudInstanceStatusDetached = "Detached"
@@ -52,4 +56,7 @@ type CloudInstance struct {
 	ExternalIP string
 	// State indicates if the instance has joined the cluster and if it needs any updates.
 	State State
+	// CreationTimestamp is when the cloud provider accepted the request to create
+	// the instance. Used as a watermark when surfacing cloud-side provisioning errors.
+	CreationTimestamp time.Time
 }

--- a/pkg/cloudinstances/errors.go
+++ b/pkg/cloudinstances/errors.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudinstances
+
+import (
+	"context"
+	"time"
+)
+
+// CloudGroupError describes a failure the cloud provider encountered while
+// trying to provision an instance in a CloudInstanceGroup. Identical errors
+// (same Code + Message) are aggregated into a single entry.
+type CloudGroupError struct {
+	// Code is the cloud provider's structured error code (e.g.
+	// "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS").
+	Code string
+	// Message is the human-readable error message.
+	Message string
+	// Instance is the name of the most recent affected instance, if known.
+	Instance string
+	// Count is the number of times an identical error was observed.
+	Count int
+	// FirstSeen and LastSeen bracket the observed occurrences.
+	FirstSeen time.Time
+	LastSeen  time.Time
+}
+
+// CloudGroupErrorReporter is an optional capability exposed by cloud
+// implementations to surface provisioning errors during cluster validation.
+//
+// Validation calls this only for groups that have fewer instances than their
+// target size, so the implementation may assume something is already wrong.
+type CloudGroupErrorReporter interface {
+	GetCloudGroupErrors(ctx context.Context, group *CloudInstanceGroup) ([]CloudGroupError, error)
+}

--- a/pkg/cloudinstances/reporting.go
+++ b/pkg/cloudinstances/reporting.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudinstances
+
+import (
+	"cmp"
+	"context"
+	"slices"
+	"time"
+)
+
+// GroupFailure describes a failure the cloud provider encountered while
+// trying to provision an instance in a CloudInstanceGroup. Identical failures
+// (same Code + Message) are aggregated into a single entry.
+//
+// It is a report rather than a Go error: it is never returned in an error
+// position and does not implement the error interface.
+type GroupFailure struct {
+	// Code is the cloud provider's structured error code (e.g.
+	// "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS").
+	Code string `json:"code"`
+	// Message is the human-readable error message.
+	Message string `json:"message"`
+	// Instance is the name of the most recent affected instance, if known.
+	Instance string `json:"instance,omitempty"`
+	// Count is the number of times an identical error was observed.
+	Count int `json:"count"`
+	// FirstSeen and LastSeen bracket the observed occurrences.
+	FirstSeen time.Time `json:"firstSeen,omitzero"`
+	LastSeen  time.Time `json:"lastSeen,omitzero"`
+}
+
+// Watermark returns the most recent instance-creation time in the group, used
+// to discard provisioning failures left over from an earlier, healthier
+// incarnation of the group. A group with no instances has a zero watermark, so
+// callers surface the provider's full retention window — precisely the
+// empty-group failure mode this reporting exists to diagnose.
+func Watermark(group *CloudInstanceGroup) time.Time {
+	var w time.Time
+	for _, m := range slices.Concat(group.Ready, group.NeedUpdate) {
+		if m.CreationTimestamp.After(w) {
+			w = m.CreationTimestamp
+		}
+	}
+	return w
+}
+
+// SortFailures orders failures most-recent-first with a total, deterministic
+// tie-break. LastSeen alone is not a total order — distinct failures commonly
+// share a timestamp — so without the Code/Message tie-break the validation
+// output and the dump artifact would reorder run to run.
+func SortFailures(failures []GroupFailure) {
+	slices.SortFunc(failures, func(a, b GroupFailure) int {
+		return cmp.Or(
+			b.LastSeen.Compare(a.LastSeen),
+			cmp.Compare(a.Code, b.Code),
+			cmp.Compare(a.Message, b.Message),
+		)
+	})
+}
+
+// GroupFailureReporter is an optional capability exposed by cloud
+// implementations to surface provisioning errors for a group.
+//
+// Cluster validation calls this only for groups short of their target size,
+// but "kops toolbox dump" calls it for every group, so implementations must
+// return cleanly for a healthy group rather than assuming a failure.
+type GroupFailureReporter interface {
+	GetGroupFailures(ctx context.Context, group *CloudInstanceGroup) ([]GroupFailure, error)
+}
+
+// GroupInstanceStatus is the cloud provider's view of an instance the
+// group is managing. Unlike CloudInstance this covers instances that do not
+// exist: a GCE MIG retrying a failed create reports each attempt here, and
+// those attempts never become CloudInstances because no instance resource was
+// ever created for them.
+type GroupInstanceStatus struct {
+	Name string `json:"name"`
+	// Status is the instance's own state, e.g. "RUNNING". Empty while the
+	// instance does not exist.
+	Status string `json:"status,omitempty"`
+	// CurrentAction is what the group is doing with the instance, e.g.
+	// "CREATING".
+	CurrentAction string `json:"currentAction,omitempty"`
+	// Failures are from the group's most recent attempt to act on the instance.
+	// These are raw per-attempt errors rather than aggregated observations, so
+	// their Count is unset.
+	Failures []GroupFailure `json:"failures,omitempty"`
+}
+
+// GroupInstanceStatusReporter is an optional capability exposed by cloud
+// implementations that can report on instances a group is managing but has not
+// successfully created.
+type GroupInstanceStatusReporter interface {
+	GetGroupInstanceStatuses(ctx context.Context, group *CloudInstanceGroup) ([]GroupInstanceStatus, error)
+}

--- a/pkg/dump/cloudgroups.go
+++ b/pkg/dump/cloudgroups.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dump
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
+	"k8s.io/kops/upup/pkg/fi"
+	"sigs.k8s.io/yaml"
+)
+
+// CloudInstanceGroupsFileName is the artifact the cloud group state is written to.
+const CloudInstanceGroupsFileName = "cloud-instance-groups.yaml"
+
+// CloudInstanceGroupDump is the cloud provider's view of one instance group.
+type CloudInstanceGroupDump struct {
+	// Name is the cloud provider's name for the group, e.g. the ASG or MIG name.
+	Name string `json:"name"`
+	// InstanceGroup is the name of the kOps InstanceGroup the group backs.
+	InstanceGroup string `json:"instanceGroup"`
+	MinSize       int    `json:"minSize"`
+	TargetSize    int    `json:"targetSize"`
+	MaxSize       int    `json:"maxSize"`
+
+	Instances []CloudInstanceDump `json:"instances,omitempty"`
+	// ManagedInstances is the provider's view of the instances the group is
+	// managing, which on GCE includes ones it is still failing to create. Absent
+	// on providers that do not report it.
+	ManagedInstances []cloudinstances.GroupInstanceStatus `json:"managedInstances,omitempty"`
+	// Failures are the provisioning failures the cloud provider attributes to
+	// the group. An empty group with failures here is the signature of a group
+	// that could not launch, e.g. InsufficientInstanceCapacity.
+	Failures []cloudinstances.GroupFailure `json:"failures,omitempty"`
+}
+
+// CloudInstanceDump is the cloud provider's view of one instance in a group.
+type CloudInstanceDump struct {
+	ID                string    `json:"id"`
+	MachineType       string    `json:"machineType,omitempty"`
+	Status            string    `json:"status,omitempty"`
+	State             string    `json:"state,omitempty"`
+	Roles             []string  `json:"roles,omitempty"`
+	PrivateIP         string    `json:"privateIP,omitempty"`
+	ExternalIP        string    `json:"externalIP,omitempty"`
+	CreationTimestamp time.Time `json:"creationTimestamp,omitzero"`
+	// Node is the name of the Kubernetes node the instance registered as, empty
+	// if it never joined the cluster.
+	Node string `json:"node,omitempty"`
+}
+
+// DumpCloudInstanceGroups writes the cloud provider's view of every instance
+// group, including any provisioning errors the provider reports, to
+// CloudInstanceGroupsFileName under artifactsDir.
+//
+// When a group launches no instances the API server never comes up, so the
+// cluster itself holds no record of what went wrong. This file is the only
+// place a failed run can attribute that to a citable provider error rather than
+// to "no instances launched".
+func DumpCloudInstanceGroups(ctx context.Context, cloud fi.Cloud, cluster *kops.Cluster, instanceGroups []*kops.InstanceGroup, nodes []v1.Node, artifactsDir string) error {
+	warnUnmatched := false
+	cloudGroups, err := cloud.GetCloudGroups(cluster, instanceGroups, warnUnmatched, nodes)
+	if err != nil {
+		return err
+	}
+
+	failureReporter, _ := cloud.(cloudinstances.GroupFailureReporter)
+	statusReporter, _ := cloud.(cloudinstances.GroupInstanceStatusReporter)
+
+	dumps := make([]CloudInstanceGroupDump, 0, len(cloudGroups))
+	for _, cloudGroup := range cloudGroups {
+		d := CloudInstanceGroupDump{
+			Name:       cloudGroup.HumanName,
+			MinSize:    cloudGroup.MinSize,
+			TargetSize: cloudGroup.TargetSize,
+			MaxSize:    cloudGroup.MaxSize,
+		}
+		if cloudGroup.InstanceGroup != nil {
+			d.InstanceGroup = cloudGroup.InstanceGroup.Name
+		}
+
+		for _, member := range slices.Concat(cloudGroup.Ready, cloudGroup.NeedUpdate) {
+			i := CloudInstanceDump{
+				ID:                member.ID,
+				MachineType:       member.MachineType,
+				Status:            member.Status,
+				State:             string(member.State),
+				Roles:             member.Roles,
+				PrivateIP:         member.PrivateIP,
+				ExternalIP:        member.ExternalIP,
+				CreationTimestamp: member.CreationTimestamp,
+			}
+			if member.Node != nil {
+				i.Node = member.Node.Name
+			}
+			d.Instances = append(d.Instances, i)
+		}
+		sort.Slice(d.Instances, func(i, j int) bool {
+			return d.Instances[i].ID < d.Instances[j].ID
+		})
+
+		if statusReporter != nil {
+			statuses, err := statusReporter.GetGroupInstanceStatuses(ctx, cloudGroup)
+			if err != nil {
+				klog.Warningf("error getting managed instances for group %q: %v", cloudGroup.HumanName, err)
+			} else {
+				d.ManagedInstances = statuses
+			}
+		}
+
+		if failureReporter != nil {
+			failures, err := failureReporter.GetGroupFailures(ctx, cloudGroup)
+			if err != nil {
+				klog.Warningf("error getting cloud provider errors for group %q: %v", cloudGroup.HumanName, err)
+			} else {
+				d.Failures = failures
+			}
+		}
+
+		dumps = append(dumps, d)
+	}
+	sort.Slice(dumps, func(i, j int) bool {
+		return dumps[i].Name < dumps[j].Name
+	})
+
+	b, err := yaml.Marshal(dumps)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(artifactsDir, CloudInstanceGroupsFileName), b, 0o600)
+}

--- a/pkg/dump/cloudgroups_test.go
+++ b/pkg/dump/cloudgroups_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dump
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"sigs.k8s.io/yaml"
+)
+
+// mockCloud reports a fixed set of groups, along with the optional provisioning
+// error and managed instance capabilities the dumper looks for.
+type mockCloud struct {
+	awsup.MockAWSCloud
+
+	groups           map[string]*cloudinstances.CloudInstanceGroup
+	errors           map[string][]cloudinstances.GroupFailure
+	managedInstances map[string][]cloudinstances.GroupInstanceStatus
+}
+
+var (
+	_ cloudinstances.GroupFailureReporter        = (*mockCloud)(nil)
+	_ cloudinstances.GroupInstanceStatusReporter = (*mockCloud)(nil)
+)
+
+func (c *mockCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+	return c.groups, nil
+}
+
+func (c *mockCloud) GetGroupFailures(_ context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupFailure, error) {
+	return c.errors[group.HumanName], nil
+}
+
+func (c *mockCloud) GetGroupInstanceStatuses(_ context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupInstanceStatus, error) {
+	return c.managedInstances[group.HumanName], nil
+}
+
+func TestDumpCloudInstanceGroups(t *testing.T) {
+	ctx := t.Context()
+
+	cluster := &kops.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "testcluster.k8s.local"}}
+	controlPlaneIG := &kops.InstanceGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "control-plane-1"},
+		Spec:       kops.InstanceGroupSpec{Role: kops.InstanceGroupRoleControlPlane},
+	}
+	nodeIG := &kops.InstanceGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "nodes-1"},
+		Spec:       kops.InstanceGroupSpec{Role: kops.InstanceGroupRoleNode},
+	}
+
+	launched := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	cloud := &mockCloud{
+		MockAWSCloud: *awsup.BuildMockAWSCloud("us-east-1", "abc"),
+		groups: map[string]*cloudinstances.CloudInstanceGroup{
+			// A group that launched nothing: the fingerprint this file exists for.
+			"cp-1.testcluster.k8s.local": {
+				HumanName:     "cp-1.testcluster.k8s.local",
+				InstanceGroup: controlPlaneIG,
+				MinSize:       1,
+				TargetSize:    1,
+				MaxSize:       1,
+			},
+			"nodes-1.testcluster.k8s.local": {
+				HumanName:     "nodes-1.testcluster.k8s.local",
+				InstanceGroup: nodeIG,
+				MinSize:       1,
+				TargetSize:    1,
+				MaxSize:       1,
+				Ready: []*cloudinstances.CloudInstance{
+					{
+						ID:                "i-00001",
+						MachineType:       "t3.medium",
+						Status:            cloudinstances.CloudInstanceStatusUpToDate,
+						PrivateIP:         "10.0.1.5",
+						CreationTimestamp: launched,
+						Node:              &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1a"}},
+					},
+				},
+			},
+		},
+		errors: map[string][]cloudinstances.GroupFailure{
+			"cp-1.testcluster.k8s.local": {
+				{
+					Code:      "InsufficientInstanceCapacity",
+					Message:   "We currently do not have sufficient t4g.large capacity in the Availability Zone you requested",
+					Count:     12,
+					FirstSeen: launched,
+					LastSeen:  launched.Add(10 * time.Minute),
+				},
+			},
+		},
+		managedInstances: map[string][]cloudinstances.GroupInstanceStatus{
+			"cp-1.testcluster.k8s.local": {
+				{
+					Name:          "cp-1-abcd",
+					CurrentAction: "CREATING",
+					Failures: []cloudinstances.GroupFailure{
+						{
+							Code:    "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+							Message: "The zone does not have enough resources available",
+							Count:   1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	err := DumpCloudInstanceGroups(ctx, cloud, cluster, []*kops.InstanceGroup{controlPlaneIG, nodeIG}, nil, dir)
+	require.NoError(t, err)
+
+	b, err := os.ReadFile(path.Join(dir, CloudInstanceGroupsFileName))
+	require.NoError(t, err)
+
+	var dumps []CloudInstanceGroupDump
+	require.NoError(t, yaml.Unmarshal(b, &dumps))
+	require.Len(t, dumps, 2)
+
+	cp := dumps[0]
+	assert.Equal(t, "cp-1.testcluster.k8s.local", cp.Name)
+	assert.Equal(t, "control-plane-1", cp.InstanceGroup)
+	assert.Equal(t, 1, cp.TargetSize)
+	assert.Empty(t, cp.Instances)
+	require.Len(t, cp.Failures, 1)
+	assert.Equal(t, "InsufficientInstanceCapacity", cp.Failures[0].Code)
+	assert.Equal(t, 12, cp.Failures[0].Count)
+	require.Len(t, cp.ManagedInstances, 1)
+	assert.Equal(t, "CREATING", cp.ManagedInstances[0].CurrentAction)
+	require.Len(t, cp.ManagedInstances[0].Failures, 1)
+	assert.Equal(t, "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS", cp.ManagedInstances[0].Failures[0].Code)
+
+	nodes := dumps[1]
+	assert.Equal(t, "nodes-1.testcluster.k8s.local", nodes.Name)
+	assert.Empty(t, nodes.Failures)
+	require.Len(t, nodes.Instances, 1)
+	assert.Equal(t, "i-00001", nodes.Instances[0].ID)
+	assert.Equal(t, "node-1a", nodes.Instances[0].Node)
+	assert.Equal(t, launched, nodes.Instances[0].CreationTimestamp)
+}
+
+// TestDumpCloudInstanceGroupsWithoutOptionalCapabilities covers a cloud that
+// implements neither optional interface, e.g. Azure or OpenStack.
+func TestDumpCloudInstanceGroupsWithoutOptionalCapabilities(t *testing.T) {
+	ctx := t.Context()
+
+	cluster := &kops.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "testcluster.k8s.local"}}
+	ig := &kops.InstanceGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "nodes-1"},
+		Spec:       kops.InstanceGroupSpec{Role: kops.InstanceGroupRoleNode},
+	}
+
+	cloud := &basicMockCloud{
+		groups: map[string]*cloudinstances.CloudInstanceGroup{
+			"nodes-1.testcluster.k8s.local": {
+				HumanName:     "nodes-1.testcluster.k8s.local",
+				InstanceGroup: ig,
+				MinSize:       1,
+				TargetSize:    1,
+				MaxSize:       1,
+			},
+		},
+	}
+
+	var c any = cloud
+	_, isErrReporter := c.(cloudinstances.GroupFailureReporter)
+	require.False(t, isErrReporter, "fixture must not implement GroupFailureReporter")
+	_, isStatusReporter := c.(cloudinstances.GroupInstanceStatusReporter)
+	require.False(t, isStatusReporter, "fixture must not implement GroupInstanceStatusReporter")
+
+	dir := t.TempDir()
+	require.NoError(t, DumpCloudInstanceGroups(ctx, cloud, cluster, []*kops.InstanceGroup{ig}, nil, dir))
+
+	b, err := os.ReadFile(path.Join(dir, CloudInstanceGroupsFileName))
+	require.NoError(t, err)
+
+	var dumps []CloudInstanceGroupDump
+	require.NoError(t, yaml.Unmarshal(b, &dumps))
+	require.Len(t, dumps, 1)
+	assert.Empty(t, dumps[0].Failures)
+	assert.Empty(t, dumps[0].ManagedInstances)
+}
+
+// basicMockCloud implements neither optional reporter interface, matching a
+// provider such as Azure or OpenStack. It embeds the fi.Cloud interface rather
+// than awsup.MockAWSCloud so that no reporter method is promoted onto it.
+type basicMockCloud struct {
+	fi.Cloud
+
+	groups map[string]*cloudinstances.CloudInstanceGroup
+}
+
+func (c *basicMockCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+	return c.groups, nil
+}

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -188,7 +189,11 @@ func (v *clusterValidatorImpl) Validate(ctx context.Context) (*ValidationCluster
 		return nil, err
 	}
 
-	readyNodes, nodeInstanceGroupMapping := validation.validateNodes(cloudGroups, v.allInstanceGroups, v.filterInstanceGroups)
+	var errorReporter cloudinstances.CloudGroupErrorReporter
+	if r, ok := v.cloud.(cloudinstances.CloudGroupErrorReporter); ok {
+		errorReporter = r
+	}
+	readyNodes, nodeInstanceGroupMapping := validation.validateNodes(ctx, cloudGroups, v.allInstanceGroups, v.filterInstanceGroups, errorReporter)
 
 	if err := validation.collectPodFailures(ctx, v.k8sClient, readyNodes, nodeInstanceGroupMapping, v.filterPodsForValidation); err != nil {
 		return nil, fmt.Errorf("cannot get pod health for %q: %v", v.cluster.Name, err)
@@ -307,7 +312,36 @@ func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kuber
 	return nil
 }
 
-func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances.CloudInstanceGroup, groups []*kops.InstanceGroup, shouldValidateInstanceGroup func(ig *kops.InstanceGroup) bool) ([]v1.Node, map[string]*kops.InstanceGroup) {
+// reportCloudGroupErrors queries the cloud provider for provisioning errors on
+// a group that's short on instances and appends them as validation failures.
+// errorReporter may be nil if the cloud does not support this capability.
+func (v *ValidationCluster) reportCloudGroupErrors(ctx context.Context, errorReporter cloudinstances.CloudGroupErrorReporter, cloudGroup *cloudinstances.CloudInstanceGroup) {
+	if errorReporter == nil {
+		return
+	}
+	cloudErrors, err := errorReporter.GetCloudGroupErrors(ctx, cloudGroup)
+	if err != nil {
+		klog.Warningf("error getting cloud provider errors for InstanceGroup %q: %v", cloudGroup.InstanceGroup.Name, err)
+		return
+	}
+	for _, e := range cloudErrors {
+		message := fmt.Sprintf("cloud provider error %s: %s", e.Code, e.Message)
+		if e.Instance != "" {
+			message = fmt.Sprintf("cloud provider error %s for instance %s: %s", e.Code, e.Instance, e.Message)
+		}
+		if e.Count > 1 {
+			message = fmt.Sprintf("%s (observed %d times, most recent %s)", message, e.Count, e.LastSeen.Format(time.RFC3339))
+		}
+		v.addError(&ValidationError{
+			Kind:          "InstanceGroup",
+			Name:          cloudGroup.InstanceGroup.Name,
+			Message:       message,
+			InstanceGroup: cloudGroup.InstanceGroup,
+		})
+	}
+}
+
+func (v *ValidationCluster) validateNodes(ctx context.Context, cloudGroups map[string]*cloudinstances.CloudInstanceGroup, groups []*kops.InstanceGroup, shouldValidateInstanceGroup func(ig *kops.InstanceGroup) bool, errorReporter cloudinstances.CloudGroupErrorReporter) ([]v1.Node, map[string]*kops.InstanceGroup) {
 	var readyNodes []v1.Node
 	groupsSeen := map[string]bool{}
 	nodeInstanceGroupMapping := map[string]*kops.InstanceGroup{}
@@ -338,6 +372,7 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 					cloudGroup.TargetSize),
 				InstanceGroup: cloudGroup.InstanceGroup,
 			})
+			v.reportCloudGroupErrors(ctx, errorReporter, cloudGroup)
 		}
 
 		for _, member := range allMembers {

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -228,7 +230,9 @@ func (v *clusterValidatorImpl) Validate(ctx context.Context) (*ValidationCluster
 		}
 	}
 
-	readyNodes, nodeInstanceGroupMapping := validation.validateNodes(cloudGroups, v.allInstanceGroups, v.filterInstanceGroups, toleratedNodes)
+	failureReporter, _ := v.cloud.(cloudinstances.GroupFailureReporter)
+
+	readyNodes, nodeInstanceGroupMapping := validation.validateNodes(ctx, cloudGroups, v.allInstanceGroups, v.filterInstanceGroups, toleratedNodes, failureReporter)
 
 	if err := validation.collectPodFailures(ctx, v.k8sClient, readyNodes, nodeInstanceGroupMapping, v.filterPodsForValidation, toleratedNodes); err != nil {
 		return nil, fmt.Errorf("cannot get pod health for %q: %v", v.cluster.Name, err)
@@ -344,7 +348,63 @@ func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kuber
 	return nil
 }
 
-func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances.CloudInstanceGroup, groups []*kops.InstanceGroup, shouldValidateInstanceGroup func(ig *kops.InstanceGroup) bool, toleratedNodes map[string]bool) ([]v1.Node, map[string]*kops.InstanceGroup) {
+// reportGroupFailures queries the cloud provider for provisioning errors on
+// a group that's short on instances and appends them as validation failures.
+// failureReporter may be nil if the cloud does not support this capability.
+func (v *ValidationCluster) reportGroupFailures(ctx context.Context, failureReporter cloudinstances.GroupFailureReporter, cloudGroup *cloudinstances.CloudInstanceGroup) {
+	if failureReporter == nil || cloudGroup.InstanceGroup == nil {
+		return
+	}
+	failures, err := failureReporter.GetGroupFailures(ctx, cloudGroup)
+	if err != nil {
+		klog.Warningf("error getting cloud provider errors for InstanceGroup %q: %v", cloudGroup.InstanceGroup.Name, err)
+		return
+	}
+	for _, e := range failures {
+		message := fmt.Sprintf("cloud provider error %s: %s", e.Code, e.Message)
+		if e.Instance != "" {
+			message = fmt.Sprintf("cloud provider error %s for instance %s: %s", e.Code, e.Instance, e.Message)
+		}
+		switch {
+		case e.Count > 1 && !e.LastSeen.IsZero():
+			message = fmt.Sprintf("%s (observed %d times, most recent %s)", message, e.Count, e.LastSeen.Format(time.RFC3339))
+		case e.Count > 1:
+			message = fmt.Sprintf("%s (observed %d times)", message, e.Count)
+		}
+		v.addError(&ValidationError{
+			Kind:          "InstanceGroup",
+			Name:          cloudGroup.InstanceGroup.Name,
+			Message:       message,
+			InstanceGroup: cloudGroup.InstanceGroup,
+		})
+	}
+}
+
+// validateGroupSize reports a group that has fewer instances than its target
+// size, along with any provisioning errors the cloud provider attributes to it.
+func (v *ValidationCluster) validateGroupSize(ctx context.Context, cloudGroup *cloudinstances.CloudInstanceGroup, failureReporter cloudinstances.GroupFailureReporter) {
+	numNodes := 0
+	for _, m := range slices.Concat(cloudGroup.Ready, cloudGroup.NeedUpdate) {
+		if m.Status != cloudinstances.CloudInstanceStatusDetached {
+			numNodes++
+		}
+	}
+	if numNodes >= cloudGroup.TargetSize {
+		return
+	}
+	v.addError(&ValidationError{
+		Kind: "InstanceGroup",
+		Name: cloudGroup.InstanceGroup.Name,
+		Message: fmt.Sprintf("InstanceGroup %q did not have enough nodes %d vs %d",
+			cloudGroup.InstanceGroup.Name,
+			numNodes,
+			cloudGroup.TargetSize),
+		InstanceGroup: cloudGroup.InstanceGroup,
+	})
+	v.reportGroupFailures(ctx, failureReporter, cloudGroup)
+}
+
+func (v *ValidationCluster) validateNodes(ctx context.Context, cloudGroups map[string]*cloudinstances.CloudInstanceGroup, groups []*kops.InstanceGroup, shouldValidateInstanceGroup func(ig *kops.InstanceGroup) bool, toleratedNodes map[string]bool, failureReporter cloudinstances.GroupFailureReporter) ([]v1.Node, map[string]*kops.InstanceGroup) {
 	var readyNodes []v1.Node
 	groupsSeen := map[string]bool{}
 	nodeInstanceGroupMapping := map[string]*kops.InstanceGroup{}
@@ -359,23 +419,7 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 		allMembers = append(allMembers, cloudGroup.NeedUpdate...)
 
 		groupsSeen[cloudGroup.InstanceGroup.Name] = true
-		numNodes := 0
-		for _, m := range allMembers {
-			if m.Status != cloudinstances.CloudInstanceStatusDetached {
-				numNodes++
-			}
-		}
-		if numNodes < cloudGroup.TargetSize {
-			v.addError(&ValidationError{
-				Kind: "InstanceGroup",
-				Name: cloudGroup.InstanceGroup.Name,
-				Message: fmt.Sprintf("InstanceGroup %q did not have enough nodes %d vs %d",
-					cloudGroup.InstanceGroup.Name,
-					numNodes,
-					cloudGroup.TargetSize),
-				InstanceGroup: cloudGroup.InstanceGroup,
-			})
-		}
+		v.validateGroupSize(ctx, cloudGroup, failureReporter)
 
 		for _, member := range allMembers {
 			node := member.Node

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -181,12 +181,34 @@ func (v *clusterValidatorImpl) Validate(ctx context.Context) (*ValidationCluster
 		}
 	}
 
+	warnUnmatched := false
+
 	nodeList, err := v.k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error listing nodes: %v", err)
+		// The API server is commonly unreachable because the control plane
+		// instances never launched. Node-level validation is impossible, but the
+		// cloud provider can still say why the instance groups are short, so
+		// report that instead of only an opaque dial error.
+		validation.addError(&ValidationError{
+			Kind:    "apiserver",
+			Name:    v.cluster.Name,
+			Message: fmt.Sprintf("error listing nodes: %v", err),
+		})
+
+		cloudGroups, groupsErr := v.cloud.GetCloudGroups(v.cluster, v.allInstanceGroups, warnUnmatched, nil)
+		if groupsErr != nil {
+			return nil, fmt.Errorf("error listing nodes: %w (and error listing cloud groups: %w)", err, groupsErr)
+		}
+		failureReporter, _ := v.cloud.(cloudinstances.GroupFailureReporter)
+		for _, cloudGroup := range cloudGroups {
+			if cloudGroup.InstanceGroup == nil || !v.filterInstanceGroups(cloudGroup.InstanceGroup) {
+				continue
+			}
+			validation.validateGroupSize(ctx, cloudGroup, failureReporter)
+		}
+		return validation, nil
 	}
 
-	warnUnmatched := false
 	cloudGroups, err := v.cloud.GetCloudGroups(v.cluster, v.allInstanceGroups, warnUnmatched, nodeList.Items)
 	if err != nil {
 		return nil, err

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,10 @@ type MockCloud struct {
 	t                      *testing.T
 	expectedCluster        *kopsapi.Cluster
 	expectedInstanceGroups []kopsapi.InstanceGroup
+
+	// cloudGroupErrors is keyed by InstanceGroup name. When non-nil, MockCloud
+	// implements cloudinstances.CloudGroupErrorReporter and returns these errors.
+	cloudGroupErrors map[string][]cloudinstances.CloudGroupError
 }
 
 var _ fi.Cloud = (*MockCloud)(nil)
@@ -912,4 +917,64 @@ func Test_ValidateDetachedNodesNotValidated(t *testing.T) {
 	if !assert.Empty(t, v.Failures) {
 		printDebug(t, v)
 	}
+}
+
+// errorReportingMockCloud wraps MockCloud to implement CloudGroupErrorReporter.
+type errorReportingMockCloud struct {
+	*MockCloud
+}
+
+func (c *errorReportingMockCloud) GetCloudGroupErrors(_ context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.CloudGroupError, error) {
+	return c.cloudGroupErrors[group.InstanceGroup.Name], nil
+}
+
+func Test_ValidateCloudGroupErrorsSurfaced(t *testing.T) {
+	ctx := context.TODO()
+
+	cluster := &kopsapi.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "testcluster.k8s.local"},
+		Spec: kopsapi.ClusterSpec{
+			ExternalDNS: &kopsapi.ExternalDNSConfig{
+				Provider: kopsapi.ExternalDNSProviderDNSController,
+			},
+		},
+	}
+
+	ig := kopsapi.InstanceGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleNode},
+	}
+	groups := map[string]*cloudinstances.CloudInstanceGroup{
+		"node-1": {
+			InstanceGroup: &ig,
+			MinSize:       1,
+			TargetSize:    2,
+		},
+	}
+
+	mockcloud := BuildMockCloud(t, groups, cluster, []kopsapi.InstanceGroup{ig})
+	mockcloud.cloudGroupErrors = map[string][]cloudinstances.CloudGroupError{
+		"node-1": {
+			{
+				Code:     "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+				Message:  "The zone does not have enough resources available",
+				Instance: "node-1a",
+				Count:    3,
+				LastSeen: time.Date(2026, 5, 12, 20, 50, 0, 0, time.UTC),
+			},
+		},
+	}
+	reporter := &errorReportingMockCloud{MockCloud: mockcloud}
+
+	restConfig := &rest.Config{Host: "https://api.testcluster.k8s.local"}
+	validator, err := NewClusterValidator(cluster, reporter, &kopsapi.InstanceGroupList{Items: []kopsapi.InstanceGroup{ig}}, nil, nil, restConfig, fake.NewClientset())
+	require.NoError(t, err)
+	v, err := validator.Validate(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, v.Failures, 2)
+	assert.Equal(t, "InstanceGroup \"node-1\" did not have enough nodes 0 vs 2", v.Failures[0].Message)
+	assert.Contains(t, v.Failures[1].Message, "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS")
+	assert.Contains(t, v.Failures[1].Message, "node-1a")
+	assert.Contains(t, v.Failures[1].Message, "observed 3 times")
 }

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/upup/pkg/fi"
@@ -1358,4 +1359,62 @@ func Test_ValidateGroupFailuresSurfaced(t *testing.T) {
 	assert.Contains(t, v.Failures[1].Message, "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS")
 	assert.Contains(t, v.Failures[1].Message, "node-1a")
 	assert.Contains(t, v.Failures[1].Message, "observed 3 times")
+}
+
+func Test_ValidateGroupFailuresWithUnreachableAPIServer(t *testing.T) {
+	ctx := context.TODO()
+
+	cluster := &kopsapi.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "testcluster.k8s.local"},
+		Spec: kopsapi.ClusterSpec{
+			Networking: kopsapi.NetworkingSpec{
+				Topology: &kopsapi.TopologySpec{
+					DNS: kopsapi.DNSTypeNone,
+				},
+			},
+		},
+	}
+
+	ig := kopsapi.InstanceGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "control-plane-1"},
+		Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleControlPlane},
+	}
+	groups := map[string]*cloudinstances.CloudInstanceGroup{
+		"control-plane-1": {
+			InstanceGroup: &ig,
+			MinSize:       1,
+			TargetSize:    1,
+		},
+	}
+
+	mockcloud := BuildMockCloud(t, groups, cluster, []kopsapi.InstanceGroup{ig})
+	mockcloud.cloudGroupFailures = map[string][]cloudinstances.GroupFailure{
+		"control-plane-1": {
+			{
+				Code:    "InsufficientInstanceCapacity",
+				Message: "We currently do not have sufficient t4g.large capacity in the Availability Zone you requested",
+				Count:   1,
+			},
+		},
+	}
+	reporter := &failureReportingMockCloud{MockCloud: mockcloud}
+
+	// The control plane never launched, so listing nodes fails the way it does
+	// in CI: an i/o timeout dialling the API load balancer.
+	k8sClient := fake.NewClientset()
+	k8sClient.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("Get \"https://api.testcluster.k8s.local/api/v1/nodes\": dial tcp 10.0.0.1:443: i/o timeout")
+	})
+
+	restConfig := &rest.Config{Host: "https://api.testcluster.k8s.local"}
+	validator, err := NewClusterValidator(cluster, reporter, &kopsapi.InstanceGroupList{Items: []kopsapi.InstanceGroup{ig}}, nil, nil, 0, restConfig, k8sClient)
+	require.NoError(t, err)
+	v, err := validator.Validate(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, v.Failures, 3)
+	assert.Equal(t, "apiserver", v.Failures[0].Kind)
+	assert.Contains(t, v.Failures[0].Message, "i/o timeout")
+	assert.Equal(t, "InstanceGroup \"control-plane-1\" did not have enough nodes 0 vs 1", v.Failures[1].Message)
+	assert.Contains(t, v.Failures[2].Message, "InsufficientInstanceCapacity")
 }

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,10 @@ type MockCloud struct {
 	t                      *testing.T
 	expectedCluster        *kopsapi.Cluster
 	expectedInstanceGroups []kopsapi.InstanceGroup
+
+	// cloudGroupFailures is keyed by InstanceGroup name. When non-nil, MockCloud
+	// implements cloudinstances.GroupFailureReporter and returns these errors.
+	cloudGroupFailures map[string][]cloudinstances.GroupFailure
 }
 
 var _ fi.Cloud = (*MockCloud)(nil)
@@ -1291,4 +1296,66 @@ func Test_ValidateAllowedNotReadyNodes(t *testing.T) {
 		assert.Len(t, v.Failures, 1)
 		assert.Equal(t, "InstanceGroup", v.Failures[0].Kind)
 	})
+}
+
+// failureReportingMockCloud wraps MockCloud to implement GroupFailureReporter.
+type failureReportingMockCloud struct {
+	*MockCloud
+}
+
+func (c *failureReportingMockCloud) GetGroupFailures(_ context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupFailure, error) {
+	return c.cloudGroupFailures[group.InstanceGroup.Name], nil
+}
+
+func Test_ValidateGroupFailuresSurfaced(t *testing.T) {
+	ctx := context.TODO()
+
+	cluster := &kopsapi.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "testcluster.k8s.local"},
+		Spec: kopsapi.ClusterSpec{
+			Networking: kopsapi.NetworkingSpec{
+				Topology: &kopsapi.TopologySpec{
+					DNS: kopsapi.DNSTypeNone,
+				},
+			},
+		},
+	}
+
+	ig := kopsapi.InstanceGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleNode},
+	}
+	groups := map[string]*cloudinstances.CloudInstanceGroup{
+		"node-1": {
+			InstanceGroup: &ig,
+			MinSize:       1,
+			TargetSize:    2,
+		},
+	}
+
+	mockcloud := BuildMockCloud(t, groups, cluster, []kopsapi.InstanceGroup{ig})
+	mockcloud.cloudGroupFailures = map[string][]cloudinstances.GroupFailure{
+		"node-1": {
+			{
+				Code:     "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+				Message:  "The zone does not have enough resources available",
+				Instance: "node-1a",
+				Count:    3,
+				LastSeen: time.Date(2026, 5, 12, 20, 50, 0, 0, time.UTC),
+			},
+		},
+	}
+	reporter := &failureReportingMockCloud{MockCloud: mockcloud}
+
+	restConfig := &rest.Config{Host: "https://api.testcluster.k8s.local"}
+	validator, err := NewClusterValidator(cluster, reporter, &kopsapi.InstanceGroupList{Items: []kopsapi.InstanceGroup{ig}}, nil, nil, 0, restConfig, fake.NewClientset())
+	require.NoError(t, err)
+	v, err := validator.Validate(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, v.Failures, 2)
+	assert.Equal(t, "InstanceGroup \"node-1\" did not have enough nodes 0 vs 2", v.Failures[0].Message)
+	assert.Contains(t, v.Failures[1].Message, "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS")
+	assert.Contains(t, v.Failures[1].Message, "node-1a")
+	assert.Contains(t, v.Failures[1].Message, "observed 3 times")
 }

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1084,8 +1086,121 @@ func buildCloudInstance(i autoscalingtypes.Instance, instances map[string]*ec2ty
 	return nil
 }
 
+// asgInstanceIDRegex extracts the first EC2 instance ID (i-xxxxxxxx) found in a
+// scaling activity's StatusMessage or Description. The capture is best-effort:
+// if no ID is found, CloudGroupError.Instance is left blank.
+var asgInstanceIDRegex = regexp.MustCompile(`i-[0-9a-f]{8,17}`)
+
+// GetCloudGroupErrors returns recent provisioning failures observed by the AWS
+// Auto Scaling group backing this CloudInstanceGroup. See getCloudGroupErrors
+// for the filtering and aggregation logic.
+func (c *awsCloudImplementation) GetCloudGroupErrors(ctx context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.CloudGroupError, error) {
+	return getCloudGroupErrors(ctx, c, group)
+}
+
+// getCloudGroupErrors returns recent failed scaling activities for the ASG
+// backing the given group.
+//
+// Results are filtered to errors timestamped after the most recent successful
+// instance creation in the group (the LaunchTime of an existing instance). If
+// the group has no instances at all, no filter is applied so the full retention
+// window is surfaced — that is precisely the failure mode this exists to
+// diagnose. Pagination short-circuits once activities pre-date the watermark,
+// since DescribeScalingActivities returns most-recent-first.
+func getCloudGroupErrors(ctx context.Context, c AWSCloud, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.CloudGroupError, error) {
+	asg, ok := group.Raw.(*autoscalingtypes.AutoScalingGroup)
+	if !ok || asg == nil {
+		return nil, nil
+	}
+	asgName := aws.ToString(asg.AutoScalingGroupName)
+	if asgName == "" {
+		return nil, nil
+	}
+
+	var watermark time.Time
+	for _, m := range group.Ready {
+		if m.CreationTimestamp.After(watermark) {
+			watermark = m.CreationTimestamp
+		}
+	}
+	for _, m := range group.NeedUpdate {
+		if m.CreationTimestamp.After(watermark) {
+			watermark = m.CreationTimestamp
+		}
+	}
+
+	type key struct{ code, message string }
+	agg := map[key]*cloudinstances.CloudGroupError{}
+
+	paginator := autoscaling.NewDescribeScalingActivitiesPaginator(c.Autoscaling(), &autoscaling.DescribeScalingActivitiesInput{
+		AutoScalingGroupName: aws.String(asgName),
+	})
+paginate:
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("describing scaling activities for ASG %q: %w", asgName, err)
+		}
+		for _, a := range page.Activities {
+			if a.StatusCode != autoscalingtypes.ScalingActivityStatusCodeFailed && a.StatusCode != autoscalingtypes.ScalingActivityStatusCodeCancelled {
+				continue
+			}
+			var ts time.Time
+			if a.StartTime != nil {
+				ts = *a.StartTime
+			}
+			if !watermark.IsZero() && !ts.IsZero() && ts.Before(watermark) {
+				// Activities are returned most-recent-first; everything after
+				// this is older, so stop paginating.
+				break paginate
+			}
+			message := aws.ToString(a.StatusMessage)
+			if message == "" {
+				message = aws.ToString(a.Cause)
+			}
+			k := key{string(a.StatusCode), message}
+			e, ok := agg[k]
+			if !ok {
+				instance := asgInstanceIDRegex.FindString(message)
+				if instance == "" {
+					instance = asgInstanceIDRegex.FindString(aws.ToString(a.Description))
+				}
+				e = &cloudinstances.CloudGroupError{
+					Code:      string(a.StatusCode),
+					Message:   message,
+					Instance:  instance,
+					FirstSeen: ts,
+					LastSeen:  ts,
+				}
+				agg[k] = e
+			}
+			e.Count++
+			if !ts.IsZero() {
+				if e.FirstSeen.IsZero() || ts.Before(e.FirstSeen) {
+					e.FirstSeen = ts
+				}
+				if ts.After(e.LastSeen) {
+					e.LastSeen = ts
+				}
+			}
+		}
+	}
+
+	out := make([]cloudinstances.CloudGroupError, 0, len(agg))
+	for _, e := range agg {
+		out = append(out, *e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].LastSeen.After(out[j].LastSeen)
+	})
+	return out, nil
+}
+
 func addCloudInstanceData(cm *cloudinstances.CloudInstance, instance *ec2types.Instance) {
 	cm.MachineType = string(instance.InstanceType)
+	if instance.LaunchTime != nil {
+		cm.CreationTimestamp = *instance.LaunchTime
+	}
 	for _, tag := range instance.Tags {
 		key := aws.ToString(tag.Key)
 		if !strings.HasPrefix(key, TagNameRolePrefix) {

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -1083,8 +1084,124 @@ func buildCloudInstance(i autoscalingtypes.Instance, instances map[string]*ec2ty
 	return nil
 }
 
+// asgInstanceIDRegex extracts the first EC2 instance ID (i-xxxxxxxx) found in a
+// scaling activity's StatusMessage or Description. The capture is best-effort:
+// if no ID is found, GroupFailure.Instance is left blank.
+//
+// Instance IDs are exactly 8 or 17 hex digits, and the word boundaries matter:
+// an unanchored `i-[0-9a-f]{8,17}` matches inside "eni-0abcdef1234567890",
+// which scaling activity messages routinely mention, and would report a
+// network interface as the failing instance.
+var asgInstanceIDRegex = regexp.MustCompile(`\bi-(?:[0-9a-f]{17}|[0-9a-f]{8})\b`)
+
+// maxScalingActivityPages bounds how far back getGroupFailures reads. The
+// activities are most-recent-first and identical failures are aggregated, so
+// later pages almost never contribute a distinct entry.
+const maxScalingActivityPages = 5
+
+var _ cloudinstances.GroupFailureReporter = (*awsCloudImplementation)(nil)
+
+// GetGroupFailures returns recent provisioning failures observed by the AWS
+// Auto Scaling group backing this CloudInstanceGroup. See getGroupFailures
+// for the filtering and aggregation logic.
+func (c *awsCloudImplementation) GetGroupFailures(ctx context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupFailure, error) {
+	return getGroupFailures(ctx, c, group)
+}
+
+// getGroupFailures returns recent failed scaling activities for the ASG
+// backing the given group.
+//
+// Results are filtered to errors timestamped after the most recent successful
+// instance creation in the group (the LaunchTime of an existing instance). If
+// the group has no instances at all, no filter is applied so the full retention
+// window is surfaced — that is precisely the failure mode this exists to
+// diagnose. Pagination short-circuits once activities pre-date the watermark,
+// since DescribeScalingActivities returns most-recent-first.
+func getGroupFailures(ctx context.Context, c AWSCloud, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupFailure, error) {
+	asg, ok := group.Raw.(*autoscalingtypes.AutoScalingGroup)
+	if !ok || asg == nil {
+		return nil, nil
+	}
+	asgName := aws.ToString(asg.AutoScalingGroupName)
+	if asgName == "" {
+		return nil, nil
+	}
+
+	watermark := cloudinstances.Watermark(group)
+
+	type key struct{ code, message string }
+	agg := map[key]*cloudinstances.GroupFailure{}
+
+	paginator := autoscaling.NewDescribeScalingActivitiesPaginator(c.Autoscaling(), &autoscaling.DescribeScalingActivitiesInput{
+		AutoScalingGroupName: aws.String(asgName),
+	})
+paginate:
+	// A group with no instances has no watermark, so the short-circuit below
+	// never fires and pagination would otherwise walk the ASG's full six-week
+	// activity retention on every validation poll.
+	for pages := 0; paginator.HasMorePages() && pages < maxScalingActivityPages; pages++ {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("describing scaling activities for ASG %q: %w", asgName, err)
+		}
+		for _, a := range page.Activities {
+			if a.StatusCode != autoscalingtypes.ScalingActivityStatusCodeFailed && a.StatusCode != autoscalingtypes.ScalingActivityStatusCodeCancelled {
+				continue
+			}
+			var ts time.Time
+			if a.StartTime != nil {
+				ts = *a.StartTime
+			}
+			if !watermark.IsZero() && !ts.IsZero() && ts.Before(watermark) {
+				// Activities are returned most-recent-first; everything after
+				// this is older, so stop paginating.
+				break paginate
+			}
+			message := aws.ToString(a.StatusMessage)
+			if message == "" {
+				message = aws.ToString(a.Cause)
+			}
+			k := key{string(a.StatusCode), message}
+			e, ok := agg[k]
+			if !ok {
+				instance := asgInstanceIDRegex.FindString(message)
+				if instance == "" {
+					instance = asgInstanceIDRegex.FindString(aws.ToString(a.Description))
+				}
+				e = &cloudinstances.GroupFailure{
+					Code:      string(a.StatusCode),
+					Message:   message,
+					Instance:  instance,
+					FirstSeen: ts,
+					LastSeen:  ts,
+				}
+				agg[k] = e
+			}
+			e.Count++
+			if !ts.IsZero() {
+				if e.FirstSeen.IsZero() || ts.Before(e.FirstSeen) {
+					e.FirstSeen = ts
+				}
+				if ts.After(e.LastSeen) {
+					e.LastSeen = ts
+				}
+			}
+		}
+	}
+
+	out := make([]cloudinstances.GroupFailure, 0, len(agg))
+	for _, e := range agg {
+		out = append(out, *e)
+	}
+	cloudinstances.SortFailures(out)
+	return out, nil
+}
+
 func addCloudInstanceData(cm *cloudinstances.CloudInstance, instance *ec2types.Instance) {
 	cm.MachineType = string(instance.InstanceType)
+	if instance.LaunchTime != nil {
+		cm.CreationTimestamp = *instance.LaunchTime
+	}
 	for _, tag := range instance.Tags {
 		key := aws.ToString(tag.Key)
 		if !strings.HasPrefix(key, TagNameRolePrefix) {

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	autoscalingtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+
+	"k8s.io/kops/cloudmock/aws/mockautoscaling"
+	"k8s.io/kops/pkg/cloudinstances"
+)
+
+func TestGetCloudGroupErrors(t *testing.T) {
+	asgName := "test-asg"
+	asg := &autoscalingtypes.AutoScalingGroup{AutoScalingGroupName: aws.String(asgName)}
+
+	t0 := time.Date(2026, 5, 12, 20, 35, 0, 0, time.UTC) // before watermark
+	t1 := time.Date(2026, 5, 12, 20, 45, 0, 0, time.UTC) // watermark (matches a LaunchTime)
+	t2 := time.Date(2026, 5, 12, 20, 50, 0, 0, time.UTC) // after watermark
+	t3 := time.Date(2026, 5, 12, 20, 55, 0, 0, time.UTC) // after watermark
+
+	insufficientCapacity := "Launching a new EC2 instance: i-0abc1234. Status Reason: Insufficient capacity."
+
+	tests := []struct {
+		name              string
+		group             *cloudinstances.CloudInstanceGroup
+		activities        []autoscalingtypes.Activity
+		wantErrors        []cloudinstances.CloudGroupError
+		wantInstanceMatch string
+	}{
+		{
+			name: "empty group surfaces all failed activities",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw:        asg,
+				TargetSize: 2,
+			},
+			activities: []autoscalingtypes.Activity{
+				{StartTime: &t3, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String(insufficientCapacity)},
+				{StartTime: &t0, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String(insufficientCapacity)},
+			},
+			wantErrors: []cloudinstances.CloudGroupError{
+				{
+					Code:     string(autoscalingtypes.ScalingActivityStatusCodeFailed),
+					Message:  insufficientCapacity,
+					Instance: "i-0abc1234",
+					Count:    2,
+				},
+			},
+		},
+		{
+			name: "watermark filters out activities older than newest instance",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw:        asg,
+				TargetSize: 2,
+				Ready: []*cloudinstances.CloudInstance{
+					{ID: "i-existing", CreationTimestamp: t1},
+				},
+			},
+			activities: []autoscalingtypes.Activity{
+				{StartTime: &t2, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String(insufficientCapacity)},
+				{StartTime: &t0, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("ancient error")},
+			},
+			wantErrors: []cloudinstances.CloudGroupError{
+				{
+					Code:     string(autoscalingtypes.ScalingActivityStatusCodeFailed),
+					Message:  insufficientCapacity,
+					Instance: "i-0abc1234",
+					Count:    1,
+				},
+			},
+		},
+		{
+			name: "non-failed activities are ignored",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw:        asg,
+				TargetSize: 2,
+			},
+			activities: []autoscalingtypes.Activity{
+				{StartTime: &t3, StatusCode: autoscalingtypes.ScalingActivityStatusCodeSuccessful, StatusMessage: aws.String("ok")},
+				{StartTime: &t2, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String(insufficientCapacity)},
+				{StartTime: &t1, StatusCode: autoscalingtypes.ScalingActivityStatusCodeInProgress, StatusMessage: aws.String("still going")},
+			},
+			wantErrors: []cloudinstances.CloudGroupError{
+				{
+					Code:     string(autoscalingtypes.ScalingActivityStatusCodeFailed),
+					Message:  insufficientCapacity,
+					Instance: "i-0abc1234",
+					Count:    1,
+				},
+			},
+		},
+		{
+			name: "identical messages are aggregated",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw:        asg,
+				TargetSize: 3,
+			},
+			activities: []autoscalingtypes.Activity{
+				{StartTime: &t3, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("same error")},
+				{StartTime: &t2, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("same error")},
+				{StartTime: &t1, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("different error")},
+			},
+			wantErrors: []cloudinstances.CloudGroupError{
+				{Code: "Failed", Message: "same error", Count: 2, FirstSeen: t2, LastSeen: t3},
+				{Code: "Failed", Message: "different error", Count: 1, FirstSeen: t1, LastSeen: t1},
+			},
+		},
+		{
+			name: "cancelled activities are surfaced",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw:        asg,
+				TargetSize: 1,
+			},
+			activities: []autoscalingtypes.Activity{
+				{StartTime: &t3, StatusCode: autoscalingtypes.ScalingActivityStatusCodeCancelled, StatusMessage: aws.String("cancelled")},
+			},
+			wantErrors: []cloudinstances.CloudGroupError{
+				{Code: "Cancelled", Message: "cancelled", Count: 1},
+			},
+		},
+		{
+			name:       "non-ASG Raw returns nil",
+			group:      &cloudinstances.CloudInstanceGroup{Raw: "not-an-asg"},
+			activities: nil,
+			wantErrors: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloud := BuildMockAWSCloud("us-east-1", "a")
+			cloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{
+				ScalingActivities: map[string][]autoscalingtypes.Activity{
+					asgName: tt.activities,
+				},
+			}
+			got, err := cloud.GetCloudGroupErrors(context.Background(), tt.group)
+			if err != nil {
+				t.Fatalf("GetCloudGroupErrors returned error: %v", err)
+			}
+			if len(got) != len(tt.wantErrors) {
+				t.Fatalf("got %d errors, want %d: %+v", len(got), len(tt.wantErrors), got)
+			}
+			for i, want := range tt.wantErrors {
+				if got[i].Code != want.Code || got[i].Message != want.Message || got[i].Count != want.Count {
+					t.Errorf("error %d: got %+v, want %+v", i, got[i], want)
+				}
+				if want.Instance != "" && got[i].Instance != want.Instance {
+					t.Errorf("error %d instance: got %q, want %q", i, got[i].Instance, want.Instance)
+				}
+				if !want.FirstSeen.IsZero() && !got[i].FirstSeen.Equal(want.FirstSeen) {
+					t.Errorf("error %d FirstSeen: got %v, want %v", i, got[i].FirstSeen, want.FirstSeen)
+				}
+				if !want.LastSeen.IsZero() && !got[i].LastSeen.Equal(want.LastSeen) {
+					t.Errorf("error %d LastSeen: got %v, want %v", i, got[i].LastSeen, want.LastSeen)
+				}
+			}
+		})
+	}
+}
+
+func TestGetCloudGroupErrors_PaginationShortCircuit(t *testing.T) {
+	asgName := "test-asg"
+	asg := &autoscalingtypes.AutoScalingGroup{AutoScalingGroupName: aws.String(asgName)}
+
+	watermark := time.Date(2026, 5, 12, 20, 45, 0, 0, time.UTC)
+	tBefore := watermark.Add(-1 * time.Hour)
+	tAfter := watermark.Add(1 * time.Minute)
+
+	// 3 recent failures + 5 older ones. The watermark must filter out everything
+	// at-or-before the existing instance's CreationTimestamp.
+	activities := []autoscalingtypes.Activity{
+		{StartTime: &tAfter, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("err A")},
+		{StartTime: &tAfter, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("err B")},
+		{StartTime: &tAfter, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("err C")},
+		{StartTime: &tBefore, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("old 1")},
+		{StartTime: &tBefore, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("old 2")},
+		{StartTime: &tBefore, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("old 3")},
+		{StartTime: &tBefore, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("old 4")},
+		{StartTime: &tBefore, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("old 5")},
+	}
+
+	cloud := BuildMockAWSCloud("us-east-1", "a")
+	cloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{
+		ScalingActivities: map[string][]autoscalingtypes.Activity{asgName: activities},
+	}
+
+	got, err := getCloudGroupErrors(context.Background(), cloud, &cloudinstances.CloudInstanceGroup{
+		Raw: asg,
+		Ready: []*cloudinstances.CloudInstance{
+			{ID: "i-existing", CreationTimestamp: watermark},
+		},
+	})
+	if err != nil {
+		t.Fatalf("getCloudGroupErrors: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 errors after watermark filter, got %d: %+v", len(got), got)
+	}
+}

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsup
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	autoscalingtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/kops/cloudmock/aws/mockautoscaling"
+	"k8s.io/kops/pkg/cloudinstances"
+)
+
+func TestGetGroupFailures(t *testing.T) {
+	asgName := "test-asg"
+	asg := &autoscalingtypes.AutoScalingGroup{AutoScalingGroupName: aws.String(asgName)}
+
+	t0 := time.Date(2026, 5, 12, 20, 35, 0, 0, time.UTC) // before watermark
+	t1 := time.Date(2026, 5, 12, 20, 45, 0, 0, time.UTC) // watermark (matches a LaunchTime)
+	t2 := time.Date(2026, 5, 12, 20, 50, 0, 0, time.UTC) // after watermark
+	t3 := time.Date(2026, 5, 12, 20, 55, 0, 0, time.UTC) // after watermark
+
+	insufficientCapacity := "Launching a new EC2 instance: i-0abc1234. Status Reason: Insufficient capacity."
+
+	tests := []struct {
+		name       string
+		group      *cloudinstances.CloudInstanceGroup
+		activities []autoscalingtypes.Activity
+		wantErrors []cloudinstances.GroupFailure
+	}{
+		{
+			name: "empty group surfaces all failed activities",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw:        asg,
+				TargetSize: 2,
+			},
+			activities: []autoscalingtypes.Activity{
+				{StartTime: &t3, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String(insufficientCapacity)},
+				{StartTime: &t0, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String(insufficientCapacity)},
+			},
+			wantErrors: []cloudinstances.GroupFailure{
+				{
+					Code:      string(autoscalingtypes.ScalingActivityStatusCodeFailed),
+					Message:   insufficientCapacity,
+					Instance:  "i-0abc1234",
+					Count:     2,
+					FirstSeen: t0,
+					LastSeen:  t3,
+				},
+			},
+		},
+		{
+			name: "watermark filters out activities older than newest instance",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw:        asg,
+				TargetSize: 2,
+				Ready: []*cloudinstances.CloudInstance{
+					{ID: "i-existing", CreationTimestamp: t1},
+				},
+			},
+			activities: []autoscalingtypes.Activity{
+				{StartTime: &t2, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String(insufficientCapacity)},
+				{StartTime: &t0, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("ancient error")},
+			},
+			wantErrors: []cloudinstances.GroupFailure{
+				{
+					Code:      string(autoscalingtypes.ScalingActivityStatusCodeFailed),
+					Message:   insufficientCapacity,
+					Instance:  "i-0abc1234",
+					Count:     1,
+					FirstSeen: t2,
+					LastSeen:  t2,
+				},
+			},
+		},
+		{
+			name: "non-failed activities are ignored",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw:        asg,
+				TargetSize: 2,
+			},
+			activities: []autoscalingtypes.Activity{
+				{StartTime: &t3, StatusCode: autoscalingtypes.ScalingActivityStatusCodeSuccessful, StatusMessage: aws.String("ok")},
+				{StartTime: &t2, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String(insufficientCapacity)},
+				{StartTime: &t1, StatusCode: autoscalingtypes.ScalingActivityStatusCodeInProgress, StatusMessage: aws.String("still going")},
+			},
+			wantErrors: []cloudinstances.GroupFailure{
+				{
+					Code:      string(autoscalingtypes.ScalingActivityStatusCodeFailed),
+					Message:   insufficientCapacity,
+					Instance:  "i-0abc1234",
+					Count:     1,
+					FirstSeen: t2,
+					LastSeen:  t2,
+				},
+			},
+		},
+		{
+			name: "identical messages are aggregated",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw:        asg,
+				TargetSize: 3,
+			},
+			activities: []autoscalingtypes.Activity{
+				{StartTime: &t3, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("same error")},
+				{StartTime: &t2, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("same error")},
+				{StartTime: &t1, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("different error")},
+			},
+			wantErrors: []cloudinstances.GroupFailure{
+				{Code: "Failed", Message: "same error", Count: 2, FirstSeen: t2, LastSeen: t3},
+				{Code: "Failed", Message: "different error", Count: 1, FirstSeen: t1, LastSeen: t1},
+			},
+		},
+		{
+			name: "cancelled activities are surfaced",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw:        asg,
+				TargetSize: 1,
+			},
+			activities: []autoscalingtypes.Activity{
+				{StartTime: &t3, StatusCode: autoscalingtypes.ScalingActivityStatusCodeCancelled, StatusMessage: aws.String("cancelled")},
+			},
+			wantErrors: []cloudinstances.GroupFailure{
+				{Code: "Cancelled", Message: "cancelled", Count: 1, FirstSeen: t3, LastSeen: t3},
+			},
+		},
+		{
+			name:       "non-ASG Raw returns nil",
+			group:      &cloudinstances.CloudInstanceGroup{Raw: "not-an-asg"},
+			activities: nil,
+			wantErrors: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloud := BuildMockAWSCloud("us-east-1", "a")
+			cloud.MockAutoscaling = &mockautoscaling.MockAutoscaling{
+				ScalingActivities: map[string][]autoscalingtypes.Activity{
+					asgName: tt.activities,
+				},
+			}
+			got, err := cloud.GetGroupFailures(t.Context(), tt.group)
+			if err != nil {
+				t.Fatalf("GetGroupFailures returned error: %v", err)
+			}
+			if diff := cmp.Diff(tt.wantErrors, got); diff != "" {
+				t.Errorf("GetGroupFailures(%s) mismatch (-want +got):\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func TestGetGroupFailuresStopsPaginatingPastWatermark(t *testing.T) {
+	asgName := "test-asg"
+	asg := &autoscalingtypes.AutoScalingGroup{AutoScalingGroupName: aws.String(asgName)}
+
+	watermark := time.Date(2026, 5, 12, 20, 45, 0, 0, time.UTC)
+	tBefore := watermark.Add(-1 * time.Hour)
+	tAfter := watermark.Add(1 * time.Minute)
+
+	// 3 recent failures then 5 older ones, most-recent-first as AWS returns them.
+	// Everything strictly before the existing instance's CreationTimestamp must
+	// be filtered out, and reaching the first of them must stop pagination.
+	activities := []autoscalingtypes.Activity{
+		{StartTime: &tAfter, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("err A")},
+		{StartTime: &tAfter, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("err B")},
+		{StartTime: &tAfter, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("err C")},
+		{StartTime: &tBefore, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("old 1")},
+		{StartTime: &tBefore, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("old 2")},
+		{StartTime: &tBefore, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("old 3")},
+		{StartTime: &tBefore, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("old 4")},
+		{StartTime: &tBefore, StatusCode: autoscalingtypes.ScalingActivityStatusCodeFailed, StatusMessage: aws.String("old 5")},
+	}
+
+	cloud := BuildMockAWSCloud("us-east-1", "a")
+	asgMock := &mockautoscaling.MockAutoscaling{
+		ScalingActivities: map[string][]autoscalingtypes.Activity{asgName: activities},
+		// Two activities per page, so 8 activities span 4 pages. Production sets
+		// no MaxRecords, so without this the mock serves everything at once and
+		// the short-circuit is indistinguishable from a plain inner-loop break.
+		ScalingActivityPageSize: 2,
+	}
+	cloud.MockAutoscaling = asgMock
+
+	got, err := getGroupFailures(t.Context(), cloud, &cloudinstances.CloudInstanceGroup{
+		Raw: asg,
+		Ready: []*cloudinstances.CloudInstance{
+			{ID: "i-existing", CreationTimestamp: watermark},
+		},
+	})
+	if err != nil {
+		t.Fatalf("getGroupFailures(%q) error = %v, want nil", asgName, err)
+	}
+
+	gotMessages := make([]string, 0, len(got))
+	for _, f := range got {
+		gotMessages = append(gotMessages, f.Message)
+	}
+	slices.Sort(gotMessages)
+	wantMessages := []string{"err A", "err B", "err C"}
+	if !slices.Equal(gotMessages, wantMessages) {
+		t.Errorf("getGroupFailures(%q) messages = %v, want %v", asgName, gotMessages, wantMessages)
+	}
+
+	// Page 1 is the first two recent failures; page 2 holds the third plus the
+	// first pre-watermark one, which ends the scan. Pages 3 and 4 must never be
+	// requested.
+	if calls := asgMock.ScalingActivityCalls(); calls != 2 {
+		t.Errorf("getGroupFailures(%q) made %d DescribeScalingActivities calls, want 2", asgName, calls)
+	}
+}
+
+func TestGetGroupFailuresCapsPagination(t *testing.T) {
+	asgName := "test-asg"
+	asg := &autoscalingtypes.AutoScalingGroup{AutoScalingGroupName: aws.String(asgName)}
+
+	// An empty group has no watermark, so the short-circuit above never fires.
+	// The page cap is the only thing bounding the scan.
+	ts := time.Date(2026, 5, 12, 20, 45, 0, 0, time.UTC)
+	activities := make([]autoscalingtypes.Activity, 40)
+	for i := range activities {
+		activities[i] = autoscalingtypes.Activity{
+			StartTime:     &ts,
+			StatusCode:    autoscalingtypes.ScalingActivityStatusCodeFailed,
+			StatusMessage: aws.String(fmt.Sprintf("failure %d", i)),
+		}
+	}
+
+	cloud := BuildMockAWSCloud("us-east-1", "a")
+	asgMock := &mockautoscaling.MockAutoscaling{
+		ScalingActivities:       map[string][]autoscalingtypes.Activity{asgName: activities},
+		ScalingActivityPageSize: 1,
+	}
+	cloud.MockAutoscaling = asgMock
+
+	if _, err := getGroupFailures(t.Context(), cloud, &cloudinstances.CloudInstanceGroup{Raw: asg}); err != nil {
+		t.Fatalf("getGroupFailures(%q) error = %v, want nil", asgName, err)
+	}
+	if calls := asgMock.ScalingActivityCalls(); calls != maxScalingActivityPages {
+		t.Errorf("getGroupFailures(%q) made %d DescribeScalingActivities calls, want the %d-page cap",
+			asgName, calls, maxScalingActivityPages)
+	}
+}

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -106,6 +106,10 @@ func (c *MockAWSCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*k
 	return getCloudGroups(ctx, c, cluster, instancegroups, warnUnmatched, nodes)
 }
 
+func (c *MockAWSCloud) GetCloudGroupErrors(ctx context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.CloudGroupError, error) {
+	return getCloudGroupErrors(ctx, c, group)
+}
+
 func (c *MockCloud) ProviderID() kops.CloudProviderID {
 	return kops.CloudProviderAWS
 }

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -105,6 +105,12 @@ func (c *MockAWSCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*k
 	return getCloudGroups(ctx, c, cluster, instancegroups, warnUnmatched, nodes)
 }
 
+var _ cloudinstances.GroupFailureReporter = (*MockAWSCloud)(nil)
+
+func (c *MockAWSCloud) GetGroupFailures(ctx context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupFailure, error) {
+	return getGroupFailures(ctx, c, group)
+}
+
 func (c *MockCloud) ProviderID() kops.CloudProviderID {
 	return kops.CloudProviderAWS
 }

--- a/upup/pkg/fi/cloudup/gce/compute.go
+++ b/upup/pkg/fi/cloudup/gce/compute.go
@@ -674,6 +674,7 @@ type InstanceGroupManagerClient interface {
 	Get(project, zone, name string) (*compute.InstanceGroupManager, error)
 	List(ctx context.Context, project, zone string) ([]*compute.InstanceGroupManager, error)
 	ListManagedInstances(ctx context.Context, project, zone, name string) ([]*compute.ManagedInstance, error)
+	ListErrors(ctx context.Context, project, zone, name string) ([]*compute.InstanceManagedByIgmError, error)
 	RecreateInstances(project, zone, name, id string) (*compute.Operation, error)
 	SetTargetPools(project, zone, name string, targetPools []string) (*compute.Operation, error)
 	SetInstanceTemplate(project, zone, name, instanceTemplateURL string) (*compute.Operation, error)
@@ -718,6 +719,17 @@ func (c *instanceGroupManagerClientImpl) ListManagedInstances(ctx context.Contex
 		return nil, err
 	}
 	return instances, nil
+}
+
+func (c *instanceGroupManagerClientImpl) ListErrors(ctx context.Context, project, zone, name string) ([]*compute.InstanceManagedByIgmError, error) {
+	var items []*compute.InstanceManagedByIgmError
+	if err := c.srv.ListErrors(project, zone, name).Pages(ctx, func(page *compute.InstanceGroupManagersListErrorsResponse) error {
+		items = append(items, page.Items...)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 func (c *instanceGroupManagerClientImpl) RecreateInstances(project, zone, name, id string) (*compute.Operation, error) {

--- a/upup/pkg/fi/cloudup/gce/compute.go
+++ b/upup/pkg/fi/cloudup/gce/compute.go
@@ -679,6 +679,7 @@ type InstanceGroupManagerClient interface {
 	Get(project, zone, name string) (*compute.InstanceGroupManager, error)
 	List(ctx context.Context, project, zone string) ([]*compute.InstanceGroupManager, error)
 	ListManagedInstances(ctx context.Context, project, zone, name string) ([]*compute.ManagedInstance, error)
+	ListErrors(ctx context.Context, project, zone, name string) ([]*compute.InstanceManagedByIgmError, error)
 	RecreateInstances(project, zone, name, id string) (*compute.Operation, error)
 	SetTargetPools(project, zone, name string, targetPools []string) (*compute.Operation, error)
 	SetInstanceTemplate(project, zone, name, instanceTemplateURL string) (*compute.Operation, error)
@@ -723,6 +724,17 @@ func (c *instanceGroupManagerClientImpl) ListManagedInstances(ctx context.Contex
 		return nil, err
 	}
 	return instances, nil
+}
+
+func (c *instanceGroupManagerClientImpl) ListErrors(ctx context.Context, project, zone, name string) ([]*compute.InstanceManagedByIgmError, error) {
+	var items []*compute.InstanceManagedByIgmError
+	if err := c.srv.ListErrors(project, zone, name).Pages(ctx, func(page *compute.InstanceGroupManagersListErrorsResponse) error {
+		items = append(items, page.Items...)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 func (c *instanceGroupManagerClientImpl) RecreateInstances(project, zone, name, id string) (*compute.Operation, error) {

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -21,8 +21,8 @@ import (
 	"encoding/base32"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"strings"
-
 	"time"
 
 	compute "google.golang.org/api/compute/v1"
@@ -298,9 +298,96 @@ func matchInstanceGroup(mig *compute.InstanceGroupManager, c *kops.Cluster, inst
 	return matches[0], nil
 }
 
+// GetCloudGroupErrors returns recent provisioning errors the GCE managed
+// instance group has hit. To avoid surfacing errors from a previous, healthier
+// incarnation of the group, results are filtered to only errors timestamped
+// after the most recent successful instance creation in the group. If the
+// group is empty (no instances were ever created), no filter is applied.
+func (c *gceCloudImplementation) GetCloudGroupErrors(ctx context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.CloudGroupError, error) {
+	mig, ok := group.Raw.(*compute.InstanceGroupManager)
+	if !ok || mig == nil {
+		return nil, nil
+	}
+	u, err := ParseGoogleCloudURL(mig.SelfLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing MIG self link %q: %w", mig.SelfLink, err)
+	}
+
+	var watermark time.Time
+	for _, m := range group.Ready {
+		if m.CreationTimestamp.After(watermark) {
+			watermark = m.CreationTimestamp
+		}
+	}
+	for _, m := range group.NeedUpdate {
+		if m.CreationTimestamp.After(watermark) {
+			watermark = m.CreationTimestamp
+		}
+	}
+
+	items, err := c.Compute().InstanceGroupManagers().ListErrors(ctx, u.Project, u.Zone, u.Name)
+	if err != nil {
+		return nil, fmt.Errorf("listing errors for MIG %q: %w", mig.Name, err)
+	}
+
+	type key struct{ code, message string }
+	agg := map[key]*cloudinstances.CloudGroupError{}
+	for _, it := range items {
+		if it == nil || it.Error == nil {
+			continue
+		}
+		var ts time.Time
+		if it.Timestamp != "" {
+			if t, err := time.Parse(time.RFC3339, it.Timestamp); err == nil {
+				ts = t
+			}
+		}
+		if !watermark.IsZero() && !ts.IsZero() && ts.Before(watermark) {
+			continue
+		}
+		k := key{it.Error.Code, it.Error.Message}
+		e, ok := agg[k]
+		if !ok {
+			e = &cloudinstances.CloudGroupError{
+				Code:      it.Error.Code,
+				Message:   it.Error.Message,
+				FirstSeen: ts,
+				LastSeen:  ts,
+			}
+			if it.InstanceActionDetails != nil {
+				e.Instance = LastComponent(it.InstanceActionDetails.Instance)
+			}
+			agg[k] = e
+		}
+		e.Count++
+		if !ts.IsZero() {
+			if e.FirstSeen.IsZero() || ts.Before(e.FirstSeen) {
+				e.FirstSeen = ts
+			}
+			if ts.After(e.LastSeen) {
+				e.LastSeen = ts
+			}
+		}
+	}
+
+	out := make([]cloudinstances.CloudGroupError, 0, len(agg))
+	for _, e := range agg {
+		out = append(out, *e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].LastSeen.After(out[j].LastSeen)
+	})
+	return out, nil
+}
+
 func addCloudInstanceData(cm *cloudinstances.CloudInstance, instance *compute.Instance) {
 	cm.MachineType = LastComponent(instance.MachineType)
 	cm.Status = instance.Status
+	if instance.CreationTimestamp != "" {
+		if t, err := time.Parse(time.RFC3339, instance.CreationTimestamp); err == nil {
+			cm.CreationTimestamp = t
+		}
+	}
 	if instance.Status == "RUNNING" {
 		cm.State = cloudinstances.CloudInstanceStatusUpToDate
 	}

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -17,12 +17,13 @@ limitations under the License.
 package gce
 
 import (
+	"cmp"
 	"context"
 	"encoding/base32"
 	"fmt"
 	"hash/fnv"
+	"slices"
 	"strings"
-
 	"time"
 
 	compute "google.golang.org/api/compute/v1"
@@ -298,9 +299,150 @@ func matchInstanceGroup(mig *compute.InstanceGroupManager, c *kops.Cluster, inst
 	return matches[0], nil
 }
 
+var (
+	_ cloudinstances.GroupFailureReporter        = (*gceCloudImplementation)(nil)
+	_ cloudinstances.GroupInstanceStatusReporter = (*gceCloudImplementation)(nil)
+)
+
+// GetGroupFailures returns recent provisioning errors the GCE managed
+// instance group has hit. To avoid surfacing errors from a previous, healthier
+// incarnation of the group, results are filtered to only errors timestamped
+// after the most recent successful instance creation in the group. If the
+// group is empty (no instances were ever created), no filter is applied.
+func (c *gceCloudImplementation) GetGroupFailures(ctx context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupFailure, error) {
+	return GetGroupFailures(ctx, c, group)
+}
+
+// GetGroupFailures implements the GroupFailureReporter capability for
+// any GCECloud. See the method above for the filtering and aggregation rules.
+func GetGroupFailures(ctx context.Context, c GCECloud, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupFailure, error) {
+	mig, ok := group.Raw.(*compute.InstanceGroupManager)
+	if !ok || mig == nil {
+		return nil, nil
+	}
+	u, err := ParseGoogleCloudURL(mig.SelfLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing MIG self link %q: %w", mig.SelfLink, err)
+	}
+
+	watermark := cloudinstances.Watermark(group)
+
+	items, err := c.Compute().InstanceGroupManagers().ListErrors(ctx, u.Project, u.Zone, u.Name)
+	if err != nil {
+		return nil, fmt.Errorf("listing errors for MIG %q: %w", mig.Name, err)
+	}
+
+	type key struct{ code, message string }
+	agg := map[key]*cloudinstances.GroupFailure{}
+	for _, it := range items {
+		if it == nil || it.Error == nil {
+			continue
+		}
+		var ts time.Time
+		if it.Timestamp != "" {
+			if t, err := time.Parse(time.RFC3339, it.Timestamp); err == nil {
+				ts = t
+			}
+		}
+		if !watermark.IsZero() && !ts.IsZero() && ts.Before(watermark) {
+			continue
+		}
+		k := key{it.Error.Code, it.Error.Message}
+		e, ok := agg[k]
+		if !ok {
+			e = &cloudinstances.GroupFailure{
+				Code:      it.Error.Code,
+				Message:   it.Error.Message,
+				FirstSeen: ts,
+				LastSeen:  ts,
+			}
+			if it.InstanceActionDetails != nil {
+				e.Instance = LastComponent(it.InstanceActionDetails.Instance)
+			}
+			agg[k] = e
+		}
+		e.Count++
+		if !ts.IsZero() {
+			if e.FirstSeen.IsZero() || ts.Before(e.FirstSeen) {
+				e.FirstSeen = ts
+			}
+			if ts.After(e.LastSeen) {
+				e.LastSeen = ts
+			}
+		}
+	}
+
+	out := make([]cloudinstances.GroupFailure, 0, len(agg))
+	for _, e := range agg {
+		out = append(out, *e)
+	}
+	cloudinstances.SortFailures(out)
+	return out, nil
+}
+
+// GetGroupInstanceStatuses reports every instance the MIG is managing,
+// including ones it is still trying and failing to create. Those never show up
+// as CloudInstances: GetCloudGroups skips a managed instance whose compute
+// instance does not exist, so a MIG stuck in a create-retry loop is otherwise
+// indistinguishable from one that never tried.
+func (c *gceCloudImplementation) GetGroupInstanceStatuses(ctx context.Context, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupInstanceStatus, error) {
+	return GetGroupInstanceStatuses(ctx, c, group)
+}
+
+// GetGroupInstanceStatuses implements the GroupInstanceStatusReporter
+// capability for any GCECloud. See the method above for what it reports.
+func GetGroupInstanceStatuses(ctx context.Context, c GCECloud, group *cloudinstances.CloudInstanceGroup) ([]cloudinstances.GroupInstanceStatus, error) {
+	mig, ok := group.Raw.(*compute.InstanceGroupManager)
+	if !ok || mig == nil {
+		return nil, nil
+	}
+
+	u, err := ParseGoogleCloudURL(mig.SelfLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing MIG self link %q: %w", mig.SelfLink, err)
+	}
+
+	// Calling the client directly rather than via ListManagedInstances, which
+	// substitutes context.Background() and so cannot be cancelled.
+	instances, err := c.Compute().InstanceGroupManagers().ListManagedInstances(ctx, u.Project, u.Zone, u.Name)
+	if err != nil {
+		return nil, fmt.Errorf("listing managed instances for MIG %q: %w", mig.Name, err)
+	}
+
+	out := make([]cloudinstances.GroupInstanceStatus, 0, len(instances))
+	for _, i := range instances {
+		s := cloudinstances.GroupInstanceStatus{
+			Name:          LastComponent(i.Instance),
+			Status:        i.InstanceStatus,
+			CurrentAction: i.CurrentAction,
+		}
+		if i.LastAttempt != nil && i.LastAttempt.Errors != nil {
+			s.Failures = make([]cloudinstances.GroupFailure, 0, len(i.LastAttempt.Errors.Errors))
+			for _, e := range i.LastAttempt.Errors.Errors {
+				// Count is left unset: these are the raw errors from one
+				// attempt, not aggregated observations.
+				s.Failures = append(s.Failures, cloudinstances.GroupFailure{
+					Code:    e.Code,
+					Message: e.Message,
+				})
+			}
+		}
+		out = append(out, s)
+	}
+	slices.SortFunc(out, func(a, b cloudinstances.GroupInstanceStatus) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	return out, nil
+}
+
 func addCloudInstanceData(cm *cloudinstances.CloudInstance, instance *compute.Instance) {
 	cm.MachineType = LastComponent(instance.MachineType)
 	cm.Status = instance.Status
+	if instance.CreationTimestamp != "" {
+		if t, err := time.Parse(time.RFC3339, instance.CreationTimestamp); err == nil {
+			cm.CreationTimestamp = t
+		}
+	}
 	if instance.Status == "RUNNING" {
 		cm.State = cloudinstances.CloudInstanceStatusUpToDate
 	}

--- a/upup/pkg/fi/cloudup/gce/instancegroups_test.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce_test
+
+import (
+	"testing"
+	"time"
+
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/kops/cloudmock/gce"
+	"k8s.io/kops/pkg/cloudinstances"
+	gceup "k8s.io/kops/upup/pkg/fi/cloudup/gce"
+)
+
+const (
+	testProject = "testproject"
+	testRegion  = "us-test1"
+	testZone    = "us-test1-a"
+	testMIG     = "a-nodes-testcluster-example-com"
+)
+
+func migSelfLink(name string) string {
+	return "https://www.googleapis.com/compute/v1/projects/" + testProject +
+		"/zones/" + testZone + "/instanceGroupManagers/" + name
+}
+
+func igmError(code, message, instance, timestamp string) *compute.InstanceManagedByIgmError {
+	e := &compute.InstanceManagedByIgmError{
+		Error:     &compute.InstanceManagedByIgmErrorManagedInstanceError{Code: code, Message: message},
+		Timestamp: timestamp,
+	}
+	if instance != "" {
+		e.InstanceActionDetails = &compute.InstanceManagedByIgmErrorInstanceActionDetails{
+			Instance: "https://www.googleapis.com/compute/v1/projects/" + testProject +
+				"/zones/" + testZone + "/instances/" + instance,
+		}
+	}
+	return e
+}
+
+func newTestCloud(t *testing.T) *gce.MockGCECloud {
+	t.Helper()
+	return gce.InstallMockGCECloud(testRegion, testProject)
+}
+
+func TestGetGroupFailures(t *testing.T) {
+	exhausted := "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS"
+	quota := "QUOTA_EXCEEDED"
+
+	watermark := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	before := watermark.Add(-time.Hour).Format(time.RFC3339)
+	after := watermark.Add(time.Minute).Format(time.RFC3339)
+	later := watermark.Add(2 * time.Minute).Format(time.RFC3339)
+
+	tests := []struct {
+		name       string
+		group      *cloudinstances.CloudInstanceGroup
+		igmErrors  []*compute.InstanceManagedByIgmError
+		wantCodes  []string
+		wantCounts []int
+		wantFirst  string
+	}{
+		{
+			name:  "empty group surfaces every error",
+			group: &cloudinstances.CloudInstanceGroup{Raw: &compute.InstanceGroupManager{Name: testMIG, SelfLink: migSelfLink(testMIG)}},
+			igmErrors: []*compute.InstanceManagedByIgmError{
+				igmError(exhausted, "the zone does not have enough resources", "node-1", after),
+				igmError(exhausted, "the zone does not have enough resources", "node-2", before),
+			},
+			wantCodes:  []string{exhausted},
+			wantCounts: []int{2},
+			wantFirst:  exhausted,
+		},
+		{
+			name: "watermark drops errors older than the newest instance",
+			group: &cloudinstances.CloudInstanceGroup{
+				Raw: &compute.InstanceGroupManager{Name: testMIG, SelfLink: migSelfLink(testMIG)},
+				Ready: []*cloudinstances.CloudInstance{
+					{ID: "existing", CreationTimestamp: watermark},
+				},
+			},
+			igmErrors: []*compute.InstanceManagedByIgmError{
+				igmError(exhausted, "recent", "node-1", after),
+				igmError(quota, "from a previous incarnation of the group", "node-0", before),
+			},
+			wantCodes:  []string{exhausted},
+			wantCounts: []int{1},
+			wantFirst:  exhausted,
+		},
+		{
+			name:  "distinct codes are not merged and sort most recent first",
+			group: &cloudinstances.CloudInstanceGroup{Raw: &compute.InstanceGroupManager{Name: testMIG, SelfLink: migSelfLink(testMIG)}},
+			igmErrors: []*compute.InstanceManagedByIgmError{
+				igmError(exhausted, "capacity", "node-1", after),
+				igmError(quota, "quota", "node-2", later),
+			},
+			wantCodes:  []string{quota, exhausted},
+			wantCounts: []int{1, 1},
+			wantFirst:  quota,
+		},
+		{
+			name:  "unparseable timestamps do not drop the error",
+			group: &cloudinstances.CloudInstanceGroup{Raw: &compute.InstanceGroupManager{Name: testMIG, SelfLink: migSelfLink(testMIG)}},
+			igmErrors: []*compute.InstanceManagedByIgmError{
+				igmError(exhausted, "capacity", "node-1", "not-a-timestamp"),
+			},
+			wantCodes:  []string{exhausted},
+			wantCounts: []int{1},
+			wantFirst:  exhausted,
+		},
+		{
+			name:      "entries without an Error payload are skipped",
+			group:     &cloudinstances.CloudInstanceGroup{Raw: &compute.InstanceGroupManager{Name: testMIG, SelfLink: migSelfLink(testMIG)}},
+			igmErrors: []*compute.InstanceManagedByIgmError{{Timestamp: after}},
+			wantCodes: nil,
+		},
+		{
+			name:      "a group whose Raw is not a MIG reports nothing",
+			group:     &cloudinstances.CloudInstanceGroup{Raw: "not-a-mig"},
+			igmErrors: []*compute.InstanceManagedByIgmError{igmError(exhausted, "capacity", "node-1", after)},
+			wantCodes: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloud := newTestCloud(t)
+			cloud.ComputeClient().SetInstanceGroupManagerErrors(testProject, testZone, testMIG, tt.igmErrors)
+
+			got, err := gceup.GetGroupFailures(t.Context(), cloud, tt.group)
+			if err != nil {
+				t.Fatalf("GetGroupFailures() error = %v, want nil", err)
+			}
+			if len(got) != len(tt.wantCodes) {
+				t.Fatalf("GetGroupFailures() returned %d failures, want %d: %+v", len(got), len(tt.wantCodes), got)
+			}
+			for i, wantCode := range tt.wantCodes {
+				if got[i].Code != wantCode {
+					t.Errorf("failure %d: Code = %q, want %q", i, got[i].Code, wantCode)
+				}
+				if got[i].Count != tt.wantCounts[i] {
+					t.Errorf("failure %d: Count = %d, want %d", i, got[i].Count, tt.wantCounts[i])
+				}
+			}
+			if tt.wantFirst != "" && got[0].Code != tt.wantFirst {
+				t.Errorf("first failure Code = %q, want %q", got[0].Code, tt.wantFirst)
+			}
+		})
+	}
+}
+
+func TestGetGroupFailuresExtractsInstanceName(t *testing.T) {
+	cloud := newTestCloud(t)
+	cloud.ComputeClient().SetInstanceGroupManagerErrors(testProject, testZone, testMIG,
+		[]*compute.InstanceManagedByIgmError{
+			igmError("ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS", "capacity", "a-nodes-xyz",
+				time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC).Format(time.RFC3339)),
+		})
+
+	got, err := gceup.GetGroupFailures(t.Context(), cloud,
+		&cloudinstances.CloudInstanceGroup{Raw: &compute.InstanceGroupManager{Name: testMIG, SelfLink: migSelfLink(testMIG)}})
+	if err != nil {
+		t.Fatalf("GetGroupFailures() error = %v, want nil", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("GetGroupFailures() returned %d failures, want 1", len(got))
+	}
+	// The API reports a full self link; only the last component is useful.
+	if got[0].Instance != "a-nodes-xyz" {
+		t.Errorf("Instance = %q, want %q", got[0].Instance, "a-nodes-xyz")
+	}
+}
+
+func TestGetGroupInstanceStatuses(t *testing.T) {
+	cloud := newTestCloud(t)
+
+	// A managed instance the MIG keeps failing to create: it has no backing
+	// compute instance, so GetCloudGroups drops it and it is invisible without
+	// this capability.
+	cloud.ComputeClient().SetManagedInstance(testProject, testZone, "a-nodes-pending", &compute.ManagedInstance{
+		Name:          "a-nodes-pending",
+		Instance:      "https://www.googleapis.com/compute/v1/projects/" + testProject + "/zones/" + testZone + "/instances/a-nodes-pending",
+		CurrentAction: "CREATING",
+		LastAttempt: &compute.ManagedInstanceLastAttempt{
+			Errors: &compute.ManagedInstanceLastAttemptErrors{
+				Errors: []*compute.ManagedInstanceLastAttemptErrorsErrors{
+					{Code: "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS", Message: "the zone does not have enough resources"},
+				},
+			},
+		},
+	})
+
+	got, err := gceup.GetGroupInstanceStatuses(t.Context(), cloud,
+		&cloudinstances.CloudInstanceGroup{Raw: &compute.InstanceGroupManager{Name: testMIG, SelfLink: migSelfLink(testMIG)}})
+	if err != nil {
+		t.Fatalf("GetGroupInstanceStatuses() error = %v, want nil", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("GetGroupInstanceStatuses() returned %d statuses, want 1: %+v", len(got), got)
+	}
+	if got[0].Name != "a-nodes-pending" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "a-nodes-pending")
+	}
+	if got[0].CurrentAction != "CREATING" {
+		t.Errorf("CurrentAction = %q, want %q", got[0].CurrentAction, "CREATING")
+	}
+	if len(got[0].Failures) != 1 {
+		t.Fatalf("got %d failures, want 1", len(got[0].Failures))
+	}
+	if got[0].Failures[0].Code != "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS" {
+		t.Errorf("failure Code = %q, want %q", got[0].Failures[0].Code, "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS")
+	}
+	// These are raw per-attempt errors, not aggregated observations.
+	if got[0].Failures[0].Count != 0 {
+		t.Errorf("failure Count = %d, want 0 (per-attempt errors are not aggregated)", got[0].Failures[0].Count)
+	}
+}
+
+func TestGetGroupInstanceStatusesNonMIG(t *testing.T) {
+	cloud := newTestCloud(t)
+	got, err := gceup.GetGroupInstanceStatuses(t.Context(), cloud,
+		&cloudinstances.CloudInstanceGroup{Raw: "not-a-mig"})
+	if err != nil {
+		t.Fatalf("GetGroupInstanceStatuses() error = %v, want nil", err)
+	}
+	if got != nil {
+		t.Errorf("GetGroupInstanceStatuses() = %+v, want nil", got)
+	}
+}

--- a/util/pkg/awsinterfaces/autoscaling.go
+++ b/util/pkg/awsinterfaces/autoscaling.go
@@ -36,6 +36,7 @@ type AutoScalingAPI interface {
 	DeleteWarmPool(ctx context.Context, params *autoscaling.DeleteWarmPoolInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DeleteWarmPoolOutput, error)
 	DescribeAutoScalingGroups(ctx context.Context, params *autoscaling.DescribeAutoScalingGroupsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
 	DescribeLifecycleHooks(ctx context.Context, params *autoscaling.DescribeLifecycleHooksInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeLifecycleHooksOutput, error)
+	DescribeScalingActivities(ctx context.Context, params *autoscaling.DescribeScalingActivitiesInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeScalingActivitiesOutput, error)
 	DescribeTags(ctx context.Context, params *autoscaling.DescribeTagsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeTagsOutput, error)
 	DescribeWarmPool(ctx context.Context, params *autoscaling.DescribeWarmPoolInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeWarmPoolOutput, error)
 	DetachInstances(ctx context.Context, params *autoscaling.DetachInstancesInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DetachInstancesOutput, error)


### PR DESCRIPTION
When an instance group fails to launch, kOps reports only the shortfall — or, if
the control plane is the group that failed, nothing at all. The cloud provider
knows why, and we never ask it.

The motivating case is the `-ko37` grid triage: six `cluster_up` failures where
`kops update cluster` completed every task, the API NLB came up, and no instance
ever registered. What the artifacts contain is 30 identical
`dial tcp <nlb>:443: i/o timeout` validations over the full 20 minute wait, a
`toolbox-dump.yaml` with no `type: instance` rows, and no way to tell
`InsufficientInstanceCapacity` from a quota ceiling from anything else. Five of
the six were `t4g.large`; a sixth launched its control plane but none of its
`t3.medium` workers, which points at a per-instance-family limit rather than
whole-AZ exhaustion. None of that could be confirmed, because the one API call
that would say so is never made.

## What this does

Adds two optional capabilities a cloud may implement, discovered by type
assertion so providers that cannot report either need no stub:

- `CloudGroupFailureReporter` — the provisioning failures the provider
  attributes to a group. AWS reads the ASG's failed and cancelled scaling
  activities; GCE reads the MIG's `ListErrors`.
- `CloudGroupInstanceStatusReporter` — the instances a group is managing but
  has not created. GCE only, and it matters there because `GetCloudGroups`
  skips a managed instance whose compute instance does not exist, which makes a
  MIG stuck in a create-retry loop indistinguishable from one that never tried.

Both are surfaced two ways:

**During validation.** An undersized group now carries the provider's reason
alongside the shortfall. And when listing nodes fails — the zero-instance case,
where there is no API server to ask — validation falls back to cloud-side group
reporting instead of returning an opaque dial error. That is the difference
between the 30 timeouts above and a citable `InsufficientInstanceCapacity`.

**During `kops toolbox dump`.** A new `cloud-instance-groups.yaml` records the
provider's view of every group: sizes, instances, attributed failures, and the
managed instances above. A run that dies before validation prints anything still
leaves this behind. The e2e deployer already passes `--dir`, so it lands in job
artifacts with no deployer change.

## Notes

Errors are aggregated by code and message with an occurrence count and a time
range, and filtered to those newer than the group's most recent successful
instance launch, so a group that recovered does not keep reporting failures from
a previous incarnation. A group with no instances has no such watermark, which
is exactly the case this exists for — a page cap bounds the scan there rather
than walking AWS's full six-week activity retention on every validation poll.

Reporting is best-effort throughout: a provider that cannot answer, or whose
call fails, degrades to a warning. Validation must not start failing because an
IAM policy lags `autoscaling:DescribeScalingActivities`.

Does not fix anything on its own — it turns "no instances launched" into a
provider error you can act on, which is the prerequisite for deciding whether
the answer is different instance types, different zones, or a quota increase.
