### PR TITLE
azure: load cloud config from a Secret instead of azure.json

### DIFF
--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -17,7 +17,6 @@ limitations under the License.
 package model
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -28,29 +27,8 @@ import (
 )
 
 const (
-	CloudConfigFilePath      = "/etc/kubernetes/cloud.config"
-	AzureCloudConfigFilePath = "/etc/kubernetes/azure.json"
+	CloudConfigFilePath = "/etc/kubernetes/cloud.config"
 )
-
-// azureCloudConfig is the configuration passed to Cloud Provider Azure.
-// The specification is described in https://cloud-provider-azure.sigs.k8s.io/install/configs/.
-// Field order follows the upstream documentation: auth configs first, then cluster config.
-type azureCloudConfig struct {
-	// Auth configs
-	TenantID                    string `json:"tenantId,omitempty"`
-	SubscriptionID              string `json:"subscriptionId,omitempty"`
-	UseManagedIdentityExtension bool   `json:"useManagedIdentityExtension,omitempty"`
-
-	// Cluster config
-	ResourceGroup               string `json:"resourceGroup,omitempty"`
-	Location                    string `json:"location,omitempty"`
-	VnetName                    string `json:"vnetName,omitempty"`
-	SubnetName                  string `json:"subnetName,omitempty"`
-	RouteTableName              string `json:"routeTableName,omitempty"`
-	SecurityGroupName           string `json:"securityGroupName,omitempty"`
-	UseInstanceMetadata         bool   `json:"useInstanceMetadata,omitempty"`
-	DisableAvailabilitySetNodes bool   `json:"disableAvailabilitySetNodes,omitempty"`
-}
 
 // CloudConfigBuilder creates the cloud configuration file
 type CloudConfigBuilder struct {
@@ -60,9 +38,13 @@ type CloudConfigBuilder struct {
 var _ fi.NodeupModelBuilder = &CloudConfigBuilder{}
 
 func (b *CloudConfigBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	// Azure worker nodes need azure.json for the azuredisk-csi-driver to query
-	// zone information from IMDS, so we always write it regardless of role.
-	if !b.HasAPIServer && b.NodeupConfig.KubeletConfig.CloudProvider == "external" && b.CloudProvider() != kops.CloudProviderAzure {
+	// Azure reads its cloud config from the azure-cloud-provider Secret, so
+	// nodeup does not write a cloud config file for Azure nodes.
+	if b.CloudProvider() == kops.CloudProviderAzure {
+		return nil
+	}
+
+	if !b.HasAPIServer && b.NodeupConfig.KubeletConfig.CloudProvider == "external" {
 		return nil
 	}
 
@@ -75,8 +57,6 @@ func (b *CloudConfigBuilder) build(c *fi.NodeupModelBuilderContext) error {
 
 	cloudProvider := b.CloudProvider()
 
-	var config string
-	requireGlobal := true
 	switch cloudProvider {
 	case kops.CloudProviderGCE:
 		if b.NodeupConfig.NodeTags != nil {
@@ -103,44 +83,10 @@ func (b *CloudConfigBuilder) build(c *fi.NodeupModelBuilderContext) error {
 		}
 	case kops.CloudProviderOpenstack:
 		lines = append(lines, openstack.MakeCloudConfig(b.NodeupConfig.Openstack)...)
-
-	case kops.CloudProviderAzure:
-		requireGlobal = false
-
-		vnetName := b.NodeupConfig.Networking.NetworkID
-		if vnetName == "" {
-			vnetName = b.NodeupConfig.ClusterName
-		}
-
-		c := &azureCloudConfig{
-			// Auth
-			TenantID:                    b.NodeupConfig.AzureTenantID,
-			SubscriptionID:              b.NodeupConfig.AzureSubscriptionID,
-			UseManagedIdentityExtension: true,
-			// Cluster
-			ResourceGroup:               b.NodeupConfig.AzureResourceGroup,
-			Location:                    b.NodeupConfig.AzureLocation,
-			VnetName:                    vnetName,
-			SubnetName:                  b.NodeupConfig.AzureSubnetName,
-			RouteTableName:              b.NodeupConfig.AzureRouteTableName,
-			SecurityGroupName:           b.NodeupConfig.AzureSecurityGroupName,
-			UseInstanceMetadata:         true,
-			DisableAvailabilitySetNodes: true,
-		}
-		data, err := json.Marshal(c)
-		if err != nil {
-			return fmt.Errorf("error marshalling azure config: %s", err)
-		}
-		config = string(data)
 	}
 
-	if requireGlobal {
-		config = "[global]\n" + strings.Join(lines, "\n") + "\n"
-	}
+	config := "[global]\n" + strings.Join(lines, "\n") + "\n"
 	path := CloudConfigFilePath
-	if cloudProvider == kops.CloudProviderAzure {
-		path = AzureCloudConfigFilePath
-	}
 	t := &nodetasks.File{
 		Path:     path,
 		Contents: fi.NewStringResource(config),

--- a/nodeup/pkg/model/cloudconfig_test.go
+++ b/nodeup/pkg/model/cloudconfig_test.go
@@ -17,12 +17,9 @@ limitations under the License.
 package model
 
 import (
-	"encoding/json"
 	"io"
-	"reflect"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/nodeup"
 	"k8s.io/kops/pkg/diff"
@@ -31,42 +28,12 @@ import (
 )
 
 func TestBuildAzure(t *testing.T) {
-	const (
-		subscriptionID    = "subID"
-		tenantID          = "tenantID"
-		resourceGroupName = "test-resource-group"
-		vnetName          = "test-vnet"
-	)
-	cluster := &kops.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "testcluster.test.com",
-		},
-		Spec: kops.ClusterSpec{
-			CloudProvider: kops.CloudProviderSpec{
-				Azure: &kops.AzureSpec{
-					SubscriptionID:    subscriptionID,
-					TenantID:          tenantID,
-					ResourceGroupName: resourceGroupName,
-				},
-			},
-			Networking: kops.NetworkingSpec{
-				NetworkID: vnetName,
-				Subnets: []kops.ClusterSubnetSpec{
-					{
-						Name:   "test-subnet",
-						Region: "eastus",
-					},
-				},
-			},
-			KubeAPIServer: &kops.KubeAPIServerConfig{},
-		},
-	}
-
-	nodeupConfig, bootConfig := nodeup.NewConfig(cluster, &kops.InstanceGroup{})
 	b := &CloudConfigBuilder{
 		NodeupModelContext: &NodeupModelContext{
-			BootConfig:   bootConfig,
-			NodeupConfig: nodeupConfig,
+			BootConfig: &nodeup.BootConfig{
+				CloudProvider: kops.CloudProviderAzure,
+			},
+			NodeupConfig: &nodeup.Config{},
 			HasAPIServer: true,
 		},
 	}
@@ -76,43 +43,12 @@ func TestBuildAzure(t *testing.T) {
 	if err := b.Build(ctx); err != nil {
 		t.Fatalf("unexpected error from Build(): %v", err)
 	}
-	var task *nodetasks.File
+	// Azure reads its cloud config from the azure-cloud-provider Secret, so
+	// nodeup must not write a cloud config file.
 	for _, v := range ctx.Tasks {
 		if f, ok := v.(*nodetasks.File); ok {
-			task = f
-			break
+			t.Errorf("unexpected File task for Azure: %q", f.Path)
 		}
-	}
-	if task == nil {
-		t.Fatalf("no File task found")
-	}
-	r, err := task.Contents.Open()
-	if err != nil {
-		t.Fatalf("unexpected error from task.Contents.Open(): %v", err)
-	}
-	data, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("unexpected error from io.ReadAll(): %v", err)
-	}
-	var actual azureCloudConfig
-	if err := json.Unmarshal(data, &actual); err != nil {
-		t.Fatalf("unexpected error from json.Unmarshal(%q): %v", string(data), err)
-	}
-	expected := azureCloudConfig{
-		SubscriptionID:              subscriptionID,
-		TenantID:                    tenantID,
-		Location:                    "eastus",
-		ResourceGroup:               resourceGroupName,
-		VnetName:                    vnetName,
-		SubnetName:                  "test-subnet",
-		RouteTableName:              cluster.Name,
-		SecurityGroupName:           vnetName,
-		UseInstanceMetadata:         true,
-		UseManagedIdentityExtension: true,
-		DisableAvailabilitySetNodes: true,
-	}
-	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("expected %+v, but got %+v", expected, actual)
 	}
 }
 

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -124,20 +124,6 @@ type Config struct {
 	// Azure-specific
 	// AzureAdminUser is the admin user of VMs.
 	AzureAdminUser string `json:",omitempty"`
-	// AzureLocation is the location of the resource group that the cluster is deployed in.
-	AzureLocation string `json:",omitempty"`
-	// AzureSubscriptionID is the ID of the Azure Subscription that the cluster is deployed in.
-	AzureSubscriptionID string `json:",omitempty"`
-	// AzureTenantID is the ID of the tenant that the cluster is deployed in.
-	AzureTenantID string `json:",omitempty"`
-	// AzureResourceGroup is the name of the resource group that the cluster is deployed in.
-	AzureResourceGroup string `json:",omitempty"`
-	// AzureRouteTableName is the name of the route table attached to the subnet that the cluster is deployed in.
-	AzureRouteTableName string `json:",omitempty"`
-	// AzureSecurityGroupName is the name of the network security group attached to the subnet.
-	AzureSecurityGroupName string `json:",omitempty"`
-	// AzureSubnetName is the name of the subnet that the cluster is deployed in.
-	AzureSubnetName string `json:",omitempty"`
 
 	// GCE-specific
 	Multizone          *bool   `json:"multizone,omitempty"`
@@ -303,13 +289,6 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 	}
 
 	if cluster.Spec.CloudProvider.Azure != nil {
-		config.AzureLocation = cluster.Spec.Networking.Subnets[0].Region
-		config.AzureSubscriptionID = cluster.Spec.CloudProvider.Azure.SubscriptionID
-		config.AzureTenantID = cluster.Spec.CloudProvider.Azure.TenantID
-		config.AzureResourceGroup = cluster.AzureResourceGroupName()
-		config.AzureRouteTableName = cluster.AzureRouteTableName()
-		config.AzureSecurityGroupName = cluster.AzureNetworkSecurityGroupName()
-		config.AzureSubnetName = cluster.Spec.Networking.Subnets[0].Name
 		config.Networking.NetworkID = cluster.Spec.Networking.NetworkID
 		config.AzureAdminUser = cluster.Spec.CloudProvider.Azure.AdminUser
 	}

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_control-plane-eastus-1.masters.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_control-plane-eastus-1.masters.gossip.k8s.local_user_data
@@ -125,7 +125,7 @@ ClusterName: gossip.k8s.local
 ConfigBase: memfs://tests/gossip.k8s.local
 InstanceGroupName: control-plane-eastus-1
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: QL2Nk4zg8bXTTgsk6t2Pr1/3FgmAybCpIEYxtR17XRI=
+NodeupConfigHash: Bkdebayuth7f6WJaFJTruBtdalD0bVdYySFfSCnXosY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_nodes-eastus-1.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_nodes-eastus-1.gossip.k8s.local_user_data
@@ -125,7 +125,7 @@ ClusterName: gossip.k8s.local
 ConfigBase: memfs://tests/gossip.k8s.local
 InstanceGroupName: nodes-eastus-1
 InstanceGroupRole: Node
-NodeupConfigHash: fcsX2QneMy3wdlG7nuf95wCwFlL9I+4hPQqV+ot9TMI=
+NodeupConfigHash: fX5WLvjzmSE+ecKdEQf3gG9RrwrCbFgrgpIhATEso+g=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-config.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-config.addons.k8s.io-k8s-1.31_source
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  cloud-config: eyJzdWJzY3JpcHRpb25JZCI6InN1Yi0xMjMiLCJ1c2VNYW5hZ2VkSWRlbnRpdHlFeHRlbnNpb24iOnRydWUsInJlc291cmNlR3JvdXAiOiJnb3NzaXAuazhzLmxvY2FsIiwibG9jYXRpb24iOiJlYXN0dXMiLCJ2bmV0TmFtZSI6Imdvc3NpcC5rOHMubG9jYWwiLCJzdWJuZXROYW1lIjoiZ29zc2lwLms4cy5sb2NhbCIsInJvdXRlVGFibGVOYW1lIjoiZ29zc2lwLms4cy5sb2NhbCIsInNlY3VyaXR5R3JvdXBOYW1lIjoiZ29zc2lwLms4cy5sb2NhbCIsInVzZUluc3RhbmNlTWV0YWRhdGEiOnRydWUsImRpc2FibGVBdmFpbGFiaWxpdHlTZXROb2RlcyI6dHJ1ZX0=
+kind: Secret
+metadata:
+  labels:
+    addon.kops.k8s.io/name: azure-cloud-config.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: azure-cloud-config.addons.k8s.io
+  name: azure-cloud-provider
+  namespace: kube-system

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
@@ -251,12 +251,14 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=false
-        - --cloud-config=/etc/kubernetes/azure.json
+        - --cloud-config=
+        - --cloud-config-secret-name=azure-cloud-provider
         - --cloud-provider=azure
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=gossip.k8s.local
         - --configure-cloud-routes=false
         - --controllers=*,-cloud-node
+        - --enable-dynamic-reloading=true
         - --leader-elect=true
         - --route-reconciliation-period=10s
         - --secure-port=10268

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source
@@ -896,11 +896,11 @@ spec:
         - --drivername=disk.csi.azure.com
         - --volume-attach-limit=-1
         - --reserved-data-disk-slot-num=0
-        - --cloud-config-secret-name=
-        - --cloud-config-secret-namespace=
+        - --cloud-config-secret-name=azure-cloud-provider
+        - --cloud-config-secret-namespace=kube-system
         - --custom-user-agent=
         - --user-agent-suffix=kops
-        - --allow-empty-cloud-config=true
+        - --allow-empty-cloud-config=false
         - --support-zone=true
         - --get-node-info-from-labels=false
         - --get-nodeid-from-imds=false

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
@@ -78,6 +78,12 @@ spec:
     selector:
       k8s-addon: storage-azure.addons.k8s.io
   - id: k8s-1.31
+    manifest: azure-cloud-config.addons.k8s.io/k8s-1.31.yaml
+    manifestHash: 94a40383b09b2f704497ec467f84635949abed8d5c2035311f86a3d34287894b
+    name: azure-cloud-config.addons.k8s.io
+    selector:
+      k8s-addon: azure-cloud-config.addons.k8s.io
+  - id: k8s-1.31
     manifest: azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml
     manifestHash: 8315b2eaff1a40b104ebd339f20f51104022a23e3fe97396700371e446e26f14
     name: azure-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
@@ -91,7 +91,7 @@ spec:
       k8s-addon: azure-cloud-controller.addons.k8s.io
   - id: k8s-1.31
     manifest: azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml
-    manifestHash: c8ce61445026fcc09d8a38f14916975baa1e577a2d1ad0cf1a4325f6e1636d06
+    manifestHash: c4e39eea11e49c4ae1dbf981e9d98256de3183c496becbb1f175306a6c354eb3
     name: azuredisk-csi-driver.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
@@ -85,7 +85,7 @@ spec:
       k8s-addon: azure-cloud-config.addons.k8s.io
   - id: k8s-1.31
     manifest: azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml
-    manifestHash: 8315b2eaff1a40b104ebd339f20f51104022a23e3fe97396700371e446e26f14
+    manifestHash: 539bf5e117db1a903ff8c4dae393b197f140cc57b003687a91aa8e5b3d17b3f4
     name: azure-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: azure-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source
@@ -71,12 +71,6 @@ Assets:
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
   - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 AzureAdminUser: kops
-AzureLocation: eastus
-AzureResourceGroup: gossip.k8s.local
-AzureRouteTableName: gossip.k8s.local
-AzureSecurityGroupName: gossip.k8s.local
-AzureSubnetName: gossip.k8s.local
-AzureSubscriptionID: sub-123
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-nodes-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-nodes-eastus-1_source
@@ -16,12 +16,6 @@ Assets:
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
   - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 AzureAdminUser: kops
-AzureLocation: eastus
-AzureResourceGroup: gossip.k8s.local
-AzureRouteTableName: gossip.k8s.local
-AzureSecurityGroupName: gossip.k8s.local
-AzureSubnetName: gossip.k8s.local
-AzureSubscriptionID: sub-123
 CAs:
   kubernetes-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/gossip-azure/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-azure/kubernetes.tf
@@ -511,6 +511,15 @@ resource "azurerm_storage_blob" "etcd-cluster-spec-main" {
   type                   = "Block"
 }
 
+resource "azurerm_storage_blob" "gossip-k8s-local-addons-azure-cloud-config-addons-k8s-io-k8s-1-31" {
+  name                   = "tests/gossip.k8s.local/addons/azure-cloud-config.addons.k8s.io/k8s-1.31.yaml"
+  provider               = azurerm.files
+  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-config.addons.k8s.io-k8s-1.31_source"
+  storage_account_name   = "teststorage"
+  storage_container_name = "testcontainer"
+  type                   = "Block"
+}
+
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-azure-cloud-controller-addons-k8s-io-k8s-1-31" {
   name                   = "tests/gossip.k8s.local/addons/azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml"
   provider               = azurerm.files

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_linux_virtual_machine_scale_set_control-plane-eastus-1.masters.minimal-azure.example.com_user_data
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_linux_virtual_machine_scale_set_control-plane-eastus-1.masters.minimal-azure.example.com_user_data
@@ -125,7 +125,7 @@ ClusterName: minimal-azure.example.com
 ConfigBase: memfs://tests/minimal-azure.example.com
 InstanceGroupName: control-plane-eastus-1
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: QtWOspW5CKZN+RaH3kMJl7MhOzLjkAGbLsWQl5wEmoc=
+NodeupConfigHash: ArT6oTKT9I1cpBa76vvccA1Wpmcui6fvM7HK25IPvWI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_linux_virtual_machine_scale_set_nodes.minimal-azure.example.com_user_data
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_linux_virtual_machine_scale_set_nodes.minimal-azure.example.com_user_data
@@ -148,7 +148,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal-azure.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: zEPsuZ/dS0S1DKOCx6k664pxqEVGq7XpVY1UJ0LRI4w=
+NodeupConfigHash: t9NlqI7fpF4IXWOst+ioE5d+/qY6fFiYQcTyKHQsoTI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-config.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-config.addons.k8s.io-k8s-1.31_source
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  cloud-config: eyJ0ZW5hbnRJZCI6InRlbmFudC0xMjMiLCJzdWJzY3JpcHRpb25JZCI6InN1Yi0xMjMiLCJ1c2VNYW5hZ2VkSWRlbnRpdHlFeHRlbnNpb24iOnRydWUsInJlc291cmNlR3JvdXAiOiJtaW5pbWFsLWF6dXJlLmV4YW1wbGUuY29tIiwibG9jYXRpb24iOiJlYXN0dXMiLCJ2bmV0TmFtZSI6Im1pbmltYWwtYXp1cmUuZXhhbXBsZS5jb20iLCJzdWJuZXROYW1lIjoiZWFzdHVzIiwicm91dGVUYWJsZU5hbWUiOiJtaW5pbWFsLWF6dXJlLmV4YW1wbGUuY29tIiwic2VjdXJpdHlHcm91cE5hbWUiOiJtaW5pbWFsLWF6dXJlLmV4YW1wbGUuY29tIiwidXNlSW5zdGFuY2VNZXRhZGF0YSI6dHJ1ZSwiZGlzYWJsZUF2YWlsYWJpbGl0eVNldE5vZGVzIjp0cnVlfQ==
+kind: Secret
+metadata:
+  labels:
+    addon.kops.k8s.io/name: azure-cloud-config.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: azure-cloud-config.addons.k8s.io
+  name: azure-cloud-provider
+  namespace: kube-system

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
@@ -251,12 +251,14 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=false
-        - --cloud-config=/etc/kubernetes/azure.json
+        - --cloud-config=
+        - --cloud-config-secret-name=azure-cloud-provider
         - --cloud-provider=azure
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-azure.example.com
         - --configure-cloud-routes=false
         - --controllers=*,-cloud-node
+        - --enable-dynamic-reloading=true
         - --leader-elect=true
         - --route-reconciliation-period=10s
         - --secure-port=10268

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source
@@ -896,11 +896,11 @@ spec:
         - --drivername=disk.csi.azure.com
         - --volume-attach-limit=-1
         - --reserved-data-disk-slot-num=0
-        - --cloud-config-secret-name=
-        - --cloud-config-secret-namespace=
+        - --cloud-config-secret-name=azure-cloud-provider
+        - --cloud-config-secret-namespace=kube-system
         - --custom-user-agent=
         - --user-agent-suffix=kops
-        - --allow-empty-cloud-config=true
+        - --allow-empty-cloud-config=false
         - --support-zone=true
         - --get-node-info-from-labels=false
         - --get-nodeid-from-imds=false

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
@@ -79,7 +79,7 @@ spec:
       k8s-addon: azure-cloud-config.addons.k8s.io
   - id: k8s-1.31
     manifest: azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml
-    manifestHash: 26f38431ce9612aea580bbef97498e7d614da9479da0fe200487d713eb4a7be6
+    manifestHash: bc6ea012c9a6fc50042ef36bd3bb5a0e6aa1a9de9b79f518e149e67265970ea0
     name: azure-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: azure-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
@@ -72,6 +72,12 @@ spec:
     selector:
       k8s-addon: storage-azure.addons.k8s.io
   - id: k8s-1.31
+    manifest: azure-cloud-config.addons.k8s.io/k8s-1.31.yaml
+    manifestHash: b5ea88366cababcfd6bd47f48832196bef47beca7f69ab815f9ad8d6ab93186c
+    name: azure-cloud-config.addons.k8s.io
+    selector:
+      k8s-addon: azure-cloud-config.addons.k8s.io
+  - id: k8s-1.31
     manifest: azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml
     manifestHash: 26f38431ce9612aea580bbef97498e7d614da9479da0fe200487d713eb4a7be6
     name: azure-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
@@ -85,7 +85,7 @@ spec:
       k8s-addon: azure-cloud-controller.addons.k8s.io
   - id: k8s-1.31
     manifest: azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml
-    manifestHash: c8ce61445026fcc09d8a38f14916975baa1e577a2d1ad0cf1a4325f6e1636d06
+    manifestHash: c4e39eea11e49c4ae1dbf981e9d98256de3183c496becbb1f175306a6c354eb3
     name: azuredisk-csi-driver.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source
@@ -73,13 +73,6 @@ Assets:
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
   - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 AzureAdminUser: admin-user
-AzureLocation: eastus
-AzureResourceGroup: minimal-azure.example.com
-AzureRouteTableName: minimal-azure.example.com
-AzureSecurityGroupName: minimal-azure.example.com
-AzureSubnetName: eastus
-AzureSubscriptionID: sub-123
-AzureTenantID: tenant-123
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_nodeupconfig-nodes_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_nodeupconfig-nodes_source
@@ -12,13 +12,6 @@ Assets:
   - 88d6e32348c36628c8500a630c6dd4b3cb8c680b1d18dc8d1d19041f67757c6e@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-arm64.tar.gz
   - d6dcab36d1b6af1b72c7f0662e5fcf446a291271ba6006532b95c4144e19d428@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.arm64
 AzureAdminUser: admin-user
-AzureLocation: eastus
-AzureResourceGroup: minimal-azure.example.com
-AzureRouteTableName: minimal-azure.example.com
-AzureSecurityGroupName: minimal-azure.example.com
-AzureSubnetName: eastus
-AzureSubscriptionID: sub-123
-AzureTenantID: tenant-123
 CAs: {}
 ClusterName: minimal-azure.example.com
 Hooks:

--- a/tests/integration/update_cluster/minimal_azure/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_azure/kubernetes.tf
@@ -555,6 +555,15 @@ resource "azurerm_storage_blob" "manifests-static-kube-apiserver-healthcheck" {
   type                   = "Block"
 }
 
+resource "azurerm_storage_blob" "minimal-azure-example-com-addons-azure-cloud-config-addons-k8s-io-k8s-1-31" {
+  name                   = "tests/minimal-azure.example.com/addons/azure-cloud-config.addons.k8s.io/k8s-1.31.yaml"
+  provider               = azurerm.files
+  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-config.addons.k8s.io-k8s-1.31_source"
+  storage_account_name   = "teststorage"
+  storage_container_name = "testcontainer"
+  type                   = "Block"
+}
+
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-azure-cloud-controller-addons-k8s-io-k8s-1-31" {
   name                   = "tests/minimal-azure.example.com/addons/azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml"
   provider               = azurerm.files

--- a/upup/models/cloudup/resources/addons/azure-cloud-config.addons.k8s.io/k8s-1.31.yaml.template
+++ b/upup/models/cloudup/resources/addons/azure-cloud-config.addons.k8s.io/k8s-1.31.yaml.template
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-cloud-provider
+  namespace: kube-system
+data:
+  cloud-config: {{ AzureCloudConfig }}

--- a/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/helm-values.yaml
+++ b/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/helm-values.yaml
@@ -17,6 +17,12 @@ cloudControllerManager:
   clusterCIDR: "{{ .Networking.PodCIDR }}"
   leaderElect: "{{ .ExternalCloudControllerManager.LeaderElection.LeaderElect }}"
   logVerbosity: "{{ .ExternalCloudControllerManager.LogLevel }}"
+  # Load cloud config from the azure-cloud-provider Secret. enableDynamicReloading
+  # activates the Secret code path; without it cloudConfigSecretName is ignored.
+  # cloudConfig must be empty or a non-empty --cloud-config path wins over the Secret.
+  cloudConfig: ""
+  cloudConfigSecretName: "azure-cloud-provider"
+  enableDynamicReloading: "true"
 
 cloudNodeManager:
   # Overridden by kustomize patch.

--- a/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml.template
+++ b/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml.template
@@ -209,12 +209,15 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=false
-        - --cloud-config=/etc/kubernetes/azure.json
+        - --cloud-config=
+        - --cloud-config-secret-name=azure-cloud-provider
         - --cloud-provider=azure
         - --cluster-cidr={{ .Networking.PodCIDR }}
         - --cluster-name={{ ClusterName }}
-        - --configure-cloud-routes={{ WithDefaultBool .ExternalCloudControllerManager.ConfigureCloudRoutes false }}
+        - --configure-cloud-routes={{ WithDefaultBool .ExternalCloudControllerManager.ConfigureCloudRoutes
+          false }}
         - --controllers=*,-cloud-node
+        - --enable-dynamic-reloading=true
         - --leader-elect={{ .ExternalCloudControllerManager.LeaderElection.LeaderElect
           }}
         - --route-reconciliation-period=10s

--- a/upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io/helm-values.yaml
+++ b/upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io/helm-values.yaml
@@ -3,9 +3,7 @@
 #   cd upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io
 #   ./regenerate.sh
 #
-# Note: No kops-specific patches are needed. The driver finds the cloud config
-# at /etc/kubernetes/azure.json (its default path) on all nodes.
-# Node pods query IMDS for zone info via the cloud config (UseInstanceMetadata: true).
+# Note: the controller and node load cloud config from the azure-cloud-provider Secret.
 #
 # Note: StorageClass is managed separately via storage-azure.addons.k8s.io
 
@@ -22,8 +20,9 @@ linux:
   hostNetwork: true
 
 node:
-  cloudConfigSecretName: ""
-  cloudConfigSecretNamespace: ""
+  # cloudConfigSecretName/Namespace inherit the chart defaults (azure-cloud-provider
+  # in kube-system). allowEmptyCloudConfig=false makes the node restart until it exists.
+  allowEmptyCloudConfig: false
 
 windows:
   enabled: false

--- a/upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml.template
+++ b/upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml.template
@@ -824,11 +824,11 @@ spec:
         - --drivername=disk.csi.azure.com
         - --volume-attach-limit=-1
         - --reserved-data-disk-slot-num=0
-        - --cloud-config-secret-name=
-        - --cloud-config-secret-namespace=
+        - --cloud-config-secret-name=azure-cloud-provider
+        - --cloud-config-secret-namespace=kube-system
         - --custom-user-agent=
         - --user-agent-suffix=kops
-        - --allow-empty-cloud-config=true
+        - --allow-empty-cloud-config=false
         - --support-zone=true
         - --get-node-info-from-labels=false
         - --get-nodeid-from-imds=false

--- a/upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io/regenerate.sh
+++ b/upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io/regenerate.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # Regenerate k8s-1.31.yaml.template from the upstream azuredisk-csi-driver
-# Helm chart. No kops-specific patches; the driver uses the default cloud
-# config path (/etc/kubernetes/azure.json) and reads zone info from IMDS.
+# Helm chart. Chart version is pinned in kustomization.yaml; kops overrides
+# are in helm-values.yaml.
 set -euo pipefail
 cd "$(dirname "$0")"
 

--- a/upup/pkg/fi/cloudup/azure/cloudconfig.go
+++ b/upup/pkg/fi/cloudup/azure/cloudconfig.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"fmt"
+
+	"k8s.io/kops/pkg/apis/kops"
+)
+
+// CloudConfig is the cloud provider configuration consumed by the Azure
+// cloud-controller-manager and the Azure CSI drivers. The schema is documented
+// at https://cloud-provider-azure.sigs.k8s.io/install/configs/.
+type CloudConfig struct {
+	// Auth config
+	TenantID                    string `json:"tenantId,omitempty"`
+	SubscriptionID              string `json:"subscriptionId,omitempty"`
+	UseManagedIdentityExtension bool   `json:"useManagedIdentityExtension,omitempty"`
+
+	// Cluster config
+	ResourceGroup               string `json:"resourceGroup,omitempty"`
+	Location                    string `json:"location,omitempty"`
+	VnetName                    string `json:"vnetName,omitempty"`
+	SubnetName                  string `json:"subnetName,omitempty"`
+	RouteTableName              string `json:"routeTableName,omitempty"`
+	SecurityGroupName           string `json:"securityGroupName,omitempty"`
+	UseInstanceMetadata         bool   `json:"useInstanceMetadata,omitempty"`
+	DisableAvailabilitySetNodes bool   `json:"disableAvailabilitySetNodes,omitempty"`
+}
+
+// BuildCloudConfig assembles the Azure cloud provider configuration for a
+// cluster. kOps publishes the result in the azure-cloud-provider Secret, which
+// the cloud-controller-manager and CSI drivers load via the
+// --cloud-config-secret-name flag.
+func BuildCloudConfig(cluster *kops.Cluster) (*CloudConfig, error) {
+	azure := cluster.Spec.CloudProvider.Azure
+	if azure == nil {
+		return nil, fmt.Errorf("cluster is not an Azure cluster")
+	}
+
+	subnets := cluster.Spec.Networking.Subnets
+	if len(subnets) == 0 {
+		return nil, fmt.Errorf("cluster has no subnets")
+	}
+
+	// In kOps the virtual network and the network security group share a name.
+	networkName := cluster.AzureNetworkSecurityGroupName()
+
+	return &CloudConfig{
+		TenantID:                    azure.TenantID,
+		SubscriptionID:              azure.SubscriptionID,
+		UseManagedIdentityExtension: true,
+		ResourceGroup:               cluster.AzureResourceGroupName(),
+		Location:                    subnets[0].Region,
+		VnetName:                    networkName,
+		SubnetName:                  subnets[0].Name,
+		RouteTableName:              cluster.AzureRouteTableName(),
+		SecurityGroupName:           networkName,
+		UseInstanceMetadata:         true,
+		DisableAvailabilitySetNodes: true,
+	}, nil
+}

--- a/upup/pkg/fi/cloudup/azure/cloudconfig_test.go
+++ b/upup/pkg/fi/cloudup/azure/cloudconfig_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kops/pkg/apis/kops"
+)
+
+func TestBuildCloudConfig(t *testing.T) {
+	grid := []struct {
+		name     string
+		cluster  *kops.Cluster
+		expected CloudConfig
+	}{
+		{
+			name: "owned resources default to the cluster name",
+			cluster: &kops.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test.k8s.local"},
+				Spec: kops.ClusterSpec{
+					CloudProvider: kops.CloudProviderSpec{
+						Azure: &kops.AzureSpec{
+							SubscriptionID: "sub-id",
+							TenantID:       "tenant-id",
+						},
+					},
+					Networking: kops.NetworkingSpec{
+						Subnets: []kops.ClusterSubnetSpec{
+							{Name: "subnet-a", Region: "eastus"},
+						},
+					},
+				},
+			},
+			expected: CloudConfig{
+				TenantID:                    "tenant-id",
+				SubscriptionID:              "sub-id",
+				UseManagedIdentityExtension: true,
+				ResourceGroup:               "test.k8s.local",
+				Location:                    "eastus",
+				VnetName:                    "test.k8s.local",
+				SubnetName:                  "subnet-a",
+				RouteTableName:              "test.k8s.local",
+				SecurityGroupName:           "test.k8s.local",
+				UseInstanceMetadata:         true,
+				DisableAvailabilitySetNodes: true,
+			},
+		},
+		{
+			name: "shared resources use the configured names",
+			cluster: &kops.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test.k8s.local"},
+				Spec: kops.ClusterSpec{
+					CloudProvider: kops.CloudProviderSpec{
+						Azure: &kops.AzureSpec{
+							SubscriptionID:    "sub-id",
+							TenantID:          "tenant-id",
+							ResourceGroupName: "shared-rg",
+							RouteTableName:    "shared-rt",
+						},
+					},
+					Networking: kops.NetworkingSpec{
+						NetworkID: "shared-vnet",
+						Subnets: []kops.ClusterSubnetSpec{
+							{Name: "subnet-a", Region: "westus2"},
+						},
+					},
+				},
+			},
+			expected: CloudConfig{
+				TenantID:                    "tenant-id",
+				SubscriptionID:              "sub-id",
+				UseManagedIdentityExtension: true,
+				ResourceGroup:               "shared-rg",
+				Location:                    "westus2",
+				VnetName:                    "shared-vnet",
+				SubnetName:                  "subnet-a",
+				RouteTableName:              "shared-rt",
+				SecurityGroupName:           "shared-vnet",
+				UseInstanceMetadata:         true,
+				DisableAvailabilitySetNodes: true,
+			},
+		},
+	}
+	for _, g := range grid {
+		t.Run(g.name, func(t *testing.T) {
+			config, err := BuildCloudConfig(g.cluster)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if *config != g.expected {
+				t.Errorf("unexpected cloud config:\n got: %+v\nwant: %+v", *config, g.expected)
+			}
+		})
+	}
+}
+
+func TestBuildCloudConfigErrors(t *testing.T) {
+	grid := []struct {
+		name    string
+		cluster *kops.Cluster
+	}{
+		{
+			name: "not an Azure cluster",
+			cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					Networking: kops.NetworkingSpec{
+						Subnets: []kops.ClusterSubnetSpec{{Name: "subnet-a", Region: "eastus"}},
+					},
+				},
+			},
+		},
+		{
+			name: "cluster has no subnets",
+			cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					CloudProvider: kops.CloudProviderSpec{Azure: &kops.AzureSpec{}},
+				},
+			},
+		},
+	}
+	for _, g := range grid {
+		t.Run(g.name, func(t *testing.T) {
+			if _, err := BuildCloudConfig(g.cluster); err == nil {
+				t.Errorf("expected an error, got none")
+			}
+		})
+	}
+}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -773,6 +773,18 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 
 	if b.Cluster.IsKubernetesGTE("1.31") && b.Cluster.GetCloudProvider() == kops.CloudProviderAzure {
 		{
+			key := "azure-cloud-config.addons.k8s.io"
+			id := "k8s-1.31"
+			location := key + "/" + id + ".yaml"
+
+			addons.Add(&channelsapi.AddonSpec{
+				Name:     fi.PtrTo(key),
+				Selector: map[string]string{"k8s-addon": key},
+				Manifest: fi.PtrTo(location),
+				Id:       id,
+			})
+		}
+		{
 			key := "azure-cloud-controller.addons.k8s.io"
 			id := "k8s-1.31"
 			location := key + "/" + id + ".yaml"
@@ -784,9 +796,6 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 				Id:       id,
 			})
 		}
