### PR TITLE
Upgrade kube-router to v2.10.0

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -1,5 +1,4 @@
-# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.6.0/daemonset/kubeadm-kuberouter.yaml
-
+# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v2.1.0/daemonset/kubeadm-kuberouter.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -61,9 +60,10 @@ spec:
           level: s0
 {{ end }}
       serviceAccountName: kube-router
+      serviceAccount: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v2.7.1
+        image: docker.io/cloudnativelabs/kube-router:v2.10.0
         args:
         - --run-router=true
         - --run-firewall=true
@@ -93,7 +93,7 @@ spec:
           periodSeconds: 3
         resources:
           requests:
-            cpu: 100m
+            cpu: 250m
             memory: 250Mi
         securityContext:
           privileged: true
@@ -117,7 +117,7 @@ spec:
           readOnly: true
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v2.7.1
+        image: docker.io/cloudnativelabs/kube-router:v2.10.0
         command:
         - /bin/sh
         - -c

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -65,6 +65,7 @@ spec:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router:v2.10.0
         args:
+        - --strict-external-ip-validation=false
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=true


### PR DESCRIPTION
https://github.com/cloudnativelabs/kube-router/releases/tag/v2.10.0

includes https://github.com/cloudnativelabs/kube-router/pull/2069 which should fix the last failing test in the kuberouter e2e jobs: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-cni-kuberouter/2059779600132608000