### PR TITLE
channels: fix region detection and discovery cache permission noise

### DIFF
--- a/pkg/applylib/applyset/health.go
+++ b/pkg/applylib/applyset/health.go
@@ -59,7 +59,8 @@ func isHealthy(u *unstructured.Unstructured) bool {
 
 	ready := true
 	statusConditions, found, err := unstructured.NestedFieldNoCopy(u.Object, "status", "conditions")
-	if err != nil || !found {
+	// CRDs may have status.conditions: null (found=true, value=nil); treat as absent.
+	if err != nil || !found || statusConditions == nil {
 		klog.Infof("status conditions not found for %s", humanName(u))
 		return true
 	}

--- a/pkg/model/components/channels/model.go
+++ b/pkg/model/components/channels/model.go
@@ -143,6 +143,12 @@ func (b *ChannelsBuilder) buildPod(channels []string) (*v1.Pod, error) {
 				Name:  "KUBECONFIG",
 				Value: channelsKubeconfigPath,
 			},
+			{
+				// client-go's discovery cache writes to $HOME/.kube; /tmp is the writable dir
+				// for the non-root uid.
+				Name:  "HOME",
+				Value: "/tmp",
+			},
 		}, env.BuildSystemComponentEnvVars(&b.Cluster.Spec).ToEnvVars()...),
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{

--- a/pkg/model/components/channels/tests/container_registry/tasks.yaml
+++ b/pkg/model/components/channels/tests/container_registry/tasks.yaml
@@ -24,6 +24,10 @@ Contents: |
             fieldPath: spec.nodeName
       - name: KUBECONFIG
         value: /var/lib/kops/kubeconfig
+      - name: HOME
+        value: /tmp
+      - name: AWS_REGION
+        value: us-test-1
       image: my-mirror.example.com/kops-channels:1.35.0-beta.1
       name: kops-channels
       resources:

--- a/pkg/model/components/channels/tests/minimal/tasks.yaml
+++ b/pkg/model/components/channels/tests/minimal/tasks.yaml
@@ -24,6 +24,10 @@ Contents: |
             fieldPath: spec.nodeName
       - name: KUBECONFIG
         value: /var/lib/kops/kubeconfig
+      - name: HOME
+        value: /tmp
+      - name: AWS_REGION
+        value: us-test-1
       image: registry.k8s.io/kops/channels:1.35.0-beta.1
       name: kops-channels
       resources:

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -85,6 +85,9 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
+      env:
+      - name: AWS_REGION
+        value: us-test-1
       image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512
       name: etcd-manager
       resources:
@@ -258,6 +261,9 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
+      env:
+      - name: AWS_REGION
+        value: us-test-1
       image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512
       name: etcd-manager
       resources:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -84,6 +84,9 @@ Contents: |
         --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
         --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      env:
+      - name: AWS_REGION
+        value: us-test-1
       image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512
       name: etcd-manager
       resources:
@@ -249,6 +252,9 @@ Contents: |
         --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
         --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+      env:
+      - name: AWS_REGION
+        value: us-test-1
       image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512
       name: etcd-manager
       resources:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -85,6 +85,8 @@ Contents: |
         --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
       env:
+      - name: AWS_REGION
+        value: us-test-1
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
       image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512
@@ -260,6 +262,8 @@ Contents: |
         --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
       env:
+      - name: AWS_REGION
+        value: us-test-1
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
       image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -85,6 +85,8 @@ Contents: |
         --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
       env:
+      - name: AWS_REGION
+        value: us-test-1
       - name: NO_PROXY
         value: noproxy.example.com
       - name: http_proxy
@@ -266,6 +268,8 @@ Contents: |
         --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
       env:
+      - name: AWS_REGION
+        value: us-test-1
       - name: NO_PROXY
         value: noproxy.example.com
       - name: http_proxy

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 21c4c6429b8492f0499a751b7c319b5e9e702679df53bdf3fa285e19da46d89a
+    manifestHash: 88983572fdad5ed54e458fbb43836170d9fb4c064c327d7d67aaae7d73ada85e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: f43a1687d0367344f1357053c4ee1e7e9c4d1ed8342d2a591ef621e65f1b574c
+    manifestHash: dc6be0c5013574096329dabe0d6d17c2d72612261465d5b87fe5d5a4348f11f1
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,6 +21,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,6 +21,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7db9baec4bb7a296a0cf825e4b83b92c942f26b6a05e9e3a09d86b344e45f523
+    manifestHash: 67e1743499075e7fa857749c6a2a68ed0a3de9908b035dc9cf40057de18e687c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -199,7 +199,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 73c7ab6f31307c97b158114dca1a5eeb991894bbf868b81e4f8d86e8c687b09b
+    manifestHash: 9de6c9b260180507ee94922630ac7e6f80e6c71cbc365ac1e0e2192f3680a854
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e4d3c51be254e422a09098024e254d157730d4ed1746b696e6a027d880ab9a85
+    manifestHash: 9438f532100c9e846defec1267943074ff6de4e345f6d74680a907216ef515d3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: f2a4d677ed22a1b44d77f64c5b6af1c0dfcb811ab84be32607740b234d97739f
+    manifestHash: e787322f496b05956d1d54e6c32a14a4590587c301682d647f9296709f6ba66c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c59f6867a3801f423740ea36e2a90b45f623296889a6cb550a911a393d9170af
+    manifestHash: 7b498a89cc3ea29340a45b9c0e816afb836d0fcc80e87e8081eaf93194b0b192
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -97,7 +97,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 11b3b23babc909e04c2a42db9872f5f71b83ff33fd3d87770dfb3d64b23a2ed6
+    manifestHash: 7be78497b071308570fe3713b52eabd6333592d05bc11a32148e39d102f2c4a6
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6017dec2efedeea5df56499e752a230598c087e7c01163d65206cd9c76e918f8
+    manifestHash: c574529bbe54b692046be39f6b2f9bda708072acdd42271633b17f48d7e6237a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -97,7 +97,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: a4f079317ef02df8b306ed9e494844702b66119d83214df1b7dfd308cddc46e4
+    manifestHash: 55c8bb9f8e6985b40c8b009f4a78cd21dc74997c50615645d0d74f0c1aac56cd
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned >
       /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned >
       /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 17e966abf05680651e9113970ae7aeb371fc039792b56afd8f4366bdb1a160e3
+    manifestHash: 297ce9d2db16553ebcc2886f751bb7f8494ad06f9de339c2f9067cbea377d5d6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -97,7 +97,7 @@ spec:
       role.kubernetes.io/authentication: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2b244e8c080581cd5ced9a30c525cd1c0c82180c05f35ca83c870d8f51d89a31
+    manifestHash: 9c58545e8729ec86ab40ad062d37791f78bdc168c982d2487e417b2ca08902fb
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f214f8b7d58ff5129bb078c7e70693472e6b392b124f0d12ec578f1c0b585d7a
+    manifestHash: 22e127628e7666be2717972502758cc73ea896c59e523bc569cb45b555ae6c4d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e1124233082a59ce12f34ed00de2a35614824b6b7d2e0cb4a1adf7557939343f
+    manifestHash: 9b9824e64a58d001a21641f43e076578b8e44533fb67314fcf9994521d6b6da1
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5f57d8ec0e2eabeebab802f4f4a148079e1735c73955b4d64cd77283e0e62e34
+    manifestHash: 996b5d415decc0e2bcd4e42754572534782e41eac6cb9dba47f9f7df560ba793
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e98167404953715e592ff821e8bf4e6eb69cc980ed995059ec710acaa0c85aba
+    manifestHash: 3c4ee296add1925160cba61a3399321a342c92d9c7d11b2c98e18bde28a47fe6
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5f57d8ec0e2eabeebab802f4f4a148079e1735c73955b4d64cd77283e0e62e34
+    manifestHash: 996b5d415decc0e2bcd4e42754572534782e41eac6cb9dba47f9f7df560ba793
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e98167404953715e592ff821e8bf4e6eb69cc980ed995059ec710acaa0c85aba
+    manifestHash: 3c4ee296add1925160cba61a3399321a342c92d9c7d11b2c98e18bde28a47fe6
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 39060838f9a862b150fef16a00f88a547505a2fe0015fd4f64a1ef79b19ac5a3
+    manifestHash: a87b853ce71d068ee0458a3b3ebb483ce8cefb7232adc0b1305319d3667a398d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9d32c9afbaa0e2ae373a16ab45dff3b81a409fe916f9b09de51c747a0c1d3945
+    manifestHash: 8f428b4e73d771170ce036caafb7abf26fb64f04cc16aeb0b5240e81a15142ef
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3d672c9a324305248943c3e8c2b84e061fb6bc57f7d3466df0a77e01a31e7b43
+    manifestHash: 064187db16959e0118baac8dfa452b57046ba30f4b734a00f136f02590f51c67
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: acd7d3685570a4fbb2e48693df5a4191230446838040aaf8933c032b913f814d
+    manifestHash: 4675c5209ff2c6e56d5c2310a2615205f8d04afa9151223f08ac71169c089edb
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 46543219d2747bcae872c80a448cfc4c315b92b7dc4c34b111f9d728f0b34e2f
+    manifestHash: 4da82bf6f186511f288d93ef78cb596daa8eda33a6a5614f335a4dbec7e16356
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 59318bb7646a07233ea170c94bdb40847f8221ca81bbec64f2e6f22acea96d0e
+    manifestHash: bbfa672d1bdd4a042f542a3cf80e4d01b8726fde97f44f5954093d4ada9a5224
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 56982927435917831fe4c135b7eba40af35400e20f810557b9a4d409e3eed37e
+    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 73c7ab6f31307c97b158114dca1a5eeb991894bbf868b81e4f8d86e8c687b09b
+    manifestHash: 9de6c9b260180507ee94922630ac7e6f80e6c71cbc365ac1e0e2192f3680a854
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a896ffbf453b951fa41714b268077eb6cde87b84901b5f4d1f64c87306565a8d
+    manifestHash: 64c48de4c1ba6532636144861982a8dffadd3827e27866dad832489de1c0096d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 5d161524d790eec2196258a9a5b22e08997d8fbfc5229de510754c8ad789feca
+    manifestHash: c163cedaac16a5ad05c6a14b242fec9773f1a14d10197142954a83ad4b67996c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7d460b6f6875da738aafb758570917d7b7640608e22572fe6e17b7ba897e4498
+    manifestHash: 0cba98209c07e96e04466e37217623e98ab8532c9bf2a19a5ebedea10eba4501
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8b34e3e5f1361bb2a4df970db9df6f65613fdbf1b37a6e09c5b72225140ba23d
+    manifestHash: ccfd2beeef630d16ce9a15baca52e63b5a1cda53187778d4c84d7865f0a8d45d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_gossip.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_gossip.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 25d3b375fa031ffd1893c658990b847c6a83210ee36ad69878fc2e7987383474
+    manifestHash: 6eda554234dd8691be5d00cfbb2392eadfe9e595a5151b42e3d17846bc6c225b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: fa3ed8a0513b99dc06e492454801e9049ad411bede3b7a7f014e4eb8f07a44ea
+    manifestHash: e0542fa55f1849b4c434335f6c68c8993cba934cdadbfe858c64902a0fda0d5b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_gossip.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_gossip.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/gossip.k8s.local=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/gossip.k8s.local=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 51cb599c2c960a2549d5fca06864d25b23b270e099351670ff339e8eac32d5a7
+    manifestHash: c4b94a97aab6b7416c178d20b2dd54fb083f5cca5486689409df54d89982141e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_source
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-channels-kops-channels_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-channels-kops-channels_source
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5719ae1dbc8fc70f396fb66481bb71a65c745334079affa0076cc4d854c511d9
+    manifestHash: 5e5dce4298cbbf3b847bf757c5505a185a3509aafe34fdaf3b2c83b4a3dc2fa4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_gossip.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_gossip.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b02f6ad18c5d1f1898a883b54a35efdfac23e74728fdf135f3b4f80b3b7b592d
+    manifestHash: fb8cb42db7fce86f3e65d7059dd66ec282d0d9cf49219c1f43298dbc9124ea1f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_gossip.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_gossip.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     - name: HCLOUD_TOKEN
       value: REDACTED
     image: registry.k8s.io/kops/channels:1.34.0-beta.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9251633c885131b71575d93f6dc6de296e155c6a8f09b3f24e904a908d24eed0
+    manifestHash: 5214a047da9e0b32cbe1b95b75b39ae9d52324148089dd305d0e2f18329b02d5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e525692d33902998a755bc8fdeeece5ddb673542556c6c3ac1ee5222d0b88b65
+    manifestHash: 33921669f32907504d8c0edf4c9e668cae0e01ffdecef4d0928ba0d8d2152a93
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: edcbf202a7349bef9473a92ed8c03d5b9d7459c4c0268c51134ae32e75728fe8
+    manifestHash: 58fe6d5f1300b0703508933aa77ea9ccf34f84b9799028dadd7079cbb9975e8e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -151,7 +151,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 56982927435917831fe4c135b7eba40af35400e20f810557b9a4d409e3eed37e
+    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 73c7ab6f31307c97b158114dca1a5eeb991894bbf868b81e4f8d86e8c687b09b
+    manifestHash: 9de6c9b260180507ee94922630ac7e6f80e6c71cbc365ac1e0e2192f3680a854
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -219,7 +219,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 51b52777f437506a94ad181cc46850e7bf97ac2f0a6a01b1fcf731a43fdb9b4c
+    manifestHash: 46f55667a95ccec288215d288ef861441e24de6e76aad7fc9f813c4ceebf5031
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -219,7 +219,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 889646791538b4b4d75f55844a453289d7a8bff082df71d96644b4b1b98799b6
+    manifestHash: 1a2c169ec8d130322c15099de960ca91b26ef9a3db1a5aa19191df0366f4447f
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ef3bbf4aa5d58a8c7dee0c60e97e88f607dbe454b927da635812d1a32e2d937d
+    manifestHash: 49a74cc9f58a05d818753385a6159bbeecbeaa39f692e594cbaca2203255aa7c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/many-addons.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/many-addons.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4bdf207ac60d9a8c4b87436a249ec4f7d0a30fa2a6ad7cb148df3ce0e7e8bb07
+    manifestHash: 80fcab6ef45caaccf18449269f69de9ecbdd299f0fbe568fffb0afeea9fa7c64
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -267,7 +267,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 6aee122ab3877e549cc008d1878ee13ad0207a4f4dde3ed17e8eb0d01a02fd01
+    manifestHash: 9a6f4a1224eef8becdd5deea7939381b4c769911cb2cfe98b1da420fb32b9e8c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 60ec034d49771c5f70f1c28eef79cce1ae97ef168e6722e00e8b0f0826845b5a
+    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 4412b776547337d8261a4d4aa4a4782e89d95dc33b1c1e0e6358d0b8378d7832
+    manifestHash: e314c8d485c43e8adc57edd7396533c505219c118ceb34900b71a81e9974bd43
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 60ec034d49771c5f70f1c28eef79cce1ae97ef168e6722e00e8b0f0826845b5a
+    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 56982927435917831fe4c135b7eba40af35400e20f810557b9a4d409e3eed37e
+    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 60ec034d49771c5f70f1c28eef79cce1ae97ef168e6722e00e8b0f0826845b5a
+    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: ee17ae1e303daa050b312d5a427969f133b64126efaaa6edf595afb496ac0a74
+    manifestHash: b1ba8eea3a03829597c565ce6f572f231bb86d02ac415a57a144931ce25ce494
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 60ec034d49771c5f70f1c28eef79cce1ae97ef168e6722e00e8b0f0826845b5a
+    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 60ec034d49771c5f70f1c28eef79cce1ae97ef168e6722e00e8b0f0826845b5a
+    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 60ec034d49771c5f70f1c28eef79cce1ae97ef168e6722e00e8b0f0826845b5a
+    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-aws.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-aws.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e332ade9fc168ccf1f869f4a48b355697732f1378595ea5b258a60ca41d76c9e
+    manifestHash: c759b8c5f4b86d6ef7956c4fefaedeccbc36620b5507accc2026d9d9d150687d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: c87a658634c866c24d1bce16f746cbead9f94b9d1598b09ce8f314f263a04479
+    manifestHash: 2f83bacafe128f6f75e35f3105cdb7570741d55ebc51ba55df36d54e474cddaa
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 60ec034d49771c5f70f1c28eef79cce1ae97ef168e6722e00e8b0f0826845b5a
+    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -85,7 +85,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 56982927435917831fe4c135b7eba40af35400e20f810557b9a4d409e3eed37e
+    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-etcd.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 30d
     - name: ETCD_MANAGER_HOURLY_BACKUPS_RETENTION

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-etcd.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 78f16141e83090391f7a30489ad913ed306d902b862ea8cd40579ad4952803e9
+    manifestHash: 62ef2a3e3c480864fea00e78fb43d575507d76c457aaeaeabbf1152b60448a60
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b8c1d92d656009951d56d31fdbe8927b5c769f212dd1b8e75335b2c448cf1571
+    manifestHash: 6106220a3d3be573897abac912daa8afc65fd905fe4339ca60e077f6f530a6bc
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 56982927435917831fe4c135b7eba40af35400e20f810557b9a4d409e3eed37e
+    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=false

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9db60c212df2172b3afd0142b4f63204bbddfddf02c6d1014027c9a50517449
+    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -145,7 +145,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8967a5fff7fd8c155e10cbf5145ffd2b6b545ee123f4603d5f07a20f76db6a3d
+    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=false

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9db60c212df2172b3afd0142b4f63204bbddfddf02c6d1014027c9a50517449
+    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8967a5fff7fd8c155e10cbf5145ffd2b6b545ee123f4603d5f07a20f76db6a3d
+    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=false

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9db60c212df2172b3afd0142b4f63204bbddfddf02c6d1014027c9a50517449
+    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8967a5fff7fd8c155e10cbf5145ffd2b6b545ee123f4603d5f07a20f76db6a3d
+    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=false

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9db60c212df2172b3afd0142b4f63204bbddfddf02c6d1014027c9a50517449
+    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8967a5fff7fd8c155e10cbf5145ffd2b6b545ee123f4603d5f07a20f76db6a3d
+    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=false

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9db60c212df2172b3afd0142b4f63204bbddfddf02c6d1014027c9a50517449
+    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8967a5fff7fd8c155e10cbf5145ffd2b6b545ee123f4603d5f07a20f76db6a3d
+    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 55211483fc9fc67692920d7a7f598844a7a5c4d2fec2ad08282a080b47a4674f
+    manifestHash: bd4bbe6a686295868a6ec58305d3b6e2a1873199af457075e5b65f71183d9162
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: f00587d0eba374409fb6a438c8d659be144ca8aa24612c9056e576132d5a6a4a
+    manifestHash: 9e8341d28e567c7c1af877e9304ff36ae69daa382e7639e08a35dff2be2407c3
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: kops.k8s.io/remapped-image/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: kops.k8s.io/remapped-image/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: kops.k8s.io/remapped-image/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a53eeb1a3dc88c771675040b00f25200a9e0224cddb10e1a28d9b7fa2f8f0b3c
+    manifestHash: 3331f594e11b433d43b80e0bd3d21689f4c6b12771b61a0d09a084f53be3033c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 562db21350941326866ef88d92602ed09386674e08ed1b60b97de55313aaa5f8
+    manifestHash: 25001fd43a14ae33c91663eb7122a8556b0258c62b03dca3fbdbe2271c49f62f
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: kops.k8s.io/remapped-image/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-channels-kops-channels_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-channels-kops-channels_source
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f748cf84722a8bb6e477741fbb3c4977799c817a1809fc1e4f13b91770522531
+    manifestHash: 733adf99aaaf10fe1081ff877c47f161d293e9c430caddb56ebab6a33c9cff32
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_source
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a69f6c89f9ea7b1ea5e986ce1a7cb733f7a5471a22859c12dcb88583c9696089
+    manifestHash: 4788c572be95e6ad6749aab30d42805095ded3d7612865c99a66ce20b31b1534
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a69f6c89f9ea7b1ea5e986ce1a7cb733f7a5471a22859c12dcb88583c9696089
+    manifestHash: 4788c572be95e6ad6749aab30d42805095ded3d7612865c99a66ce20b31b1534
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 388a80a505d6668c9185c294fd9f82552bf125a66ce8f03e05f545e2e50e4aec
+    manifestHash: 789618d218a90771d66dcd684c841bb684b7c4feefad1fac0d907a119617d92f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 99889fc8356062a43edf7c268daebd7684cfaca146c891fbede6d89a8e42f02f
+    manifestHash: 182b4b26986b5d6c7bfc00d7e3d2dd305bc70ef54b35bb4a0a6ed57d0d314c8d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 46e2a23bceb01e676386e3ac5957f5fa3c2a4f36b5423877173e457f25cc75be
+    manifestHash: 7b1d9e5aaef2d14e3c1c7be13bf566739f830898269d7a7a0440c700113a05e1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 46e2a23bceb01e676386e3ac5957f5fa3c2a4f36b5423877173e457f25cc75be
+    manifestHash: 7b1d9e5aaef2d14e3c1c7be13bf566739f830898269d7a7a0440c700113a05e1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a7400354b4fc0ef2511be9e82d4b68dd815c9f89b6c686d6e24d3a0849eb2f6c
+    manifestHash: 291dc9847850d9a62ccc065fc3534049967fc6eaab84b603f9564a185481ad37
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b8e9a476caee1c005c511b0ebf5d6608f65576e150ad8e9bf3cfe2dce25d5c4f
+    manifestHash: 0896a0ad40518e6d05e127c2816acc03281d24ec77787937fdcabaeae5f1df7e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 44e4de82e42f107d929d08b90b91bc8eadc83cb074afbbc55ebee416b782dfe6
+    manifestHash: 03624453e7296c0b13649f867830ad22d205322e9e0e6200c56f9a4a48ccfc98
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c1fcf51297f7407bab74b816182c2a3185f4ffd3cd2fe5d42190e63562758dd6
+    manifestHash: e9fefe4a40f180eef4892b1dfac5dfadb988e560c77e79872368c7005bb8017f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: da26e38230b520c88756b223584083a8658a9a98358f54fe1aef2551dac24cac
+    manifestHash: b7d715a340d3bdaaa4706f63ea6c8c789aa1971a1e3492ce0e925c95e53172a7
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c1fcf51297f7407bab74b816182c2a3185f4ffd3cd2fe5d42190e63562758dd6
+    manifestHash: e9fefe4a40f180eef4892b1dfac5dfadb988e560c77e79872368c7005bb8017f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e731fdaa42c0b552303fc8b336e11cc986cb091ff74829c07edc5deee5e7afda
+    manifestHash: d384e093bce79b1f30d17adbc6cef9df479b8397f9882663304d011c1755140f
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     - name: HCLOUD_TOKEN
       value: REDACTED
     image: registry.k8s.io/kops/channels:1.34.0-beta.1

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 84f87393a0703609e98983f01abc766b75c687423ea0cf505a27202a36608239
+    manifestHash: bc6d3ec51739764572058d2ed42a1dfe3c1393b1ea1512265cba75c2fee9e9aa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,8 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
     - name: SCW_ACCESS_KEY
     - name: SCW_DEFAULT_PROJECT_ID
     - name: SCW_SECRET_KEY

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c07989e26124bf19c35f3179c46bc43decbdaee3570781bdba05fd5b68bbbc32
+    manifestHash: cc0e56636734a811c1924cde05ec3876d6fa65b45b4ae273731077df497db612
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8fb6a383807d2016afb06e77894378991e7ba4aa6e416511585366b72ca765af
+    manifestHash: e33be1206444f8fba258e6ed374dbe1740f2d37ba9a544d383a5da4534c01c42
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 0ec155e6d13d3aec106dc3b40ac2d679b47f39add67ad2b69974d223cb9c8361
+    manifestHash: 5fe9fc377054d32f7f903069119f8923f08871fa4c7cd71db40cb97f75f0c828
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8fb6a383807d2016afb06e77894378991e7ba4aa6e416511585366b72ca765af
+    manifestHash: e33be1206444f8fba258e6ed374dbe1740f2d37ba9a544d383a5da4534c01c42
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 0ec155e6d13d3aec106dc3b40ac2d679b47f39add67ad2b69974d223cb9c8361
+    manifestHash: 5fe9fc377054d32f7f903069119f8923f08871fa4c7cd71db40cb97f75f0c828
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 265a8ea321e0fd6a4b42d6f514dec0ed77d953e7b0f995e7660f910249fdaf5c
+    manifestHash: deff1f0e8700755dad51198fed2308135b30a5dd60c38953df3ec54e0b9dbd69
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -89,7 +89,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 1464d2fd7dce3da33057913639d9db855a779b790349578fff1d1a27ee3ada06
+    manifestHash: 87c153a8d190d13b30eac66117f56f1124d207b28818e4ed5a222c144a8ad1a1
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 265a8ea321e0fd6a4b42d6f514dec0ed77d953e7b0f995e7660f910249fdaf5c
+    manifestHash: deff1f0e8700755dad51198fed2308135b30a5dd60c38953df3ec54e0b9dbd69
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -89,7 +89,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: dab380276c484c41f36e506594e1c36912aaf014ec034cdab3e63272a61314d3
+    manifestHash: 796f038bac2c845bc6f11da1fe6f5c447cbf0ef7708e00e1ea34a0b30384d51a
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -97,7 +97,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 56982927435917831fe4c135b7eba40af35400e20f810557b9a4d409e3eed37e
+    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05ae2ed6aef6e12db193d82859d2290585bd30c43f10f77c522cb9a95aab6a42
+    manifestHash: f3c8bceca99432bfd69a2f402e4ce78bf61bffaf73dd4bc573a4c60952fee590
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 4448d4d366c0c179a38609552894af64620fd23d8b7428def5684a8b5eafc7f8
+    manifestHash: 5523aba8aba70c5b68f0b771a3b1fc442e3bf1ea46a6afc5293bb70f597d3dc9
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
       /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
       /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 253914878d5af55d2e510af9cd1790a10f90724c0e4b2dcf34b7895036f1fcae
+    manifestHash: ae5321a60b97e5ca5d9fa11111abb2646d721fe0c191b49f80a80ca18472d541
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: fca6f20026a6db3012e2c38f88de574bc370dbfe153a405210a2f7d7d60e65c4
+    manifestHash: 707ddaec3e8eaa8ef8eea07613f0eaceb6820dbd5c2c89027aa9eb71cfa468d4
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 474f753d6c26f7e2c1c3139ba1cd3bd7dd598b6341104a12152c0d083165c3c9
+    manifestHash: 4f86bf3756203f2a0f252948c16be51e126da5af9e9a61b94306624e213adf91
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -145,7 +145,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 1649ce64c25fbb90c4ff85d0e185617773ba5497de45e227f6f3ff9fa603971c
+    manifestHash: 9fbf176db11352011d6b5c378cc7e6625aaebb7e04526cf3c84354a2ead855a8
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4d640fd0455da8bca572c8b4db6602ff49c231dfec0a5d0eb0c2b73fdd4ade2e
+    manifestHash: dda00e3c15f5780d3b842605e36d1a7857ef5386fc69c75577725a47c897197b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 16d68835be384982add8a09347cbf94bbc532293e4cbb2c463b216da3bd8280a
+    manifestHash: 8fe93d5de53463def33ae1bc261bb089ae26b9b1d5c96fada4386a4bdb3e2f8f
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4d640fd0455da8bca572c8b4db6602ff49c231dfec0a5d0eb0c2b73fdd4ade2e
+    manifestHash: dda00e3c15f5780d3b842605e36d1a7857ef5386fc69c75577725a47c897197b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 16d68835be384982add8a09347cbf94bbc532293e4cbb2c463b216da3bd8280a
+    manifestHash: 8fe93d5de53463def33ae1bc261bb089ae26b9b1d5c96fada4386a4bdb3e2f8f
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4d640fd0455da8bca572c8b4db6602ff49c231dfec0a5d0eb0c2b73fdd4ade2e
+    manifestHash: dda00e3c15f5780d3b842605e36d1a7857ef5386fc69c75577725a47c897197b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -152,7 +152,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 38f19e50ebbff7462fe38a973581a02471595da407e9ffcbbf3375ccd0460f0e
+    manifestHash: 96137cba2dd45aabd780e54fff06d20bacb1094f18f998b5c49bb4e90aa93855
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
       > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
       /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
       /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1d53f5d8c9f2f31ee9ed6a9b06cca0a99f495d46e2b34847f23e83676f7f2771
+    manifestHash: 151fcf9748c00411b81354bb9d6c149d0e15189017b0d88ea8df04af3fdcef18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 6666b752c56d14d5772ebf90b1b337d2d7e28fd263201725a2639374172708e2
+    manifestHash: 909fae67a7f84fd7a71bd763960f1bfa846014671e98b35d5ff17652fee1078d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: be74b357e1f88a96837769c4c87c2e21d1af117e31e7cde31230de69cd469b5c
+    manifestHash: f26a9eff62bd9bb57d5386b6f592f91694dd66605ad873c87e615306e277f4f3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2d098ec1e875b8cfde60a085be81b700cd86c244ea4ca4e31c823c14b57b35d5
+    manifestHash: dbbc3527ca3ab0bcb3acb9ffcd94c24650a66c9dbb24890f887870f8a1cc7aa3
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7b6f0779fb49aa87a08017f757ac88b70795605fd3ca9687a724d353bb604bd0
+    manifestHash: cbe1d68907c90d6bf963f4682465b71cc037ea0ad03e0354ca8b4c59f3a7cfca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 471b8b962e838707cde28100a68c774a0612c32262962f4b01dae32ad98dda63
+    manifestHash: 0c8760e9e730a88658c771ac947e6b471e0e750b39847027dfa125062fd683e6
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3c1750deb5c6d4b07a2bc74693c99bc478ff2c1e7ca83167e469861d1069b00a
+    manifestHash: d9edaf81808af059c6425a8ba1dd8a21ee8d10d55155c2a7060004a1aace0e4e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -141,7 +141,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 0cafa1faf5f7cbc7a1ea218d155f3afdd7f82bbc57a77ea21c00a2ad6e1e5a9e
+    manifestHash: da2e7a9aeaa36e9442110a73a49efa12891d5b1d3db4fa44376e82f534b28c84
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatekindnet.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatekindnet.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e57e72db1776550719822ea395e19c86c869a3d5a06d6238447bbfb52f6c62f7
+    manifestHash: c7c08f6f0e77788796878ffd3b055aeb89881ebb7484c0696dacf285f36b2e19
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b20654d42b745bebc7adace87992dd9d306938cf489dcccd7db9a468989421f0
+    manifestHash: ac3e0e4295a3782ef4856569cb047e2701fd5f98772a76c478e5c467da461bf8
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7392cb4cbd3789d6ea2cf06664788d1639bc461d6be0f998bf2376bbccb54382
+    manifestHash: ccbba19667ed491737f8c9655bbd4d55580b239816e7fe3319985754bdce6205
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -139,7 +139,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3221bd67c481e965df4bd48d82cfead8aaa7b040ff09a1861e87cf12f8245366
+    manifestHash: 5498fc4ba791012d64ae8a38dcd84b841455a1892b5c0e4980bc1c06ec2357fa
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 88c3573af033e37c184ea510f9df0851b8783d34012d65a324744e3c61012799
+    manifestHash: 49df9879eebd02e13adcad2c2fc8014c3aa0e320ec1ddf6ad57451bf7b46d1e9
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f3585e15ca5682d654ed4cb4a69277b6db006ef13b584749d01cdaf2d614b88c
+    manifestHash: e94e75a64c24dc8429f73706f9b32605d77942eda583b6e2a144e255cb074e42
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 4c413085ca824ed6f4d607d9abbedd661a31daf7b4b19fbf4769aca069506178
+    manifestHash: a7d28b813e7e04e0f024c7712f1de8c81ac93d052497da1b66312b8e11f32e4e
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2afc920d533bf2f4375d628829b8145f1df53f81f5edc84926ae3e4164ff8c17
+    manifestHash: 06e123f04dc4f66e83a6267f5eb2c1f4edb2da796833d6739c4d94d0a8da2d8b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 13bdb2e7435a3d37e7b666dc9b3e587d4277e6ccf7f5253c03cf07f379d47d86
+    manifestHash: ee9cc5a223f9f9176acd4d8fa1e3ef92172786f5fc903a3dc0ffc1da05bdb40d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,6 +19,8 @@ spec:
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=false

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9db60c212df2172b3afd0142b4f63204bbddfddf02c6d1014027c9a50517449
+    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8967a5fff7fd8c155e10cbf5145ffd2b6b545ee123f4603d5f07a20f76db6a3d
+    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ee650d613cac2640f670e2b12107daa4c56f0ecc7ab02813209d95344b9f0d49
+    manifestHash: a5da3e3a97bcc8d78b2f88f617859e4d0344ce62282af7511dcb57c3f269591a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 5b070d52113f4072f4cb51d727226afd462b33fbcaf3a9d2498d12cc1ffd14de
+    manifestHash: 8e34b44c34f08c5470d3374c0570cb73d7e880df797ad60075dd7a6c6df39e06
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -22,6 +22,10 @@ spec:
           fieldPath: spec.nodeName
     - name: KUBECONFIG
       value: /var/lib/kops/kubeconfig
+    - name: HOME
+      value: /tmp
+    - name: AWS_REGION
+      value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
     resources:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,6 +18,8 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
     env:
+    - name: AWS_REGION
+      value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
     image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260512

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33c5913c89e15b5dba30a850b5ca09082d1b55f6f0af7df56f82f6f892fe310d
+    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 56982927435917831fe4c135b7eba40af35400e20f810557b9a4d409e3eed37e
+    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         - name: KOPS_RUN_TOO_NEW_VERSION
           value: "1"
         image: registry.k8s.io/kops/kops-controller:1.34.0-beta.1

--- a/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -44,11 +44,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       priorityClassName: system-cluster-critical
       nodeSelector: null
       tolerations:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -25,9 +25,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e19326504c8118002e5bfa15533d661750e6969a88be5e079fbe826698a86a54
+    manifestHash: bb2aae2f50be553a55945513ac25d68bf656b7a89f21d811eed1d8396c6fe6ec
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -97,7 +97,7 @@ spec:
       role.kubernetes.io/authentication: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -97,7 +97,7 @@ spec:
       role.kubernetes.io/authentication: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         image: registry.k8s.io/kops/kops-controller:1.35.0-beta.1
         name: kops-controller
         resources:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -104,7 +104,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -158,7 +158,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         image: registry.k8s.io/kops/kops-controller:1.35.0-beta.1
         name: kops-controller
         resources:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 5d2af03c7ce3c102575454497c0d4b87ada602f443ca56b7558faf8760f3fb02
+    manifestHash: 7fffc651bf20882d8a4d0726872354b225c781d2536cf071a045d29ef9d941f5
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -47,11 +47,6 @@ spec:
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-              - key: kops.k8s.io/kops-controller-pki
-                operator: Exists
       containers:
       - args:
         - --v=2
@@ -60,6 +55,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: AWS_REGION
+          value: us-test-1
         image: registry.k8s.io/kops/kops-controller:1.35.0-beta.1
         name: kops-controller
         resources:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bda7568b99fce2a498b3896223edd707cf74e4530d7c4b03577461196e8230a
+    manifestHash: ec27285a0c8ab1afa5bf4e9538f9c4c3ced93031401f040d61942fc598fa2e93
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 173838a4aa1bb0119022edb4a47dd54c5154f2054d0bb187916b3f06b7645240
+    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/util/pkg/env/standard.go
+++ b/util/pkg/env/standard.go
@@ -43,6 +43,15 @@ func BuildSystemComponentEnvVars(spec *kops.ClusterSpec) EnvVars {
 		vars[v.Name] = v.Value
 	}
 
+	// VFS uses AWS_REGION to skip the IMDS region probe, which fails as non-root because
+	// /sys/.../product_uuid is mode 0400.
+	if region := awsRegionFromSpec(spec); region != "" {
+		vars["AWS_REGION"] = region
+	} else {
+		// Stub specs without subnets fall back to the parent process env.
+		vars.addEnvVariableIfExist("AWS_REGION")
+	}
+
 	// Custom S3 endpoint
 	vars.addEnvVariableIfExist("S3_REGION")
 	vars.addEnvVariableIfExist("S3_ENDPOINT")
@@ -88,6 +97,21 @@ func BuildSystemComponentEnvVars(spec *kops.ClusterSpec) EnvVars {
 	}
 
 	return vars
+}
+
+// awsRegionFromSpec returns the region derived from a subnet zone, or "" for non-AWS specs and
+// AWS specs without zoned subnets.
+func awsRegionFromSpec(spec *kops.ClusterSpec) string {
+	if spec.CloudProvider.AWS == nil {
+		return ""
+	}
+	for _, subnet := range spec.Networking.Subnets {
+		// "us-east-1a" -> "us-east-1".
+		if len(subnet.Zone) > 1 {
+			return subnet.Zone[:len(subnet.Zone)-1]
+		}
+	}
+	return ""
 }
 
 func (m EnvVars) ToEnvVars() []corev1.EnvVar {

--- a/util/pkg/env/standard_test.go
+++ b/util/pkg/env/standard_test.go
@@ -32,6 +32,46 @@ func TestBuildSystemComponentEnvVars(t *testing.T) {
 		wantExist bool
 	}{
 		{
+			name: "AWS region derived from subnet zone",
+			spec: &kops.ClusterSpec{
+				CloudProvider: kops.CloudProviderSpec{
+					AWS: &kops.AWSSpec{},
+				},
+				Networking: kops.NetworkingSpec{
+					Subnets: []kops.ClusterSubnetSpec{
+						{Zone: "ap-northeast-1a"},
+						{Zone: "ap-northeast-1c"},
+					},
+				},
+			},
+			envVar:    "AWS_REGION",
+			wantVal:   "ap-northeast-1",
+			wantExist: true,
+		},
+		{
+			name: "AWS region absent when no subnets",
+			spec: &kops.ClusterSpec{
+				CloudProvider: kops.CloudProviderSpec{
+					AWS: &kops.AWSSpec{},
+				},
+			},
+			envVar:    "AWS_REGION",
+			wantExist: false,
+		},
+		{
+			name: "AWS region not set for non-AWS clouds",
+			spec: &kops.ClusterSpec{
+				CloudProvider: kops.CloudProviderSpec{},
+				Networking: kops.NetworkingSpec{
+					Subnets: []kops.ClusterSubnetSpec{
+						{Zone: "us-east-1a"},
+					},
+				},
+			},
+			envVar:    "AWS_REGION",
+			wantExist: false,
+		},
+		{
 			name: "Openstack nil",
 			spec: &kops.ClusterSpec{
 				CloudProvider: kops.CloudProviderSpec{},


### PR DESCRIPTION
Audit of a recent `kops-channels` log surfaced four sources of avoidable noise on every pod start. Each fix is its own commit and can be cherry-picked independently.

### env: derive `AWS_REGION` from cluster spec

VFS reads `AWS_REGION` to skip its IMDS region probe. The probe fails for non-root pods (`/sys/devices/virtual/dmi/id/product_uuid` is mode `0400`), so the container defaults to `us-east-1` and pays for a cross-region S3 round-trip on every cold start:

```
unable to read /sys/devices/virtual/dmi/id/product_uuid, assuming not running on EC2
defaulting region to "us-east-1"
found bucket in region "ap-northeast-1"
```

`BuildSystemComponentEnvVars` now derives the region from `spec.Networking.Subnets[].Zone` when the cluster is on AWS. Stub specs without subnets (the nodeup-side `ChannelsBuilder`) fall back to the parent process env, matching the existing `S3_REGION` pattern.

### channels: set `HOME` so client-go can write its discovery cache

`kops-channels` runs as UID 10013 with no `HOME`, so client-go's cached discovery falls back to `/.kube` and emits 22 lines per pod start before silently giving up:

```
failed to write cache to /.kube/cache/discovery/127.0.0.1/servergroups.json due to mkdir /.kube: permission denied
failed to write cache to /.kube/cache/discovery/127.0.0.1/flowcontrol.apiserver.k8s.io/v1/serverresources.json due to mkdir /.kube: permission denied
[...20 more...]
```

`HOME=/tmp` (mode `1777` via `wolfi-baselayout`, writable for the non-root uid) silences all 22. No emptyDir needed.

### addons: drop deprecated master `nodeAffinity` term

`aws-cloud-controller-manager` and `kops-controller` still list `node-role.kubernetes.io/master` alongside `control-plane` in `nodeSelectorTerms`. The apiserver warns on every channel apply:

```
Warning: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[1].matchExpressions[0].key: node-role.kubernetes.io/master is use "node-role.kubernetes.io/control-plane" instead
```

kops hasn't applied the `master` label to nodes for years; the fallback term selects nothing. Drop the `matchExpressions`; keep the matching toleration as harmless backward-compat.

### applyset: treat nil `status.conditions` as absent

CRDs that set `status.conditions: null` (rather than omitting the key) trigger `pkg/applylib/applyset/health.go`'s warn path. The two amazon-vpc-routed-eni CRDs hit it every reconcile:

```
expected status.conditions to be list, got <nil>
expected status.conditions to be list, got <nil>
```

Fold the nil case into the existing `status conditions not found` info path.

### Source log

[`kops-channels.log` from pull-kops-e2e-k8s-aws-amazonvpc / job 2057268228035448832`](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kops/18373/pull-kops-e2e-k8s-aws-amazonvpc/2057268228035448832/artifacts/cluster-info/kube-system/kops-channels-i-00318f969356da921/kops-channels.log)

/cc @rifelpet @ameukam 