### PR TITLE
aws: pin LBC selectors to fix in-place upgrades

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19-irsa_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19-irsa_content
@@ -2928,7 +2928,7 @@ spec:
     port: 443
     targetPort: webhook-server
   selector:
-    app.kubernetes.io/instance: aws-load-balancer-controller
+    app.kubernetes.io/component: controller
     app.kubernetes.io/name: aws-load-balancer-controller
 
 ---
@@ -2951,7 +2951,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/instance: aws-load-balancer-controller
+      app.kubernetes.io/component: controller
       app.kubernetes.io/name: aws-load-balancer-controller
   template:
     metadata:
@@ -2959,6 +2959,7 @@ spec:
         prometheus.io/port: "9442"
         prometheus.io/scrape: "true"
       labels:
+        app.kubernetes.io/component: controller
         app.kubernetes.io/instance: aws-load-balancer-controller
         app.kubernetes.io/name: aws-load-balancer-controller
         kops.k8s.io/managed-by: kops

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -138,7 +138,7 @@ spec:
       k8s-addon: node-termination-handler.aws
   - id: k8s-1.19-irsa
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19-irsa.yaml
-    manifestHash: f3a272f4583d44771e45adb25882747125f0c7bda09de2485c7cd983cd42f9d7
+    manifestHash: 539c85e848a87847f10ff61c8648fc42446eec5bdad6b806daa5fa6501367494
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     prune:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19-irsa_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19-irsa_content
@@ -2928,7 +2928,7 @@ spec:
     port: 443
     targetPort: webhook-server
   selector:
-    app.kubernetes.io/instance: aws-load-balancer-controller
+    app.kubernetes.io/component: controller
     app.kubernetes.io/name: aws-load-balancer-controller
 
 ---
@@ -2951,7 +2951,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/instance: aws-load-balancer-controller
+      app.kubernetes.io/component: controller
       app.kubernetes.io/name: aws-load-balancer-controller
   template:
     metadata:
@@ -2959,6 +2959,7 @@ spec:
         prometheus.io/port: "9442"
         prometheus.io/scrape: "true"
       labels:
+        app.kubernetes.io/component: controller
         app.kubernetes.io/instance: aws-load-balancer-controller
         app.kubernetes.io/name: aws-load-balancer-controller
         kops.k8s.io/managed-by: kops

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -151,7 +151,7 @@ spec:
       k8s-addon: node-termination-handler.aws
   - id: k8s-1.19-irsa
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19-irsa.yaml
-    manifestHash: a3adf8913d5a7d7ffb5a3df7c66bb7586add10b01d73c7ca79ca126584a8a05b
+    manifestHash: c2fcf3c260bc15004f08927637b17749275532ce80fa572ae13a48bfc6ff7d4d
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     prune:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -2928,7 +2928,7 @@ spec:
     port: 443
     targetPort: webhook-server
   selector:
-    app.kubernetes.io/instance: aws-load-balancer-controller
+    app.kubernetes.io/component: controller
     app.kubernetes.io/name: aws-load-balancer-controller
 
 ---
@@ -2951,7 +2951,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/instance: aws-load-balancer-controller
+      app.kubernetes.io/component: controller
       app.kubernetes.io/name: aws-load-balancer-controller
   strategy:
     rollingUpdate:
@@ -2963,6 +2963,7 @@ spec:
         prometheus.io/port: "9442"
         prometheus.io/scrape: "true"
       labels:
+        app.kubernetes.io/component: controller
         app.kubernetes.io/instance: aws-load-balancer-controller
         app.kubernetes.io/name: aws-load-balancer-controller
         kops.k8s.io/managed-by: kops

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -151,7 +151,7 @@ spec:
       k8s-addon: node-termination-handler.aws
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 953ef58b7c791720b5b36c5a0f4b4c54eccad80742acfc32d761a6ab3da473fd
+    manifestHash: e21f7118d81931a591c336e0bf331a07aba550984bde9078939615441224e021
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     prune:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -2928,7 +2928,7 @@ spec:
     port: 443
     targetPort: webhook-server
   selector:
-    app.kubernetes.io/instance: aws-load-balancer-controller
+    app.kubernetes.io/component: controller
     app.kubernetes.io/name: aws-load-balancer-controller
 
 ---
@@ -2951,7 +2951,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/instance: aws-load-balancer-controller
+      app.kubernetes.io/component: controller
       app.kubernetes.io/name: aws-load-balancer-controller
   strategy:
     rollingUpdate:
@@ -2963,6 +2963,7 @@ spec:
         prometheus.io/port: "9442"
         prometheus.io/scrape: "true"
       labels:
