### PR TITLE
Use N4A machine type in GCE

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -245,8 +245,8 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		args = appendIfUnset(args, "--node-size", "Standard_D4ls_v6")
 	case "gce":
 		if isArm {
-			args = appendIfUnset(args, "--control-plane-size", "t2a-standard-2")
-			args = appendIfUnset(args, "--node-size", "t2a-standard-2")
+			args = appendIfUnset(args, "--control-plane-size", "n4a-standard-2")
+			args = appendIfUnset(args, "--node-size", "n4a-standard-2")
 		} else {
 			args = appendIfUnset(args, "--control-plane-size", "e2-standard-2")
 			args = appendIfUnset(args, "--node-size", "e2-standard-2")


### PR DESCRIPTION
The T2A is getting stockout errors in some zones:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-calico-u2404arm64-k35-ko35/2054249634708066304

`W0512 19:12:34.172249   13098 dump.go:71] instance "https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-108/zones/us-central1-a/instances/control-plane-us-central1-a-qlnf" not found (currentAction="CREATING" instanceStatus=""); lastAttempt.error code="ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS" location="" message="Instance 'control-plane-us-central1-a-qlnf' creation failed: The zone 'projects/k8s-infra-e2e-boskos-108/zones/us-central1-a' does not have enough resources available to fulfill the request.  'NULL:0/NULL:0/NULL:0 (state:STOCKOUT, sub-state:STOCKOUT, resource type:compute)'."`


Lets see if the newer N4A has better capacity.

https://docs.cloud.google.com/compute/docs/machine-resource#arm