### PR TITLE
e2e: delete upgraded clusters with the new kops binary

### DIFF
--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -58,6 +58,9 @@ fi
 
 # Always tear-down the cluster when we're done
 function kops-finish {
+    # The env file persists the kops binary used for --up. After an A->B upgrade
+    # that is the older binary, so keep the one the test last selected.
+    local down_kops="${KOPS-}"
     # If we failed to start the cluster, we might not have sourced KOPS_STATE_STORE, so try to source it if we have an env file
     if [[ -z "${ENV_FILE-}" ]]; then
         ENV_FILE="${WORKSPACE}/env"
@@ -67,9 +70,12 @@ function kops-finish {
         . "${ENV_FILE}"
         export KOPS_STATE_STORE
     fi
+    if [[ -n "${down_kops}" ]]; then
+        KOPS="${down_kops}"
+    fi
 
     # shellcheck disable=SC2153
-    ${KUBETEST2} --kops-binary-path="${KOPS}" --down || echo "kubetest2 down failed"
+    ${KUBETEST2} --kops-binary-path="${KOPS-}" --down || echo "kubetest2 down failed"
 }
 trap kops-finish EXIT
 


### PR DESCRIPTION
Noticed things that were already fixed during cluster deletion:
https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kops/18245/pull-kops-azure-upgrade-gossip/2055391382440251392/build-log.txt
```
VMScaleSetVM:/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/pr18245-kops-azure-upgrade-gossip.k8s.local/providers/Microsoft.Compute/virtualMachineScaleSets/nodes-uksouth-3.pr18245-kops-azure-upgrade-gossip.k8s.local/virtualMachines/7	error deleting resources, will retry: deleting VMSS VM: DELETE https://management.azure.com/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/pr18245-kops-azure-upgrade-gossip.k8s.local/providers/Microsoft.Compute/virtualMachineScaleSets/nodes-uksouth-3.pr18245-kops-azure-upgrade-gossip.k8s.local/virtualMachines/7
--------------------------------------------------------------------------------
RESPONSE 409: 409 Conflict
ERROR CODE: Conflict
--------------------------------------------------------------------------------
{
  "error": {
    "code": "Conflict",
    "message": "The request failed due to conflict with a concurrent request. To resolve it, please refer to https://aka.ms/activitylog to get more details on the conflicting requests."
  }
}
--------------------------------------------------------------------------------

RouteTable:/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/pr18245-kops-azure-upgrade-gossip.k8s.local/providers/Microsoft.Network/routeTables/pr18245-kops-azure-upgrade-gossip.k8s.local	error deleting resources, will retry: deleting route table: DELETE https://management.azure.com/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/pr18245-kops-azure-upgrade-gossip.k8s.local/providers/Microsoft.Network/routeTables/pr18245-kops-azure-upgrade-gossip.k8s.local
--------------------------------------------------------------------------------
RESPONSE 400: 400 Bad Request
ERROR CODE: InUseRouteTableCannotBeDeleted
--------------------------------------------------------------------------------
{
  "error": {
    "code": "InUseRouteTableCannotBeDeleted",
    "message": "Route table pr18245-kops-azure-upgrade-gossip.k8s.local is in use and cannot be deleted.",
    "details": []
  }
}
--------------------------------------------------------------------------------
```

/cc @rifelpet @ameukam 