### PR TITLE
decouple client HTTP traffic in kops scalability tests

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -87,6 +87,7 @@ fi
 create_args+=("--set spec.etcdClusters[0].manager.listenMetricsURLs=http://localhost:2382")
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_QUOTA_BACKEND_BYTES=${ETCD_QUOTA_BACKEND_BYTES}")
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_ENABLE_PPROF=true")
+create_args+=("--set spec.etcdClusters[0].manager.env=ETCD_LISTEN_CLIENT_HTTP_URLS=http://localhost:2385")
 create_args+=("--set spec.cloudControllerManager.concurrentNodeSyncs=10")
 create_args+=("--set spec.kubelet.maxPods=96")
 create_args+=("--set spec.kubelet.kubeAPIQPS=100")


### PR DESCRIPTION
decouple client HTTP traffic in kops. There is no HTTP traffic, apiserver communicates only over grpc. skips cmux multiplexing with the change. 

https://github.com/etcd-io/etcd/blob/main/server/etcdmain/config.go#L226

addressing https://github.com/etcd-io/etcd/issues/21605#issuecomment-4490467141