### PR TITLE
aws: scope ec2:DescribeInstances/DescribeRegions to roles that use them

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -468,6 +468,9 @@ func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	b.addNodeupPermissions(p, r.enableLifecycleHookPermissions)
 
 	if !model.UseKopsControllerForNodeConfig(b.Cluster) {
+		// Legacy-gossip workers that bootstrap without kops-controller run protokube.
+		addProtokubePermissions(p)
+
 		if err := b.AddS3Permissions(p); err != nil {
 			return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
 		}
@@ -825,8 +828,6 @@ func addKindnetSrcDstCheckPermissions(p *Policy) {
 func (b *PolicyBuilder) addNodeupPermissions(p *Policy, enableHookSupport bool) {
 	addASLifecyclePolicies(p, enableHookSupport)
 	p.unconditionalAction.Insert(
-		"ec2:DescribeRegions",
-		"ec2:DescribeInstances", // aws.go
 		"ec2:DescribeInstanceTypes",
 	)
 
@@ -837,6 +838,13 @@ func (b *PolicyBuilder) addNodeupPermissions(p *Policy, enableHookSupport bool) 
 	}
 }
 
+// addProtokubePermissions adds the permission protokube uses to discover gossip seeds.
+func addProtokubePermissions(p *Policy) {
+	p.unconditionalAction.Insert(
+		"ec2:DescribeInstances",
+	)
+}
+
 func addKopsControllerIPAMPermissions(p *Policy) {
 	p.unconditionalAction.Insert(
 		"ec2:DescribeNetworkInterfaces",
@@ -845,7 +853,9 @@ func addKopsControllerIPAMPermissions(p *Policy) {
 
 func addEtcdManagerPermissions(p *Policy) {
 	p.unconditionalAction.Insert(
-		"ec2:DescribeVolumes", // aws.go
+		"ec2:DescribeInstances",
+		"ec2:DescribeRegions",
+		"ec2:DescribeVolumes",
 	)
 
 	p.Statement = append(p.Statement,

--- a/pkg/model/iam/tests/iam_builder_node_gossip.json
+++ b/pkg/model/iam/tests/iam_builder_node_gossip.json
@@ -25,8 +25,7 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
+        "ec2:DescribeInstances"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/pkg/model/iam/tests/iam_builder_node_gossip_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_gossip_ecr.json
@@ -26,7 +26,6 @@
       "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_nodes.additionalobjects.example.com_policy
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_nodes.additionalobjects.example.com_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_apiservers.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_apiservers.minimal.example.com_policy
@@ -22,8 +22,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_nodes.cas-priority-expander-custom.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_nodes.cas-priority-expander-custom.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_nodes.cas-priority-expander.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_nodes.cas-priority-expander.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_nodes.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_nodes.containerd.example.com_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchImportUpstreamImage",
         "ecr:CreateRepository",
         "ecr:ReplicateImage",

--- a/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_nodes.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_nodes.containerd.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_nodes.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_nodes.123.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/gossip-aws/data/aws_iam_role_policy_nodes.gossip.k8s.local_policy
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_iam_role_policy_nodes.gossip.k8s.local_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -18,7 +18,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
-        "ec2:DescribeRegions",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
         "ec2:DetachNetworkInterface",

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -18,7 +18,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
-        "ec2:DescribeRegions",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
         "ec2:DetachNetworkInterface",

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.many-addons.example.com_policy
@@ -18,7 +18,6 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
-        "ec2:DescribeRegions",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
         "ec2:DetachNetworkInterface",

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_nodes.minimal-aws.example.com_policy
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_nodes.minimal-aws.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_nodes.minimal-etcd.example.com_policy
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_nodes.minimal-etcd.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -3,9 +3,7 @@
     {
       "Action": [
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
+        "ec2:DescribeInstanceTypes"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -3,9 +3,7 @@
     {
       "Action": [
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
+        "ec2:DescribeInstanceTypes"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -4,8 +4,6 @@
       "Action": [
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ec2:ModifyInstanceAttribute"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -3,9 +3,7 @@
     {
       "Action": [
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
+        "ec2:DescribeInstanceTypes"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -3,9 +3,7 @@
     {
       "Action": [
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
+        "ec2:DescribeInstanceTypes"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_nodes.this.is.truly.a.really.really.really.really.really.-d86ibl_policy
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_nodes.this.is.truly.a.really.really.really.really.really.-d86ibl_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
@@ -3,9 +3,7 @@
     {
       "Action": [
         "autoscaling:DescribeLifecycleHooks",
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
+        "ec2:DescribeInstanceTypes"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
@@ -25,8 +25,7 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
+        "ec2:DescribeInstances"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
@@ -25,8 +25,7 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
+        "ec2:DescribeInstances"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_nodes.nthimdsprocessor.longclustername.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
@@ -4,7 +4,6 @@
       "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ec2:ModifyNetworkInterfaceAttribute",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_nodes.privatekindnet.example.com_policy
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_nodes.privatekindnet.example.com_policy
@@ -3,8 +3,6 @@
     {
       "Action": [
         "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions",
         "ec2:ModifyInstanceAttribute"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -3,9 +3,7 @@
     {
       "Action": [
         "ec2:AssignIpv6Addresses",
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
+        "ec2:DescribeInstanceTypes"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -1,11 +1,7 @@
 {
   "Statement": [
     {
-      "Action": [
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstances",
-        "ec2:DescribeRegions"
-      ],
+      "Action": "ec2:DescribeInstanceTypes",
       "Effect": "Allow",
       "Resource": "*"
     }


### PR DESCRIPTION
addNodeupPermissions granted both actions to every instance role, a leftover from the in-tree AWS cloud provider. The only consumers left are etcd-manager and protokube. Grant them via addEtcdManagerPermissions, and re-add ec2:DescribeInstances to the node role only where protokube runs (legacy-gossip clusters without kops-controller).

Refs: https://github.com/kubernetes/kops/issues/18240 

/cc @rifelpet @ameukam 