### PR TITLE
vfs: Use HeadBucket to resolve S3 bucket region

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -83,7 +83,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.16 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.276.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.45.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.33.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -209,8 +209,6 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEG
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.16 h1:CjMzUs78RDDv4ROu3JnJn/Ig1r6ZD7/T2DXLLRpejic=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.16/go.mod h1:uVW4OLBqbJXSHJYA9svT9BluSvvwbzLQ2Crf6UPzR3c=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.276.1 h1:P7db/Z55pXvwnueLuHUuVlxnqjbAtiadm01+QIC42OA=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.276.1/go.mod h1:Wg68QRgy2gEGGdmTPU/UbVpdv8sM14bUZmF64KFwAsY=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.45.1 h1:Bwzh202Aq7/MYnAjXA9VawCf6u+hjwMdoYmZ4HYsdf8=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.45.1/go.mod h1:xZzWl9AXYa6zsLLH41HBFW8KRKJRIzlGmvSM0mVMIX4=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.33.2 h1:XJ/AEFYj9VFPJdF+VFi4SUPEDfz1akHwxxm07JfZJcs=

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -18,6 +18,7 @@ package vfs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -31,9 +32,9 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	smithyendpoints "github.com/aws/smithy-go/endpoints"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"k8s.io/klog/v2"
 )
 
@@ -189,11 +190,6 @@ func (s *S3Context) getDetailsForBucket(ctx context.Context, bucket string) (*S3
 		klog.V(2).Infof("defaulting region to %q", awsRegion)
 	}
 
-	request := &s3.GetBucketLocationInput{
-		Bucket: &bucket,
-	}
-	var response *s3.GetBucketLocationOutput
-
 	s3Client, err := s.getClient(ctx, awsRegion, func(o *s3.Options) {
 		o.EndpointResolverV2 = &ResolverV2{}
 	})
@@ -201,19 +197,19 @@ func (s *S3Context) getDetailsForBucket(ctx context.Context, bucket string) (*S3
 		return bucketDetails, fmt.Errorf("error connecting to S3: %s", err)
 	}
 	// Attempt one GetBucketLocation call the "normal" way (i.e. as the bucket owner)
