### PR TITLE
kube-proxy: bind-mount kubeconfig directory instead of the file

### DIFF
--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -203,7 +203,7 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 		container.Args = append(container.Args, sortedStrings(flags)...)
 	}
 	{
-		kubemanifest.AddHostPathMapping(pod, container, "kubeconfig", "/var/lib/kube-proxy/kubeconfig")
+		kubemanifest.AddHostPathMapping(pod, container, "kubeconfig", "/var/lib/kube-proxy")
 		// @note: mapping the host modules directory to fix the missing ipvs kernel module
 		kubemanifest.AddHostPathMapping(pod, container, "modules", "/lib/modules")
 

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
@@ -32,7 +32,7 @@ contents: |
       volumeMounts:
       - mountPath: /var/log/kube-proxy.log
         name: logfile
-      - mountPath: /var/lib/kube-proxy/kubeconfig
+      - mountPath: /var/lib/kube-proxy
         name: kubeconfig
         readOnly: true
       - mountPath: /lib/modules
@@ -53,7 +53,7 @@ contents: |
         path: /var/log/kube-proxy.log
       name: logfile
     - hostPath:
-        path: /var/lib/kube-proxy/kubeconfig
+        path: /var/lib/kube-proxy
       name: kubeconfig
     - hostPath:
         path: /lib/modules

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-amd64.yaml
@@ -32,7 +32,7 @@ contents: |
       volumeMounts:
       - mountPath: /var/log/kube-proxy.log
         name: logfile
-      - mountPath: /var/lib/kube-proxy/kubeconfig
+      - mountPath: /var/lib/kube-proxy
         name: kubeconfig
         readOnly: true
       - mountPath: /lib/modules
@@ -53,7 +53,7 @@ contents: |
         path: /var/log/kube-proxy.log
       name: logfile
     - hostPath:
-        path: /var/lib/kube-proxy/kubeconfig
+        path: /var/lib/kube-proxy
       name: kubeconfig
     - hostPath:
         path: /lib/modules

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-arm64.yaml
@@ -32,7 +32,7 @@ contents: |
       volumeMounts:
       - mountPath: /var/log/kube-proxy.log
         name: logfile
-      - mountPath: /var/lib/kube-proxy/kubeconfig
+      - mountPath: /var/lib/kube-proxy
         name: kubeconfig
         readOnly: true
       - mountPath: /lib/modules
@@ -53,7 +53,7 @@ contents: |
         path: /var/log/kube-proxy.log
       name: logfile
     - hostPath:
-        path: /var/lib/kube-proxy/kubeconfig
+        path: /var/lib/kube-proxy
       name: kubeconfig
     - hostPath:
         path: /lib/modules


### PR DESCRIPTION
A single-file hostPath mount binds to the source inode at mount time, so when something rewrites the kubeconfig the container keeps reading the orphaned inode. Mounting the parent directory matches what kube-scheduler and kube-controller-manager already do.

Fixes #16400

/cc @ameukam @rifelpet 