### PR TITLE
e2e: trim job name

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -401,11 +401,16 @@ func (d *deployer) defaultClusterName() (string, error) {
 		suffix = "k8s.local"
 	}
 
-	if len(jobName) > 79 { // SNS has char limit of 80
+	// Most pull request jobs have the "pull-" prefix.
+	jobName = strings.TrimPrefix(jobName, "pull-")
+
+	// SNS has char limit of 80
+	if len(jobName) > 79 {
 		jobName = jobName[:79]
 	}
+
 	if jobType == "presubmit" {
-		jobName = fmt.Sprintf("e2e-pr%s.%s", pullNumber, jobName)
+		jobName = fmt.Sprintf("pr%s-%s", pullNumber, jobName)
 	} else {
 		jobName = fmt.Sprintf("e2e-%s", jobName)
 	}


### PR DESCRIPTION
Job name gets pulled into becoming the cluster name. It becomes quite long when building the resource names.

Example:
```
W0515 12:47:38.815987   50734 executor.go:141] error running task "VMScaleSet/control-plane-uksouth-1-2.masters.e2e-pr18345.pull-kops-azure-upgrade-gossip.k8s.local" (8m37s remaining to succeed): creating/updating VMSS: PUT https://management.azure.com/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/e2e-pr18345.pull-kops-azure-upgrade-gossip.k8s.local/providers/Microsoft.Compute/virtualMachineScaleSets/control-plane-uksouth-1-2.masters.e2e-pr18345.pull-kops-azure-upgrade-gossip.k8s.local
--------------------------------------------------------------------------------
RESPONSE 400: 400 Bad Request
ERROR CODE: InvalidParameter
--------------------------------------------------------------------------------
{
  "error": {
    "code": "InvalidParameter",
    "message": "The entity name 'vmScaleSetName' is invalid according to its validation rule: ^[^_\\W][\\w-._]{0,79}(?<![-.])$.",
    "target": "vmScaleSetName"
  }
}
```

/cc @rifelpet 