### PR TITLE
gossip: restrict seed discovery to control-plane nodes

### DIFF
--- a/protokube/pkg/gossip/aws/seeds.go
+++ b/protokube/pkg/gossip/aws/seeds.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"k8s.io/kops/protokube/pkg/gossip"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )
 
 type SeedProvider struct {
@@ -47,6 +48,11 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 	request.Filters = append(request.Filters, ec2types.Filter{
 		Name:   aws.String("instance-state-name"),
 		Values: []string{"running", "pending"},
+	})
+	// Seed only from control-plane nodes; workers do not run gossip.
+	request.Filters = append(request.Filters, ec2types.Filter{
+		Name:   aws.String("tag-key"),
+		Values: []string{awsup.TagNameRolePrefix + awsup.TagRoleControlPlane},
 	})
 
 	var seeds []string

--- a/protokube/pkg/gossip/azure/seed.go
+++ b/protokube/pkg/gossip/azure/seed.go
@@ -23,7 +23,9 @@ import (
 	compute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/protokube/pkg/gossip"
+	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 )
 
 type client interface {
@@ -61,7 +63,8 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 
 	var vmssNames []string
 	for _, vmss := range vmsses {
-		if p.isVMSSForCluster(vmss) {
+		// Seed only from control-plane nodes; workers do not run gossip.
+		if p.isVMSSForCluster(vmss) && isControlPlaneVMSS(vmss) {
 			vmssNames = append(vmssNames, *vmss.Name)
 		}
 	}
@@ -97,4 +100,13 @@ func (p *SeedProvider) isVMSSForCluster(vmss *compute.VirtualMachineScaleSet) bo
 	}
 	// TODO(kenji): Filter by ProvisioningState if necessary.
 	return found == len(p.tags)
+}
+
+// isControlPlaneVMSS reports whether the scale set hosts control-plane nodes.
+func isControlPlaneVMSS(vmss *compute.VirtualMachineScaleSet) bool {
+	// VMSS carry the "control-plane" role tag; azure.TagRoleControlPlane
+	// ("control_plane") is a different spelling, used for disk tags.
+	controlPlaneRoleTag := azure.TagNameRolePrefix + kops.InstanceGroupRoleControlPlane.ToLowerString()
+	_, ok := vmss.Tags[controlPlaneRoleTag]
+	return ok
 }

--- a/protokube/pkg/gossip/azure/seed_test.go
+++ b/protokube/pkg/gossip/azure/seed_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	compute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 )
 
 type mockClient struct {
@@ -59,32 +60,45 @@ func newTestInterfaces(ip string) []*network.Interface {
 
 func TestGetSeeds(t *testing.T) {
 	const (
-		clusterTag  = "KubernetesCluster"
-		clusterName = "test-cluster"
+		clusterTag      = "KubernetesCluster"
+		clusterName     = "test-cluster"
+		controlPlaneTag = azure.TagNameRolePrefix + "control-plane"
+		nodeTag         = azure.TagNameRolePrefix + "node"
 	)
 
-	vmssNames := []string{"vmss0", "vmss1", "vmss"}
-	ips := []string{"ip0", "ip1", "ip2"}
+	vmssNames := []string{"control-plane-0", "control-plane-1", "unrelated", "nodes"}
+	ips := []string{"ip0", "ip1", "ip2", "ip3"}
 	client := &mockClient{
 		vmss: []*compute.VirtualMachineScaleSet{
 			{
 				Name: to.Ptr(vmssNames[0]),
 				Tags: map[string]*string{
-					clusterTag: to.Ptr(clusterName),
+					clusterTag:      to.Ptr(clusterName),
+					controlPlaneTag: to.Ptr("1"),
 				},
 			},
 			{
 				Name: to.Ptr(vmssNames[1]),
 				Tags: map[string]*string{
 					clusterTag:             to.Ptr(clusterName),
+					controlPlaneTag:        to.Ptr("1"),
 					"not-relevant-tag-key": to.Ptr("val"),
 				},
 			},
 			{
-				// Irrelevalent VM that has no matching tag.
+				// Irrelevant VM that has no matching cluster tag.
 				Name: to.Ptr(vmssNames[2]),
 				Tags: map[string]*string{
 					"not-relevant-tag-key": to.Ptr("val"),
+				},
+			},
+			{
+				// Worker scale set: same cluster, but not control-plane, so it
+				// does not run gossip and must not be used as a seed.
+				Name: to.Ptr(vmssNames[3]),
+				Tags: map[string]*string{
+					clusterTag: to.Ptr(clusterName),
+					nodeTag:    to.Ptr("1"),
 				},
 			},
 		},
@@ -92,6 +106,7 @@ func TestGetSeeds(t *testing.T) {
 			vmssNames[0]: newTestInterfaces(ips[0]),
 			vmssNames[1]: newTestInterfaces(ips[1]),
 			vmssNames[2]: newTestInterfaces(ips[2]),
+			vmssNames[3]: newTestInterfaces(ips[3]),
 		},
 	}
 	provider := SeedProvider{

--- a/protokube/pkg/gossip/do/seeds.go
+++ b/protokube/pkg/gossip/do/seeds.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/digitalocean/godo"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/protokube/pkg/gossip"
+	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 )
 
 type SeedProvider struct {
@@ -42,6 +44,10 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 	}
 
 	for _, droplet := range droplets {
+		// Seed only from control-plane nodes; workers do not run gossip.
+		if !dropletIsControlPlane(droplet) {
+			continue
+		}
 		for _, dropTag := range droplet.Tags {
 			klog.V(4).Infof("Get Seeds - droplet found=%s,SeedProvider Tag=%s", dropTag, p.tag)
 			if strings.Contains(dropTag, strings.ReplaceAll(p.tag, ".", "-")) {
@@ -70,4 +76,15 @@ func NewSeedProvider(godoClient *godo.Client, tag string) (*SeedProvider, error)
 		godoClient: godoClient,
 		tag:        tag,
 	}, nil
+}
+
+// dropletIsControlPlane reports whether the droplet hosts a control-plane node.
+func dropletIsControlPlane(droplet godo.Droplet) bool {
+	roleTag := do.TagKubernetesInstanceRole + ":" + string(kops.InstanceGroupRoleControlPlane)
+	for _, tag := range droplet.Tags {
+		if tag == roleTag {
+			return true
+		}
+	}
+	return false
 }

--- a/protokube/pkg/gossip/hetzner/seeds.go
+++ b/protokube/pkg/gossip/hetzner/seeds.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/protokube/pkg/gossip"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
 )
@@ -43,7 +44,10 @@ func NewSeedProvider(hcloudClient *hcloud.Client, tag string) (*SeedProvider, er
 func (p *SeedProvider) GetSeeds() ([]string, error) {
 	var seeds []string
 
-	labelSelector := fmt.Sprintf("%s=%s", hetzner.TagKubernetesClusterName, p.tag)
+	// Seed only from control-plane nodes; workers do not run gossip.
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		hetzner.TagKubernetesClusterName, p.tag,
+		hetzner.TagKubernetesInstanceRole, string(kops.InstanceGroupRoleControlPlane))
 	listOptions := hcloud.ListOpts{
 		PerPage:       50,
 		LabelSelector: labelSelector,

--- a/protokube/pkg/gossip/openstack/seeds.go
+++ b/protokube/pkg/gossip/openstack/seeds.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/protokube/pkg/gossip"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 )
@@ -52,6 +53,11 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 			if clusterName, ok := server.Metadata[openstack.TagClusterName]; ok {
 				// verify that the instance is from the same cluster
 				if clusterName != p.clusterName {
+					continue
+				}
+
+				// Seed only from control-plane nodes; workers do not run gossip.
+				if server.Metadata[openstack.TagKopsRole] != string(kops.InstanceGroupRoleControlPlane) {
 					continue
 				}
 

--- a/protokube/pkg/gossip/scaleway/seeds.go
+++ b/protokube/pkg/gossip/scaleway/seeds.go
@@ -68,6 +68,10 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 	}
 
 	for _, server := range servers {
+		// Seed only from control-plane nodes; workers do not run gossip.
+		if scaleway.InstanceRoleFromTags(server.Tags) != scaleway.TagRoleControlPlane {
+			continue
+		}
 		ip, err := scwCloud.GetServerIP(server.ID, server.Zone)
 		if err != nil {
 			return nil, fmt.Errorf("getting server IP: %w", err)

--- a/upup/pkg/fi/cloudup/gce/gcediscovery/resolver.go
+++ b/upup/pkg/fi/cloudup/gce/gcediscovery/resolver.go
@@ -49,8 +49,24 @@ func (r *Discovery) GetSeeds() ([]string, error) {
 
 	ctx := context.TODO()
 
+	// Seed only from control-plane nodes; workers do not run gossip.
+	controlPlaneTag := gce.TagForRole(r.clusterName, kops.InstanceGroupRoleControlPlane)
+
 	if err := r.findInstances(ctx, func(i *compute.Instance) (bool, error) {
 		// TODO: Expose multiple IPs topologies?
+
+		hasControlPlaneTag := false
+		if i.Tags != nil {
+			for _, tag := range i.Tags.Items {
+				if tag == controlPlaneTag {
+					hasControlPlaneTag = true
+					break
+				}
+			}
+		}
+		if !hasControlPlaneTag {
+			return true, nil
+		}
 
 		for _, ni := range i.NetworkInterfaces {
 			// TODO: Check e.g. Network


### PR DESCRIPTION
In gossip clusters, control-plane protokube discovers its mesh peers by listing every instance in the cluster — `GetSeeds()` applies no role filter. Worker nodes that bootstrap via the API load balancer instead of gossip (hybrid mode, #18245) don't run protokube, so their IPs are dead seeds: control-plane protokube keeps trying to gossip-join them indefinitely, producing continuous `failed to join`log spam, wasted reconnects, and a mesh that never converges. This scales with worker count and affects freshly-created hybrid clusters, not just upgrades.

This restricts `GetSeeds()` to control-plane instances on every cloud provider:
- **AWS** — `k8s.io/role/control-plane` tag-key filter on `DescribeInstances`
- **Azure** — filter VM scale sets by the control-plane role tag
- **GCE** — filter by the control-plane network tag (as `Resolve()` already does)
- **OpenStack** — filter servers by `KopsRole` metadata
- **Hetzner** — add the role to the server label selector
- **Scaleway** — filter servers by the role tag
- **DigitalOcean** — require the control-plane role tag on the droplet

`GetSeeds()` is consumed only by the gossip subsystem, so the change is scoped to gossip seeding. It remains correct for legacy all-gossip clusters where workers still run protokube — workers reach the mesh by seeding from control-plane nodes, and gossip converges from any single connected peer.

Refs: https://github.com/kubernetes/kops/issues/18240

/cc @rifelpet @ameukam 