### PR TITLE
Remove the unused in-tree cloud config

### DIFF
--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -28,12 +28,8 @@ import (
 )
 
 const (
-	CloudConfigFilePath       = "/etc/kubernetes/cloud.config"
-	AzureCloudConfigFilePath  = "/etc/kubernetes/azure.json"
-	InTreeCloudConfigFilePath = "/etc/kubernetes/in-tree-cloud.config"
-
-	// VM UUID is set by cloud-init
-	VM_UUID_FILE_PATH = "/etc/vmware/vm_uuid"
+	CloudConfigFilePath      = "/etc/kubernetes/cloud.config"
+	AzureCloudConfigFilePath = "/etc/kubernetes/azure.json"
 )
 
 // azureCloudConfig is the configuration passed to Cloud Provider Azure.
@@ -70,16 +66,10 @@ func (b *CloudConfigBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		return nil
 	}
 
-	if err := b.build(c, true); err != nil {
-		return err
-	}
-	if err := b.build(c, false); err != nil {
-		return err
-	}
-	return nil
+	return b.build(c)
 }
 
-func (b *CloudConfigBuilder) build(c *fi.NodeupModelBuilderContext, inTree bool) error {
+func (b *CloudConfigBuilder) build(c *fi.NodeupModelBuilderContext) error {
 	// Add cloud config file if needed
 	var lines []string
 
@@ -108,10 +98,8 @@ func (b *CloudConfigBuilder) build(c *fi.NodeupModelBuilderContext, inTree bool)
 		if b.NodeupConfig.NLBSecurityGroupMode != nil {
 			lines = append(lines, "NLBSecurityGroupMode = "+*b.NodeupConfig.NLBSecurityGroupMode)
 		}
-		if !inTree {
-			for _, family := range b.NodeupConfig.NodeIPFamilies {
-				lines = append(lines, "NodeIPFamilies = "+family)
-			}
+		for _, family := range b.NodeupConfig.NodeIPFamilies {
+			lines = append(lines, "NodeIPFamilies = "+family)
 		}
 	case kops.CloudProviderOpenstack:
 		lines = append(lines, openstack.MakeCloudConfig(b.NodeupConfig.Openstack)...)
@@ -150,9 +138,7 @@ func (b *CloudConfigBuilder) build(c *fi.NodeupModelBuilderContext, inTree bool)
 		config = "[global]\n" + strings.Join(lines, "\n") + "\n"
 	}
 	path := CloudConfigFilePath
-	if inTree {
-		path = InTreeCloudConfigFilePath
-	} else if cloudProvider == kops.CloudProviderAzure {
+	if cloudProvider == kops.CloudProviderAzure {
 		path = AzureCloudConfigFilePath
 	}
 	t := &nodetasks.File{

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -628,10 +628,6 @@ func (b *KubeAPIServerBuilder) buildPod(ctx context.Context, kubeAPIServer *kops
 		return nil, fmt.Errorf("error building kube-apiserver flags: %v", err)
 	}
 
-	if b.IsKubernetesLT("1.33") {
-		flags = append(flags, fmt.Sprintf("--cloud-config=%s", InTreeCloudConfigFilePath))
-	}
-
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -786,8 +782,6 @@ func (b *KubeAPIServerBuilder) buildPod(ctx context.Context, kubeAPIServer *kops
 		name := strings.ReplaceAll(path, "/", "")
 		kubemanifest.AddHostPathMapping(pod, container, name, path)
 	}
-
-	kubemanifest.AddHostPathMapping(pod, container, "cloudconfig", InTreeCloudConfigFilePath)
 
 	kubemanifest.AddHostPathMapping(pod, container, "kubernetesca", filepath.Join(b.PathSrvKubernetes(), "ca.crt"))
 

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -151,8 +151,6 @@ func (b *KubeControllerManagerBuilder) buildPod(kcm *kops.KubeControllerManagerC
 		return nil, fmt.Errorf("error building kube-controller-manager flags: %v", err)
 	}
 
-	flags = append(flags, "--cloud-config="+InTreeCloudConfigFilePath)
-
 	// Add kubeconfig flags
 	for _, flag := range []string{"", "authentication-", "authorization-"} {
 		flags = append(flags, "--"+flag+"kubeconfig="+"/var/lib/kube-controller-manager/kubeconfig")
@@ -264,8 +262,6 @@ func (b *KubeControllerManagerBuilder) buildPod(kcm *kops.KubeControllerManagerC
 		name := strings.ReplaceAll(path, "/", "")
 		kubemanifest.AddHostPathMapping(pod, container, name, path)
 	}
-
-	kubemanifest.AddHostPathMapping(pod, container, "cloudconfig", InTreeCloudConfigFilePath)
 
 	kubemanifest.AddHostPathMapping(pod, container, "cabundle", filepath.Join(b.PathSrvKubernetes(), "ca.crt"))
 

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -465,13 +465,6 @@ func (b *KubeletBuilder) buildSystemdEnvironmentFile(ctx context.Context, kubele
 		return nil, fmt.Errorf("error building kubelet flags: %v", err)
 	}
 
-	// We build this flag differently because it depends on CloudConfig, and to expose it directly
-	// would be a degree of freedom we don't have (we'd have to write the config to different files)
-	// We can always add this later if it is needed.
-	if b.IsKubernetesLT("1.33") {
-		flags += " --cloud-config=" + InTreeCloudConfigFilePath
-	}
-
 	if b.UsesSecondaryIP() {
 		localIP, err := b.GetMetadataLocalIP(ctx)
 		if err != nil {

--- a/nodeup/pkg/model/tests/golden/audit/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/audit/tasks-kube-apiserver.yaml
@@ -127,9 +127,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: kubernetesca
         readOnly: true
@@ -180,9 +177,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: kubernetesca

--- a/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
@@ -141,9 +141,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: kubernetesca
         readOnly: true
@@ -192,9 +189,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: kubernetesca

--- a/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
@@ -119,9 +119,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: kubernetesca
         readOnly: true
@@ -167,9 +164,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: kubernetesca

--- a/nodeup/pkg/model/tests/golden/envvars/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/envvars/tasks-kube-apiserver.yaml
@@ -127,9 +127,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: kubernetesca
         readOnly: true
@@ -175,9 +172,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: kubernetesca

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
@@ -119,9 +119,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: kubernetesca
         readOnly: true
@@ -167,9 +164,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: kubernetesca

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
@@ -16,7 +16,6 @@ contents: |
       - --attach-detach-reconcile-sync-period=1m0s
       - --authentication-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
       - --authorization-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
-      - --cloud-config=/etc/kubernetes/in-tree-cloud.config
       - --cloud-provider=external
       - --cluster-cidr=100.96.0.0/11
       - --cluster-name=minimal.example.com
@@ -77,9 +76,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: cabundle
         readOnly: true
@@ -127,9 +123,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: cabundle

--- a/nodeup/pkg/model/tests/golden/oidc/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/oidc/tasks-kube-apiserver.yaml
@@ -131,9 +131,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: kubernetesca
         readOnly: true
@@ -179,9 +176,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: kubernetesca

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
@@ -119,9 +119,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: kubernetesca
         readOnly: true
@@ -167,9 +164,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: kubernetesca

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
@@ -119,9 +119,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: kubernetesca
         readOnly: true
@@ -167,9 +164,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: kubernetesca

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
@@ -16,7 +16,6 @@ contents: |
       - --attach-detach-reconcile-sync-period=1m0s
       - --authentication-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
       - --authorization-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
-      - --cloud-config=/etc/kubernetes/in-tree-cloud.config
       - --cloud-provider=external
       - --cluster-cidr=100.96.0.0/11
       - --cluster-name=minimal.example.com
@@ -77,9 +76,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: cabundle
         readOnly: true
@@ -127,9 +123,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: cabundle

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
@@ -16,7 +16,6 @@ contents: |
       - --attach-detach-reconcile-sync-period=1m0s
       - --authentication-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
       - --authorization-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
-      - --cloud-config=/etc/kubernetes/in-tree-cloud.config
       - --cloud-provider=external
       - --cluster-cidr=100.96.0.0/11
       - --cluster-name=minimal.example.com
@@ -77,9 +76,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: cabundle
         readOnly: true
@@ -127,9 +123,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: cabundle

--- a/nodeup/pkg/model/tests/golden/without-etcd-events/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/without-etcd-events/tasks-kube-apiserver.yaml
@@ -118,9 +118,6 @@ contents: |
       - mountPath: /etc/openssl
         name: etcopenssl
         readOnly: true
-      - mountPath: /etc/kubernetes/in-tree-cloud.config
-        name: cloudconfig
-        readOnly: true
       - mountPath: /srv/kubernetes/ca.crt
         name: kubernetesca
         readOnly: true
@@ -166,9 +163,6 @@ contents: |
     - hostPath:
         path: /etc/openssl
       name: etcopenssl
-    - hostPath:
-        path: /etc/kubernetes/in-tree-cloud.config
-      name: cloudconfig
     - hostPath:
         path: /srv/kubernetes/ca.crt
       name: kubernetesca

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--cloud-provider=external --kubeconfig=/var/lib/kubelet/kubeconfig --register-schedulable=true --runtime-request-timeout=15m0s --v=2 --cloud-config=/etc/kubernetes/in-tree-cloud.config --config=/var/lib/kubelet/kubelet.conf --image-credential-provider-config=/var/lib/kubelet/credential-provider.conf --image-credential-provider-bin-dir=/usr/local/bin"
+  DAEMON_ARGS="--cloud-provider=external --kubeconfig=/var/lib/kubelet/kubeconfig --register-schedulable=true --runtime-request-timeout=15m0s --v=2 --config=/var/lib/kubelet/kubelet.conf --image-credential-provider-config=/var/lib/kubelet/credential-provider.conf --image-credential-provider-bin-dir=/usr/local/bin"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file

--- a/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--cloud-provider=external --kubeconfig=/var/lib/kubelet/kubeconfig --register-schedulable=true --runtime-request-timeout=15m0s --v=2 --cloud-config=/etc/kubernetes/in-tree-cloud.config --config=/var/lib/kubelet/kubelet.conf --image-credential-provider-config=/var/lib/kubelet/credential-provider.conf --image-credential-provider-bin-dir=/usr/local/bin"
+  DAEMON_ARGS="--cloud-provider=external --kubeconfig=/var/lib/kubelet/kubeconfig --register-schedulable=true --runtime-request-timeout=15m0s --v=2 --config=/var/lib/kubelet/kubelet.conf --image-credential-provider-config=/var/lib/kubelet/credential-provider.conf --image-credential-provider-bin-dir=/usr/local/bin"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file


### PR DESCRIPTION
kOps sets --cloud-provider=external for every cloud on all supported Kubernetes versions (1.31+), so no in-tree cloud provider is ever initialized. The --cloud-config flag and the in-tree-cloud.config file it points to are read only by an in-tree provider, so they have been a no-op on every supported version.

/cc @rifelpet @ameukam 