### PR TITLE
scaletest: decouple client HTTP traffic for etcd events

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -88,6 +88,7 @@ create_args+=("--set spec.etcdClusters[0].manager.listenMetricsURLs=http://local
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_QUOTA_BACKEND_BYTES=${ETCD_QUOTA_BACKEND_BYTES}")
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_ENABLE_PPROF=true")
 create_args+=("--set spec.etcdClusters[0].manager.env=ETCD_LISTEN_CLIENT_HTTP_URLS=http://localhost:2385")
+create_args+=("--set spec.etcdClusters[1].manager.env=ETCD_LISTEN_CLIENT_HTTP_URLS=http://localhost:2386")
 create_args+=("--set spec.cloudControllerManager.concurrentNodeSyncs=10")
 create_args+=("--set spec.kubelet.maxPods=96")
 create_args+=("--set spec.kubelet.kubeAPIQPS=100")


### PR DESCRIPTION
Follow up for https://github.com/kubernetes/kops/pull/18370#discussion_r3271798928