### PR TITLE
nodeup: skip protokube/channels assets on workers

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -66,7 +66,8 @@ func (t *ProtokubeBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		})
 	}
 
-	{
+	// The channels binary is only invoked on control-plane nodes.
+	if t.IsMaster {
 		name, res, err := t.Assets.FindMatch(regexp.MustCompile("channels$"))
 		if err != nil {
 			return err

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -313,21 +313,6 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 				}
 			}
 		}
-
-		if isMaster || usesLegacyGossip {
-			config.Channels = n.channels
-			for _, arch := range architectures.GetSupported() {
-				for _, a := range n.protokubeAsset[arch] {
-					config.Assets[arch] = append(config.Assets[arch], a.CompactString())
-				}
-			}
-
-			for _, arch := range architectures.GetSupported() {
-				for _, a := range n.channelsAsset[arch] {
-					config.Assets[arch] = append(config.Assets[arch], a.CompactString())
-				}
-			}
-		}
 	}
 
 	if hasAPIServer {
@@ -390,6 +375,27 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 		switch cluster.GetCloudProvider() {
 		case kops.CloudProviderHetzner, kops.CloudProviderScaleway, kops.CloudProviderDO, kops.CloudProviderMetal:
 			bootConfig.APIServerIPs = controlPlaneIPs
+		}
+	}
+
+	if role != kops.InstanceGroupRoleBastion {
+		// protokube runs on control-plane nodes, and on legacy-gossip workers that don't bootstrap via kops-controller (mirrors nodeup's ProtokubeBuilder.Build).
+		if isMaster || (usesLegacyGossip && len(bootConfig.APIServerIPs) == 0) {
+			config.Channels = n.channels
+			for _, arch := range architectures.GetSupported() {
+				for _, a := range n.protokubeAsset[arch] {
+					config.Assets[arch] = append(config.Assets[arch], a.CompactString())
+				}
+			}
+		}
+
+		// The channels binary is only ever run by protokube on control-plane nodes.
+		if isMaster {
+			for _, arch := range architectures.GetSupported() {
+				for _, a := range n.channelsAsset[arch] {
+					config.Assets[arch] = append(config.Assets[arch], a.CompactString())
+				}
+			}
 		}
 	}
 

--- a/tests/integration/update_cluster/gossip-aws/data/aws_launch_template_nodes.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_launch_template_nodes.gossip.k8s.local_user_data
@@ -149,7 +149,7 @@ ConfigServer:
   - https://kops-controller.internal.gossip.k8s.local:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 4pK9aRKK+peUykRrpjE5uI4ms+BHch2SFkbvBIRGRE4=
+NodeupConfigHash: K34abW9ejLXuqbOWE+GjyQ6w5kb0T5ISpkMvHaosEq4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_nodeupconfig-nodes_content
@@ -7,7 +7,6 @@ Assets:
   - 4793dc5c1f34ebf8402990d0050f3c294aa3c794cd5a4baa403c1cf10602326d@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-amd64.tar.gz
   - 5966ca40b6187b30e33bfc299c5f1fe72e8c1aa01cf3fefdadf391668f47f103@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
@@ -16,7 +15,6 @@ Assets:
   - 88d6e32348c36628c8500a630c6dd4b3cb8c680b1d18dc8d1d19041f67757c6e@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-arm64.tar.gz
   - d6dcab36d1b6af1b72c7f0662e5fcf446a291271ba6006532b95c4144e19d428@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs: {}
 ClusterName: gossip.k8s.local
 Hooks:

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_nodes-eastus-1.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_nodes-eastus-1.gossip.k8s.local_user_data
@@ -148,7 +148,7 @@ ConfigServer:
   - https://kops-controller.internal.gossip.k8s.local:3988/
 InstanceGroupName: nodes-eastus-1
 InstanceGroupRole: Node
