### PR TITLE
Align instancegroup node label across create cluster/instancegroup

### DIFF
--- a/tests/integration/create_cluster/calico_bpf/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/calico_bpf/expected-v1alpha2.yaml
@@ -74,6 +74,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -92,6 +94,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/cilium-eni/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/cilium-eni/expected-v1alpha2.yaml
@@ -75,6 +75,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -93,6 +95,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
@@ -139,6 +139,8 @@ spec:
   machineType: t2.micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test-1a
@@ -163,6 +165,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -181,6 +185,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1b
   role: Master
   subnets:
   - us-test-1b
@@ -199,6 +205,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1c
   role: Master
   subnets:
   - us-test-1c
@@ -217,6 +225,8 @@ spec:
   machineType: t2.medium
   maxSize: 4
   minSize: 4
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a-1
@@ -236,6 +246,8 @@ spec:
   machineType: t2.medium
   maxSize: 3
   minSize: 3
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1b
   role: Node
   subnets:
   - us-test-1b-2
@@ -254,6 +266,8 @@ spec:
   machineType: t2.medium
   maxSize: 3
   minSize: 3
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1c
   role: Node
   subnets:
   - us-test-1c-3

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -111,6 +111,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -129,6 +131,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1b
   role: Master
   subnets:
   - us-test-1b
@@ -147,6 +151,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1c
   role: Master
   subnets:
   - us-test-1c
@@ -165,6 +171,8 @@ spec:
   machineType: t2.medium
   maxSize: 4
   minSize: 4
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a-1
@@ -184,6 +192,8 @@ spec:
   machineType: t2.medium
   maxSize: 3
   minSize: 3
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1b
   role: Node
   subnets:
   - us-test-1b-2
@@ -202,6 +212,8 @@ spec:
   machineType: t2.medium
   maxSize: 3
   minSize: 3
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1c
   role: Node
   subnets:
   - us-test-1c-3

--- a/tests/integration/create_cluster/different-amis/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/different-amis/expected-v1alpha2.yaml
@@ -78,6 +78,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: apiserver-us-test-1a
   role: APIServer
   subnets:
   - us-test-1a
@@ -96,6 +98,8 @@ spec:
   machineType: t2.micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test-1a
@@ -114,6 +118,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -132,6 +138,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
@@ -70,6 +70,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -90,6 +92,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/gossip-aws/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gossip-aws/expected-v1alpha2.yaml
@@ -71,6 +71,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -89,6 +91,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/gossip-azure/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gossip-azure/expected-v1alpha2.yaml
@@ -74,6 +74,8 @@ spec:
   machineType: Standard_B2s
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-eastus-1
   role: Master
   subnets:
   - gossip.k8s.local
@@ -94,6 +96,8 @@ spec:
   machineType: Standard_B2s
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-eastus-1
   role: Node
   subnets:
   - gossip.k8s.local

--- a/tests/integration/create_cluster/gossip-gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gossip-gce/expected-v1alpha2.yaml
@@ -69,6 +69,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -89,6 +91,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/gossip-hetzner/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gossip-hetzner/expected-v1alpha2.yaml
@@ -66,6 +66,8 @@ spec:
   machineType: cx23
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-fsn1
   role: Master
   subnets:
   - fsn1
@@ -84,6 +86,8 @@ spec:
   machineType: cx23
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-fsn1
   role: Node
   subnets:
   - fsn1

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -91,6 +91,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -109,6 +111,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1b
   role: Master
   subnets:
   - us-test-1b
@@ -127,6 +131,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1c
   role: Master
   subnets:
   - us-test-1c
@@ -145,6 +151,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a
@@ -163,6 +171,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1b
   role: Node
   subnets:
   - us-test-1b
@@ -181,6 +191,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1c
   role: Node
   subnets:
   - us-test-1c

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -91,6 +91,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -109,6 +111,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1b
   role: Master
   subnets:
   - us-test-1b
@@ -127,6 +131,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1c
   role: Master
   subnets:
   - us-test-1c
@@ -145,6 +151,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a
@@ -163,6 +171,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1b
   role: Node
   subnets:
   - us-test-1b
@@ -181,6 +191,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1c
   role: Node
   subnets:
   - us-test-1c

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -77,6 +77,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -97,6 +99,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-b
   role: Master
   subnets:
   - us-test1
@@ -117,6 +121,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-c
   role: Master
   subnets:
   - us-test1
@@ -137,6 +143,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1
@@ -157,6 +165,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1-b
   role: Node
   subnets:
   - us-test1
@@ -177,6 +187,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1-c
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha_hetzner/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_hetzner/expected-v1alpha2.yaml
@@ -75,6 +75,8 @@ spec:
   machineType: cx23
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-fsn1-1
   role: Master
   subnets:
   - fsn1
@@ -93,6 +95,8 @@ spec:
   machineType: cx23
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-fsn1-2
   role: Master
   subnets:
   - fsn1
@@ -111,6 +115,8 @@ spec:
   machineType: cx23
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-fsn1-3
   role: Master
   subnets:
   - fsn1
@@ -129,6 +135,8 @@ spec:
   machineType: cx23
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-fsn1
   role: Node
   subnets:
   - fsn1

--- a/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
@@ -90,6 +90,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-1
   role: Master
   subnets:
   - us-test1
@@ -108,6 +110,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-2
   role: Master
   subnets:
   - us-test1
