### PR TITLE
nodeup: populate DefaultMachineType for Cilium-ENI clusters

### DIFF
--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -330,6 +330,7 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 		config.Networking.Cilium = &kops.CiliumNetworkingSpec{}
 		if cluster.Spec.Networking.Cilium.IPAM == kops.CiliumIpamEni {
 			config.Networking.Cilium.IPAM = kops.CiliumIpamEni
+			config.DefaultMachineType = aws.String(strings.Split(instanceGroup.Spec.MachineType, ",")[0])
 		}
 		if model.UseCiliumEtcd(cluster) {
 			config.UseCiliumEtcd = true

--- a/pkg/apis/nodeup/config_test.go
+++ b/pkg/apis/nodeup/config_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeup
+
+import (
+	"testing"
+
+	"k8s.io/kops/pkg/apis/kops"
+)
+
+// TestNewConfigDefaultMachineType verifies that NewConfig populates DefaultMachineType
+// for exactly the networking modes whose kubelet maxPods calculation in nodeup falls
+// back to it when the IMDS instance-type lookup fails: AmazonVPC and Cilium-ENI.
+func TestNewConfigDefaultMachineType(t *testing.T) {
+	grid := []struct {
+		name       string
+		networking kops.NetworkingSpec
+		want       string
+	}{
+		{
+			name:       "AmazonVPC",
+			networking: kops.NetworkingSpec{AmazonVPC: &kops.AmazonVPCNetworkingSpec{}},
+			want:       "m5.large",
+		},
+		{
+			name:       "Cilium with ENI IPAM",
+			networking: kops.NetworkingSpec{Cilium: &kops.CiliumNetworkingSpec{IPAM: kops.CiliumIpamEni}},
+			want:       "m5.large",
+		},
+		{
+			name:       "Cilium without ENI IPAM",
+			networking: kops.NetworkingSpec{Cilium: &kops.CiliumNetworkingSpec{}},
+			want:       "",
+		},
+		{
+			name:       "Calico",
+			networking: kops.NetworkingSpec{Calico: &kops.CalicoNetworkingSpec{}},
+			want:       "",
+		},
+	}
+
+	for _, tc := range grid {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					KubernetesVersion: "1.32.0",
+					KubeAPIServer:     &kops.KubeAPIServerConfig{},
+					Networking:        tc.networking,
+				},
+			}
+			cluster.Name = "test.example.com"
+
+			ig := &kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					Role:        kops.InstanceGroupRoleNode,
+					MachineType: "m5.large,m5.xlarge",
+				},
+			}
+
+			config, _ := NewConfig(cluster, ig)
+
+			if tc.want == "" {
+				if config.DefaultMachineType != nil {
+					t.Errorf("DefaultMachineType = %q, want nil", *config.DefaultMachineType)
+				}
+				return
+			}
+			if config.DefaultMachineType == nil {
+				t.Fatalf("DefaultMachineType = nil, want %q", tc.want)
+			}
+			if *config.DefaultMachineType != tc.want {
+				t.Errorf("DefaultMachineType = %q, want %q", *config.DefaultMachineType, tc.want)
+			}
+		})
+	}
+}

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatecilium.example.com
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 8ri898eSELD96zBXq6X5EUp0cB9NFGhcsKlkCcL1qvY=
+NodeupConfigHash: e0a5a8HFqxr9LXok5ek2jVUVPQFxyjvkzmggrIlYxe0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -149,7 +149,7 @@ ConfigServer:
   - https://kops-controller.internal.privatecilium.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: hrPqpfhue+BeiTdz5rsG9UEpy7OJlzNKiWOAfWBq2d8=
+NodeupConfigHash: xqw4pujaL18targJp9pgzLefw8lfCWWq+dwk/i86tXc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -244,6 +244,7 @@ ControlPlaneConfig:
       leaderElect: true
     logLevel: 2
 DNSZone: Z1AFAKE1ZON3YO
+DefaultMachineType: m3.medium
 EtcdClusterNames:
 - main
 - events

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-nodes_content
@@ -13,6 +13,7 @@ Assets:
   - d6dcab36d1b6af1b72c7f0662e5fcf446a291271ba6006532b95c4144e19d428@https://github.com/opencontainers/runc/releases/download/v1.3.4/runc.arm64
 CAs: {}
 ClusterName: privatecilium.example.com
+DefaultMachineType: t2.medium
 Hooks:
 - null
 - null

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privateciliumadvanced.example.com
 ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: waHPFHdmBZRgoKP/5SWveFKYtSfdey/Z20pwMWGThbA=
+NodeupConfigHash: ufDtScRBE1ZQvE/UBmFo8auQ4ICMH5Yj0d3LyXWKCwg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
@@ -149,7 +149,7 @@ ConfigServer:
   - https://kops-controller.internal.privateciliumadvanced.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 9GlPFhTuBdjMo9sZv6xA14PBPhJzGQaBZi3lFI0WecE=
+NodeupConfigHash: mg+73/zOUPXU+C/51u+JZg+UY0mBQIK37aaqF+O5uYk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -311,6 +311,7 @@ ControlPlaneConfig:
       leaderElect: true
     logLevel: 2
 DNSZone: Z1AFAKE1ZON3YO
+DefaultMachineType: m3.medium
 EtcdClusterNames:
 - main
 - events

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-nodes_content
@@ -36,6 +36,7 @@ CAs:
     MQNfAQ==
     -----END CERTIFICATE-----
 ClusterName: privateciliumadvanced.example.com
+DefaultMachineType: t2.medium
 Hooks:
 - null
 - null


### PR DESCRIPTION
The kubelet maxPods calculation runs for AmazonVPC and Cilium-ENI networking and falls back to DefaultMachineType when the IMDS instance-type lookup fails. NewConfig only set DefaultMachineType for AmazonVPC, so a Cilium-ENI node would dereference a nil pointer if IMDS was unavailable.

/cc @rifelpet @ameukam 