### PR TITLE
gce: stop granting compute.viewer to worker nodes

### DIFF
--- a/pkg/model/gcemodel/service_accounts.go
+++ b/pkg/model/gcemodel/service_accounts.go
@@ -109,20 +109,7 @@ func (b *ServiceAccountsBuilder) addInstanceGroupServiceAccountPermissions(c *fi
 		})
 
 	case kops.InstanceGroupRoleNode:
-		// Known permissions:
-		//  * compute.zones.list (to find out region; we could replace this with string manipulation)
-		//  * compute.instances.list (for discovery; we don't need in the case of a load balancer or DNS)
-
-		// We use the GCE viewer role
-
-		c.AddTask(&gcetasks.ProjectIAMBinding{
-			Name:      s("serviceaccount-nodes"),
-			Lifecycle: b.Lifecycle,
-
-			Project:              s(b.ProjectID),
-			MemberServiceAccount: serviceAccount,
-			Role:                 s("roles/compute.viewer"),
-		})
+		// Worker nodes need no project-level role.
 	}
 	return nil
 }

--- a/tests/integration/update_cluster/gossip-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-gce/kubernetes.tf
@@ -694,12 +694,6 @@ resource "google_project_iam_binding" "serviceaccount-control-plane" {
   role    = "roles/container.serviceAgent"
 }
 
-resource "google_project_iam_binding" "serviceaccount-nodes" {
-  members = [format("serviceAccount:%s", google_service_account.node.email)]
-  project = "testproject"
-  role    = "roles/compute.viewer"
-}
-
 resource "google_service_account" "control-plane" {
   account_id   = "control-plane-gossip-k8s-local"
   description  = "kubernetes control-plane instances"

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -583,12 +583,6 @@ resource "google_project_iam_binding" "serviceaccount-control-plane" {
   role    = "roles/container.serviceAgent"
 }
 
-resource "google_project_iam_binding" "serviceaccount-nodes" {
-  members = [format("serviceAccount:%s", google_service_account.node.email)]
-  project = "testproject"
-  role    = "roles/compute.viewer"
-}
-
 resource "google_service_account" "control-plane" {
   account_id   = "control-plane-minimal-e-rabo9p"
   description  = "kubernetes control-plane instances"

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -672,12 +672,6 @@ resource "google_project_iam_binding" "serviceaccount-control-plane" {
   role    = "roles/container.serviceAgent"
 }
 
-resource "google_project_iam_binding" "serviceaccount-nodes" {
-  members = [format("serviceAccount:%s", google_service_account.node.email)]
-  project = "testproject"
-  role    = "roles/compute.viewer"
-}
-
 resource "google_service_account" "control-plane" {
   account_id   = "control-plane-minimal-g-fu1mg6"
   description  = "kubernetes control-plane instances"


### PR DESCRIPTION
The worker service account was granted roles/compute.viewer on the whole project. Its only consumer was protokube, which called the Compute API (compute.zones.list, compute.instances.list) for gossip peer discovery. Workers no longer run protokube, they bootstrap via kops-controller, so the role is unused on worker nodes.

Refs: https://github.com/kubernetes/kops/issues/18240

/cc @rifelpet @ameukam 