@@ -126,6 +130,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-3
   role: Master
   subnets:
   - us-test1
@@ -144,6 +150,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha_openstack_nodns/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_nodns/expected-v1alpha2.yaml
@@ -102,6 +102,8 @@ spec:
   machineType: m1.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-1
   role: Master
   subnets:
   - us-test1
@@ -120,6 +122,8 @@ spec:
   machineType: m1.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-2
   role: Master
   subnets:
   - us-test1
@@ -138,6 +142,8 @@ spec:
   machineType: m1.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-3
   role: Master
   subnets:
   - us-test1
@@ -156,6 +162,8 @@ spec:
   machineType: m1.large
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
@@ -100,6 +100,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-1
   role: Master
   subnets:
   - us-test1
@@ -118,6 +120,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-2
   role: Master
   subnets:
   - us-test1
@@ -136,6 +140,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-3
   role: Master
   subnets:
   - us-test1
@@ -154,6 +160,8 @@ spec:
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -83,6 +83,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a-1
   role: Master
   subnets:
   - us-test-1a
@@ -101,6 +103,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a-2
   role: Master
   subnets:
   - us-test-1a
@@ -119,6 +123,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a-3
   role: Master
   subnets:
   - us-test-1a
@@ -137,6 +143,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -99,6 +99,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a-1
   role: Master
   subnets:
   - us-test-1a
@@ -117,6 +119,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a-2
   role: Master
   subnets:
   - us-test-1a
@@ -135,6 +139,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a-3
   role: Master
   subnets:
   - us-test-1a
@@ -153,6 +159,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1b-1
   role: Master
   subnets:
   - us-test-1b
@@ -171,6 +179,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1b-2
   role: Master
   subnets:
   - us-test-1b
@@ -189,6 +199,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a
@@ -207,6 +219,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1b
   role: Node
   subnets:
   - us-test-1b

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -76,6 +76,8 @@ spec:
   machineType: t2.micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test-1a
@@ -94,6 +96,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -112,6 +116,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
@@ -82,6 +82,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - dualstack-us-test-1a
@@ -100,6 +102,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
@@ -86,6 +86,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -102,6 +104,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
   manager: Karpenter
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.31/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.31/expected-v1alpha2.yaml
@@ -71,6 +71,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -89,6 +91,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.32/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.32/expected-v1alpha2.yaml
@@ -71,6 +71,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -89,6 +91,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.35/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.35/expected-v1alpha2.yaml
@@ -71,6 +71,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -89,6 +91,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.36/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.36/expected-v1alpha2.yaml
@@ -71,6 +71,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -89,6 +91,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-arm64/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-arm64/expected-v1alpha2.yaml
@@ -71,6 +71,8 @@ spec:
   machineType: m6g.xlarge
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -89,6 +91,8 @@ spec:
   machineType: m6g.xlarge
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-gce-dns-none/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-gce-dns-none/expected-v1alpha2.yaml
@@ -69,6 +69,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -89,6 +91,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/minimal-gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-gce/expected-v1alpha2.yaml
@@ -69,6 +69,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -89,6 +91,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/minimal-irsa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-irsa/expected-v1alpha2.yaml
@@ -75,6 +75,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -93,6 +95,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal_feature-gates/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal_feature-gates/expected-v1alpha2.yaml
@@ -95,6 +95,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -113,6 +115,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal_hetzner/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal_hetzner/expected-v1alpha2.yaml
@@ -67,6 +67,8 @@ spec:
   machineType: cx23
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-fsn1
   role: Master
   subnets:
   - fsn1
@@ -85,6 +87,8 @@ spec:
   machineType: cx23
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-fsn1
   role: Node
   subnets:
   - fsn1

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -76,6 +76,8 @@ spec:
   machineType: t2.micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test-1a
@@ -94,6 +96,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -112,6 +116,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -74,6 +74,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -92,6 +94,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -79,6 +79,8 @@ spec:
   machineType: t2.micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test-1a
@@ -100,6 +102,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -121,6 +125,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -74,6 +74,8 @@ spec:
   machineType: e2-micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test1
@@ -97,6 +99,8 @@ spec:
   machineType: e2-standard-2
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -120,6 +124,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -78,6 +78,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -96,6 +98,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -73,6 +73,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -91,6 +93,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -73,6 +73,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -91,6 +93,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -72,6 +72,8 @@ spec:
   machineType: m3.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -90,6 +92,8 @@ spec:
   machineType: t2.medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/volume_type/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/volume_type/expected-v1alpha2.yaml
@@ -69,6 +69,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-test1-a
   role: Master
   rootVolumeSize: 32
   rootVolumeType: pd-balanced
@@ -91,6 +93,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   rootVolumeSize: 64
   subnets:

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -587,6 +587,8 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 		if len(g.Spec.Subnets) == 0 {
 			return nil, fmt.Errorf("unable to infer any Subnets for InstanceGroup %s ", g.ObjectMeta.Name)
 		}
+
+		ig.AddInstanceGroupNodeLabel()
 	}
 
 	result := NewClusterResult{


### PR DESCRIPTION
The kops create instancegroup command applies a kops.k8s.io/instancegroup node label so workloads can target a specific instance group via affinity or label selectors. Instance groups generated by kops create cluster did not receive this label, leaving the two code paths inconsistent.

Fixes #16378

/cc @rifelpet 