### PR TITLE
gce: allow BGP from nodes to control plane for Calico

### DIFF
--- a/pkg/model/awsmodel/firewall.go
+++ b/pkg/model/awsmodel/firewall.go
@@ -324,7 +324,7 @@ func (b *AWSModelContext) GetSecurityGroups(role kops.InstanceGroupRole) ([]Secu
 			"port=" + strconv.Itoa(wellknownports.EtcdMainClientPort),   // etcd main
 			"port=" + strconv.Itoa(wellknownports.EtcdEventsClientPort), // etcd events
 			"port=4789", // VXLAN
-			"port=179",  // Calico
+			"port=" + strconv.Itoa(wellknownports.BGP), // Calico
 			"port=8443", // k8s api secondary listener
 			"port=3:4",  // ICMP
 			"port=-1",   // ICMPv6

--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -148,6 +148,7 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		}
 		if b.NetworkingIsCalico() {
 			t.Allowed = append(t.Allowed, "ipip")
+			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.BGP))
 		}
 		if b.NetworkingIsCilium() {
 			t.Allowed = append(t.Allowed, fmt.Sprintf("udp:%d", wellknownports.VxlanUDP))

--- a/pkg/model/openstackmodel/firewall.go
+++ b/pkg/model/openstackmodel/firewall.go
@@ -528,7 +528,7 @@ func (b *FirewallModelBuilder) addCNIRules(c *fi.CloudupModelBuilderContext, sgM
 	}
 
 	if b.Cluster.Spec.Networking.Calico != nil {
-		tcpPorts = append(tcpPorts, 179)
+		tcpPorts = append(tcpPorts, wellknownports.BGP)
 		protocols = append(protocols, ProtocolIPEncap)
 	}
 

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -20,6 +20,9 @@ const (
 	// KubeAPIServer is the port where kube-apiserver listens.
 	KubeAPIServer = 443
 
+	// BGP is the port used by the BGP routing protocol (Calico node-to-node mesh).
+	BGP = 179
+
 	// EtcdMetricsPort is used to serve etcd metrics
 	EtcdMetricsPort = 2382
 


### PR DESCRIPTION
Allow TCP/179 from nodes to control-plane nodes when Calico is in use, matching the existing AWS and OpenStack firewall models. Also add a wellknownports.BGP constant and use it across the three models.

Should fix flakes noticed in https://github.com/kubernetes/kops/pull/18245#issuecomment-4466643860.

/cc @rifelpet 