### PR TITLE
gossip: stop exporting unused cloud credentials to worker nodes

### DIFF
--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -391,11 +391,7 @@ func buildEnvironmentVariables(cluster *kops.Cluster, ig *kops.InstanceGroup) (m
 			os.Setenv(openstackconfig.EnvKeyOpenstackTLSInsecureSkipVerify, "true")
 		}
 
-		// credentials needed always in control-plane and when using gossip also in nodes
-		passEnvs := false
-		if ig.IsControlPlane() || cluster.UsesLegacyGossip() {
-			passEnvs = true
-		}
+		passEnvs := ig.IsControlPlane()
 		// Pass in required credentials when using user-defined swift endpoint
 		if os.Getenv("OS_AUTH_URL") != "" && passEnvs {
 			for _, envVar := range osEnvs {
@@ -413,7 +409,7 @@ func buildEnvironmentVariables(cluster *kops.Cluster, ig *kops.InstanceGroup) (m
 		}
 	}
 
-	if cluster.GetCloudProvider() == kops.CloudProviderHetzner && (ig.IsControlPlane() || cluster.UsesLegacyGossip()) {
+	if cluster.GetCloudProvider() == kops.CloudProviderHetzner && ig.IsControlPlane() {
 		hcloudToken := os.Getenv("HCLOUD_TOKEN")
 		if hcloudToken != "" {
 			env["HCLOUD_TOKEN"] = hcloudToken
@@ -439,7 +435,7 @@ func buildEnvironmentVariables(cluster *kops.Cluster, ig *kops.InstanceGroup) (m
 		}
 	}
 
-	if cluster.GetCloudProvider() == kops.CloudProviderScaleway && (ig.IsControlPlane() || cluster.UsesLegacyGossip()) {
+	if cluster.GetCloudProvider() == kops.CloudProviderScaleway && ig.IsControlPlane() {
 		profile, err := scaleway.CreateValidScalewayProfile()
 		if err != nil {
 			return nil, err

--- a/tests/integration/update_cluster/gossip-hetzner/data/hcloud_server_nodes-fsn1_user_data
+++ b/tests/integration/update_cluster/gossip-hetzner/data/hcloud_server_nodes-fsn1_user_data
@@ -8,7 +8,6 @@ NODEUP_HASH_AMD64=c86e072f622b91546b7b3f3cb1a0f8a131e48b966ad018a0ac1520ceedf377
 NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/nodeup-linux-arm64
 NODEUP_HASH_ARM64=64a9a9510538a449e85d05e13e3cd98b80377d68a673447c26821d40f00f0075
 
-export HCLOUD_TOKEN=REDACTED
 
 
 

--- a/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_nodes-fr-par-1-0_user_data
+++ b/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_nodes-fr-par-1-0_user_data
@@ -8,9 +8,6 @@ NODEUP_HASH_AMD64=c86e072f622b91546b7b3f3cb1a0f8a131e48b966ad018a0ac1520ceedf377
 NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/nodeup-linux-arm64
 NODEUP_HASH_ARM64=64a9a9510538a449e85d05e13e3cd98b80377d68a673447c26821d40f00f0075
 
-export SCW_ACCESS_KEY=
-export SCW_DEFAULT_PROJECT_ID=
-export SCW_SECRET_KEY=
 
 
 


### PR DESCRIPTION
Since #18245, workers in gossip clusters bootstrap via kops-controller rather than protokube. The Hetzner (HCLOUD_TOKEN), Scaleway (SCW_*) and OpenStack (OS_*) credentials were written into worker user-data only for protokube's gossip peer discovery, so they be removed.

Refs: https://github.com/kubernetes/kops/issues/18240

/cc @rifelpet @ameukam 