### PR TITLE
Automated cherry pick of #18379: kops-controller and nodeup bug fixes

### DIFF
--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -255,8 +255,10 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 	// Skew the certificate lifetime by up to 30 days based on information about the requesting node.
 	// This is so that different nodes created at the same time have the certificates they generated
 	// expire at different times, but all certificates on a given node expire around the same time.
+	// We salt on the verified NodeName so nodes sharing a NAT/load balancer (same RemoteAddr) still
+	// get independent skews.
 	hash := fnv.New32()
-	_, _ = hash.Write([]byte(r.RemoteAddr))
+	_, _ = hash.Write([]byte(id.NodeName))
 	validHours := (455 * 24) + (hash.Sum32() % (30 * 24))
 
 	for name, pubKey := range req.Certs {

--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -279,6 +279,9 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) issueCert(ctx context.Context, name string, pubKey string, id *bootstrap.VerifyResult, validHours uint32, keypairIDs map[string]string) (string, error) {
 	block, _ := pem.Decode([]byte(pubKey))
+	if block == nil {
+		return "", fmt.Errorf("decoding pem public key")
+	}
 	if block.Type != "RSA PUBLIC KEY" {
 		return "", fmt.Errorf("unexpected key type %q", block.Type)
 	}

--- a/pkg/bootstrap/challenge_client.go
+++ b/pkg/bootstrap/challenge_client.go
@@ -114,6 +114,7 @@ func (c *ChallengeClient) DoCallbackChallenge(ctx context.Context, clusterName s
 	if err != nil {
 		return fmt.Errorf("error dialing target %q: %w", targetEndpoint, err)
 	}
+	defer conn.Close()
 	client := pb.NewCallbackServiceClient(conn)
 
 	response, err := client.Challenge(ctx, req)

--- a/pkg/bootstrap/pkibootstrap/pkiverifier.go
+++ b/pkg/bootstrap/pkibootstrap/pkiverifier.go
@@ -61,7 +61,7 @@ var _ bootstrap.Verifier = &verifier{}
 // TODO: Dedup with gce
 func (v *verifier) parseTokenData(tokenPrefix string, authToken string, body []byte) (*AuthToken, *AuthTokenData, error) {
 	if !strings.HasPrefix(authToken, tokenPrefix) {
-		return nil, nil, fmt.Errorf("incorrect authorization type")
+		return nil, nil, bootstrap.ErrNotThisVerifier
 	}
 	authToken = strings.TrimPrefix(authToken, tokenPrefix)
 

--- a/pkg/pki/privatekey.go
+++ b/pkg/pki/privatekey.go
@@ -153,7 +153,7 @@ func (k *PrivateKey) WriteTo(w io.Writer) (int64, error) {
 
 	switch pk := k.Key.(type) {
 	case *rsa.PrivateKey:
-		if err := pem.Encode(w, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(pk)}); err != nil {
+		if err := pem.Encode(&data, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(pk)}); err != nil {
 			return 0, fmt.Errorf("error encoding RSA private key: %w", err)
 		}
 	case *ecdsa.PrivateKey:
@@ -161,7 +161,7 @@ func (k *PrivateKey) WriteTo(w io.Writer) (int64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("error encoding ECDSA private key: %w", err)
 		}
-		if err := pem.Encode(w, &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}); err != nil {
+		if err := pem.Encode(&data, &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}); err != nil {
 			return 0, fmt.Errorf("error encoding ECDSA private key: %w", err)
 		}
 	default:

--- a/upup/pkg/fi/files.go
+++ b/upup/pkg/fi/files.go
@@ -88,6 +88,10 @@ func writeFileContents(destPath string, src Resource, fileMode os.FileMode) erro
 		return fmt.Errorf("error writing file %q: %v", tempFile.Name(), err)
 	}
 
+	if err := tempFile.Chmod(fileMode); err != nil {
+		return fmt.Errorf("error setting mode on temp file %q: %w", tempFile.Name(), err)
+	}
+
 	if err := tempFile.Close(); err != nil {
 		return fmt.Errorf("error closing temp file %q: %w", tempFile.Name(), err)
 	}


### PR DESCRIPTION
Cherry pick of #18379 on release-1.34.

#18379: kops-controller and nodeup bug fixes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```