### PR TITLE
channels: stop distributing the standalone binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,19 +101,15 @@ endif
 kops-install: kops
 	cp ${DIST}/$(shell go env GOOS)/$(shell go env GOARCH)/kops* ${GOBIN}
 
-.PHONY: channels-install # install channels to local $gopath/bin
-channels-install: channels
-	cp ${DIST}/${OSARCH}/channels ${GOPATH_1ST}/bin
-
-.PHONY: nodeup-install # install channels to local $gopath/bin
+.PHONY: nodeup-install # install nodeup to local $gopath/bin
 nodeup-install: nodeup
-	cp ${DIST}/${OSARCH}/channels ${GOPATH_1ST}/bin
+	cp ${DIST}/${OSARCH}/nodeup ${GOPATH_1ST}/bin
 
 .PHONY: all-install # Install all kops project binaries
-all-install: all kops-install channels-install nodeup-install
+all-install: all kops-install nodeup-install
 
 .PHONY: all
-all: kops protokube nodeup channels ko-kops-controller-export ko-kops-channels-export ko-dns-controller-export ko-kops-utils-cp-export ko-kube-apiserver-healthcheck-export ko-discovery-server-export
+all: kops protokube nodeup ko-kops-controller-export ko-kops-channels-export ko-dns-controller-export ko-kops-utils-cp-export ko-kube-apiserver-healthcheck-export ko-discovery-server-export
 
 include tests/e2e/e2e.mk
 
@@ -234,16 +230,10 @@ protokube: protokube-amd64
 .PHONY: crossbuild-protokube
 crossbuild-protokube: protokube-amd64 protokube-arm64
 
-.PHONY: channels-amd64 channels-arm64
-channels-amd64 channels-arm64: channels-%:
-	mkdir -p ${DIST}/linux/$*
-	GOOS=linux GOARCH=$* go build ${GCFLAGS} ${BUILDFLAGS} ${EXTRA_BUILDFLAGS} -o ${DIST}/linux/$*/channels ${LDFLAGS}"${EXTRA_LDFLAGS} -X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA}" k8s.io/kops/channels/cmd/channels
-
 .PHONY: channels
-channels: channels-amd64
-
-.PHONY: crossbuild-channels
-crossbuild-channels: channels-amd64 channels-arm64
+channels:
+	mkdir -p ${DIST}/linux/amd64
+	GOOS=linux GOARCH=amd64 go build ${GCFLAGS} ${BUILDFLAGS} ${EXTRA_BUILDFLAGS} -o ${DIST}/linux/amd64/channels ${LDFLAGS}"${EXTRA_LDFLAGS} -X k8s.io/kops.Version=${VERSION} -X k8s.io/kops.GitVersion=${GITSHA}" k8s.io/kops/channels/cmd/channels
 
 .PHONY: upload
 upload: version-dist # Upload kops to S3
@@ -672,23 +662,6 @@ dev-upload-protokube: version-dist-protokube
 dev-upload-protokube-amd64 dev-upload-protokube-arm64: dev-upload-protokube-%: version-dist-protokube-%
 	${UPLOAD_CMD} ${UPLOAD}/ ${UPLOAD_DEST}
 
-# dev-upload-channels uploads channels
-.PHONY: version-dist-channels version-dist-channels-amd64 version-dist-channels-arm64
-version-dist-channels: version-dist-channels-amd64 version-dist-channels-arm64
-
-version-dist-channels-amd64 version-dist-channels-arm64: version-dist-channels-%: channels-%
-	mkdir -p ${UPLOAD}/kops/${VERSION}/linux/$*/
-	cp -fp ${DIST}/linux/$*/channels ${UPLOAD}/kops/${VERSION}/linux/$*/channels
-	tools/sha256 ${UPLOAD}/kops/${VERSION}/linux/$*/channels ${UPLOAD}/kops/${VERSION}/linux/$*/channels.sha256
-
-.PHONY: dev-upload-channels
-dev-upload-channels: version-dist-channels
-	${UPLOAD_CMD} ${PLOAD}/ ${UPLOAD_DEST}
-
-.PHONY: dev-upload-channels-amd64 dev-upload-channels-arm64
-dev-upload-channels-amd64 dev-upload-channels-arm64: dev-upload-channels-%: version-dist-channels-%
-	${UPLOAD_CMD} ${UPLOAD}/ ${UPLOAD_DEST}
-
 # dev-upload-kops-controller uploads kops-controller
 .PHONY: version-dist-kops-controller version-dist-kops-controller-amd64 version-dist-kops-controller-arm64
 version-dist-kops-controller: version-dist-kops-controller-amd64 version-dist-kops-controller-arm64
@@ -795,7 +768,7 @@ dev-upload-discovery-server-amd64 dev-upload-discovery-server-arm64: dev-upload-
 .PHONY: dev-version-dist dev-version-dist-amd64 dev-version-dist-arm64
 dev-version-dist: dev-version-dist-amd64 dev-version-dist-arm64
 
-dev-version-dist-amd64 dev-version-dist-arm64: dev-version-dist-%: version-dist-nodeup-% version-dist-channels-% version-dist-protokube-% version-dist-kops-controller-% version-dist-kops-channels-% version-dist-kube-apiserver-healthcheck-% version-dist-dns-controller-% version-dist-kops-utils-cp-% version-dist-discovery-server-%
+dev-version-dist-amd64 dev-version-dist-arm64: dev-version-dist-%: version-dist-nodeup-% version-dist-protokube-% version-dist-kops-controller-% version-dist-kops-channels-% version-dist-kube-apiserver-healthcheck-% version-dist-dns-controller-% version-dist-kops-utils-cp-% version-dist-discovery-server-%
 
 .PHONY: dev-upload-linux-amd64 dev-upload-linux-arm64
 dev-upload-linux-amd64 dev-upload-linux-arm64: dev-upload-linux-%: dev-version-dist-%

