### PR TITLE
Automated cherry pick of #18375: cilium: add flags for bpf-lb-sock and bpf-lb-sock-hostns-only

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5445,6 +5445,11 @@ spec:
                           BPFLBMapMax is the maximum number of entries in bpf lb service, backend and affinity maps.
                           Default: 65536
                         type: integer
+                      bpfLBSock:
+                        description: |-
+                          BPFLBSock enables socket-based LB for E/W traffic.
+                          Default: false
+                        type: boolean
                       bpfLBSockHostNSOnly:
                         description: |-
                           BPFLBSockHostNSOnly enables skipping socket LB for services when inside a pod namespace,

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -453,6 +453,9 @@ type CiliumNetworkingSpec struct {
 	// BPFLBMapMax is the maximum number of entries in bpf lb service, backend and affinity maps.
 	// Default: 65536
 	BPFLBMapMax int `json:"bpfLBMapMax,omitempty"`
+	// BPFLBSock enables socket-based LB for E/W traffic.
+	// Default: false
+	BPFLBSock bool `json:"bpfLBSock,omitempty"`
 	// BPFLBSockHostNSOnly enables skipping socket LB for services when inside a pod namespace,
 	// in favor of service LB at the pod interface. Socket LB is still used when in the host namespace.
 	// Required by service mesh (e.g., Istio, Linkerd).

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -552,6 +552,9 @@ type CiliumNetworkingSpec struct {
 	// BPFLBMapMax is the maximum number of entries in bpf lb service, backend and affinity maps.
 	// Default: 65536
 	BPFLBMapMax int `json:"bpfLBMapMax,omitempty"`
+	// BPFLBSock enables socket-based LB for E/W traffic.
+	// Default: false
+	BPFLBSock bool `json:"bpfLBSock,omitempty"`
 	// BPFLBSockHostNSOnly enables skipping socket LB for services when inside a pod namespace,
 	// in favor of service LB at the pod interface. Socket LB is still used when in the host namespace.
 	// Required by service mesh (e.g., Istio, Linkerd).

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2136,6 +2136,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.BPFNeighGlobalMax = in.BPFNeighGlobalMax
 	out.BPFPolicyMapMax = in.BPFPolicyMapMax
 	out.BPFLBMapMax = in.BPFLBMapMax
+	out.BPFLBSock = in.BPFLBSock
 	out.BPFLBSockHostNSOnly = in.BPFLBSockHostNSOnly
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage
@@ -2225,6 +2226,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.BPFNeighGlobalMax = in.BPFNeighGlobalMax
 	out.BPFPolicyMapMax = in.BPFPolicyMapMax
 	out.BPFLBMapMax = in.BPFLBMapMax
+	out.BPFLBSock = in.BPFLBSock
 	out.BPFLBSockHostNSOnly = in.BPFLBSockHostNSOnly
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -401,6 +401,9 @@ type CiliumNetworkingSpec struct {
 	// BPFLBMapMax is the maximum number of entries in bpf lb service, backend and affinity maps.
 	// Default: 65536
 	BPFLBMapMax int `json:"bpfLBMapMax,omitempty"`
+	// BPFLBSock enables socket-based LB for E/W traffic.
+	// Default: false
+	BPFLBSock bool `json:"bpfLBSock,omitempty"`
 	// BPFLBSockHostNSOnly enables skipping socket LB for services when inside a pod namespace,
 	// in favor of service LB at the pod interface. Socket LB is still used when in the host namespace.
 	// Required by service mesh (e.g., Istio, Linkerd).

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2273,6 +2273,7 @@ func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.BPFNeighGlobalMax = in.BPFNeighGlobalMax
 	out.BPFPolicyMapMax = in.BPFPolicyMapMax
 	out.BPFLBMapMax = in.BPFLBMapMax
+	out.BPFLBSock = in.BPFLBSock
 	out.BPFLBSockHostNSOnly = in.BPFLBSockHostNSOnly
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage
@@ -2361,6 +2362,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *
 	out.BPFNeighGlobalMax = in.BPFNeighGlobalMax
 	out.BPFPolicyMapMax = in.BPFPolicyMapMax
 	out.BPFLBMapMax = in.BPFLBMapMax
+	out.BPFLBSock = in.BPFLBSock
 	out.BPFLBSockHostNSOnly = in.BPFLBSockHostNSOnly
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1273,6 +1273,10 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 		allErrs = append(allErrs, IsValidValue(fldPath.Child("bpfLBAlgorithm"), &v.BPFLBAlgorithm, []string{"random", "maglev"})...)
 	}
 
+	if !v.BPFLBSock && v.BPFLBSockHostNSOnly {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("bpfLBSockHostNSOnly"), "bpfLBSockHostNSOnly requires bpfLBSock to be enabled"))
+	}
+
 	if v.EnableEncryption && c.IsIPv6Only() {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableEncryption"), "encryption is not supported on IPv6 clusters"))
 	}

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -1243,6 +1243,19 @@ func Test_Validate_Cilium(t *testing.T) {
 				},
 			},
 		},
