### PR TITLE
nodeup: fix protokube skip on hybrid-bootstrap workers

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -43,8 +43,10 @@ var _ fi.NodeupModelBuilder = &ProtokubeBuilder{}
 
 // Build is responsible for generating the options for protokube
 func (t *ProtokubeBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	if !t.UsesLegacyGossip() {
-		klog.V(2).Infof("skipping protokube provisioning: legacy gossip is not in use")
+	// Skip the cluster doesn't use gossip, or this is a worker that bootstraps via kops-controller.
+	// Must match the asset-skip condition in pkg/nodemodel/nodeupconfigbuilder.go.
+	if !t.UsesLegacyGossip() || (!t.IsMaster && len(t.BootConfig.APIServerIPs) > 0) {
+		klog.V(2).Infof("skipping protokube provisioning")
 		return nil
 	}
 

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -379,9 +379,8 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 	}
 
 	if role != kops.InstanceGroupRoleBastion {
-		// protokube runs on control-plane nodes, and on legacy-gossip workers that don't bootstrap via
-		// kops-controller. Must match the provisioning condition in nodeup/pkg/model/protokube.go.
-		if usesLegacyGossip && (isMaster || len(bootConfig.APIServerIPs) == 0) {
+		// protokube runs on control-plane nodes, and on legacy-gossip workers that don't bootstrap via kops-controller (mirrors nodeup's ProtokubeBuilder.Build).
+		if isMaster || (usesLegacyGossip && len(bootConfig.APIServerIPs) == 0) {
 			config.Channels = n.channels
 			for _, arch := range architectures.GetSupported() {
 				for _, a := range n.protokubeAsset[arch] {
@@ -529,6 +528,7 @@ func (n *nodeUpConfigBuilder) buildWarmPoolImages(ig *kops.InstanceGroup) []stri
 	}
 	assetBuilder := n.assetBuilder
 	if assetBuilder != nil {
+		// Add kops-managed images
 		for _, image := range assetBuilder.ImageAssets() {
 			for _, prefix := range desiredImagePrefixes {
 				remappedPrefix := assets.NormalizeImage(assetBuilder, prefix)
@@ -537,13 +537,13 @@ func (n *nodeUpConfigBuilder) buildWarmPoolImages(ig *kops.InstanceGroup) []stri
 				}
 			}
 		}
-	}
 
-	// Add ig-level extra images
-	if ig.Spec.WarmPool != nil && len(ig.Spec.WarmPool.AdditionalImages) > 0 {
-		for _, image := range ig.Spec.WarmPool.AdditionalImages {
-			remapped := assets.NormalizeImage(assetBuilder, image)
-			images[remapped] = true
+		// Add ig-level extra images
+		if ig.Spec.WarmPool != nil && len(ig.Spec.WarmPool.AdditionalImages) > 0 {
+			for _, image := range ig.Spec.WarmPool.AdditionalImages {
+				remapped := assets.NormalizeImage(assetBuilder, image)
+				images[remapped] = true
+			}
 		}
 	}
 

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -379,8 +379,9 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 	}
 
 	if role != kops.InstanceGroupRoleBastion {
-		// protokube runs on control-plane nodes, and on legacy-gossip workers that don't bootstrap via kops-controller (mirrors nodeup's ProtokubeBuilder.Build).
-		if isMaster || (usesLegacyGossip && len(bootConfig.APIServerIPs) == 0) {
+		// protokube runs on control-plane nodes, and on legacy-gossip workers that don't bootstrap via
+		// kops-controller. Must match the provisioning condition in nodeup/pkg/model/protokube.go.
+		if usesLegacyGossip && (isMaster || len(bootConfig.APIServerIPs) == 0) {
 			config.Channels = n.channels
 			for _, arch := range architectures.GetSupported() {
 				for _, a := range n.protokubeAsset[arch] {


### PR DESCRIPTION
All gossip upgrade tests are broken at the moment:
* https://testgrid.k8s.io/kops-upgrades#kops-aws-upgrade-gossip
* https://testgrid.k8s.io/kops-upgrades#kops-azure-upgrade-gossip
* https://testgrid.k8s.io/kops-upgrades#kops-gce-upgrade-gossip
> W main.go:138] got error running nodeup (will retry in 30s): error building loader:
  building *model.ProtokubeBuilder: found no matching assets for expr: "protokube$"

/cc @rifelpet 