### PR TITLE
vfs: reject GCS paths without buckets

### DIFF
--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -491,6 +491,9 @@ func (c *VFSContext) buildGCSPath(p string) (*GSPath, error) {
 	}
 
 	bucket := strings.TrimSuffix(u.Host, "/")
+	if bucket == "" {
+		return nil, fmt.Errorf("invalid google cloud storage path: %q", p)
+	}
 
 	gcsPath := NewGSPath(c, bucket, u.Path)
 	return gcsPath, nil

--- a/util/pkg/vfs/gsfs_test.go
+++ b/util/pkg/vfs/gsfs_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vfs
+
+import "testing"
+
+func Test_GSPath_Parse(t *testing.T) {
+	grid := []struct {
+		Input          string
+		ExpectError    bool
+		ExpectedBucket string
+		ExpectedPath   string
+	}{
+		{
+			Input:          "gs://bucket",
+			ExpectedBucket: "bucket",
+			ExpectedPath:   "",
+		},
+		{
+			Input:          "gs://bucket/path",
+			ExpectedBucket: "bucket",
+			ExpectedPath:   "path",
+		},
+		{
+			Input:          "gs://bucket2/path/subpath",
+			ExpectedBucket: "bucket2",
+			ExpectedPath:   "path/subpath",
+		},
+		{
+			Input:       "gs:///bucket/path/subpath",
+			ExpectError: true,
+		},
+		{
+			Input:       "gs://",
+			ExpectError: true,
+		},
+	}
+	for _, g := range grid {
+		gspath, err := Context.buildGCSPath(g.Input)
+		if !g.ExpectError {
+			if err != nil {
+				t.Fatalf("unexpected error parsing gs path: %v", err)
+			}
+			if gspath.bucket != g.ExpectedBucket {
+				t.Fatalf("unexpected gs path: %v", gspath)
+			}
+			if gspath.key != g.ExpectedPath {
+				t.Fatalf("unexpected gs path: %v", gspath)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("unexpected success parsing %q", g.Input)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Reject `gs://` VFS paths when the bucket part is empty.

Before this, these parsed as valid paths, kinda a tiny footgun:

```text
gs:///bucket/key -> ok: "gs:///bucket/key"
gs:// -> ok: "gs:///"
```

But GCS bucket names must be real bucket names, so these should fail at parse time. This now matches the S3/Swift behavior and keeps bad state-store/configBase URLs from drifting into later cloud calls.

```text
gs:///bucket/key -> error: invalid google cloud storage path: "gs:///bucket/key"
gs:// -> error: invalid google cloud storage path: "gs://"
```

Added parser coverage for valid and invalid `gs://` paths.

Tests:
- `go test ./util/pkg/vfs/...`
- `golangci-lint run ./util/pkg/vfs`

Related: #2082