-NodeupConfigHash: GB2MAxzWLpOE3N+f3bV3f24FarOTjnbltOxLPxEI4wg=
+NodeupConfigHash: jjcqiPz3lTkaxe3xxfSQxavm/KG6hCrJN5a4uyH3jR0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-nodes-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-nodes-eastus-1_source
@@ -6,7 +6,6 @@ Assets:
   - 4793dc5c1f34ebf8402990d0050f3c294aa3c794cd5a4baa403c1cf10602326d@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-amd64.tar.gz
   - 5966ca40b6187b30e33bfc299c5f1fe72e8c1aa01cf3fefdadf391668f47f103@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
@@ -14,7 +13,6 @@ Assets:
   - 88d6e32348c36628c8500a630c6dd4b3cb8c680b1d18dc8d1d19041f67757c6e@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-arm64.tar.gz
   - d6dcab36d1b6af1b72c7f0662e5fcf446a291271ba6006532b95c4144e19d428@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 AzureAdminUser: kops
 CAs: {}
 ClusterName: gossip.k8s.local

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_nodeupconfig-nodes_content
@@ -7,7 +7,6 @@ Assets:
   - 4793dc5c1f34ebf8402990d0050f3c294aa3c794cd5a4baa403c1cf10602326d@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-amd64.tar.gz
   - 5966ca40b6187b30e33bfc299c5f1fe72e8c1aa01cf3fefdadf391668f47f103@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
@@ -16,7 +15,6 @@ Assets:
   - 88d6e32348c36628c8500a630c6dd4b3cb8c680b1d18dc8d1d19041f67757c6e@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-arm64.tar.gz
   - d6dcab36d1b6af1b72c7f0662e5fcf446a291271ba6006532b95c4144e19d428@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs: {}
 ClusterName: gossip.k8s.local
 Hooks:

--- a/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_nodes-gossip-k8s-local_metadata_user-data
+++ b/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_nodes-gossip-k8s-local_metadata_user-data
@@ -148,7 +148,7 @@ ConfigServer:
   - https://kops-controller.internal.gossip.k8s.local:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: cMB9N+44MKID0GSmNn6vUqrSVyBTMn7Fw+2g4qHAgf4=
+NodeupConfigHash: fON9buaGy3r7LYOK35mu43Cm7km0asaiN1iKLtTYGPY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_nodeupconfig-nodes-fsn1_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_nodeupconfig-nodes-fsn1_content
@@ -6,7 +6,6 @@ Assets:
   - 4793dc5c1f34ebf8402990d0050f3c294aa3c794cd5a4baa403c1cf10602326d@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-amd64.tar.gz
   - 5966ca40b6187b30e33bfc299c5f1fe72e8c1aa01cf3fefdadf391668f47f103@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
@@ -14,7 +13,6 @@ Assets:
   - 88d6e32348c36628c8500a630c6dd4b3cb8c680b1d18dc8d1d19041f67757c6e@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-arm64.tar.gz
   - d6dcab36d1b6af1b72c7f0662e5fcf446a291271ba6006532b95c4144e19d428@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs: {}
 ClusterName: gossip.k8s.local
 Hooks:

--- a/tests/integration/update_cluster/gossip-hetzner/data/hcloud_server_nodes-fsn1_user_data
+++ b/tests/integration/update_cluster/gossip-hetzner/data/hcloud_server_nodes-fsn1_user_data
@@ -149,7 +149,7 @@ ConfigServer:
   - https://kops-controller.internal.gossip.k8s.local:3988/
 InstanceGroupName: nodes-fsn1
 InstanceGroupRole: Node
