### PR TITLE
aws: remove unused IAM server certificate permissions

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -823,7 +823,6 @@ func addKindnetSrcDstCheckPermissions(p *Policy) {
 }
 
 func (b *PolicyBuilder) addNodeupPermissions(p *Policy, enableHookSupport bool) {
-	addCertIAMPolicies(p)
 	addKMSGenerateRandomPolicies(p)
 	addASLifecyclePolicies(p, enableHookSupport)
 	p.unconditionalAction.Insert(
@@ -1217,14 +1216,6 @@ func addASLifecyclePolicies(p *Policy, enableHookSupport bool) {
 			"autoscaling:DescribeLifecycleHooks",
 		)
 	}
-}
-
-func addCertIAMPolicies(p *Policy) {
-	// TODO: Make optional only if using IAM SSL Certs on ELBs
-	p.unconditionalAction.Insert(
-		"iam:ListServerCertificates",
-		"iam:GetServerCertificate",
-	)
 }
 
 func addCiliumEniPermissions(p *Policy) {

--- a/pkg/model/iam/tests/iam_builder_master_gossip.json
+++ b/pkg/model/iam/tests/iam_builder_master_gossip.json
@@ -132,8 +132,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/pkg/model/iam/tests/iam_builder_master_gossip_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_gossip_ecr.json
@@ -139,8 +139,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/pkg/model/iam/tests/iam_builder_master_nlb_sg_managed.json
+++ b/pkg/model/iam/tests/iam_builder_master_nlb_sg_managed.json
@@ -132,8 +132,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -132,8 +132,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -139,8 +139,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/pkg/model/iam/tests/iam_builder_node_gossip.json
+++ b/pkg/model/iam/tests/iam_builder_node_gossip.json
@@ -27,8 +27,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/pkg/model/iam/tests/iam_builder_node_gossip_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_gossip_ecr.json
@@ -34,8 +34,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -12,8 +12,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
@@ -201,8 +201,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_nodes.additionalobjects.example.com_policy
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_nodes.additionalobjects.example.com_policy
@@ -12,8 +12,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_apiservers.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_apiservers.minimal.example.com_policy
@@ -24,8 +24,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,6 @@
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_masters.cas-priority-expander-custom.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_masters.cas-priority-expander-custom.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_nodes.cas-priority-expander-custom.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_nodes.cas-priority-expander-custom.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_masters.cas-priority-expander.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_masters.cas-priority-expander.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_nodes.cas-priority-expander.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_nodes.cas-priority-expander.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -198,8 +198,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_nodes.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_nodes.containerd.example.com_policy
@@ -9,8 +9,6 @@
         "ecr:CreateRepository",
         "ecr:ReplicateImage",
         "ecr:TagResource",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_nodes.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_nodes.containerd.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_nodes.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_nodes.123.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,6 @@
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/gossip-aws/data/aws_iam_role_policy_masters.gossip.k8s.local_policy
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_iam_role_policy_masters.gossip.k8s.local_policy
@@ -171,8 +171,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/gossip-aws/data/aws_iam_role_policy_nodes.gossip.k8s.local_policy
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_iam_role_policy_nodes.gossip.k8s.local_policy
@@ -12,8 +12,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,6 @@
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -119,8 +119,6 @@
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",
         "ec2:UnassignPrivateIpAddresses",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -24,8 +24,6 @@
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",
         "ec2:UnassignPrivateIpAddresses",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -307,8 +307,6 @@
         "elasticloadbalancing:DescribeTrustStores",
         "elasticloadbalancing:SetRulePriorities",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -24,8 +24,6 @@
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",
         "ec2:UnassignPrivateIpAddresses",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
@@ -307,8 +307,6 @@
         "elasticloadbalancing:DescribeTrustStores",
         "elasticloadbalancing:SetRulePriorities",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.many-addons.example.com_policy
@@ -24,8 +24,6 @@
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",
         "ec2:UnassignPrivateIpAddresses",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -201,8 +201,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -12,8 +12,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -201,8 +201,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -12,8 +12,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -201,8 +201,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -12,8 +12,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -201,8 +201,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -12,8 +12,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -201,8 +201,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -12,8 +12,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -201,8 +201,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -12,8 +12,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_masters.minimal-aws.example.com_policy
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_masters.minimal-aws.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_nodes.minimal-aws.example.com_policy
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_nodes.minimal-aws.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -171,8 +171,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -12,8 +12,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_nodes.minimal-etcd.example.com_policy
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_nodes.minimal-etcd.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -196,8 +196,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -6,8 +6,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -196,8 +196,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -6,8 +6,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -197,8 +197,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -7,8 +7,6 @@
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:ModifyInstanceAttribute",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -196,8 +196,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -6,8 +6,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -196,8 +196,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -6,8 +6,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.really.really.reall-g6fsnu_policy
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.really.really.reall-g6fsnu_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_nodes.this.is.truly.a.really.really.really.really.really.-d86ibl_policy
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_nodes.this.is.truly.a.really.really.really.really.really.-d86ibl_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
@@ -6,8 +6,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -164,8 +164,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
@@ -27,8 +27,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -70,8 +70,6 @@
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
@@ -27,8 +27,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
@@ -100,8 +100,6 @@
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
@@ -202,8 +202,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
@@ -13,8 +13,6 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:GetRepositoryPolicy",
         "ecr:ListImages",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -202,8 +202,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
@@ -212,8 +212,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_masters.privatekindnet.example.com_policy
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_masters.privatekindnet.example.com_policy
@@ -195,8 +195,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_nodes.privatekindnet.example.com_policy
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_nodes.privatekindnet.example.com_policy
@@ -6,8 +6,6 @@
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:ModifyInstanceAttribute",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -100,8 +100,6 @@
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -196,8 +196,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -6,8 +6,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -194,8 +194,6 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -5,8 +5,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
-        "iam:GetServerCertificate",
-        "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
       "Effect": "Allow",


### PR DESCRIPTION
Refs: https://github.com/kubernetes/kops/issues/18240

/cc @rifelpet @ameukam 