-	}
-
-	if b.Cluster.IsKubernetesGTE("1.31") && b.Cluster.GetCloudProvider() == kops.CloudProviderAzure {
 		{
 			key := "azuredisk-csi-driver.addons.k8s.io"
 			id := "k8s-1.31"

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -163,6 +163,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["DnsControllerArgv"] = tf.DNSControllerArgv
 	dest["ExternalDnsArgv"] = tf.ExternalDNSArgv
 	dest["CloudControllerConfigArgv"] = tf.CloudControllerConfigArgv
+	dest["AzureCloudConfig"] = tf.AzureCloudConfig
 	// TODO: Only for GCE?
 	dest["EncodeGCELabel"] = gce.EncodeGCELabel
 	dest["Region"] = func() string {
@@ -560,6 +561,21 @@ func (tf *TemplateFunctions) CloudControllerConfigArgv() ([]string, error) {
 	}
 
 	return argv, nil
+}
+
+// AzureCloudConfig returns the base64-encoded Azure cloud provider
+// configuration. kOps publishes it in the azure-cloud-provider Secret, which the
+// cloud-controller-manager and CSI drivers load via --cloud-config-secret-name.
+func (tf *TemplateFunctions) AzureCloudConfig() (string, error) {
+	config, err := azure.BuildCloudConfig(tf.Cluster)
+	if err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", fmt.Errorf("marshaling Azure cloud config: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(data), nil
 }
 
 // DNSControllerArgv returns the args to the DNS controller

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -555,7 +555,7 @@ func (tf *TemplateFunctions) CloudControllerConfigArgv() ([]string, error) {
 	case kops.CloudProviderHetzner:
 		// Hetzner does not use cloud config.
 	case kops.CloudProviderAzure:
-		argv = append(argv, "--cloud-config=/etc/kubernetes/azure.json")
+		// Azure reads its cloud config from the azure-cloud-provider Secret.
 	default:
 		argv = append(argv, "--cloud-config=/etc/kubernetes/cloud.config")
 	}


### PR DESCRIPTION
The Azure cloud-controller-manager and azuredisk CSI driver read their cloud configuration from /etc/kubernetes/azure.json, a file kOps writes on every node via nodeup. This moves that configuration into the azure-cloud-provider Kubernetes Secret, built cluster-side from the cluster spec and published by a new azure-cloud-config addon, so it becomes a single cluster-managed object instead of a per-node file, and matches the upstream Helm-chart conventions for both projects.

CCM and the CSI driver (controller + node) now load config from the Secret; those addon changes go through helm-values.yaml and regenerate.sh. nodeup no longer writes the file or passes --cloud-config for Azure, and the now-unused NodeupConfig fields are removed. The components are configured to exit and restart until the Secret exists (enableDynamicReloading for CCM, allowEmptyCloudConfig=false for CSI) rather than silently starting with empty cloud config.

/cc @rifelpet @ameukam 

Assisted by Claude Opus