-NodeupConfigHash: kz0h4eIDUNbNu4Hwj9lxoLCOi3efytMfWZZbJ1LZdJE=
+NodeupConfigHash: kqUOXEywfW6m9tQ6x9mVp3UI8VKcSnQlv7fNrYHmrns=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.k8s.local
 ConfigBase: memfs://clusters.example.com/minimal.k8s.local
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: rogNUJwZq6BoxCFVOTscsh7nnQyTHKgwKlI72juVIBU=
+NodeupConfigHash: hO4P1ino6omlAOu5ZwgdA/pKmjuMBpAZoZd6Iqr/mKk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-nodes_content
@@ -7,7 +7,6 @@ Assets:
   - 4793dc5c1f34ebf8402990d0050f3c294aa3c794cd5a4baa403c1cf10602326d@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-amd64.tar.gz
   - 5966ca40b6187b30e33bfc299c5f1fe72e8c1aa01cf3fefdadf391668f47f103@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -16,7 +15,6 @@ Assets:
   - 88d6e32348c36628c8500a630c6dd4b3cb8c680b1d18dc8d1d19041f67757c6e@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-arm64.tar.gz
   - d6dcab36d1b6af1b72c7f0662e5fcf446a291271ba6006532b95c4144e19d428@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   kubernetes-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_nodes.minimal.k8s.local_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.k8s.local
 ConfigBase: memfs://clusters.example.com/minimal.k8s.local
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: rogNUJwZq6BoxCFVOTscsh7nnQyTHKgwKlI72juVIBU=
+NodeupConfigHash: hO4P1ino6omlAOu5ZwgdA/pKmjuMBpAZoZd6Iqr/mKk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-nodes_content
@@ -7,7 +7,6 @@ Assets:
   - 4793dc5c1f34ebf8402990d0050f3c294aa3c794cd5a4baa403c1cf10602326d@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-amd64.tar.gz
   - 5966ca40b6187b30e33bfc299c5f1fe72e8c1aa01cf3fefdadf391668f47f103@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -16,7 +15,6 @@ Assets:
   - 88d6e32348c36628c8500a630c6dd4b3cb8c680b1d18dc8d1d19041f67757c6e@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-arm64.tar.gz
   - d6dcab36d1b6af1b72c7f0662e5fcf446a291271ba6006532b95c4144e19d428@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   kubernetes-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-nodes-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-nodes-fr-par-1_content
@@ -5,14 +5,12 @@ Assets:
   - 4793dc5c1f34ebf8402990d0050f3c294aa3c794cd5a4baa403c1cf10602326d@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-amd64.tar.gz
   - 5966ca40b6187b30e33bfc299c5f1fe72e8c1aa01cf3fefdadf391668f47f103@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
   - 88d6e32348c36628c8500a630c6dd4b3cb8c680b1d18dc8d1d19041f67757c6e@https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-linux-arm64.tar.gz
   - d6dcab36d1b6af1b72c7f0662e5fcf446a291271ba6006532b95c4144e19d428@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs: {}
 ClusterName: scw-minimal.k8s.local
 Hooks:

--- a/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_nodes-fr-par-1-0_user_data
+++ b/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_nodes-fr-par-1-0_user_data
@@ -151,7 +151,7 @@ ConfigServer:
   - https://kops-controller.internal.scw-minimal.k8s.local:3988/
 InstanceGroupName: nodes-fr-par-1
 InstanceGroupRole: Node
-NodeupConfigHash: QWjH908ZZi8HXT0kRVD/sJwRLFeD9GSW6/K9nIQw0+8=
+NodeupConfigHash: DQr395fwjXmZUHQ2ueAmdtN8W5ZV63zZhOyeacWBnrM=
 
 __EOF_KUBE_ENV
 


### PR DESCRIPTION
Workers that bootstrap via kops-controller (hybrid mode) never run protokube, and the channels binary is only ever run by protokube on control-plane nodes. Both binaries were still listed as nodeup assets on every gossip-cluster worker, so each one downloaded them for nothing. Gate the protokube asset to control-plane nodes and non-hybrid legacy-gossip workers, and the channels asset to control-plane nodes only.

Refs: https://github.com/kubernetes/kops/issues/18240

/cc @rifelpet @ameukam 