-	response, err = s3Client.GetBucketLocation(ctx, request)
-
-	// and fallback to brute-forcing if it fails
-	if err != nil {
-		klog.V(2).Infof("unable to get bucket location from region %q; scanning all regions: %v", awsRegion, err)
-		response, err = bruteforceBucketLocation(ctx, awsRegion, request)
-	}
+	response, err := s3Client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
+		Bucket: &bucket,
+	})
 
 	if err != nil {
-		return bucketDetails, err
-	}
-
-	if len(response.LocationConstraint) == 0 {
+		// GetBucketLocation only works for the bucket owner from any region, or from the bucket's
+		// region. Fall back to HeadBucket, which works cross-account and cross-region.
+		klog.V(2).Infof("unable to get bucket location from region %q; falling back to HeadBucket: %v", awsRegion, err)
+		bucketDetails.region, err = bucketLocationViaHead(ctx, s3Client, bucket)
+		if err != nil {
+			return bucketDetails, err
+		}
+	} else if len(response.LocationConstraint) == 0 {
 		// US Classic does not return a region
 		bucketDetails.region = "us-east-1"
 	} else {
@@ -285,57 +281,32 @@ func (b *S3BucketDetails) hasServerSideEncryptionByDefault(ctx context.Context, 
 	return applyServerSideEncryptionByDefault
 }
 
-/*
-Amazon's S3 API provides the GetBucketLocation call to determine the region in which a bucket is located.
-This call can however only be used globally by the owner of the bucket, as mentioned on the documentation page.
-
-For S3 buckets that are shared across multiple AWS accounts using bucket policies the call will only work if it is sent
-to the correct region in the first place.
-
-This method will attempt to "bruteforce" the bucket location by sending a request to every available region and picking
-out the first result.
-
-See also: https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLocationRequest
-*/
-func bruteforceBucketLocation(ctx context.Context, region string, request *s3.GetBucketLocationInput) (*s3.GetBucketLocationOutput, error) {
-	ctx, span := tracer.Start(ctx, "bruteforceBucketLocation")
+// bucketLocationViaHead resolves the region for a bucket using HeadBucket.
+// GetBucketLocation does not work for cross-account buckets queried from a different region.
+// HeadBucket can be called against any region in the partition: on success the response carries
+// BucketRegion, and on a cross-region failure (e.g. 301 PermanentRedirect) S3 still sets the
+// x-amz-bucket-region response header, which we recover from the wrapped response error.
+func bucketLocationViaHead(ctx context.Context, s3Client *s3.Client, bucket string) (string, error) {
+	ctx, span := tracer.Start(ctx, "bucketLocationViaHead")
 	defer span.End()
 
-	config, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
-	if err != nil {
-		return nil, fmt.Errorf("creating aws config: %w", err)
-	}
-	//config, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(*config.Region), awsconfig.WithSharedCredentialsFiles())
-
-	regions, err := ec2.NewFromConfig(config).DescribeRegions(ctx, &ec2.DescribeRegionsInput{})
-	if err != nil {
-		return nil, fmt.Errorf("listing AWS regions: %w", err)
-	}
-
-	klog.V(2).Infof("Querying S3 for bucket location for %s", *request.Bucket)
-
-	out := make(chan *s3.GetBucketLocationOutput, len(regions.Regions))
-	for _, region := range regions.Regions {
-		go func(regionName string) {
-			config, err = awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(regionName))
-			if err == nil {
-				klog.V(8).Infof("Doing GetBucketLocation in %q", regionName)
-				s3Client := s3.NewFromConfig(config)
-				result, bucketError := s3Client.GetBucketLocation(ctx, request)
-				if bucketError == nil {
-					klog.V(8).Infof("GetBucketLocation succeeded in %q", regionName)
-					out <- result
-				}
-			}
-		}(*region.RegionName)
+	out, err := s3Client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err == nil {
+		if out.BucketRegion != nil && *out.BucketRegion != "" {
+			return *out.BucketRegion, nil
+		}
+		return "", fmt.Errorf("HeadBucket on %q did not return a bucket region", bucket)
 	}
 
-	select {
-	case bucketLocation := <-out:
-		return bucketLocation, nil
-	case <-time.After(5 * time.Second):
-		return nil, fmt.Errorf("Could not retrieve location for AWS bucket %s", *request.Bucket)
+	var respErr *smithyhttp.ResponseError
+	if errors.As(err, &respErr) && respErr.Response != nil && respErr.Response.Response != nil {
+		if bucketRegion := respErr.Response.Header.Get("x-amz-bucket-region"); bucketRegion != "" {
+			return bucketRegion, nil
+		}
 	}
+	return "", fmt.Errorf("getting location for bucket %q: %w", bucket, err)
 }
 
 // isRunningOnEC2 determines if we could be running on EC2.

--- a/util/pkg/vfs/s3context_test.go
+++ b/util/pkg/vfs/s3context_test.go
@@ -16,7 +16,88 @@ limitations under the License.
 
 package vfs
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestBucketLocationViaHead(t *testing.T) {
+	cases := []struct {
+		name         string
+		status       int
+		bucketRegion string
+		wantRegion   string
+		wantErr      bool
+	}{
+		{
+			name:         "200 reads BucketRegion header",
+			status:       http.StatusOK,
+			bucketRegion: "us-west-2",
+			wantRegion:   "us-west-2",
+		},
+		{
+			name:         "301 recovers region from response header",
+			status:       http.StatusMovedPermanently,
+			bucketRegion: "eu-central-1",
+			wantRegion:   "eu-central-1",
+		},
+		{
+			name:         "403 recovers region from response header",
+			status:       http.StatusForbidden,
+			bucketRegion: "ap-southeast-1",
+			wantRegion:   "ap-southeast-1",
+		},
+		{
+			name:    "404 without region header is an error",
+			status:  http.StatusNotFound,
+			wantErr: true,
+		},
+		{
+			name:    "200 without region header is an error",
+			status:  http.StatusOK,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.bucketRegion != "" {
+					w.Header().Set("x-amz-bucket-region", tc.bucketRegion)
+				}
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			client := s3.New(s3.Options{
+				BaseEndpoint: aws.String(srv.URL),
+				Region:       "us-east-1",
+				Credentials:  credentials.NewStaticCredentialsProvider("AKID", "SECRET", ""),
+				UsePathStyle: true,
+			})
+
+			region, err := bucketLocationViaHead(context.Background(), client, "my-bucket")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got region %q", region)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if region != tc.wantRegion {
+				t.Errorf("got region %q, want %q", region, tc.wantRegion)
+			}
+		})
+	}
+}
 
 func Test_VFSPath(t *testing.T) {
 	grid := []struct {


### PR DESCRIPTION
VFS used to fall back to listing every EC2 region via DescribeRegions and fanning out one GetBucketLocation per region whenever the initial GetBucketLocation failed (cross-account buckets). That pulled the entire EC2 SDK into every kops binary purely for one call.

HeadBucket can be called against any region in the partition: S3 returns the bucket region in BucketRegion on success and in the x-amz-bucket-region response header on cross-region 301 redirects. One call replaces the fanout and drops the EC2 SDK from the channels binary (~28 MB smaller).

/cc @rifelpet @ameukam 

Assisted by Claude Opus