### PR TITLE
azure: fix control-plane role tag spelling

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -548,7 +548,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 				// allowed as a tag key in Azure.
 				fmt.Sprintf("kubernetes.io_cluster_%s=owned", b.Cluster.Name),
 				azure.TagNameEtcdClusterPrefix + etcdCluster.Name,
-				azure.TagNameRolePrefix + "control_plane=1",
+				azure.TagNameRolePrefix + azure.TagRoleControlPlane + "=1",
 			}
 			config.VolumeNameTag = azure.TagNameEtcdClusterPrefix + etcdCluster.Name
 

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
@@ -15,7 +15,7 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.gossip.k8s.local
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io_etcd_events --volume-provider=azure --volume-tag=k8s.io_etcd_events
-      --volume-tag=k8s.io_role_control_plane=1 --volume-tag=kubernetes.io_cluster_gossip.k8s.local=owned
+      --volume-tag=k8s.io_role_control-plane=1 --volume-tag=kubernetes.io_cluster_gossip.k8s.local=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
@@ -15,7 +15,7 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.gossip.k8s.local
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io_etcd_main --volume-provider=azure --volume-tag=k8s.io_etcd_main
-      --volume-tag=k8s.io_role_control_plane=1 --volume-tag=kubernetes.io_cluster_gossip.k8s.local=owned
+      --volume-tag=k8s.io_role_control-plane=1 --volume-tag=kubernetes.io_cluster_gossip.k8s.local=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/gossip-azure/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-azure/kubernetes.tf
@@ -224,7 +224,7 @@ resource "azurerm_managed_disk" "etcd-1-etcd-events-gossip-k8s-local" {
   tags = {
     "KubernetesCluster"                      = "test-cluster.k8s"
     "k8s.io_etcd_events"                     = "etcd-1/etcd-1"
-    "k8s.io_role_control_plane"              = "1"
+    "k8s.io_role_control-plane"              = "1"
     "k8s.io_role_master"                     = "1"
     "kubernetes.io_cluster_gossip.k8s.local" = "owned"
   }
@@ -241,7 +241,7 @@ resource "azurerm_managed_disk" "etcd-1-etcd-main-gossip-k8s-local" {
   tags = {
     "KubernetesCluster"                      = "test-cluster.k8s"
     "k8s.io_etcd_main"                       = "etcd-1/etcd-1"
-    "k8s.io_role_control_plane"              = "1"
+    "k8s.io_role_control-plane"              = "1"
     "k8s.io_role_master"                     = "1"
     "kubernetes.io_cluster_gossip.k8s.local" = "owned"
   }

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
@@ -15,7 +15,7 @@ spec:
       --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal-azure.example.com
       --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io_etcd_events --volume-provider=azure --volume-tag=k8s.io_etcd_events
-      --volume-tag=k8s.io_role_control_plane=1 --volume-tag=kubernetes.io_cluster_minimal-azure.example.com=owned
+      --volume-tag=k8s.io_role_control-plane=1 --volume-tag=kubernetes.io_cluster_minimal-azure.example.com=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
@@ -15,7 +15,7 @@ spec:
       --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal-azure.example.com
       --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io_etcd_main --volume-provider=azure --volume-tag=k8s.io_etcd_main
-      --volume-tag=k8s.io_role_control_plane=1 --volume-tag=kubernetes.io_cluster_minimal-azure.example.com=owned
+      --volume-tag=k8s.io_role_control-plane=1 --volume-tag=kubernetes.io_cluster_minimal-azure.example.com=owned
       > /tmp/pipe 2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/minimal_azure/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_azure/kubernetes.tf
@@ -224,7 +224,7 @@ resource "azurerm_managed_disk" "a-etcd-events-minimal-azure-example-com" {
   tags = {
     "KubernetesCluster"                               = "test-cluster.k8s"
     "k8s.io_etcd_events"                              = "a/a"
-    "k8s.io_role_control_plane"                       = "1"
+    "k8s.io_role_control-plane"                       = "1"
     "k8s.io_role_master"                              = "1"
     "kubernetes.io_cluster_minimal-azure.example.com" = "owned"
   }
@@ -241,7 +241,7 @@ resource "azurerm_managed_disk" "a-etcd-main-minimal-azure-example-com" {
   tags = {
     "KubernetesCluster"                               = "test-cluster.k8s"
     "k8s.io_etcd_main"                                = "a/a"
-    "k8s.io_role_control_plane"                       = "1"
+    "k8s.io_role_control-plane"                       = "1"
     "k8s.io_role_master"                              = "1"
     "kubernetes.io_cluster_minimal-azure.example.com" = "owned"
   }

--- a/upup/pkg/fi/cloudup/azure/azure_cloud.go
+++ b/upup/pkg/fi/cloudup/azure/azure_cloud.go
@@ -37,7 +37,7 @@ const (
 	// Use dash (_) as a splitter. Other CSPs use slash (/), but slash is not
 	// allowed as a tag key in Azure.
 	TagNameRolePrefix        = "k8s.io_role_"
-	TagRoleControlPlane      = "control_plane"
+	TagRoleControlPlane      = "control-plane"
 	TagRoleMaster            = "master"
 	TagNameEtcdClusterPrefix = "k8s.io_etcd_"
 )


### PR DESCRIPTION
VM scale sets are tagged via InstanceGroupRole.ToLowerString(), which yields k8s.io_role_control-plane (hyphen), but the TagRoleControlPlane constant was "control_plane" (underscore). Disks and the etcd-manager volume tag used the underscore form, so GetApiIngressStatus looked up a key the scale sets never had -- it matched only via the legacy k8s.io_role_master tag.

/cc @rifelpet @ameukam 

Assisted by Claude Opus