### PR TITLE
e2e: set the v3 runtime class path in apiserver templates

### DIFF
--- a/tests/e2e/templates/apiserver-gce.yaml.tmpl
+++ b/tests/e2e/templates/apiserver-gce.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
   configBase: "{{.stateStore}}/{{.clusterName}}"
   containerd:
     configAdditions:
-      plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.runtime_type: io.containerd.runc.v2
+      plugins."io.containerd.cri.v1.runtime".containerd.runtimes.test-handler.runtime_type: io.containerd.runc.v2
   etcdClusters:
   - etcdMembers:
     - instanceGroup: control-plane-{{$zone}}

--- a/tests/e2e/templates/apiserver.yaml.tmpl
+++ b/tests/e2e/templates/apiserver.yaml.tmpl
@@ -17,7 +17,7 @@ spec:
   configBase: "{{.stateStore}}/{{.clusterName}}"
   containerd:
     configAdditions:
-      plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.runtime_type: io.containerd.runc.v2
+      plugins."io.containerd.cri.v1.runtime".containerd.runtimes.test-handler.runtime_type: io.containerd.runc.v2
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-{{$zone}}


### PR DESCRIPTION
Ref: https://testgrid.k8s.io/kops-misc#kops-aws-apiserver-nodes

/cc @ameukam @rifelpet

Assisted by Calude Opus