### PR TITLE
dump: time out per-node log dumping after one minute

### DIFF
--- a/pkg/dump/dumper.go
+++ b/pkg/dump/dumper.go
@@ -244,6 +244,11 @@ func (d *logDumper) dumpNotRegistered(ctx context.Context, node *resources.Insta
 	return "", fmt.Errorf("no known addresses for node %s", node.Name)
 }
 
+// nodeDumpTimeout bounds the time spent connecting to and dumping a single node.
+// A healthy node dumps in well under a minute. Without this cap, an SSH operation
+// against an unreachable node blocks until the OS TCP timeout (~15 min) expires.
+const nodeDumpTimeout = time.Minute
+
 // DumpNode connects to a node and dumps the logs.
 func (d *logDumper) dumpNode(ctx context.Context, name string, ip string, useBastion bool) error {
 	if ip == "" {
@@ -251,6 +256,9 @@ func (d *logDumper) dumpNode(ctx context.Context, name string, ip string, useBas
 	}
 
 	klog.Infof("Dumping node %s", name)
+
+	ctx, cancel := context.WithTimeout(ctx, nodeDumpTimeout)
+	defer cancel()
 
 	n, err := d.connectToNode(ctx, name, ip, useBastion)
 	if err != nil {


### PR DESCRIPTION
https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/pr-logs/pull/kops/18245/pull-kops-gce-upgrade-gossip/2055391382536720384/
```
I0515 21:43:06.763758   51511 dumper.go:245] Dumping node nodes-us-west1-c-30jl
I0515 21:43:11.583262   51511 dumper.go:245] Dumping node nodes-us-west1-c-5lvq
I0515 21:43:17.498011   51511 dumper.go:245] Dumping node nodes-us-west1-c-k23h
I0515 21:47:32.982137   51490 boskos.go:86] Sending heartbeat to Boskos
I0515 21:52:33.002852   51490 boskos.go:86] Sending heartbeat to Boskos
I0515 21:57:33.050651   51490 boskos.go:86] Sending heartbeat to Boskos
W0515 21:59:50.073979   51511 dumper.go:258] error dumping node nodes-us-west1-c-k23h: error executing command "sudo cat '/var/log/kern.log'": wait: remote command exited without exit status or exit signal
```

/cc @rifelpet @ameukam 