### PR TITLE
gomod: tidy and verify all modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,9 +313,10 @@ ko-kops-utils-cp-push:
 gomod:
 	go mod tidy
 	go mod vendor
-	cd hack; go mod tidy
-	cd tests/e2e; go mod tidy
-	cd tools/otel/traceserver; go mod tidy
+	for dir in $$(find . -name go.mod -not -path './go.mod' -not -path './vendor/*' -not -path '*/.*' | xargs -n1 dirname | sort); do \
+		echo "go mod tidy: $$dir"; \
+		( cd "$$dir" && go mod tidy ); \
+	done
 
 .PHONY: gofmt
 gofmt:

--- a/hack/verify-gomod.sh
+++ b/hack/verify-gomod.sh
@@ -24,7 +24,9 @@ cd "${KOPS_ROOT}"
 
 make gomod
 
-changes=$(git status --porcelain go.mod go.sum vendor/ tests/e2e/go.mod  tests/e2e/go.sum || true)
+# Check every module's go.mod/go.sum plus the vendored tree, excluding hidden directories
+# that aren't part of the source (e.g. .claude worktrees, .idea).
+changes=$(git status --porcelain -- '*go.mod' '*go.sum' vendor/ ':(exclude,glob)**/.*/**' || true)
 if [ -n "${changes}" ]; then
   echo "ERROR: go modules are not up to date; please run: make gomod"
   echo "changed files:"


### PR DESCRIPTION
Replace the hardcoded module lists in the `gomod` make target and verify-gomod.sh with dynamic discovery, so no module is left untidied or unverified. Hidden directories are excluded.

/cc @ameukam @rifelpet 

Assisted by Calude Opus