### PR TITLE
Validate Kubernetes feature gate input during cluster creation

### DIFF
--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -285,19 +285,16 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 		}
 
 		for _, featureGate := range opt.KubernetesFeatureGates {
-			enabled := true
-			if featureGate[0] == '+' {
-				featureGate = featureGate[1:]
+			featureGate, enabled, err := parseKubernetesFeatureGate(featureGate)
+			if err != nil {
+				return nil, err
 			}
-			if featureGate[0] == '-' {
-				enabled = false
-				featureGate = featureGate[1:]
-			}
-			cluster.Spec.Kubelet.FeatureGates[featureGate] = strconv.FormatBool(enabled)
-			cluster.Spec.KubeAPIServer.FeatureGates[featureGate] = strconv.FormatBool(enabled)
-			cluster.Spec.KubeControllerManager.FeatureGates[featureGate] = strconv.FormatBool(enabled)
-			cluster.Spec.KubeProxy.FeatureGates[featureGate] = strconv.FormatBool(enabled)
-			cluster.Spec.KubeScheduler.FeatureGates[featureGate] = strconv.FormatBool(enabled)
+			value := strconv.FormatBool(enabled)
+			cluster.Spec.Kubelet.FeatureGates[featureGate] = value
+			cluster.Spec.KubeAPIServer.FeatureGates[featureGate] = value
+			cluster.Spec.KubeControllerManager.FeatureGates[featureGate] = value
+			cluster.Spec.KubeProxy.FeatureGates[featureGate] = value
+			cluster.Spec.KubeScheduler.FeatureGates[featureGate] = value
 		}
 	}
 
@@ -597,6 +594,28 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 		Channel:        channel,
 	}
 	return &result, nil
+}
+
+func parseKubernetesFeatureGate(featureGate string) (string, bool, error) {
+	featureGate = strings.TrimSpace(featureGate)
+	if featureGate == "" {
+		return "", false, fmt.Errorf("kubernetes feature gate must not be empty")
+	}
+
+	enabled := true
+	switch featureGate[0] {
+	case '+':
+		featureGate = strings.TrimSpace(featureGate[1:])
+	case '-':
+		enabled = false
+		featureGate = strings.TrimSpace(featureGate[1:])
+	}
+
+	if featureGate == "" {
+		return "", false, fmt.Errorf("kubernetes feature gate must include a feature name")
+	}
+
+	return featureGate, enabled, nil
 }
 
 func setupVPC(opt *NewClusterOptions, cluster *api.Cluster, cloud fi.Cloud) error {

--- a/upup/pkg/fi/cloudup/new_cluster_test.go
+++ b/upup/pkg/fi/cloudup/new_cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kops/pkg/client/simple/vfsclientset"
 	"k8s.io/kops/util/pkg/vfs"
 	"sigs.k8s.io/yaml"
 
@@ -431,6 +432,67 @@ func TestSetupTopology(t *testing.T) {
 			diffString := diff.FormatDiff(string(expectedYaml), string(actualYaml))
 			t.Errorf("unexpected cluster topology setup:\n%s", diffString)
 		}
+	}
+}
+
+func TestNewClusterValidatesKubernetesFeatureGates(t *testing.T) {
+	vfsContext := vfs.NewTestingVFSContext()
+	basePath, err := vfsContext.BuildVfsPath("memfs://tests")
+	if err != nil {
+		t.Fatalf("error building test state store: %v", err)
+	}
+	clientset := vfsclientset.NewVFSClientset(vfsContext, basePath)
+
+	tests := []struct {
+		name    string
+		gates   []string
+		wantErr string
+	}{
+		{
+			name:    "should reject empty feature gate if entry is blank",
+			gates:   []string{""},
+			wantErr: "must not be empty",
+		},
+		{
+			name:    "should reject feature gate if entry is sign only plus",
+			gates:   []string{"+"},
+			wantErr: "must include a feature name",
+		},
+		{
+			name:    "should reject feature gate if entry is sign only minus",
+			gates:   []string{"-"},
+			wantErr: "must include a feature name",
+		},
+		{
+			name:    "should continue past feature gate validation if entry is valid",
+			gates:   []string{"+ReadWriteOncePod"},
+			wantErr: "must specify at least one zone",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opt := &NewClusterOptions{
+				ClusterName:            "test.example.com",
+				Channel:                "file://tests/channels/channel.yaml",
+				KubernetesVersion:      "v1.32.0",
+				KubernetesFeatureGates: test.gates,
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("NewCluster panicked: %v", r)
+				}
+			}()
+
+			_, err := NewCluster(opt, clientset)
+			if err == nil {
+				t.Fatalf("expected error containing %q", test.wantErr)
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("unexpected error %q, expected to contain %q", err, test.wantErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate Kubernetes feature gate entries before indexing them during `kops create cluster`
- return errors for empty and sign-only entries instead of panicking or creating an empty feature gate key
- add regression coverage for invalid entries and a valid pass-through case

## Root cause
`NewCluster` indexed `featureGate[0]` before checking whether the string was empty, and then indexed it again after stripping a leading `+` or `-`.

## Testing
- `go test ./upup/pkg/fi/cloudup -run TestNewClusterValidatesKubernetesFeatureGates`
- `go test ./cmd/kops -run TestCreateClusterKubernetesFeatureGates`

Fixes #18407.
