### PR TITLE
fix: validate taint effects

### DIFF
--- a/pkg/apis/kops/util/taints.go
+++ b/pkg/apis/kops/util/taints.go
@@ -37,6 +37,11 @@ func ParseTaint(st string) (map[string]string, error) {
 		key = parts[0]
 	case 2:
 		effect = parts[1]
+		switch effect {
+		case "NoSchedule", "PreferNoSchedule", "NoExecute":
+		default:
+			return taint, fmt.Errorf("invalid taint effect: %v", effect)
+		}
 
 		partsKV := strings.Split(parts[0], "=")
 		if len(partsKV) > 2 {

--- a/pkg/apis/kops/util/taints_test.go
+++ b/pkg/apis/kops/util/taints_test.go
@@ -70,6 +70,18 @@ func TestParseTaint(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name:    "invalid taint spec (unknown effect)",
+			taint:   "key1:PreferToSchedule",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid taint spec (empty effect)",
+			taint:   "key1:",
+			want:    nil,
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range grid {

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -334,6 +334,12 @@ func TestValidTaints(t *testing.T) {
 			},
 			expected: []string{"Duplicate value::spec.taints[1]"},
 		},
+		{
+			taints: []string{
+				"nvidia.com/gpu:ScheduleSometimes",
+			},
+			expected: []string{"Invalid value::spec.taints[0]"},
+		},
 	}
 
 	for _, g := range grid {

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -41,6 +41,7 @@ import (
 	netutils "k8s.io/utils/net"
 
 	"k8s.io/kops/pkg/apis/kops"
+	kopsutil "k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/model/iam"
 	"k8s.io/kops/upup/pkg/fi"
@@ -1086,6 +1087,13 @@ func validateKubelet(k *kops.KubeletConfigSpec, c *kops.Cluster, kubeletPath *fi
 
 		if k.MemorySwapBehavior != "" {
 			allErrs = append(allErrs, IsValidValue(kubeletPath.Child("memorySwapBehavior"), &k.MemorySwapBehavior, []string{"LimitedSwap", "UnlimitedSwap"})...)
+		}
+
+		for i, taint := range k.Taints {
+			path := kubeletPath.Child("taints").Index(i)
+			if _, err := kopsutil.ParseTaint(taint); err != nil {
+				allErrs = append(allErrs, field.Invalid(path, taint, "invalid taint value"))
+			}
 		}
 	}
 	return allErrs

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -112,6 +112,32 @@ func testErrors(t *testing.T, context interface{}, actual field.ErrorList, expec
 	}
 }
 
+func TestValidateKubeletTaints(t *testing.T) {
+	grid := []struct {
+		taints   []string
+		expected []string
+	}{
+		{
+			taints: []string{
+				"dedicated=gpu:NoSchedule",
+				"spot:PreferNoSchedule",
+				"drain:NoExecute",
+			},
+		},
+		{
+			taints: []string{
+				"dedicated=gpu:ScheduleSometimes",
+			},
+			expected: []string{"Invalid value::spec.kubelet.taints[0]"},
+		},
+	}
+
+	for _, g := range grid {
+		errs := validateKubelet(&kops.KubeletConfigSpec{Taints: g.taints}, &kops.Cluster{}, field.NewPath("spec", "kubelet"))
+		testErrors(t, g.taints, errs, g.expected)
+	}
+}
+
 func TestValidateSubnets(t *testing.T) {
 	grid := []struct {
 		Input          []kops.ClusterSubnetSpec


### PR DESCRIPTION
**What this PR does / why we need it**:

Reject invalid node taint effects in kOps validation.

Repro before this: put `nvidia.com/gpu:ScheduleSometimes` in `spec.taints` or `spec.kubelet.taints`. kOps accepted it, then the value could flow into kubelet taints / autoscaler tags. That effect is not a real Kubernetes node taint effect, so this is a tiny config footgun.

Now kOps accepts only `NoSchedule`, `PreferNoSchedule`, and `NoExecute` when an effect is set. Bad values get bounced early, nice.

**Which issue(s) this PR fixes**:

None found, searched issues/PRs for taint validation bits.

**Special notes for your reviewer**:

Tested with:

```
go test ./pkg/apis/kops/util ./pkg/apis/kops/validation ./pkg/model ./nodeup/pkg/model ./pkg/model/awsmodel ./pkg/model/azuremodel
```