### PR TITLE
Automated cherry pick of #18403: build: use gcr.io/distroless/static as base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,3 +1,4 @@
+defaultBaseImage: gcr.io/distroless/static:nonroot
 defaultLdflags:
 - -s -w
 - -X k8s.io/kops.Version={{.Env.VERSION}}


### PR DESCRIPTION
Cherry pick of #18403 on release-1.35.

#18403: build: use gcr.io/distroless/static as base image

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```