+		{
+			Cilium: kops.CiliumNetworkingSpec{
+				BPFLBSock:           false,
+				BPFLBSockHostNSOnly: true,
+			},
+			ExpectedErrors: []string{"Forbidden::cilium.bpfLBSockHostNSOnly"},
+		},
+		{
+			Cilium: kops.CiliumNetworkingSpec{
+				BPFLBSock:           true,
+				BPFLBSockHostNSOnly: true,
+			},
+		},
 	}
 	for _, g := range grid {
 		g.Spec.Networking.Cilium = &g.Cilium

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 3250c972b52b57cd23a58d3f5962aa372215d17e5581f868d605213faaaf6384
+    manifestHash: fe3394185bfd1b218fa69b689c4ac1a6d0cf5cb3dd2ee98b400d54db473ce49e
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -58,6 +58,7 @@ data:
   bpf-lb-map-max: "65536"
   bpf-lb-mode-annotation: "false"
   bpf-lb-sock: "false"
+  bpf-lb-sock-hostns-only: "false"
   bpf-lb-source-range-all-types: "false"
   bpf-map-dynamic-size-ratio: "0.0025"
   bpf-policy-map-max: "16384"
@@ -1084,6 +1085,15 @@ spec:
         name: cilium-operator
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 7480ed4fef9226f0ac8f67b10bab414f5902c19a27566aba11f026cf7b602932
+    manifestHash: ea73345a4c1c8615772302d46e8ef08d2a1e448079c755838dea4842272b0e18
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -58,6 +58,7 @@ data:
   bpf-lb-map-max: "65536"
   bpf-lb-mode-annotation: "false"
   bpf-lb-sock: "false"
+  bpf-lb-sock-hostns-only: "false"
   bpf-lb-source-range-all-types: "false"
   bpf-map-dynamic-size-ratio: "0.0025"
   bpf-policy-map-max: "16384"
@@ -1087,6 +1088,15 @@ spec:
         name: cilium-operator
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 3ab75bd474f37dbab884191a90e5d7732041be44b1be29be75efb250edddfced
+    manifestHash: dd73a7e0bb9dde0f92a8647eb368050717457d6c8edf34112bbfc656db91772f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
@@ -58,6 +58,7 @@ data:
   bpf-lb-map-max: "65536"
   bpf-lb-mode-annotation: "false"
   bpf-lb-sock: "false"
+  bpf-lb-sock-hostns-only: "false"
   bpf-lb-source-range-all-types: "false"
   bpf-map-dynamic-size-ratio: "0.0025"
   bpf-policy-map-max: "16384"
@@ -1087,6 +1088,15 @@ spec:
         name: cilium-operator
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: de10b714bc23b418243ee8557b516893fbe391d2389ee014872044e3ce4d3b6f
+    manifestHash: 71005b6761849bedd05210ea06f37e072e1a88ca6cc7dbcbba3f2386ccb4777b
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -59,6 +59,7 @@ data:
   bpf-lb-map-max: "65536"
   bpf-lb-mode-annotation: "false"
   bpf-lb-sock: "false"
+  bpf-lb-sock-hostns-only: "false"
   bpf-lb-source-range-all-types: "false"
   bpf-map-dynamic-size-ratio: "0.0025"
   bpf-policy-map-max: "16384"
@@ -1112,6 +1113,15 @@ spec:
         name: cilium-operator
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: d0f05fc0dbd97d949f198186b2f4ed274cadcaeba5ae06523f56b630bfed0424
+    manifestHash: 73d84329c0798944636acf03cb1710cfbecb7c8ab8c2aea805394de40aff881c
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -58,6 +58,7 @@ data:
   bpf-lb-map-max: "65536"
   bpf-lb-mode-annotation: "false"
   bpf-lb-sock: "false"
+  bpf-lb-sock-hostns-only: "false"
   bpf-lb-source-range-all-types: "false"
   bpf-map-dynamic-size-ratio: "0.0025"
   bpf-policy-map-max: "16384"
@@ -1094,6 +1095,15 @@ spec:
         name: cilium-operator
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -152,7 +152,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 85ea52dd26ad82530959c12f10b60d0a82ab4fc5f6bf272a9aceadb075097479
+    manifestHash: 604fc7fd3a03b1a2e3b7ec0c4c8194e5b835951b7f8408165e466a84abf7401f
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -71,6 +71,7 @@ data:
   bpf-lb-map-max: "65536"
   bpf-lb-mode-annotation: "false"
   bpf-lb-sock: "false"
+  bpf-lb-sock-hostns-only: "false"
   bpf-lb-source-range-all-types: "false"
   bpf-map-dynamic-size-ratio: "0.0025"
   bpf-policy-map-max: "16384"
@@ -1399,6 +1400,15 @@ spec:
         name: cilium-operator
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 395d067af92a3a5cdc2817eefc2d328b8f9cdf3c24244547ee526fdad96ca0ba
+    manifestHash: 84e2f16f9c0cb26ea3f3a4c69d401d57fa06c597be21aacd4d4af04c46d4b473
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -59,6 +59,7 @@ data:
   bpf-lb-map-max: "65536"
   bpf-lb-mode-annotation: "false"
   bpf-lb-sock: "false"
+  bpf-lb-sock-hostns-only: "false"
   bpf-lb-source-range-all-types: "false"
   bpf-map-dynamic-size-ratio: "0.0025"
   bpf-policy-map-max: "16384"
@@ -1138,6 +1139,15 @@ spec:
         name: cilium-operator
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -342,7 +342,8 @@ data:
   enable-local-redirect-policy: "{{ .EnableLocalRedirectPolicy }}"
 
   kube-proxy-replacement: "{{- if .EnableNodePort -}}true{{- else -}}false{{- end -}}"
-  bpf-lb-sock: "false"
+  bpf-lb-sock: "{{ .BPFLBSock }}"
+  bpf-lb-sock-hostns-only: "{{ .BPFLBSockHostNSOnly }}"
   enable-node-port: "{{ .EnableNodePort }}"
   nodeport-addresses: ""
   enable-health-check-nodeport: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -2073,6 +2073,15 @@ spec:
       # In HA mode, cilium-operator pods must not be scheduled on the same
       # node as they will clash with each other.
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: dd3d4fa2e2b698c20678ef546e31dc574480a478da2e2f1d1f4b1491b31cb24f
+    manifestHash: 893c87881650522a349c68333ed706fe04ca8332a765522fa088fe920f1bc9eb
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -105,7 +105,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: dd3d4fa2e2b698c20678ef546e31dc574480a478da2e2f1d1f4b1491b31cb24f
+    manifestHash: 893c87881650522a349c68333ed706fe04ca8332a765522fa088fe920f1bc9eb
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -160,7 +160,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: dd3d4fa2e2b698c20678ef546e31dc574480a478da2e2f1d1f4b1491b31cb24f
+    manifestHash: 893c87881650522a349c68333ed706fe04ca8332a765522fa088fe920f1bc9eb
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #18375 on release-1.35.

#18375: cilium: add flags for bpf-lb-sock and bpf-lb-sock-hostns-only

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```