--- a/hack/promote-to-github.sh
+++ b/hack/promote-to-github.sh
@@ -47,10 +47,6 @@ declare -A BINARIES=(
   ["linux/amd64/protokube.sha256"]="protokube-linux-amd64.sha256"
   ["linux/arm64/protokube"]="protokube-linux-arm64"
   ["linux/arm64/protokube.sha256"]="protokube-linux-arm64.sha256"
-  ["linux/amd64/channels"]="channels-linux-amd64"
-  ["linux/amd64/channels.sha256"]="channels-linux-amd64.sha256"
-  ["linux/arm64/channels"]="channels-linux-arm64"
-  ["linux/arm64/channels.sha256"]="channels-linux-arm64.sha256"
 )
 
 if [[ $# -ne 1 ]]; then

--- a/pkg/assets/mirrors.go
+++ b/pkg/assets/mirrors.go
@@ -62,8 +62,6 @@ func (m *mirrorConfig) findMirrors(u string) ([]string, bool) {
 			suffix = strings.ReplaceAll(suffix, "linux-arm64-nodeup", "nodeup-linux-arm64")
 			suffix = strings.ReplaceAll(suffix, "linux-amd64-protokube", "protokube-linux-amd64")
 			suffix = strings.ReplaceAll(suffix, "linux-arm64-protokube", "protokube-linux-arm64")
-			suffix = strings.ReplaceAll(suffix, "linux-amd64-channels", "channels-linux-amd64")
-			suffix = strings.ReplaceAll(suffix, "linux-arm64-channels", "channels-linux-arm64")
 		}
 
 		mirrors = append(mirrors, mirror+suffix)

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -48,7 +48,6 @@ type nodeUpConfigBuilder struct {
 	etcdManifests              map[string][]string
 	images                     map[kops.InstanceGroupRole]map[architectures.Architecture][]*nodeup.Image
 	protokubeAsset             map[architectures.Architecture][]*assets.MirroredAsset
-	channelsAsset              map[architectures.Architecture][]*assets.MirroredAsset
 	encryptionConfigSecretHash string
 }
 
@@ -69,7 +68,6 @@ func NewNodeUpConfigBuilder(cluster *kops.Cluster, assetBuilder *assets.AssetBui
 	etcdManifests := map[string][]string{}
 	images := map[kops.InstanceGroupRole]map[architectures.Architecture][]*nodeup.Image{}
 	protokubeAsset := map[architectures.Architecture][]*assets.MirroredAsset{}
-	channelsAsset := map[architectures.Architecture][]*assets.MirroredAsset{}
 
 	for _, arch := range architectures.GetSupported() {
 		asset, err := wellknownassets.ProtokubeAsset(assetBuilder, arch)
@@ -77,14 +75,6 @@ func NewNodeUpConfigBuilder(cluster *kops.Cluster, assetBuilder *assets.AssetBui
 			return nil, err
 		}
 		protokubeAsset[arch] = append(protokubeAsset[arch], asset)
-	}
-
-	for _, arch := range architectures.GetSupported() {
-		asset, err := wellknownassets.ChannelsAsset(assetBuilder, arch)
-		if err != nil {
-			return nil, err
-		}
-		channelsAsset[arch] = append(channelsAsset[arch], asset)
 	}
 
 	for _, role := range kops.AllInstanceGroupRoles {
@@ -193,7 +183,6 @@ func NewNodeUpConfigBuilder(cluster *kops.Cluster, assetBuilder *assets.AssetBui
 		etcdManifests:              etcdManifests,
 		images:                     images,
 		protokubeAsset:             protokubeAsset,
-		channelsAsset:              channelsAsset,
 		encryptionConfigSecretHash: encryptionConfigSecretHash,
 	}
 
@@ -384,15 +373,6 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 			config.Channels = n.channels
 			for _, arch := range architectures.GetSupported() {
 				for _, a := range n.protokubeAsset[arch] {
-					config.Assets[arch] = append(config.Assets[arch], a.CompactString())
-				}
-			}
-		}
-
-		// The channels binary is only ever run by protokube on control-plane nodes.
-		if isMaster {
-			for _, arch := range architectures.GetSupported() {
-				for _, a := range n.channelsAsset[arch] {
 					config.Assets[arch] = append(config.Assets[arch], a.CompactString())
 				}
 			}

--- a/pkg/nodemodel/wellknownassets/kopsassets.go
+++ b/pkg/nodemodel/wellknownassets/kopsassets.go
@@ -40,9 +40,6 @@ var nodeUpAsset map[architectures.Architecture]*assets.MirroredAsset
 // protokubeAsset caches the protokube binary download url/hash
 var protokubeAsset map[architectures.Architecture]*assets.MirroredAsset
 
-// channelsAsset caches the channels binary download url/hash
-var channelsAsset map[architectures.Architecture]*assets.MirroredAsset
-
 // BaseURL returns the base url for the distribution of kops - in particular for nodeup & docker images
 func BaseURL() (*url.URL, error) {
 	// returning cached value
@@ -127,26 +124,6 @@ func ProtokubeAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Archi
 	klog.V(8).Infof("Using default protokube location for %s: %q", arch, asset.DownloadURL.String())
 
 	return protokubeAsset[arch], nil
-}
-
-// ChannelsAsset returns the url and hash of the channels binary
-func ChannelsAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Architecture) (*assets.MirroredAsset, error) {
-	if channelsAsset == nil {
-		channelsAsset = make(map[architectures.Architecture]*assets.MirroredAsset)
-	}
-	if channelsAsset[arch] != nil {
-		klog.V(8).Infof("Using cached channels binary location for %s: %v", arch, channelsAsset[arch].Locations)
-		return channelsAsset[arch], nil
-	}
-
-	asset, err := KopsFileURL(fmt.Sprintf("linux/%s/channels", arch), assetsBuilder)
-	if err != nil {
-		return nil, err
-	}
-	channelsAsset[arch] = assets.BuildMirroredAsset(asset)
-	klog.V(8).Infof("Using default channels location for %s: %q", arch, asset.DownloadURL.String())
-
-	return channelsAsset[arch], nil
 }
 
 // KopsFileURL returns the base url for the distribution of kops - in particular for nodeup & docker images

--- a/tests/e2e/scenarios/addon-resource-tracking/test.sh
+++ b/tests/e2e/scenarios/addon-resource-tracking/test.sh
@@ -45,7 +45,7 @@ CLUSTER_NAME=$(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
 "${KOPS}" update cluster
 "${KOPS}" update cluster --yes
 
-# Rolling-upgrade is needed so we get the new channels binary that supports prune
+# Rolling-upgrade is needed so we get the new kops-channels image that supports prune
 "${KOPS}" rolling-update cluster --instance-group-roles=master --yes
 
 # just make sure pods are ready

--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -37,7 +37,6 @@ fi
 
 export KOPS_BASE_URL
 export KOPS
-export CHANNELS
 
 export KOPS_RUN_TOO_NEW_VERSION=1
 
@@ -97,14 +96,6 @@ function kops-download-from-base() {
     echo "${kops}"
 }
 
-function kops-channels-download-from-base() {
-    local channels
-    channels=$(mktemp -t channels.XXXXXXXXX)
-    wget -qO "${channels}" "$KOPS_BASE_URL/$(go env GOOS)/$(go env GOARCH)/channels"
-    chmod +x "${channels}"
-    echo "${channels}"
-}
-
 function kops-base-from-marker() {
     if [[ "${1}" =~ ^https: ]]; then
         curl -fs "${1}"
@@ -120,14 +111,12 @@ function kops-acquire-latest() {
     if [[ "${JOB_TYPE-}" == "periodic" ]]; then
         KOPS_BASE_URL="$(curl -fs https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt)"
         KOPS=$(kops-download-from-base)
-        CHANNELS=$(kops-channels-download-from-base)
     else
          if [[ -n "${KOPS_BASE_URL-}" ]]; then
             KOPS_BASE_URL=""
          fi
          $KUBETEST2 --build
          KOPS="${REPO_ROOT}/.build/dist/linux/amd64/kops"
-         CHANNELS="${REPO_ROOT}/.build/dist/linux/amd64/channels"
          KOPS_BASE_URL=$(cat "${REPO_ROOT}/.kubetest2/kops-base-url")
          export KOPS_BASE_URL
          echo "KOPS_BASE_URL=$KOPS_BASE_URL"

--- a/tests/e2e/scenarios/lib/upgrade.sh
+++ b/tests/e2e/scenarios/lib/upgrade.sh
@@ -77,8 +77,6 @@ function kops-upgrade() {
         KOPS_BASE_URL=$(kops-base-from-marker "${KOPS_VERSION_B}")
         KOPS_BASE_URL_B="${KOPS_BASE_URL}"
         KOPS_B=$(kops-download-from-base)
-        CHANNELS=$(kops-channels-download-from-base)
-        export CHANNELS
     fi
 
     ${KUBETEST2} \

--- a/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_master-us-test-1a.masters.additionalobjects.example.com_user_data
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_master-us-test-1a.masters.additionalobjects.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: additionalobjects.example.com
 ConfigBase: memfs://tests/additionalobjects.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: t2n7DtzGc7GDSHMnNu1sypRScrVT3Y/KH72GxJUz/so=
+NodeupConfigHash: pzYGi4NknWqFbZyMM3EJYkmY41nNRWWVTcslO6Uu4TY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - e45a7795391cd62ee226666039153832d3096c0f892266cd968936e18b2b40b0@https://dl.k8s.io/release/v1.34.0/bin/linux/arm64/kubelet
   - 00b182d103a8a73da7a4d11e7526d0543dcf352f06cc63a1fde25ce9243f49a0@https://dl.k8s.io/release/v1.34.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: MTrwyNeStE4iVqOW3Cd8saKw6G3yQ0OUnZm3JGujyos=
+NodeupConfigHash: s+T7bpyrW7k6llzOnmd9na80E86802uCJyqbgluhPZs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - e45a7795391cd62ee226666039153832d3096c0f892266cd968936e18b2b40b0@https://dl.k8s.io/release/v1.34.0/bin/linux/arm64/kubelet
   - 00b182d103a8a73da7a4d11e7526d0543dcf352f06cc63a1fde25ce9243f49a0@https://dl.k8s.io/release/v1.34.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 2s6ZjRadl0IhsgOc7BAbJWWE1pENjIYyUYewfmFWFdk=
+NodeupConfigHash: SC2s15U40G90/kKTs/BnBl84Emn/qTaOfVDmaZQxNC4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: bastionuserdata.example.com
 ConfigBase: memfs://clusters.example.com/bastionuserdata.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Pp8ZJOMugVNXLLnEiNZmFoblxIQxnUggdyvLRQxFl/c=
+NodeupConfigHash: TxRE1teDx+fy+VsBFDTDpOJWIGq06cprz3/wSA2QiwE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander-custom.example.com_user_data
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander-custom.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: cas-priority-expander-custom.example.com
 ConfigBase: memfs://clusters.example.com/cas-priority-expander-custom.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: UngmDNs8iPkAUlJQufzfXLFz2KHhprIRfeZzpGu5V4Q=
+NodeupConfigHash: HK2t7+xDvwM4c0Zu6fc78gdVzKmswsfbszOQ/KNAebg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander.example.com_user_data
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: cas-priority-expander.example.com
 ConfigBase: memfs://clusters.example.com/cas-priority-expander.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: vvMxenvCCQ5ix8Q9RWi76c7p5JyC+2F+miBq5EpoCtQ=
+NodeupConfigHash: m/lRPZgF0CSIny0XJVdprGWKeKF3vzvhWHYTd4dcK/c=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -135,7 +135,7 @@ ClusterName: complex.example.com
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: n0cDeUIYA50OpLR2vX9zYLiVszcl5MY611sBTzLjciA=
+NodeupConfigHash: b1ELudbpBT6FTAvOZ5HwhW2yhNfL4Kpe812TuoBiD+Q=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -72,7 +72,6 @@ Assets:
   - 85795979166ae04c6c0681664ab54d0810d472e390cf54dde0de399ff6d54bef@https://github.com/containerd/containerd/releases/download/v1.7.31/containerd-1.7.31-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - b310da449a9d2f8b928cab5ca12a6772617ba421023894e061ca2647e6d9f1c3@https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubelet
   - f42832db7d77897514639c6df38214a6d8ae1262ee34943364ec1ffaee6c009c@https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubectl
@@ -81,7 +80,6 @@ Assets:
   - d375de285eaaa5a3a58c0b03d92aff6bfa7987657781bce8cd5d30335f9aa2a6@https://github.com/containerd/containerd/releases/download/v1.7.31/containerd-1.7.31-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/compress/data/aws_launch_template_master-us-test-1a.masters.compress.example.com_user_data
+++ b/tests/integration/update_cluster/compress/data/aws_launch_template_master-us-test-1a.masters.compress.example.com_user_data
@@ -129,7 +129,7 @@ function download-release() {
 echo "== nodeup node config starting =="
 ensure-install-dir
 
-echo "H4sIAAAAAAAA/2zOsU7DMBDG8d1P4RdII8SEJQbwABVR1RYilW6Hcy4VPp/x2Wng6RHKFKn7/6fvs4HrsM08ngfMRsNFlA1VCuYNEBrtmFJGkRVOQCngyjEpy9GfT48gaDQheTFt62a1CNureh2lQHT4lLmmeYXg3zZVmoJSmhtYRnsOaLTlWDKHbYCIasMD1jQfeQb5NPp1OrzfXR7eupd66r/WON7u4uj6vT0SdB5+v7sPzz8Hd9z19+oPAAD//wEAAP//bYKl1vcAAAA=" | base64 -d | gzip -d > conf/kube_env.yaml
+echo "H4sIAAAAAAAA/2zOwUoDMRDG8XueInfZBntrwINN261aShUpurchO3WrmUzIJLqPL7KnBe//H9/nAtf+lPn72mO2Gn5EuVClYD4CodWeKWUUWeAIlAIuPJNyHC/XjzUIWk1IF7HG+EnNQvOvfohSIHpsM9c0rRD82aZKU1BKcwvz6IUDWu04lszhFCCiOnKPNU1H9iCD1fH8fr+kzbCiPG6H9XJfTFef39Kq3XRj9/X5eHN42h3a1/Nue6d+AQAA//8BAAD//yD/Znf3AAAA" | base64 -d | gzip -d > conf/kube_env.yaml
 
 download-release
 echo "== nodeup node config done =="

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: containerd.example.com
 ConfigBase: memfs://clusters.example.com/containerd.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 13GErHjMgBwFnqps0lZGyVm+/OzkK1DNH2Bmh9mSC5g=
+NodeupConfigHash: w8o016QsusVO2gaxM50sBVg+66VkRP9dFV8G2z1WSHg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -63,14 +63,12 @@ Assets:
   - 7644623e4ec9ad443ab352a8a5800a5180ee28741288be805286ba72bb8e7164@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/amd64/ecr-credential-provider-linux-amd64
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
   - 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/containerd/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
+++ b/tests/integration/update_cluster/containerd/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: containerd.example.com
 ConfigBase: memfs://clusters.example.com/containerd.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: GjbSmF4GCIwMUv8MDPLyb5tsNWitwnskO7oCs6Qq6KE=
+NodeupConfigHash: K6Td6bu1JOl6CfaEaUvyG+5K1VTD3oKFoC0U19oVm9c=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
+++ b/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: 123.example.com
 ConfigBase: memfs://clusters.example.com/123.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: xTLt6FC59byL7YaLN4om5ErARljXl1vqQdu9w88CpRA=
+NodeupConfigHash: dEkGlf4JjU+gX/M1s6vDxVQUZR/NtxhHPRj86abl51k=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existing-iam.example.com
 ConfigBase: memfs://tests/existing-iam.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: sBuKUU/Vy/UvB1TcCtxR69YX4c5Bj38UZ86EvtQEIh0=
+NodeupConfigHash: 4Amr6AxE5b0GqyKV8ErHdpgdqC1NHDTnyzyEqNO9/ds=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existing-iam.example.com
 ConfigBase: memfs://tests/existing-iam.example.com
 InstanceGroupName: master-us-test-1b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: uzV7HvqpFjcSLA6g2v0PbPVYCi7L30dzde5eoM8/ZyM=
+NodeupConfigHash: E2oOpcB9wpiorICw7R2/tsPuEOH0PrDudXZCLKE2tcA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existing-iam.example.com
 ConfigBase: memfs://tests/existing-iam.example.com
 InstanceGroupName: master-us-test-1c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: VFqC3vq2VEwqGQjBsa3FmAZtnBPdtcoJ09Xn+2QydSg=
+NodeupConfigHash: Y15zPdt/a/ar24oziN3rZ5/QSrNpuOKj+s13Pu30yI4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existingsg.example.com
 ConfigBase: memfs://clusters.example.com/existingsg.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: w0m6nKNTSyISJ/vUyRRlr7PeelMZuNZtjBG4CeiWtEg=
+NodeupConfigHash: Fcx7S758qjAaiAQvRfPIIJmUMk3mGkAGl/Inu36szNI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existingsg.example.com
 ConfigBase: memfs://clusters.example.com/existingsg.example.com
 InstanceGroupName: master-us-test-1b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: YsFvA/MYDki/VgbwcQxwAwN9lwost/PwAjJQydWJE7k=
+NodeupConfigHash: SAOSVlFAxenF1bqT7XV2rPBD/82PzocpjPaGf7N2S4Q=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existingsg.example.com
 ConfigBase: memfs://clusters.example.com/existingsg.example.com
 InstanceGroupName: master-us-test-1c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Zv/iQthJ/MyPnVyJj67uJ9pdOQlUYp1F5Heqe3KJy7Q=
+NodeupConfigHash: PWgdfOBQ56eAn+JO6MkODaG4UA+2tTD9kjL7jgOiAqA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/external_dns/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/external_dns/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 1o61MESyoWDihF2jeqQbgMDz/5eTCaI5Pq1N6RxeyPs=
+NodeupConfigHash: u0T28bncbYMMwUwMwT4ZNC2HjUy0CYZQ6F4AvgLPsW8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 2s6ZjRadl0IhsgOc7BAbJWWE1pENjIYyUYewfmFWFdk=
+NodeupConfigHash: SC2s15U40G90/kKTs/BnBl84Emn/qTaOfVDmaZQxNC4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
+++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: externallb.example.com
 ConfigBase: memfs://clusters.example.com/externallb.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: d11eOhkH1/7o/0IDYA/AqOER4uVysDmvxkpLiM/T4VM=
+NodeupConfigHash: Lr8IjyufPqma55LOLzB4c+mV/hDFW6ozwk/YPJIJ2FE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: externalpolicies.example.com
 ConfigBase: memfs://clusters.example.com/externalpolicies.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: AYSSLT/gbGh4XVYPCCVzjggcfCBv6dZePnoQcMPwpww=
+NodeupConfigHash: gwjfuXz84QmKKNLH15/Lsdm5SdryuXrSNRNnX0nZUwg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -66,7 +66,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -75,7 +74,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/gossip-aws/data/aws_launch_template_master-us-test-1a.masters.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_launch_template_master-us-test-1a.masters.gossip.k8s.local_user_data
@@ -126,7 +126,7 @@ ClusterName: gossip.k8s.local
 ConfigBase: memfs://tests/gossip.k8s.local
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Wkwu/o45p4+G2fg6m2gHICMAX2f4KzOuBb8YfdPdBH4=
+NodeupConfigHash: x9sjxB+dkbg24q/k4+zPvhqN4MPlW3TwZEVo+o3osfs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -62,7 +62,6 @@ Assets:
   - 4cb83e7100a5e73fcb626207d0b5bcfd1294e26aeddfe075dcfb38f375c5f887@https://github.com/containerd/containerd/releases/download/v2.3.0/containerd-2.3.0-linux-amd64.tar.gz
   - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
@@ -71,7 +70,6 @@ Assets:
   - 06623dc8719b30d06303420f7eae91b0a9ade4e71243a4102f6375e585fb0a42@https://github.com/containerd/containerd/releases/download/v2.3.0/containerd-2.3.0-linux-arm64.tar.gz
   - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_control-plane-eastus-1.masters.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_control-plane-eastus-1.masters.gossip.k8s.local_user_data
@@ -125,7 +125,7 @@ ClusterName: gossip.k8s.local
 ConfigBase: memfs://tests/gossip.k8s.local
 InstanceGroupName: control-plane-eastus-1
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 3cpq9voJTR7MEvr4M3T4zR1P4JG7vOLi2bkz2hI+5xU=
+NodeupConfigHash: Re/PmsOQ0UBqZf5BSJOTUUMsJtzp+lwVxQRQ5A2wA6I=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source
@@ -61,7 +61,6 @@ Assets:
   - 4cb83e7100a5e73fcb626207d0b5bcfd1294e26aeddfe075dcfb38f375c5f887@https://github.com/containerd/containerd/releases/download/v2.3.0/containerd-2.3.0-linux-amd64.tar.gz
   - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
@@ -69,7 +68,6 @@ Assets:
   - 06623dc8719b30d06303420f7eae91b0a9ade4e71243a4102f6375e585fb0a42@https://github.com/containerd/containerd/releases/download/v2.3.0/containerd-2.3.0-linux-arm64.tar.gz
   - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 AzureAdminUser: kops
 CAs:
   apiserver-aggregator-ca: |

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -62,7 +62,6 @@ Assets:
   - 4cb83e7100a5e73fcb626207d0b5bcfd1294e26aeddfe075dcfb38f375c5f887@https://github.com/containerd/containerd/releases/download/v2.3.0/containerd-2.3.0-linux-amd64.tar.gz
   - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
@@ -71,7 +70,6 @@ Assets:
   - 06623dc8719b30d06303420f7eae91b0a9ade4e71243a4102f6375e585fb0a42@https://github.com/containerd/containerd/releases/download/v2.3.0/containerd-2.3.0-linux-arm64.tar.gz
   - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_master-us-test1-a-gossip-k8s-local_metadata_user-data
+++ b/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_master-us-test1-a-gossip-k8s-local_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: gossip.k8s.local
 ConfigBase: memfs://tests/gossip.k8s.local
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: DwaRXA1KpxbCN+wMJk1Ihh8xO4dgYTG0Zx9N+S4CQCA=
+NodeupConfigHash: 59FgxYSEK0TQ8bgbsekTFIKrUg5ySkPicFBHTBeDCME=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
@@ -61,7 +61,6 @@ Assets:
   - 4cb83e7100a5e73fcb626207d0b5bcfd1294e26aeddfe075dcfb38f375c5f887@https://github.com/containerd/containerd/releases/download/v2.3.0/containerd-2.3.0-linux-amd64.tar.gz
   - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
@@ -69,7 +68,6 @@ Assets:
   - 06623dc8719b30d06303420f7eae91b0a9ade4e71243a4102f6375e585fb0a42@https://github.com/containerd/containerd/releases/download/v2.3.0/containerd-2.3.0-linux-arm64.tar.gz
   - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/gossip-hetzner/data/hcloud_server_master-fsn1_user_data
+++ b/tests/integration/update_cluster/gossip-hetzner/data/hcloud_server_master-fsn1_user_data
@@ -126,7 +126,7 @@ ClusterName: gossip.k8s.local
 ConfigBase: memfs://tests/gossip.k8s.local
 InstanceGroupName: master-fsn1
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: gHG93OYoCSSHjlrzAHGxKJmv+xE51b8qTNzb3GccpG4=
+NodeupConfigHash: +h6PmSOYpZB8wquxjOdFdr/yXQ3j/9znAiIMPbG7tW0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: ha.example.com
 ConfigBase: memfs://tests/ha.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: BKbTQJ+zcRFpxii5sjCgNmf78q988D0qs/741F4txAo=
+NodeupConfigHash: 2T59/5rOBp8c31ezf152Bze6IW3izMLyI7EPjoNtQ1Q=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: ha.example.com
 ConfigBase: memfs://tests/ha.example.com
 InstanceGroupName: master-us-test-1b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: r9pCmvSzEKh3Zz4l/8rcaP7bGuqplYoBUBloYvLFaio=
+NodeupConfigHash: RW522FlY6hCITA8zK6RyIBVtRLy7iwpkXY9EzMOvhBY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: ha.example.com
 ConfigBase: memfs://tests/ha.example.com
 InstanceGroupName: master-us-test-1c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: qcUj2yx/J7arywet6WLotZDR6vStRPVUTqNWeTQrelw=
+NodeupConfigHash: 4rixJMaeudSTzvVuHrCBqkdU86tRS0kkGrZJshttRis=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-b_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-c_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: ha-gce.example.com
 ConfigBase: memfs://tests/ha-gce.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: A7t4Tdg6eZU1z+G4hWfCzyWb96SmJEAJqbl9KFGvIt4=
+NodeupConfigHash: cGPxzBrqLCdwOit2lMTJQQhi8hW3odJxUe66xYrF0HQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: ha-gce.example.com
 ConfigBase: memfs://tests/ha-gce.example.com
 InstanceGroupName: master-us-test1-b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Q4pyZE0wkpu4r75Hj64weUgULsdmClq9vV0hunt1ddg=
+NodeupConfigHash: aek6VU0EaDDjA1u0kaWud0xRDcwX9a0sNnaur2f+P18=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: ha-gce.example.com
 ConfigBase: memfs://tests/ha-gce.example.com
 InstanceGroupName: master-us-test1-c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: rrty4Z6hTGsfbIJLoyR3KmddhOlc2ZQFldI8qO2Rz4w=
+NodeupConfigHash: jHOLOmQ4gc9bb/gKzyK/3TJbYLIUuBXfFGYWMRQEL70=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 2s6ZjRadl0IhsgOc7BAbJWWE1pENjIYyUYewfmFWFdk=
+NodeupConfigHash: SC2s15U40G90/kKTs/BnBl84Emn/qTaOfVDmaZQxNC4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 2s6ZjRadl0IhsgOc7BAbJWWE1pENjIYyUYewfmFWFdk=
+NodeupConfigHash: SC2s15U40G90/kKTs/BnBl84Emn/qTaOfVDmaZQxNC4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: TBCN65fGHy3D8zCei5s3aPXFF2QptWPCGMPucoAKWy8=
+NodeupConfigHash: 71iQk+ISBON6f03g8V1fwsIGru4KE2B9IK64z9n8MyI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: GgVd1WsNMqpeWQChnek6KgoIqCqYj+4j/WHiSKqFCeI=
+NodeupConfigHash: F9PgkFvADdT8IgQy5VRdy3NccHn/Q0utBrO8l+3WQG0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -66,7 +66,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -75,7 +74,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_master-us-test1-a-minimal-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_master-us-test1-a-minimal-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: wt/IMaJUlp/ZXOIN5R1TyuaOIgDxt3F0xQsg60ijAWg=
+NodeupConfigHash: 5P3ffraE8QJtgX5rlTgAIfj9WWh+d6mIjoSiSS5IC1M=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.many-addons.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.many-addons.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: many-addons.example.com
 ConfigBase: memfs://tests/many-addons.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: suDUby1eG9iDtg+wFxXpLopciOfFBc9dFqvNgAX6Lag=
+NodeupConfigHash: HBQEXpSRpD+GegnFx+KeETQstoFOjzoGsNWyYih0L5s=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: MEQ+uEUZjOepSjIzobS40LXUm4bwKSRFwGiLRzP+cLM=
+NodeupConfigHash: 9YsRjDKrgiZ6Djyu/XpgdVmRVsrJ0Y/xJQqP/Ort9nA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - 85795979166ae04c6c0681664ab54d0810d472e390cf54dde0de399ff6d54bef@https://github.com/containerd/containerd/releases/download/v1.7.31/containerd-1.7.31-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - b310da449a9d2f8b928cab5ca12a6772617ba421023894e061ca2647e6d9f1c3@https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubelet
   - f42832db7d77897514639c6df38214a6d8ae1262ee34943364ec1ffaee6c009c@https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - d375de285eaaa5a3a58c0b03d92aff6bfa7987657781bce8cd5d30335f9aa2a6@https://github.com/containerd/containerd/releases/download/v1.7.31/containerd-1.7.31-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: BwrdPMH4ILnt2iAyWLzEoSkfKRRngSz1SB2RgPNIdic=
+NodeupConfigHash: PnOYYK4VgXY0XGovByxlVRlhuTJHsinvwXTGfjo1RBo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: DzRTAKL9pHdnP2TYQ9ZaF+cb0n0E4LgCAKPIdvqbLCY=
+NodeupConfigHash: 6VorfVG3sSEBTE2aRXOUcISQFeKkcjbpEWjSQfEoZyk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - ae5a4fc6d733fc28ff198e2d80334e21fcb5c34e76b411c50fff9cb25accf05a@https://dl.k8s.io/release/v1.33.0/bin/linux/arm64/kubelet
   - 48541d119455ac5bcc5043275ccda792371e0b112483aa0b29378439cf6322b9@https://dl.k8s.io/release/v1.33.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: SGW/mhVj/zlMbThfQQMMkDS5xEFRj1JeTjbuvuqQeXo=
+NodeupConfigHash: lymIHAp3hgYniseo/0Nrga28l8fz4EHeNDKon/6ozXE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - 32b713cae8d3a9cea7e1a9942704a6cf1c7f7b7de44818fde9f862ebcd4fd61a@https://dl.k8s.io/release/v1.34.0-alpha.1/bin/linux/arm64/kubelet
   - 099a8152095537427b3bb2621593caa3793ff7dd416c11f6768812aeca940786@https://dl.k8s.io/release/v1.34.0-alpha.1/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: F30EYLCjWzI8nr3t18nGGCImHrogX7DkSqirbwB8bRk=
+NodeupConfigHash: vZiz+KZ0SsRSE1W0g81QuG9LxMuiuEBLkzFmlQ5hoW4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bcf8aa61e7284423870dc84875ed5d09c79a7b61285832446900ca3383157396@https://dl.k8s.io/release/v1.35.0-alpha.1/bin/linux/arm64/kubelet
   - 44f0eebabc162e8a9a1fcec40922f1ccb7c6cbd37e00e17c54315ae08f05dee2@https://dl.k8s.io/release/v1.35.0-alpha.1/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 5xnMA6+o6dX3xtcz/fDHxZ5Z01RV3sQOvY/jhW5fRs0=
+NodeupConfigHash: XPiegsoZ58Mty6F9oVEkdvHY9Euj4c51ZW5pMhSx6aw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - 4cb83e7100a5e73fcb626207d0b5bcfd1294e26aeddfe075dcfb38f375c5f887@https://github.com/containerd/containerd/releases/download/v2.3.0/containerd-2.3.0-linux-amd64.tar.gz
   - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - c7fd6b5d5af23079afb98695d9b2e2ed764c1b5581c43a994f8ca062fd154139@https://dl.k8s.io/release/v1.36.0-rc.1/bin/linux/arm64/kubelet
   - 626d71ed21b05fedd56a1dc49ebee8e7217d170d75496f7cd8ee1f0721262e59@https://dl.k8s.io/release/v1.36.0-rc.1/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 06623dc8719b30d06303420f7eae91b0a9ade4e71243a4102f6375e585fb0a42@https://github.com/containerd/containerd/releases/download/v2.3.0/containerd-2.3.0-linux-arm64.tar.gz
   - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_master-us-test-1a.masters.minimal-aws.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_master-us-test-1a.masters.minimal-aws.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-aws.example.com
 ConfigBase: memfs://clusters.example.com/minimal-aws.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: JS/qYDG2EsWvAhsgUuReHX3PTGRTC7CM1lWFdEkyztQ=
+NodeupConfigHash: Et7jK0X6b3sn227KsDbCqLavbgOLQNTM8PYxsFHxqdU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - e45a7795391cd62ee226666039153832d3096c0f892266cd968936e18b2b40b0@https://dl.k8s.io/release/v1.34.0/bin/linux/arm64/kubelet
   - 00b182d103a8a73da7a4d11e7526d0543dcf352f06cc63a1fde25ce9243f49a0@https://dl.k8s.io/release/v1.34.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: A8xmynhr6hwQ6S9beAOAY4hNKMOXX0woRpvFBkr7IoU=
+NodeupConfigHash: pv0OhPCYnHFTo/KDsGRWkRjKPp14yA6zS66UNXI2c1E=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_master-us-test-1a.masters.minimal-etcd.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_master-us-test-1a.masters.minimal-etcd.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-etcd.example.com
 ConfigBase: memfs://clusters.example.com/minimal-etcd.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: qijxTaots+WcmeKMl3nRJpRY88hT84XL31R0+ubqHhs=
+NodeupConfigHash: ywt+sbJvdHrmcfvr2eIXmcOJAMXxvGziYbzJRsh0xHc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 1o61MESyoWDihF2jeqQbgMDz/5eTCaI5Pq1N6RxeyPs=
+NodeupConfigHash: u0T28bncbYMMwUwMwT4ZNC2HjUy0CYZQ6F4AvgLPsW8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 01f/VnUY29jn1edx9rN4fy6hXQaFkhzcLPOp5+TGoXc=
+NodeupConfigHash: 05GSmAfBkAzWgkjqSuiteKKEdtjqVB/mjbdR+r75zcE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -63,7 +63,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -71,7 +70,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Y595ZLdJqt00fokwwaT9t29XbNx8NujH0KWVSTxMuhk=
+NodeupConfigHash: HnZtSZo7LiKiO1wgUUx32Kr/1fGNGNWWnaZ/Wh4672k=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -63,7 +63,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -71,7 +70,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Eoo7iBaR0fBExNTEdApm24vEQki+HrcH6uK8nCC2tps=
+NodeupConfigHash: gTtaiNSiceHEMDz9lHCBRyVGbGbtD79+9GWM+UuMkVE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: ijF/cU10oXO/aScA11DrfzsWOWuwAIGYI3fnWLUdXvo=
+NodeupConfigHash: eRE4UHqNppDj4yy4v+jDHhlA7XKTWQQ1JmrDSFn2ZTs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: ijF/cU10oXO/aScA11DrfzsWOWuwAIGYI3fnWLUdXvo=
+NodeupConfigHash: eRE4UHqNppDj4yy4v+jDHhlA7XKTWQQ1JmrDSFn2ZTs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_master-us-test-1a.masters.this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_master-us-test-1a.masters.this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: this.is.truly.a.really.really.really.really.really.long.cluster-nam
 ConfigBase: memfs://clusters.example.com/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 9gzva7D5VQ8ji/bgrhbt1EI0iU7iVfvKsgbtlm7PENs=
+NodeupConfigHash: xP6fpgXyLhfdIRfic1xZrZGuMTbJfMhxHJKOlcc/BkQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-warmpool.example.com
 ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: BH3p8Le8fcC5bWX/PSwGL8ZDPe7VJS1VW7sDZXKT2NQ=
+NodeupConfigHash: lv+EQdwjz5w5SVkBrELuOc2Qzv2DWsey0cwO4d/DrLU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -72,7 +71,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_linux_virtual_machine_scale_set_control-plane-eastus-1.masters.minimal-azure.example.com_user_data
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_linux_virtual_machine_scale_set_control-plane-eastus-1.masters.minimal-azure.example.com_user_data
@@ -125,7 +125,7 @@ ClusterName: minimal-azure.example.com
 ConfigBase: memfs://tests/minimal-azure.example.com
 InstanceGroupName: control-plane-eastus-1
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: An+YFkJ5ZXnmqJvufcMCMp6wlGSFCcxQ7aw15XcyzrA=
+NodeupConfigHash: 8sHziohk4JiZg78o4P8swmmLOkI/HwqwrfeWtzXxcEM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source
@@ -63,7 +63,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - aa658d077348b43d238f50966a583f4244b2a7d45590c77b3b165b7d44983ab8@https://dl.k8s.io/release/v1.35.0/bin/linux/arm64/kubelet
   - 58f82f9fe796c375c5c4b8439850b0f3f4d401a52434052f2df46035a8789e25@https://dl.k8s.io/release/v1.35.0/bin/linux/arm64/kubectl
@@ -71,7 +70,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 AzureAdminUser: admin-user
 CAs:
   apiserver-aggregator-ca: |

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal-gce.example.com
 ConfigBase: memfs://tests/minimal-gce.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 8J/OsthN1sjExtKN6AHQSDJzjUb6NAUIk3ft6wB5CgQ=
+NodeupConfigHash: LZkTUbubPOEUHI9U//3F23HwSfmYRsiKHrsmtKw/7hU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -66,7 +66,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -75,7 +74,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal-gce.example.com
 ConfigBase: memfs://tests/minimal-gce.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Fe2r3umN2Ej4qwzUkzlo96qfhGHcCjkNJbCGOab85dc=
+NodeupConfigHash: X5t/F0LKUQva/sDzjOFOTuZ94WVp9o5/okg46hden+k=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -66,7 +66,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -75,7 +74,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal-gce-ilb.example.com
 ConfigBase: memfs://tests/minimal-gce-ilb.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: WE7EF8Qj3y4hUjVstx0UXKuHxYhtyLak0nyl3nZ43IY=
+NodeupConfigHash: vy5jJhQMb7BqWbkg4OjCHrCHCkJO/QS/TMzCYiKL9cE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-cilium-etcd-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-cilium-etcd-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal-gce-ilb-cilium-etcd.example.com
 ConfigBase: memfs://tests/minimal-gce-ilb-cilium-etcd.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: njy3deUMg9uQxbvlO+cDb4/gQw+BPp2qhq2beFkt+W4=
+NodeupConfigHash: w0BwXqDVU9KtXRCDRdm29VsEA9WeAZhCnp9k1Z+f5zM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -66,7 +66,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -75,7 +74,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal-gce-with-a-very-very-very-very-very-long-name.example.com
 ConfigBase: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: j5Grn3YBoaIt//lbr44FQFJpe6XJ7PYodHsoWXdLrWE=
+NodeupConfigHash: /RR6NW5f/5OG2LbGyVgPebYflDBUbOgrn3LjvcS2a2A=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
@@ -125,7 +125,7 @@ ClusterName: minimal-gce-with-a-very-very-very-very-very-long-name.example.com
 ConfigBase: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 2vWMpM/FBXiinL40ySCY67oBprcA0FOw+vLSy7VaU58=
+NodeupConfigHash: KsXB4n/Jl0tN+tTWXW0Wv0TZC8ieu718pi+oh/jOnGM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -66,7 +66,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -75,7 +74,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal-gce-plb.example.com
 ConfigBase: memfs://tests/minimal-gce-plb.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: crC0vl0hzY0OnkQ4WSuWZlP+scWqCVuiRQn83svYJkw=
+NodeupConfigHash: BEH2isFBQ0PnNtIG7+YRsmk2tAOSdgJNlw18qYzvwZI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -66,7 +66,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -75,7 +74,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal-gce-plb-apiserver.example.com
 ConfigBase: memfs://tests/minimal-gce-plb-apiserver.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: KQcULhLZiJEgXHZmoxmTIOHGvtsjD3KujlL4iCuvZuQ=
+NodeupConfigHash: soHVGD7AsAJAxGw9zgsb1xQoYzPI6PQJEf0RzWZVG94=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal-gce-private.example.com
 ConfigBase: memfs://tests/minimal-gce-private.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: ZXtMvMoVlsCjZ+LGHFiWRmTvxiHulX8KzluQi8nAH+Q=
+NodeupConfigHash: Q9c0JhRYtX9jtLieaqxikgqZHoGm/MClfhb3ifIBRXw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.k8s.local
 ConfigBase: memfs://clusters.example.com/minimal.k8s.local
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 0raahMILywEjvh7SGIpK3bgKnezuWevBbmog3VLfv4k=
+NodeupConfigHash: FSLl6oamDlrRuhaHQivmL2lZ2xeIEPhpKt8R3x87vq0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.k8s.local
 ConfigBase: memfs://clusters.example.com/minimal.k8s.local
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 5rw6ZCsp7OHe4c+nHX2gdrUARzY0yf/NJVT4IovfuAc=
+NodeupConfigHash: HvVBsf9XysLmMaMlz/RRdLrwbXBoVp784PtSpoT2nsY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
@@ -62,7 +62,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -70,7 +69,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_master-fsn1_user_data
+++ b/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_master-fsn1_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-fsn1
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: AG5YVTvG1Qrn6+lQA6kPPJpYlWUGrmCddwjgqwTZtmQ=
+NodeupConfigHash: XIKSGFu1m/03GzyT7pfcwEEd4G58Ms7trz/Xx1EpGTI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-control-plane-fr-par-1_content
@@ -61,14 +61,12 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_control-plane-fr-par-1-0_user_data
+++ b/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_control-plane-fr-par-1-0_user_data
@@ -128,7 +128,7 @@ ClusterName: scw-minimal.k8s.local
 ConfigBase: memfs://tests/scw-minimal.k8s.local
 InstanceGroupName: control-plane-fr-par-1
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 0ozDv3EUtcgkjd8mk9LkOgqNjTB696dBBlduo43HtuE=
+NodeupConfigHash: uBVZpJNGrb9/NSS/IO4YW7OQGfk6pQC9YeEwqROdBPA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 63TzR5EYHlIX+QqAj4An54PyaqkyM2OGvBgnoe3U0qE=
+NodeupConfigHash: 0teIkFoBFnvtggAkV+V0Jtu8TLu7JowDRR49s50ERNk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: scHxV35VkmXyv92175wulwNRxHX/lch99PbVMaGoXFA=
+NodeupConfigHash: VLthjW8Ay8gQ8dMyhVF/CaHPPie7BXiAFsidehsdhn4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: igynA9zCC3OZC1brNtHgBnuu47cHoxtzIT8rfslY7hY=
+NodeupConfigHash: pUKx3SlgQG+3semGdvOHlDZVsAzdLJE3L5UufD5sqLI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 63TzR5EYHlIX+QqAj4An54PyaqkyM2OGvBgnoe3U0qE=
+NodeupConfigHash: 0teIkFoBFnvtggAkV+V0Jtu8TLu7JowDRR49s50ERNk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: scHxV35VkmXyv92175wulwNRxHX/lch99PbVMaGoXFA=
+NodeupConfigHash: VLthjW8Ay8gQ8dMyhVF/CaHPPie7BXiAFsidehsdhn4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: igynA9zCC3OZC1brNtHgBnuu47cHoxtzIT8rfslY7hY=
+NodeupConfigHash: pUKx3SlgQG+3semGdvOHlDZVsAzdLJE3L5UufD5sqLI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: nthimdsprocessor.longclustername.example.com
 ConfigBase: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: h0SbSo1BVMTSlJjqHdCIg28j40Vf8+BVFjR0pmzTk+g=
+NodeupConfigHash: EWlFdG4UNBVS0RXnSQ6Z3HuMlhhTA1gR2rTScccIG7w=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: nthimdsprocessor.longclustername.example.com
 ConfigBase: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: HsPrA9iZnTK02qRNr7isnlioCvKDzmw1e5vuRLaLYRk=
+NodeupConfigHash: 87jgtLQ0gcB8iQVOLB0R/X9Uz+q0bj66Q6KXglJMBZc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: uZDLvYg4Hw3LUgNWP1J+HuEF3Hm+SRwK3KZmlRhk2K8=
+NodeupConfigHash: aTAzIa09yigRWfrNoPCx5C1eVr+volAJuusJpZA/EAM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: private-shared-ip.example.com
 ConfigBase: memfs://clusters.example.com/private-shared-ip.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: k2peTVxOzep0h0qCTdLMKB+QbKhjDf1qlMZQmnITWOU=
+NodeupConfigHash: 3K/6qjfiqVIin/8312w3N3mH3Bios7kjskbJNjii7AA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: private-shared-subnet.example.com
 ConfigBase: memfs://clusters.example.com/private-shared-subnet.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: zmYe+FgdrAcM+pGnGRpsiafrXhn9Fgtd4suQD4a3Z5A=
+NodeupConfigHash: x5v1WMTUt0tUqKLTFKqkXjFFUZPWP6R+zmH7otHpzuo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatecalico.example.com
 ConfigBase: memfs://clusters.example.com/privatecalico.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 7HPeO4xGHT3nu5l9sgljSwDjVVWFdBTiyUoLtS2cgWk=
+NodeupConfigHash: OvkuQG+OCepg2p8bmurhkUG6Z2nXKnafgWtfMUf7oUI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -63,7 +63,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -71,7 +70,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatecilium.example.com
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 5yz0Enj0WjdgrfFdOJzmkj/MoygdoXuNEtmzzesK1Vc=
+NodeupConfigHash: 817QOqToZhNmAqhmexnkVSsp+F/HdOcCmMgF/16cGyg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -63,7 +63,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -71,7 +70,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatecilium.example.com
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: b17WvgvtMUE3K5ilSnribtwdDJRLNBeq3aFq2cH84lg=
+NodeupConfigHash: Brz59V0moBUL/FolgPB65GVjZqOHDQ3t99SRH1/8774=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -63,7 +63,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -71,7 +70,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatecilium.example.com
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: umOGUkqeIzouCnxzfyyHsQ+n8jAvoCfJH16WlmwtVwY=
+NodeupConfigHash: sZvLq/eoyMfDWOmspYeBMvCQ49LwJKMZ2Npw/2QQjoE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -63,7 +63,6 @@ Assets:
   - 85795979166ae04c6c0681664ab54d0810d472e390cf54dde0de399ff6d54bef@https://github.com/containerd/containerd/releases/download/v1.7.31/containerd-1.7.31-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - b310da449a9d2f8b928cab5ca12a6772617ba421023894e061ca2647e6d9f1c3@https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubelet
   - f42832db7d77897514639c6df38214a6d8ae1262ee34943364ec1ffaee6c009c@https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubectl
@@ -71,7 +70,6 @@ Assets:
   - d375de285eaaa5a3a58c0b03d92aff6bfa7987657781bce8cd5d30335f9aa2a6@https://github.com/containerd/containerd/releases/download/v1.7.31/containerd-1.7.31-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privateciliumadvanced.example.com
 ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: fBApIyGAgFS+/fqpwQUYwHUE04GU3c5CvevIz0Zxs28=
+NodeupConfigHash: YHGbWj6Vi01Hr+wggkc5j3J0CyA6Qfih4MaFjucdWoU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -63,7 +63,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -71,7 +70,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatedns1.example.com
 ConfigBase: memfs://clusters.example.com/privatedns1.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: n8B0FvevQxmxPUz39BjXM/05sqnEihmiouejueDafrQ=
+NodeupConfigHash: oLAu7qSMCcQ1d2WOpRMtzilvOtOJEIhInBCOdnWVVZ0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -63,7 +63,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - e45a7795391cd62ee226666039153832d3096c0f892266cd968936e18b2b40b0@https://dl.k8s.io/release/v1.34.0/bin/linux/arm64/kubelet
   - 00b182d103a8a73da7a4d11e7526d0543dcf352f06cc63a1fde25ce9243f49a0@https://dl.k8s.io/release/v1.34.0/bin/linux/arm64/kubectl
@@ -72,7 +71,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatedns2.example.com
 ConfigBase: memfs://clusters.example.com/privatedns2.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 93bu11Ct6+dvqcpHr2ldX3RSYLeTgms3ca3dNoY0J8s=
+NodeupConfigHash: lYFDfQeDNAvD9YifnxFIKT8LbsC2pcr/4zjfw5afVAs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privateflannel.example.com
 ConfigBase: memfs://clusters.example.com/privateflannel.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: RlflHdEItwKQCUpxk4FUNGSCLfw9ef7vuOezFL/Fv1U=
+NodeupConfigHash: npELH8PydZ9olWPPGvhCNW86E1cSnlO9Bu4XtAvCNjI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -63,7 +63,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - e45a7795391cd62ee226666039153832d3096c0f892266cd968936e18b2b40b0@https://dl.k8s.io/release/v1.34.0/bin/linux/arm64/kubelet
   - 00b182d103a8a73da7a4d11e7526d0543dcf352f06cc63a1fde25ce9243f49a0@https://dl.k8s.io/release/v1.34.0/bin/linux/arm64/kubectl
@@ -72,7 +71,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_master-us-test-1a.masters.privatekindnet.example.com_user_data
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_master-us-test-1a.masters.privatekindnet.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatekindnet.example.com
 ConfigBase: memfs://clusters.example.com/privatekindnet.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: bkw1TUdIVX5qD+ng4a1IMsK7n17dN1nI5UHlUG+HG4A=
+NodeupConfigHash: wcyJTB8y6hUDMhVCM0cFNCUd/pkIW+XD7hbB2YVdu2g=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - 85795979166ae04c6c0681664ab54d0810d472e390cf54dde0de399ff6d54bef@https://github.com/containerd/containerd/releases/download/v1.7.31/containerd-1.7.31-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - b310da449a9d2f8b928cab5ca12a6772617ba421023894e061ca2647e6d9f1c3@https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubelet
   - f42832db7d77897514639c6df38214a6d8ae1262ee34943364ec1ffaee6c009c@https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - d375de285eaaa5a3a58c0b03d92aff6bfa7987657781bce8cd5d30335f9aa2a6@https://github.com/containerd/containerd/releases/download/v1.7.31/containerd-1.7.31-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatekopeio.example.com
 ConfigBase: memfs://clusters.example.com/privatekopeio.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: hceUudekIZZwkymAhqMazHZwR8XnQMDb9hbML4bzUmQ=
+NodeupConfigHash: 0cxH4kErrnsaw1NSN7QFA6slzPf1FTPKhFGOT+HezSo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 0tSKzEos2kT0yorHTb0Du05zL5AZ9+gnrhN6l+3b8lQ=
+NodeupConfigHash: 5K+ybvxxS4HVW5kIauEQ94Bw5gsTrz+crFKXeQjL5xM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -67,7 +67,6 @@ Assets:
   - 85795979166ae04c6c0681664ab54d0810d472e390cf54dde0de399ff6d54bef@https://github.com/containerd/containerd/releases/download/v1.7.31/containerd-1.7.31-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - b310da449a9d2f8b928cab5ca12a6772617ba421023894e061ca2647e6d9f1c3@https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubelet
   - f42832db7d77897514639c6df38214a6d8ae1262ee34943364ec1ffaee6c009c@https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubectl
@@ -76,7 +75,6 @@ Assets:
   - d375de285eaaa5a3a58c0b03d92aff6bfa7987657781bce8cd5d30335f9aa2a6@https://github.com/containerd/containerd/releases/download/v1.7.31/containerd-1.7.31-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: sharedsubnet.example.com
 ConfigBase: memfs://clusters.example.com/sharedsubnet.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: TRsW4HkdPrLmn502w7WAgRV7EwGXQLJvs6TlUndBKg8=
+NodeupConfigHash: SGCBFsyOOYPNHFmVeC9MNO+Yd5jZEAeUf5zo0m1Z938=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: sharedvpc.example.com
 ConfigBase: memfs://clusters.example.com/sharedvpc.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: CZjl+wXYpJ1FFlfcmumDykHCJNfrv04tyRlS4AONepo=
+NodeupConfigHash: e4PSypG6XrJr3xrgGzC9IB+PK3HtCjvbklOLDdDeyN8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: ijF/cU10oXO/aScA11DrfzsWOWuwAIGYI3fnWLUdXvo=
+NodeupConfigHash: eRE4UHqNppDj4yy4v+jDHhlA7XKTWQQ1JmrDSFn2ZTs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
+++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: unmanaged.example.com
 ConfigBase: memfs://clusters.example.com/unmanaged.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: S2wZe7TxGvuEQKgTu00+uOesY4thECFN0skfb/wPBjg=
+NodeupConfigHash: FaJfC85mrI6l90NCRZQ7FLfsjvSUx+G1DaAvJsSQAY8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -73,7 +72,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 2s6ZjRadl0IhsgOc7BAbJWWE1pENjIYyUYewfmFWFdk=
+NodeupConfigHash: SC2s15U40G90/kKTs/BnBl84Emn/qTaOfVDmaZQxNC4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,7 +65,6 @@ Assets:
   - ca26ef5138f17b847bbeeec36d4bf5e002b54d25858197a870c125d57f44d32f@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-amd64.tar.gz
   - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
-  - 0172d3c560aebe1eb4e8599f71c0d8fc68e4eca880add8031de41c8057ca8e3c@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-amd64
   arm64:
   - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
   - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
@@ -74,7 +73,6 @@ Assets:
   - 2942d72435b18610f7b69c1ddb74f99cef5c549425ff80d3e74f04e5e80db6a4@https://github.com/containerd/containerd/releases/download/v2.2.3/containerd-2.2.3-linux-arm64.tar.gz
   - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
-  - 04470f8313796032fce85b974da4fc26420f36931e574fff6d117d21caf22770@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/channels-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -310,7 +310,7 @@ func (a *AddonList) Add(spec *channelsapi.AddonSpec) *Addon {
 }
 
 type Addon struct {
-	// Spec is the spec that will (eventually) be passed to the channels binary.
+	// Spec is the spec that will (eventually) be passed to the kops-channels static pod.
 	Spec *channelsapi.AddonSpec
 
 	// ManifestData is the object data loaded from the manifest.


### PR DESCRIPTION
The kops-channels static pod (added in #18328) replaces the standalone channels binary that protokube used to invoke. This drops the binary from asset distribution, GitHub release uploads, and the per-node asset download list. `make channels` is kept as a local build target for debugging.

/cc @rifelpet 