### PR TITLE
Abort rolling update on load balancer deregister failure

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -67,6 +67,28 @@ func (v *ValidationTimeoutError) Is(err error) bool {
 	return ok
 }
 
+// DeregisterError represents a failure to deregister an instance from
+// the cloud's load balancers. The rolling update treats this as fatal
+// because continuing would leave traffic routed to nodes that are about
+// to be terminated.
+type DeregisterError struct {
+	err error
+}
+
+func (d *DeregisterError) Error() string {
+	return d.err.Error()
+}
+
+func (d *DeregisterError) Unwrap() error {
+	return d.err
+}
+
+// Is checks that a given error is a DeregisterError.
+func (d *DeregisterError) Is(err error) bool {
+	_, ok := err.(*DeregisterError)
+	return ok
+}
+
 // promptInteractive asks the user to continue, mostly copied from vendor/google.golang.org/api/examples/gmail.go.
 func promptInteractive(upgradedHostID, upgradedHostName string) (stopPrompting bool, err error) {
 	stopPrompting = false
@@ -432,7 +454,7 @@ func (c *RollingUpdateCluster) drainTerminateAndWait(ctx context.Context, u *clo
 
 			if err := c.drainNode(ctx, u); err != nil {
 				if c.FailOnDrainError {
-					return fmt.Errorf("failed to drain node %q: %v", nodeName, err)
+					return fmt.Errorf("failed to drain node %q: %w", nodeName, err)
 				}
 				klog.Infof("Ignoring error draining node %q: %v", nodeName, err)
 			}
@@ -700,7 +722,9 @@ func (c *RollingUpdateCluster) drainNode(ctx context.Context, u *cloudinstances.
 
 	if shouldDeregister {
 		if err := c.Cloud.DeregisterInstance(u); err != nil {
-			return fmt.Errorf("error deregistering instance %q, node %q: %w", u.ID, u.Node.Name, err)
+			return &DeregisterError{
+				err: fmt.Errorf("error deregistering instance %q, node %q: %w", u.ID, u.Node.Name, err),
+			}
 		}
 	}
 

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -251,7 +251,10 @@ func sortGroups(groupMap map[string]*cloudinstances.CloudInstanceGroup) []string
 //
 // For example, if a cluster is unable to be validated by the deadline, then it
 // is unlikely that it will validate on the next instance roll, so an early exit as a
-// warning to the user is more appropriate.
+// warning to the user is more appropriate. Likewise, if we cannot deregister an
+// instance from cloud load balancers, continuing would leave traffic routed to
+// nodes that are being terminated, so we bail out instead of plowing through
+// the remaining instance groups.
 func isExitableError(err error) bool {
-	return stderrors.Is(err, &ValidationTimeoutError{})
+	return stderrors.Is(err, &ValidationTimeoutError{}) || stderrors.Is(err, &DeregisterError{})
 }

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -198,6 +198,25 @@ func getGroups(k8sClient kubernetes.Interface, cloud awsup.AWSCloud) map[string]
 	return groups
 }
 
+func TestIsExitableError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", fmt.Errorf("boom"), false},
+		{"validation timeout", &ValidationTimeoutError{operation: " after node update", err: fmt.Errorf("x")}, true},
+		{"deregister error", &DeregisterError{err: fmt.Errorf("x")}, true},
+		{"wrapped deregister error", fmt.Errorf("failed to drain node %q: %w", "n", &DeregisterError{err: fmt.Errorf("x")}), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isExitableError(tc.err))
+		})
+	}
+}
+
 func getGroupsAllNeedUpdate(k8sClient kubernetes.Interface, cloud awsup.AWSCloud) map[string]*cloudinstances.CloudInstanceGroup {
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, k8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 3, 3)


### PR DESCRIPTION
Cloud.DeregisterInstance failures were logged but the node-groups loop continued, leaving every worker tainted with kops.k8s.io/scheduled-for-update. Mark these errors exitable so the roll bails out on the first failure.

Fixes #17649

/cc @rifelpet @ameukam 