+        app.kubernetes.io/component: controller
         app.kubernetes.io/instance: aws-load-balancer-controller
         app.kubernetes.io/name: aws-load-balancer-controller
         kops.k8s.io/managed-by: kops

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -199,7 +199,7 @@ spec:
       k8s-addon: node-problem-detector.addons.k8s.io
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: a4466493d7a1e189794d94fb4f6ca951cce4c3e3bbc35f86449547bdcb8529c6
+    manifestHash: 928391bbbfa66210295892df78122f224060b14e985ccfdd70af58d1ade2c934
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     prune:

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/default/kustomization.yaml
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/default/kustomization.yaml
@@ -89,6 +89,31 @@ patches:
         path: /spec/template/spec/volumes/0/secret/secretName
         value: aws-load-balancer-webhook-tls
 
+  # A Deployment's spec.selector is immutable, so adopting the chart's
+  # {instance, name} selector breaks in-place upgrades from kops <1.36. Pin both
+  # selectors to the historical {component, name} labels and label pods to match.
+  - target:
+      kind: Deployment
+      name: aws-load-balancer-controller
+    patch: |
+      - op: replace
+        path: /spec/selector/matchLabels
+        value:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/name: aws-load-balancer-controller
+      - op: add
+        path: /spec/template/metadata/labels/app.kubernetes.io~1component
+        value: controller
+  - target:
+      kind: Service
+      name: aws-load-balancer-webhook-service
+    patch: |
+      - op: replace
+        path: /spec/selector
+        value:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/name: aws-load-balancer-controller
+
   # The E2E suite runs a test that requires the ALBTargetControlAgent=true feature gate
   # the test is skipped based on the presence of this CRD and the upstream helm chart
   # doesn't offer a way to not render it, so we delete it here instead.

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/irsa/kustomization.yaml
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/irsa/kustomization.yaml
@@ -90,6 +90,31 @@ patches:
         path: /spec/template/spec/volumes/0/secret/secretName
         value: aws-load-balancer-webhook-tls
 
+  # A Deployment's spec.selector is immutable, so adopting the chart's
+  # {instance, name} selector breaks in-place upgrades from kops <1.36. Pin both
+  # selectors to the historical {component, name} labels and label pods to match.
+  - target:
+      kind: Deployment
+      name: aws-load-balancer-controller
+    patch: |
+      - op: replace
+        path: /spec/selector/matchLabels
+        value:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/name: aws-load-balancer-controller
+      - op: add
+        path: /spec/template/metadata/labels/app.kubernetes.io~1component
+        value: controller
+  - target:
+      kind: Service
+      name: aws-load-balancer-webhook-service
+    patch: |
+      - op: replace
+        path: /spec/selector
+        value:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/name: aws-load-balancer-controller
+
   # The E2E suite runs a test that requires the ALBTargetControlAgent=true feature gate
   # the test is skipped based on the presence of this CRD and the upstream helm chart
   # doesn't offer a way to not render it, so we delete it here instead.

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19-irsa.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19-irsa.yaml.template
@@ -2870,7 +2870,7 @@ spec:
     port: 443
     targetPort: webhook-server
   selector:
-    app.kubernetes.io/instance: aws-load-balancer-controller
+    app.kubernetes.io/component: controller
     app.kubernetes.io/name: aws-load-balancer-controller
 ---
 apiVersion: apps/v1
@@ -2889,7 +2889,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/instance: aws-load-balancer-controller
+      app.kubernetes.io/component: controller
       app.kubernetes.io/name: aws-load-balancer-controller
   template:
     metadata:
@@ -2897,6 +2897,7 @@ spec:
         prometheus.io/port: "9442"
         prometheus.io/scrape: "true"
       labels:
+        app.kubernetes.io/component: controller
         app.kubernetes.io/instance: aws-load-balancer-controller
         app.kubernetes.io/name: aws-load-balancer-controller
     spec:

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
@@ -2870,7 +2870,7 @@ spec:
     port: 443
     targetPort: webhook-server
   selector:
-    app.kubernetes.io/instance: aws-load-balancer-controller
+    app.kubernetes.io/component: controller
     app.kubernetes.io/name: aws-load-balancer-controller
 ---
 apiVersion: apps/v1
@@ -2889,7 +2889,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/instance: aws-load-balancer-controller
+      app.kubernetes.io/component: controller
       app.kubernetes.io/name: aws-load-balancer-controller
   strategy:
     rollingUpdate:
@@ -2901,6 +2901,7 @@ spec:
         prometheus.io/port: "9442"
         prometheus.io/scrape: "true"
       labels:
+        app.kubernetes.io/component: controller
         app.kubernetes.io/instance: aws-load-balancer-controller
         app.kubernetes.io/name: aws-load-balancer-controller
     spec:


### PR DESCRIPTION
The helm+kustomize migration switched the controller Deployment and webhook Service selectors from {component, name} to the chart's {instance, name}. A Deployment's spec.selector is immutable, so upgrading from kops <1.36 has the apply rejected: the pod template is never updated, the webhook Service loses its endpoints, and the mutating webhooks (failurePolicy: Fail) time out, breaking target registration. Pin both selectors back to the historical {component, name} labels and add the component label to the pod template so it still satisfies the selector, keeping upgrades working without touching the immutable field.

/cc @rifelpet @ameukam 