### PR TITLE
Reject non-http(s) URLs for assets.fileRepository

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -218,6 +218,9 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 		if spec.Assets.ContainerProxy != nil && spec.Assets.ContainerRegistry != nil {
 			allErrs = append(allErrs, field.Forbidden(fieldPath.Child("assets", "containerProxy"), "containerProxy cannot be used in conjunction with containerRegistry"))
 		}
+		if spec.Assets.FileRepository != nil {
+			allErrs = append(allErrs, validateFileRepository(*spec.Assets.FileRepository, fieldPath.Child("assets", "fileRepository"))...)
+		}
 	}
 
 	for i, sysctlParameter := range spec.SysctlParameters {
@@ -762,6 +765,24 @@ func validateFileAssetSpec(v *kops.FileAssetSpec, fieldPath *field.Path) field.E
 	}
 	if v.Content == "" {
 		allErrs = append(allErrs, field.Required(fieldPath.Child("content"), ""))
+	}
+
+	return allErrs
+}
+
+func validateFileRepository(s string, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("cannot parse fileRepository URL: %v", err)))
+		return allErrs
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must be an http:// or https:// URL"))
+	}
+	if u.Host == "" {
+		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must include a host"))
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -2115,3 +2115,41 @@ func TestValidateAzureBlobAccountUniformity(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateFileRepository(t *testing.T) {
+	grid := []struct {
+		Input          string
+		ExpectedErrors []string
+	}{
+		{
+			Input: "https://example.com/files",
+		},
+		{
+			Input: "http://example.com/files",
+		},
+		{
+			Input:          "s3://example-k8s-assets/kops",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
+			Input:          "gs://example-k8s-assets/kops",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
+			Input:          "example.com/files",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
+			Input:          "",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
+			Input:          "https://",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+	}
+	for _, g := range grid {
+		errs := validateFileRepository(g.Input, field.NewPath("spec", "assets", "fileRepository"))
+		testErrors(t, g.Input, errs, g.ExpectedErrors)
+	}
+}


### PR DESCRIPTION
Nodeup uses curl which does not support s3://, so accepting such URLs silently leads to nodes failing to boot. Validate the scheme upfront.

Fixes #16760

/cc @rifelpet 