### PR TITLE
Disable kube-proxy when Calico runs in eBPF mode

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -675,6 +675,19 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		return err
 	}
 
+	// Calico's eBPF dataplane replaces kube-proxy and from v3.31 also binds the
+	// kube-proxy healthz port (10256), so kube-proxy must be disabled to avoid
+	// a port conflict that breaks the BPF dataplane.
+	// https://docs.tigera.io/calico-enterprise/latest/operations/ebpf/install#disable-kube-proxy-or-avoid-conflicts
+	if calico := cluster.Spec.Networking.Calico; calico != nil && calico.BPFEnabled {
+		if cluster.Spec.KubeProxy == nil {
+			cluster.Spec.KubeProxy = &api.KubeProxyConfig{}
+		}
+		if cluster.Spec.KubeProxy.Enabled == nil {
+			cluster.Spec.KubeProxy.Enabled = fi.PtrTo(false)
+		}
+	}
+
 	cloud, err := cloudup.BuildCloud(cluster)
 	if err != nil {
 		return err

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -98,6 +98,13 @@ func TestCreateClusterOpenStackNoDNS(t *testing.T) {
 }
 
 // TestCreateClusterCilium runs kops with the cilium networking flags
+// TestCreateClusterCalicoBPF verifies that --set cluster.spec.networking.calico.bpfEnabled=true
+// causes kops to default spec.kubeProxy.enabled=false, because Calico's BPF mode replaces
+// kube-proxy and from v3.31 binds the kube-proxy healthz port.
+func TestCreateClusterCalicoBPF(t *testing.T) {
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/calico_bpf", "v1alpha2")
+}
+
 func TestCreateClusterCilium(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/cilium-eni", "v1alpha2")
 }

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5203,7 +5203,12 @@ spec:
                           Options: Disable (default for IPv4), Enable, or DoNothing
                         type: string
                       bpfEnabled:
-                        description: BPFEnabled enables the eBPF dataplane mode.
+                        description: |-
+                          BPFEnabled enables the eBPF dataplane mode. When set to true, kube-proxy
+                          must be disabled (spec.kubeProxy.enabled=false); kops will default it
+                          at cluster creation. Calico's BPF mode replaces kube-proxy and from
+                          v3.31 binds the kube-proxy healthz port (10256), so running both
+                          produces a port conflict.
                         type: boolean
                       bpfExternalServiceMode:
                         description: |-

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -188,7 +188,11 @@ type CalicoNetworkingSpec struct {
 	// AWSSrcDstCheck enables/disables ENI source/destination checks (AWS IPv4 only)
 	// Options: Disable (default for IPv4), Enable, or DoNothing
 	AWSSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
-	// BPFEnabled enables the eBPF dataplane mode.
+	// BPFEnabled enables the eBPF dataplane mode. When set to true, kube-proxy
+	// must be disabled (spec.kubeProxy.enabled=false); kops will default it
+	// at cluster creation. Calico's BPF mode replaces kube-proxy and from
+	// v3.31 binds the kube-proxy healthz port (10256), so running both
+	// produces a port conflict.
 	BPFEnabled bool `json:"bpfEnabled,omitempty"`
 	// BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled.
 	// In Tunnel mode, packet is tunneled from the ingress host to the host with the backing pod and back again.

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -143,7 +143,11 @@ type CalicoNetworkingSpec struct {
 	// AWSSrcDstCheck enables/disables ENI source/destination checks (AWS IPv4 only)
 	// Options: Disable (default for IPv4), Enable, or DoNothing
 	AWSSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
-	// BPFEnabled enables the eBPF dataplane mode.
+	// BPFEnabled enables the eBPF dataplane mode. When set to true, kube-proxy
+	// must be disabled (spec.kubeProxy.enabled=false); kops will default it
+	// at cluster creation. Calico's BPF mode replaces kube-proxy and from
+	// v3.31 binds the kube-proxy healthz port (10256), so running both
+	// produces a port conflict.
 	BPFEnabled bool `json:"bpfEnabled,omitempty"`
 	// BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled.
 	// In Tunnel mode, packet is tunneled from the ingress host to the host with the backing pod and back again.

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -152,7 +152,11 @@ type CalicoNetworkingSpec struct {
 	// AWSSrcDstCheck enables/disables ENI source/destination checks (AWS IPv4 only)
 	// Options: Disable (default for IPv4), Enable, or DoNothing
 	AWSSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`
-	// BPFEnabled enables the eBPF dataplane mode.
+	// BPFEnabled enables the eBPF dataplane mode. When set to true, kube-proxy
+	// must be disabled (spec.kubeProxy.enabled=false); kops will default it
+	// at cluster creation. Calico's BPF mode replaces kube-proxy and from
+	// v3.31 binds the kube-proxy healthz port (10256), so running both
+	// produces a port conflict.
 	BPFEnabled bool `json:"bpfEnabled,omitempty"`
 	// BPFExternalServiceMode controls how traffic from outside the cluster to NodePorts and ClusterIPs is handled.
 	// In Tunnel mode, packet is tunneled from the ingress host to the host with the backing pod and back again.

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1669,6 +1669,10 @@ func validateNetworkingCalico(c *kops.ClusterSpec, v *kops.CalicoNetworkingSpec,
 		}
 	}
 
+	if v.BPFEnabled && c.KubeProxy != nil && (c.KubeProxy.Enabled == nil || *c.KubeProxy.Enabled) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "kubeProxy", "enabled"), "calico in BPF mode (spec.networking.calico.bpfEnabled=true) requires kubeProxy to be disabled"))
+	}
+
 	if v.BPFExternalServiceMode != "" {
 		valid := []string{"Tunnel", "DSR"}
 		allErrs = append(allErrs, IsValidValue(fldPath.Child("bpfExternalServiceMode"), &v.BPFExternalServiceMode, valid)...)

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -1081,6 +1081,35 @@ func Test_Validate_Calico(t *testing.T) {
 				},
 			},
 		},
+		{
+			Description: "Calico BPF with kube-proxy explicitly disabled",
+			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					KubeProxy: &kops.KubeProxyConfig{Enabled: fi.PtrTo(false)},
+				},
+				Calico: &kops.CalicoNetworkingSpec{BPFEnabled: true},
+			},
+		},
+		{
+			Description: "Calico BPF with kube-proxy implicitly enabled",
+			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					KubeProxy: &kops.KubeProxyConfig{},
+				},
+				Calico: &kops.CalicoNetworkingSpec{BPFEnabled: true},
+			},
+			ExpectedErrors: []string{"Forbidden::spec.kubeProxy.enabled"},
+		},
+		{
+			Description: "Calico BPF with kube-proxy explicitly enabled",
+			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					KubeProxy: &kops.KubeProxyConfig{Enabled: fi.PtrTo(true)},
+				},
+				Calico: &kops.CalicoNetworkingSpec{BPFEnabled: true},
+			},
+			ExpectedErrors: []string{"Forbidden::spec.kubeProxy.enabled"},
+		},
 	}
 	rootFieldPath := field.NewPath("calico")
 	for _, g := range grid {

--- a/tests/integration/create_cluster/calico_bpf/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/calico_bpf/expected-v1alpha2.yaml
@@ -1,0 +1,97 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  name: calico-bpf.example.com
+spec:
+  api:
+    loadBalancer:
+      class: Network
+      type: Public
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/calico-bpf.example.com
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - encryptedVolume: true
+      instanceGroup: control-plane-us-test-1a
+      name: a
+    manager:
+      backupRetentionDays: 90
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - encryptedVolume: true
+      instanceGroup: control-plane-us-test-1a
+      name: a
+    manager:
+      backupRetentionDays: 90
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubeProxy:
+    enabled: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  - ::/0
+  kubernetesVersion: v1.35.0
+  networkCIDR: 172.20.0.0/16
+  networking:
+    calico:
+      bpfEnabled: true
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  - ::/0
+  subnets:
+  - cidr: 172.20.0.0/16
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  topology:
+    dns:
+      type: None
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: calico-bpf.example.com
+  name: control-plane-us-test-1a
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: calico-bpf.example.com
+  name: nodes-us-test-1a
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  role: Node
+  subnets:
+  - us-test-1a

--- a/tests/integration/create_cluster/calico_bpf/options.yaml
+++ b/tests/integration/create_cluster/calico_bpf/options.yaml
@@ -1,0 +1,8 @@
+ClusterName: calico-bpf.example.com
+Zones:
+- us-test-1a
+CloudProvider: aws
+Networking: calico
+KubernetesVersion: v1.35.0
+Sets:
+- cluster.spec.networking.calico.bpfEnabled=true


### PR DESCRIPTION
More context in https://github.com/kubernetes/test-infra/pull/37032

Once this merges (and if cherrypicked to 1.35) we can remove the --set in test-infra.