### PR TITLE
Automated cherry pick of #18144: Move johngmyers to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,18 +12,17 @@ emeritus_approvers:
   - gambol99
   - geojaz
   - granular-ryanbonham
+  - johngmyers
   - kashifsaadat
   - mikesplain
   - rdrgmnzs
 approvers:
   - hakman
-  - johngmyers
   - justinsb
   - olemarkus
   - rifelpet
   - zetaab
 reviewers:
   - hakman
-  - johngmyers
   - olemarkus
   - zetaab


### PR DESCRIPTION
Cherry pick of #18144 on release-1.35.

#18144: Move johngmyers to emeritus

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```