### PR TITLE
aws: Use kms:ViaService condition on KMS data actions

### DIFF
--- a/pkg/model/awsmodel/nodeterminationhandler.go
+++ b/pkg/model/awsmodel/nodeterminationhandler.go
@@ -115,7 +115,7 @@ func (b *NodeTerminationHandlerBuilder) configureASG(c *fi.CloudupModelBuilderCo
 func (b *NodeTerminationHandlerBuilder) build(c *fi.CloudupModelBuilderContext) error {
 	queueName := model.QueueNamePrefix(b.ClusterName()) + "-nth"
 
-	policy := iam.NewPolicy(b.ClusterName(), b.AWSPartition)
+	policy := iam.NewPolicy(b.ClusterName(), b.AWSPartition, b.Region)
 	arn := arn.ARN{
 		Partition: b.AWSPartition,
 		Service:   "sqs",

--- a/pkg/model/components/addonmanifests/awscloudcontrollermanager/iam.go
+++ b/pkg/model/components/addonmanifests/awscloudcontrollermanager/iam.go
@@ -31,7 +31,7 @@ var _ iam.Subject = &ServiceAccount{}
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
 func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
-	p := iam.NewPolicy(clusterName, b.Partition)
+	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 
 	// Only inject NLBSecurityMode=Managed specific IAM permissions if enabled
 	nlbSecurityGroupMode := b.Cluster.Spec.CloudProvider.AWS.NLBSecurityGroupMode

--- a/pkg/model/components/addonmanifests/awsebscsidriver/iam.go
+++ b/pkg/model/components/addonmanifests/awsebscsidriver/iam.go
@@ -31,7 +31,7 @@ var _ iam.Subject = &ServiceAccount{}
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
 func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
-	p := iam.NewPolicy(clusterName, b.Partition)
+	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 
 	addSnapshotControllerPermissions := b.Cluster.Spec.SnapshotController != nil && fi.ValueOf(b.Cluster.Spec.SnapshotController.Enabled)
 	iam.AddAWSEBSCSIDriverPermissions(b, p, addSnapshotControllerPermissions)

--- a/pkg/model/components/addonmanifests/awsloadbalancercontroller/iam.go
+++ b/pkg/model/components/addonmanifests/awsloadbalancercontroller/iam.go
@@ -30,7 +30,7 @@ var _ iam.Subject = &ServiceAccount{}
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
 func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
-	p := iam.NewPolicy(clusterName, b.Partition)
+	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 
 	var enableWAF bool
 	var enableWAFv2 bool

--- a/pkg/model/components/addonmanifests/certmanager/iam.go
+++ b/pkg/model/components/addonmanifests/certmanager/iam.go
@@ -34,7 +34,7 @@ var _ iam.Subject = &ServiceAccount{}
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
 func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
-	p := iam.NewPolicy(clusterName, b.Partition)
+	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 
 	addCertManagerPermissions(b, p)
 

--- a/pkg/model/components/addonmanifests/clusterautoscaler/iam.go
+++ b/pkg/model/components/addonmanifests/clusterautoscaler/iam.go
@@ -31,7 +31,7 @@ var _ iam.Subject = &ServiceAccount{}
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
 func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
-	p := iam.NewPolicy(clusterName, b.Partition)
+	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 
 	var useStaticInstanceList bool
 	if ca := b.Cluster.Spec.ClusterAutoscaler; ca != nil && fi.ValueOf(ca.AWSUseStaticInstanceList) {

--- a/pkg/model/components/addonmanifests/dnscontroller/iam.go
+++ b/pkg/model/components/addonmanifests/dnscontroller/iam.go
@@ -30,7 +30,7 @@ var _ iam.Subject = &ServiceAccount{}
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
 func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
-	p := iam.NewPolicy(clusterName, b.Partition)
+	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 
 	iam.AddDNSControllerPermissions(b, p)
 

--- a/pkg/model/components/addonmanifests/karpenter/iam.go
+++ b/pkg/model/components/addonmanifests/karpenter/iam.go
@@ -31,7 +31,7 @@ var _ iam.Subject = &ServiceAccount{}
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
 func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
-	p := iam.NewPolicy(clusterName, b.Partition)
+	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 
 	addKarpenterPermissions(p)
 

--- a/pkg/model/components/addonmanifests/kuberouter/iam.go
+++ b/pkg/model/components/addonmanifests/kuberouter/iam.go
@@ -31,7 +31,7 @@ var _ iam.Subject = &ServiceAccount{}
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
 func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
-	p := iam.NewPolicy(clusterName, b.Partition)
+	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 	iam.AddKubeRouterPermissions(b, p)
 	return p, nil
 }

--- a/pkg/model/components/addonmanifests/nodeterminationhandler/iam.go
+++ b/pkg/model/components/addonmanifests/nodeterminationhandler/iam.go
@@ -30,7 +30,7 @@ var _ iam.Subject = &ServiceAccount{}
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
 func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
-	p := iam.NewPolicy(clusterName, b.Partition)
+	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 
 	iam.AddNodeTerminationHandlerSQSPermissions(p)
 

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -50,9 +50,11 @@ const PolicyDefaultVersion = "2012-10-17"
 // Policy Struct is a collection of fields that form a valid AWS policy document
 type Policy struct {
 	clusterName               string
+	region                    string
 	unconditionalAction       sets.Set[string]
 	clusterTaggedAction       sets.Set[string]
 	clusterTaggedCreateAction sets.Set[string]
+	kmsDataPlaneAction        sets.Set[string]
 	Statement                 []*Statement
 	partition                 string
 	Version                   string
@@ -108,6 +110,19 @@ func (p *Policy) AddEC2CreateAction(actions, resources []string) {
 
 // AsJSON converts the policy document to JSON format (parsable by AWS)
 func (p *Policy) AsJSON() (string, error) {
+	if len(p.kmsDataPlaneAction) > 0 {
+		services := kmsViaServices(p.partition, p.region)
+		p.Statement = append(p.Statement, &Statement{
+			Effect:   StatementEffectAllow,
+			Action:   stringorset.Of(sets.List(p.kmsDataPlaneAction)...),
+			Resource: stringorset.String("*"),
+			Condition: Condition{
+				"StringLike": map[string][]string{
+					"kms:ViaService": services,
+				},
+			},
+		})
+	}
 	if len(p.unconditionalAction) > 0 {
 		p.Statement = append(p.Statement, &Statement{
 			Effect:   StatementEffectAllow,
@@ -334,13 +349,15 @@ func (b *PolicyBuilder) BuildAWSPolicy() (*Policy, error) {
 	return p, nil
 }
 
-func NewPolicy(clusterName, partition string) *Policy {
+func NewPolicy(clusterName, partition, region string) *Policy {
 	p := &Policy{
 		Version:                   PolicyDefaultVersion,
 		clusterName:               clusterName,
+		region:                    region,
 		unconditionalAction:       sets.New[string](),
 		clusterTaggedAction:       sets.New[string](),
 		clusterTaggedCreateAction: sets.New[string](),
+		kmsDataPlaneAction:        sets.New[string](),
 		partition:                 partition,
 	}
 	return p
@@ -348,7 +365,7 @@ func NewPolicy(clusterName, partition string) *Policy {
 
 // BuildAWSPolicy generates a custom policy for a Kubernetes master.
 func (r *NodeRoleAPIServer) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
-	p := NewPolicy(b.Cluster.GetName(), b.Partition)
+	p := NewPolicy(b.Cluster.GetName(), b.Partition, b.Region)
 
 	b.addNodeupPermissions(p, r.warmPool)
 
@@ -356,7 +373,10 @@ func (r *NodeRoleAPIServer) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
 	}
 
-	addKMSIAMPolicies(p)
+	// The API server role may host a kms-plugin sidecar wired to the instance role
+	// when EncryptionConfig is enabled; bypass kms:ViaService so that direct KMS
+	// calls from kube-apiserver are not denied.
+	addKMSIAMPolicies(p, fi.ValueOf(b.Cluster.Spec.EncryptionConfig))
 
 	if b.Cluster.Spec.IAM != nil && b.Cluster.Spec.IAM.AllowContainerRegistry {
 		addECRPermissions(p)
@@ -389,7 +409,7 @@ func (r *NodeRoleAPIServer) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	clusterName := b.Cluster.GetName()
 
-	p := NewPolicy(clusterName, b.Partition)
+	p := NewPolicy(clusterName, b.Partition, b.Region)
 
 	addEtcdManagerPermissions(p)
 	b.addNodeupPermissions(p, false)
@@ -402,7 +422,10 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
 	}
 
-	addKMSIAMPolicies(p)
+	// The combined master role hosts kube-apiserver, so a user-supplied kms-plugin
+	// for EncryptionConfig will call KMS directly from this role. Bypass ViaService
+	// in that case.
+	addKMSIAMPolicies(p, fi.ValueOf(b.Cluster.Spec.EncryptionConfig))
 
 	// Protokube needs dns-controller permissions in instance role even if UseServiceAccountExternalPermissions.
 	AddDNSControllerPermissions(b, p)
@@ -463,7 +486,7 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 
 // BuildAWSPolicy generates a custom policy for a Kubernetes node.
 func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
-	p := NewPolicy(b.Cluster.GetName(), b.Partition)
+	p := NewPolicy(b.Cluster.GetName(), b.Partition, b.Region)
 
 	b.addNodeupPermissions(p, r.enableLifecycleHookPermissions)
 
@@ -505,7 +528,7 @@ func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 
 // BuildAWSPolicy generates a custom policy for a bastion host.
 func (r *NodeRoleBastion) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
-	p := NewPolicy(b.Cluster.GetName(), b.Partition)
+	p := NewPolicy(b.Cluster.GetName(), b.Partition, b.Region)
 
 	// Bastion hosts currently don't require any specific permissions.
 	// A trivial permission is granted, because empty policies are not allowed.
@@ -1084,7 +1107,8 @@ func AddClusterAutoscalerPermissions(p *Policy, useStaticInstanceList bool) {
 
 // AddAWSEBSCSIDriverPermissions appens policy statements that the AWS EBS CSI Driver needs to operate.
 func AddAWSEBSCSIDriverPermissions(b *PolicyBuilder, p *Policy, appendSnapshotPermissions bool) {
-	addKMSIAMPolicies(p)
+	// EBS CSI's data-plane KMS calls flow through EC2, so kms:ViaService applies.
+	addKMSIAMPolicies(p, false)
 
 	if appendSnapshotPermissions {
 		addSnapshotPermissions(b, p)
@@ -1197,16 +1221,76 @@ func AddKubeRouterPermissions(b *PolicyBuilder, p *Policy) {
 	)
 }
 
-func addKMSIAMPolicies(p *Policy) {
-	// TODO could use "kms:ViaService" Condition Key here?
+func addKMSIAMPolicies(p *Policy, bypassViaService bool) {
+	// kms:CreateGrant is called directly by the EBS CSI driver pod (no AWS
+	// service makes the call on its behalf), so kms:ViaService is not set and
+	// we cannot use it as a guard here. kms:DescribeKey is also typically
+	// called directly. Phase 3 of the KMS restriction plan will scope
+	// CreateGrant with kms:GrantIsForAWSResource.
 	p.unconditionalAction.Insert(
 		"kms:CreateGrant",
-		"kms:Decrypt",
 		"kms:DescribeKey",
+	)
+
+	dataActions := []string{
+		"kms:Decrypt",
 		"kms:Encrypt",
 		"kms:GenerateDataKey*",
 		"kms:ReEncrypt*",
-	)
+	}
+
+	// bypassViaService is set by callers whose role may need to talk to KMS
+	// without an AWS service in the call chain -- currently only the API server
+	// role when EncryptionConfig is enabled, since a user-supplied kms-plugin
+	// sidecar wired to the instance role calls KMS directly from kube-apiserver.
+	// In that mode kms:ViaService never matches and the conditional grant
+	// would deny every encrypt/decrypt of etcd data.
+	//
+	// An empty region also falls back to unconditional grants to preserve
+	// existing behavior for callers (e.g. unit tests) that have not populated
+	// PolicyBuilder.Region; kmsViaServices needs the region to build the
+	// service endpoint strings.
+	if bypassViaService || p.region == "" {
+		p.unconditionalAction.Insert(dataActions...)
+		return
+	}
+
+	p.kmsDataPlaneAction.Insert(dataActions...)
+}
+
+// kmsViaServices returns the kms:ViaService endpoint patterns that AWS services
+// present to KMS when acting on behalf of an IAM principal. Used to bound the
+// data-plane KMS actions (Decrypt/Encrypt/GenerateDataKey*/ReEncrypt*) to the
+// services we actually use them through: EC2 (for EBS volume encryption) and
+// S3 (for SSE-KMS on the state-store bucket).
+//
+// Per AWS KMS docs, the value is "<service>.<region>.<url-suffix>" where the
+// URL suffix is partition-specific. Suffixes mirror the four forms recognized
+// by aws-cdk's region-info defaults; aws-us-gov shares the commercial suffix.
+// See: https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/region-info/lib/default.ts
+//
+// EC2 is pinned to the cluster's region (EBS is always in-region). S3 uses a
+// region wildcard because kops supports cross-region state-store buckets; the
+// caller must therefore evaluate the values under StringLike, not StringEquals.
+func kmsViaServices(partition, region string) []string {
+	if region == "" {
+		return nil
+	}
+	var suffix string
+	switch partition {
+	case "aws-cn":
+		suffix = "amazonaws.com.cn"
+	case "aws-iso":
+		suffix = "c2s.ic.gov"
+	case "aws-iso-b":
+		suffix = "sc2s.sgov.gov"
+	default:
+		suffix = "amazonaws.com"
+	}
+	return []string{
+		fmt.Sprintf("ec2.%s.%s", region, suffix),
+		fmt.Sprintf("s3.*.%s", suffix),
+	}
 }
 
 func addASLifecyclePolicies(p *Policy, enableHookSupport bool) {

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -18,6 +18,7 @@ package iam
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -224,6 +225,7 @@ func TestPolicyGeneration(t *testing.T) {
 				},
 			},
 			Role:      x.Role,
+			Region:    "us-test-1",
 			Partition: "aws-test",
 		}
 		if x.Gossip {
@@ -274,5 +276,78 @@ func TestEmptyPolicy(t *testing.T) {
 
 	if policy != "" {
 		t.Errorf("empty policy should result in empty string, but was %q", policy)
+	}
+}
+
+func TestAddKMSIAMPolicies(t *testing.T) {
+	dataActions := []string{
+		"kms:Decrypt",
+		"kms:Encrypt",
+		"kms:GenerateDataKey*",
+		"kms:ReEncrypt*",
+	}
+	alwaysUnconditional := []string{"kms:CreateGrant", "kms:DescribeKey"}
+
+	tests := []struct {
+		name             string
+		region           string
+		bypassViaService bool
+		wantConditional  bool
+	}{
+		{name: "region set, bypass off", region: "us-east-1", bypassViaService: false, wantConditional: true},
+		{name: "region set, bypass on", region: "us-east-1", bypassViaService: true, wantConditional: false},
+		{name: "region unset, bypass off", region: "", bypassViaService: false, wantConditional: false},
+		{name: "region unset, bypass on", region: "", bypassViaService: true, wantConditional: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewPolicy("c.example.com", "aws", tc.region)
+			addKMSIAMPolicies(p, tc.bypassViaService)
+			for _, action := range dataActions {
+				inConditional := p.kmsDataPlaneAction.Has(action)
+				inUnconditional := p.unconditionalAction.Has(action)
+				wantInConditional := tc.wantConditional
+				wantInUnconditional := !tc.wantConditional
+				if inConditional != wantInConditional || inUnconditional != wantInUnconditional {
+					t.Errorf("addKMSIAMPolicies(region=%q, bypass=%v) action %q: conditional=%v unconditional=%v, want conditional=%v unconditional=%v",
+						tc.region, tc.bypassViaService, action, inConditional, inUnconditional, wantInConditional, wantInUnconditional)
+				}
+			}
+			// CreateGrant and DescribeKey are always unconditional regardless of
+			// region or bypass, since the EBS CSI driver calls them directly.
+			for _, action := range alwaysUnconditional {
+				if !p.unconditionalAction.Has(action) {
+					t.Errorf("addKMSIAMPolicies(region=%q, bypass=%v) missing unconditional %q", tc.region, tc.bypassViaService, action)
+				}
+				if p.kmsDataPlaneAction.Has(action) {
+					t.Errorf("addKMSIAMPolicies(region=%q, bypass=%v) %q unexpectedly in kmsDataPlaneAction", tc.region, tc.bypassViaService, action)
+				}
+			}
+		})
+	}
+}
+
+func TestKmsViaServices(t *testing.T) {
+	tests := []struct {
+		name      string
+		partition string
+		region    string
+		want      []string
+	}{
+		{name: "empty region returns nil", partition: "aws", region: "", want: nil},
+		{name: "aws commercial", partition: "aws", region: "us-east-1", want: []string{"ec2.us-east-1.amazonaws.com", "s3.*.amazonaws.com"}},
+		{name: "aws-us-gov uses commercial suffix", partition: "aws-us-gov", region: "us-gov-west-1", want: []string{"ec2.us-gov-west-1.amazonaws.com", "s3.*.amazonaws.com"}},
+		{name: "aws-cn", partition: "aws-cn", region: "cn-north-1", want: []string{"ec2.cn-north-1.amazonaws.com.cn", "s3.*.amazonaws.com.cn"}},
+		{name: "aws-iso", partition: "aws-iso", region: "us-iso-east-1", want: []string{"ec2.us-iso-east-1.c2s.ic.gov", "s3.*.c2s.ic.gov"}},
+		{name: "aws-iso-b", partition: "aws-iso-b", region: "us-isob-east-1", want: []string{"ec2.us-isob-east-1.sc2s.sgov.gov", "s3.*.sc2s.sgov.gov"}},
+		{name: "unknown partition falls through to commercial suffix", partition: "made-up", region: "x-1", want: []string{"ec2.x-1.amazonaws.com", "s3.*.amazonaws.com"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := kmsViaServices(tc.partition, tc.region)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("kmsViaServices(%q, %q) = %v, want %v", tc.partition, tc.region, got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/model/iam/tests/iam_builder_master_gossip.json
+++ b/pkg/model/iam/tests/iam_builder_master_gossip.json
@@ -103,6 +103,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -133,11 +151,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/pkg/model/iam/tests/iam_builder_master_gossip_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_gossip_ecr.json
@@ -103,6 +103,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -140,11 +158,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/pkg/model/iam/tests/iam_builder_master_nlb_sg_managed.json
+++ b/pkg/model/iam/tests/iam_builder_master_nlb_sg_managed.json
@@ -103,6 +103,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -133,11 +151,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -103,6 +103,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -133,11 +151,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -103,6 +103,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -140,11 +158,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -202,11 +220,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_apiservers.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_apiservers.minimal.example.com_policy
@@ -21,13 +21,27 @@
     },
     {
       "Action": [
-        "ec2:DescribeInstanceTypes",
-        "kms:CreateGrant",
         "kms:Decrypt",
-        "kms:DescribeKey",
         "kms:Encrypt",
         "kms:GenerateDataKey*",
         "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "ec2:DescribeInstanceTypes",
+        "kms:CreateGrant",
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -38,6 +38,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
@@ -46,11 +64,7 @@
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -96,16 +96,30 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_masters.cas-priority-expander-custom.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_masters.cas-priority-expander-custom.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_masters.cas-priority-expander.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_masters.cas-priority-expander.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -199,11 +217,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -38,6 +38,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
@@ -46,11 +64,7 @@
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -96,16 +96,30 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/gossip-aws/data/aws_iam_role_policy_masters.gossip.k8s.local_policy
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_iam_role_policy_masters.gossip.k8s.local_policy
@@ -135,6 +135,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -172,11 +190,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -38,6 +38,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
@@ -46,11 +64,7 @@
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -96,16 +96,30 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -85,6 +85,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:CreateSnapshot",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
@@ -95,11 +113,7 @@
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -105,6 +105,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:AssignPrivateIpAddresses",
         "ec2:AttachNetworkInterface",
         "ec2:CreateNetworkInterface",
@@ -120,11 +138,7 @@
         "ec2:ModifyNetworkInterfaceAttribute",
         "ec2:UnassignPrivateIpAddresses",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -254,6 +254,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
         "autoscaling:DescribeAutoScalingGroups",
@@ -308,11 +326,7 @@
         "elasticloadbalancing:SetRulePriorities",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
@@ -254,6 +254,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
         "autoscaling:DescribeAutoScalingGroups",
@@ -308,11 +326,7 @@
         "elasticloadbalancing:SetRulePriorities",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -202,11 +220,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -202,11 +220,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -202,11 +220,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -202,11 +220,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -202,11 +220,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -202,11 +220,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_masters.minimal-aws.example.com_policy
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_masters.minimal-aws.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -135,6 +135,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -172,11 +190,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -197,11 +215,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -197,11 +215,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -198,11 +216,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -197,11 +215,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -197,11 +215,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.really.really.reall-g6fsnu_policy
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.really.really.reall-g6fsnu_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -135,6 +135,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -165,11 +183,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local_policy
@@ -38,6 +38,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
@@ -46,11 +64,7 @@
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -66,16 +66,30 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l_policy
@@ -38,6 +38,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
@@ -46,11 +64,7 @@
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
@@ -96,16 +96,30 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -203,11 +221,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -203,11 +221,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
@@ -175,6 +175,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -213,11 +231,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_masters.privatekindnet.example.com_policy
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_iam_role_policy_masters.privatekindnet.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -196,11 +214,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -38,6 +38,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
@@ -46,11 +64,7 @@
         "ec2:DescribeVolumes",
         "ec2:DescribeVolumesModifications",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -96,16 +96,30 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeVolumes",
         "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*"
+        "kms:DescribeKey"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -197,11 +215,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -165,6 +165,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
@@ -195,11 +213,7 @@
         "elasticloadbalancing:DescribeTargetHealth",
         "iam:CreateServiceLinkedRole",
         "kms:CreateGrant",
-        "kms:Decrypt",
         "kms:DescribeKey",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*",
-        "kms:ReEncrypt*",
         "sqs:DeleteMessage",
         "sqs:ReceiveMessage"
       ],


### PR DESCRIPTION
  ## Summary

Closes https://github.com/kubernetes/kops/issues/16741

Tightens the IAM policies kops generates so the data-plane KMS actions (`kms:Decrypt`, `kms:Encrypt`, `kms:GenerateDataKey*`, `kms:ReEncrypt*`) can only succeed when invoked through the AWS services kops actually relies on them for: **EC2** (EBS volume encryption) and **S3** (SSE-KMS on the state store bucket). The restriction is expressed via the `kms:ViaService` condition key, so any direct KMS API call with a control plane / node / service-account credential is now denied even if the credential is leaked or misused.

Resolves a `// TODO could use "kms:ViaService" Condition Key here?` left in `addKMSIAMPolicies` since the original KMS grant was added.

## What this changes for users

- The control plane, node, API server, and service account roles still get `kms:Decrypt`, `kms:Encrypt`, `kms:GenerateDataKey*`, and `kms:ReEncrypt*` on `Resource: "*"`, but now under a `StringEquals` condition matching
  `kms:ViaService` to:
  - `ec2.<region>.<suffix>`
  - `s3.<region>.<suffix>`
- `kms:CreateGrant` and `kms:DescribeKey` keep their unconditional grants. Both are called directly by the EBS CSI driver (no AWS service relays the call), so `kms:ViaService` doesn't apply. A later phase will tighten `CreateGrant` with `kms:GrantIsForAWSResource`.


When a cluster opts in to the Kubernetes EncryptionConfig feature, users may ship a `kms-plugin` sidecar that calls KMS directly from the kube-apiserver process. There is no AWS service in the call chain, so a `kms:ViaService` condition
would silently deny every encrypt/decrypt of etcd data and the apiserver would refuse to start. When `EncryptionConfig` is set on the cluster, `NodeRoleAPIServer` and `NodeRoleMaster` policies skip the ViaService gate and emit the data actions unconditionally. The `NodeRoleNode` and EBS CSI driver paths are unaffected, they always flow through EC2 and continue to be gated. Users who run the kms-plugin under IRSA are also unaffected (separate role).