### PR TITLE
aws: Use amazonaws.com suffix for kms:ViaService in all partitions

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -111,7 +111,7 @@ func (p *Policy) AddEC2CreateAction(actions, resources []string) {
 // AsJSON converts the policy document to JSON format (parsable by AWS)
 func (p *Policy) AsJSON() (string, error) {
 	if len(p.kmsDataPlaneAction) > 0 {
-		services := kmsViaServices(p.partition, p.region)
+		services := kmsViaServices(p.region)
 		p.Statement = append(p.Statement, &Statement{
 			Effect:   StatementEffectAllow,
 			Action:   stringorset.Of(sets.List(p.kmsDataPlaneAction)...),
@@ -1264,32 +1264,22 @@ func addKMSIAMPolicies(p *Policy, bypassViaService bool) {
 // services we actually use them through: EC2 (for EBS volume encryption) and
 // S3 (for SSE-KMS on the state-store bucket).
 //
-// Per AWS KMS docs, the value is "<service>.<region>.<url-suffix>" where the
-// URL suffix is partition-specific. Suffixes mirror the four forms recognized
-// by aws-cdk's region-info defaults; aws-us-gov shares the commercial suffix.
-// See: https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/region-info/lib/default.ts
+// Per AWS KMS docs the value is "<service>.<region>.amazonaws.com" — the
+// ".amazonaws.com" suffix is used in all partitions (including aws-cn,
+// aws-us-gov, aws-iso, aws-iso-b); the partition-specific suffixes used for
+// service endpoints do NOT apply to kms:ViaService.
+// See: https://docs.aws.amazon.com/kms/latest/developerguide/conditions-kms.html
 //
 // EC2 is pinned to the cluster's region (EBS is always in-region). S3 uses a
 // region wildcard because kops supports cross-region state-store buckets; the
 // caller must therefore evaluate the values under StringLike, not StringEquals.
-func kmsViaServices(partition, region string) []string {
+func kmsViaServices(region string) []string {
 	if region == "" {
 		return nil
 	}
-	var suffix string
-	switch partition {
-	case "aws-cn":
-		suffix = "amazonaws.com.cn"
-	case "aws-iso":
-		suffix = "c2s.ic.gov"
-	case "aws-iso-b":
-		suffix = "sc2s.sgov.gov"
-	default:
-		suffix = "amazonaws.com"
-	}
 	return []string{
-		fmt.Sprintf("ec2.%s.%s", region, suffix),
-		fmt.Sprintf("s3.*.%s", suffix),
+		fmt.Sprintf("ec2.%s.amazonaws.com", region),
+		"s3.*.amazonaws.com",
 	}
 }
 

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -328,25 +328,24 @@ func TestAddKMSIAMPolicies(t *testing.T) {
 }
 
 func TestKmsViaServices(t *testing.T) {
+	// Per AWS KMS docs, kms:ViaService uses the .amazonaws.com suffix in all
+	// partitions, so the result depends only on the region.
 	tests := []struct {
-		name      string
-		partition string
-		region    string
-		want      []string
+		name   string
+		region string
+		want   []string
 	}{
-		{name: "empty region returns nil", partition: "aws", region: "", want: nil},
-		{name: "aws commercial", partition: "aws", region: "us-east-1", want: []string{"ec2.us-east-1.amazonaws.com", "s3.*.amazonaws.com"}},
-		{name: "aws-us-gov uses commercial suffix", partition: "aws-us-gov", region: "us-gov-west-1", want: []string{"ec2.us-gov-west-1.amazonaws.com", "s3.*.amazonaws.com"}},
-		{name: "aws-cn", partition: "aws-cn", region: "cn-north-1", want: []string{"ec2.cn-north-1.amazonaws.com.cn", "s3.*.amazonaws.com.cn"}},
-		{name: "aws-iso", partition: "aws-iso", region: "us-iso-east-1", want: []string{"ec2.us-iso-east-1.c2s.ic.gov", "s3.*.c2s.ic.gov"}},
-		{name: "aws-iso-b", partition: "aws-iso-b", region: "us-isob-east-1", want: []string{"ec2.us-isob-east-1.sc2s.sgov.gov", "s3.*.sc2s.sgov.gov"}},
-		{name: "unknown partition falls through to commercial suffix", partition: "made-up", region: "x-1", want: []string{"ec2.x-1.amazonaws.com", "s3.*.amazonaws.com"}},
+		{name: "empty region returns nil", region: "", want: nil},
+		{name: "commercial region", region: "us-east-1", want: []string{"ec2.us-east-1.amazonaws.com", "s3.*.amazonaws.com"}},
+		{name: "gov region keeps amazonaws.com suffix", region: "us-gov-west-1", want: []string{"ec2.us-gov-west-1.amazonaws.com", "s3.*.amazonaws.com"}},
+		{name: "china region keeps amazonaws.com suffix", region: "cn-north-1", want: []string{"ec2.cn-north-1.amazonaws.com", "s3.*.amazonaws.com"}},
+		{name: "iso region keeps amazonaws.com suffix", region: "us-iso-east-1", want: []string{"ec2.us-iso-east-1.amazonaws.com", "s3.*.amazonaws.com"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := kmsViaServices(tc.partition, tc.region)
+			got := kmsViaServices(tc.region)
 			if !slices.Equal(got, tc.want) {
-				t.Errorf("kmsViaServices(%q, %q) = %v, want %v", tc.partition, tc.region, got, tc.want)
+				t.Errorf("kmsViaServices(%q) = %v, want %v", tc.region, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kops/pull/18363#issuecomment-4478912566

[docs.aws.amazon.com/kms/latest/developerguide/conditions-kms.html#conditions-kms-schedule-key-deletion-pending-window-in-days](https://docs.aws.amazon.com/kms/latest/developerguide/conditions-kms.html#conditions-kms-schedule-key-deletion-pending-window-in-days)

>    Use the .amazonaws.com suffix of the AWS KMS ViaService name in all AWS partitions.

I confirmed via testing in the aws-gov-us partition that this works (though .amazonaws.com was used for that partition originally).

We don't have access to accounts in any other partitions, so we can't validate this. We'll just rely on the docs and any subsequent bug reports.