### PR TITLE
Automated cherry pick of #18428: cert-manager: upgrade to v1.19.5 and set AWS_REGION for Route53 dns-01

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 89c8798d6650ec7ff12281d6c6d98b4dbaca8901ec1ec714ef3fce416222cdad
+    manifestHash: 11a84ee13e25fd8bbcff57a21d822cef8951be71c673ed2960cdbb25d5037b70
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -470,7 +470,7 @@ spec:
                             description: |-
                               The IP address or hostname of an authoritative DNS server supporting
                               RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                              enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                              enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                               This field is required.
                             type: string
                           protocol:
@@ -3543,7 +3543,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -3825,7 +3825,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4152,7 +4152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4987,7 +4987,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5515,7 +5515,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -9063,7 +9063,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -9590,7 +9590,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -13138,7 +13138,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -13210,7 +13210,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -13260,7 +13260,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -13310,7 +13310,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -13383,7 +13383,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -13453,7 +13453,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -13562,7 +13562,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -13635,7 +13635,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:
@@ -13660,7 +13660,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -13699,7 +13699,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -13746,7 +13746,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -13771,7 +13771,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -13818,7 +13818,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -13840,7 +13840,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13863,7 +13863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13886,7 +13886,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13909,7 +13909,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13932,7 +13932,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13955,7 +13955,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13978,7 +13978,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14001,7 +14001,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14024,7 +14024,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14047,7 +14047,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14070,7 +14070,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -14104,7 +14104,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -14137,7 +14137,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 rules:
@@ -14162,7 +14162,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -14196,7 +14196,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -14220,7 +14220,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -14244,7 +14244,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 roleRef:
@@ -14268,7 +14268,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -14292,7 +14292,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14318,7 +14318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14345,7 +14345,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14376,7 +14376,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14397,7 +14397,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14419,7 +14419,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.19.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.19.5
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         ports:
@@ -14459,7 +14459,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14480,7 +14480,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14498,7 +14498,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.2
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.5
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -14506,7 +14506,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.19.2
+        - name: AWS_REGION
+          value: us-test-1
+        image: quay.io/jetstack/cert-manager-controller:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
@@ -14559,7 +14561,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14580,7 +14582,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14607,7 +14609,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.19.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -14675,7 +14677,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -14714,7 +14716,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 89c8798d6650ec7ff12281d6c6d98b4dbaca8901ec1ec714ef3fce416222cdad
+    manifestHash: 11a84ee13e25fd8bbcff57a21d822cef8951be71c673ed2960cdbb25d5037b70
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -470,7 +470,7 @@ spec:
                             description: |-
                               The IP address or hostname of an authoritative DNS server supporting
                               RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                              enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                              enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                               This field is required.
                             type: string
                           protocol:
@@ -3543,7 +3543,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -3825,7 +3825,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4152,7 +4152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4987,7 +4987,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5515,7 +5515,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -9063,7 +9063,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -9590,7 +9590,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -13138,7 +13138,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -13210,7 +13210,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -13260,7 +13260,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -13310,7 +13310,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -13383,7 +13383,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -13453,7 +13453,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -13562,7 +13562,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -13635,7 +13635,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:
@@ -13660,7 +13660,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -13699,7 +13699,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -13746,7 +13746,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -13771,7 +13771,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -13818,7 +13818,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -13840,7 +13840,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13863,7 +13863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13886,7 +13886,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13909,7 +13909,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13932,7 +13932,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13955,7 +13955,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13978,7 +13978,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14001,7 +14001,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14024,7 +14024,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14047,7 +14047,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14070,7 +14070,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -14104,7 +14104,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -14137,7 +14137,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 rules:
@@ -14162,7 +14162,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -14196,7 +14196,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -14220,7 +14220,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -14244,7 +14244,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 roleRef:
@@ -14268,7 +14268,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -14292,7 +14292,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14318,7 +14318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14345,7 +14345,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14376,7 +14376,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14397,7 +14397,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14419,7 +14419,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.19.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.19.5
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         ports:
@@ -14459,7 +14459,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14480,7 +14480,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14498,7 +14498,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.2
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.5
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -14506,7 +14506,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.19.2
+        - name: AWS_REGION
+          value: us-test-1
+        image: quay.io/jetstack/cert-manager-controller:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
@@ -14559,7 +14561,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14580,7 +14582,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14607,7 +14609,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.19.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -14675,7 +14677,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -14714,7 +14716,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 89c8798d6650ec7ff12281d6c6d98b4dbaca8901ec1ec714ef3fce416222cdad
+    manifestHash: 11a84ee13e25fd8bbcff57a21d822cef8951be71c673ed2960cdbb25d5037b70
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -470,7 +470,7 @@ spec:
                             description: |-
                               The IP address or hostname of an authoritative DNS server supporting
                               RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                              enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                              enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                               This field is required.
                             type: string
                           protocol:
@@ -3543,7 +3543,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -3825,7 +3825,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4152,7 +4152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4987,7 +4987,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5515,7 +5515,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -9063,7 +9063,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -9590,7 +9590,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -13138,7 +13138,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -13210,7 +13210,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -13260,7 +13260,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -13310,7 +13310,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -13383,7 +13383,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -13453,7 +13453,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -13562,7 +13562,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -13635,7 +13635,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:
@@ -13660,7 +13660,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -13699,7 +13699,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -13746,7 +13746,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -13771,7 +13771,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -13818,7 +13818,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -13840,7 +13840,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13863,7 +13863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13886,7 +13886,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13909,7 +13909,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13932,7 +13932,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13955,7 +13955,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13978,7 +13978,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14001,7 +14001,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14024,7 +14024,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14047,7 +14047,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14070,7 +14070,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -14104,7 +14104,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -14137,7 +14137,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 rules:
@@ -14162,7 +14162,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -14196,7 +14196,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -14220,7 +14220,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -14244,7 +14244,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 roleRef:
@@ -14268,7 +14268,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -14292,7 +14292,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14318,7 +14318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14345,7 +14345,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14376,7 +14376,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14397,7 +14397,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14419,7 +14419,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.19.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.19.5
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         ports:
@@ -14459,7 +14459,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14480,7 +14480,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14498,7 +14498,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.2
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.5
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -14506,7 +14506,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.19.2
+        - name: AWS_REGION
+          value: us-test-1
+        image: quay.io/jetstack/cert-manager-controller:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
@@ -14559,7 +14561,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14580,7 +14582,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14607,7 +14609,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.19.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -14675,7 +14677,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -14714,7 +14716,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 89c8798d6650ec7ff12281d6c6d98b4dbaca8901ec1ec714ef3fce416222cdad
+    manifestHash: 11a84ee13e25fd8bbcff57a21d822cef8951be71c673ed2960cdbb25d5037b70
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -470,7 +470,7 @@ spec:
                             description: |-
                               The IP address or hostname of an authoritative DNS server supporting
                               RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                              enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                              enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                               This field is required.
                             type: string
                           protocol:
@@ -3543,7 +3543,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -3825,7 +3825,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4152,7 +4152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4987,7 +4987,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5515,7 +5515,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -9063,7 +9063,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -9590,7 +9590,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -13138,7 +13138,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -13210,7 +13210,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -13260,7 +13260,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -13310,7 +13310,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -13383,7 +13383,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -13453,7 +13453,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -13562,7 +13562,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -13635,7 +13635,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:
@@ -13660,7 +13660,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -13699,7 +13699,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -13746,7 +13746,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -13771,7 +13771,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -13818,7 +13818,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -13840,7 +13840,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13863,7 +13863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13886,7 +13886,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13909,7 +13909,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13932,7 +13932,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13955,7 +13955,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13978,7 +13978,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14001,7 +14001,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14024,7 +14024,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14047,7 +14047,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14070,7 +14070,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -14104,7 +14104,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -14137,7 +14137,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 rules:
@@ -14162,7 +14162,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -14196,7 +14196,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -14220,7 +14220,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -14244,7 +14244,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 roleRef:
@@ -14268,7 +14268,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -14292,7 +14292,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14318,7 +14318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14345,7 +14345,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14376,7 +14376,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14397,7 +14397,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14419,7 +14419,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.19.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.19.5
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         ports:
@@ -14459,7 +14459,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14480,7 +14480,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14498,7 +14498,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.2
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.5
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -14506,7 +14506,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.19.2
+        - name: AWS_REGION
+          value: us-test-1
+        image: quay.io/jetstack/cert-manager-controller:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
@@ -14559,7 +14561,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14580,7 +14582,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14607,7 +14609,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.19.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -14675,7 +14677,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -14714,7 +14716,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 89c8798d6650ec7ff12281d6c6d98b4dbaca8901ec1ec714ef3fce416222cdad
+    manifestHash: 43732258f53c5ff0b3485cad284217ef52f0aebdaa75bdc8d3d1aa76e1434cd8
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -470,7 +470,7 @@ spec:
                             description: |-
                               The IP address or hostname of an authoritative DNS server supporting
                               RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                              enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                              enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                               This field is required.
                             type: string
                           protocol:
@@ -3543,7 +3543,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -3825,7 +3825,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4152,7 +4152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4987,7 +4987,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5515,7 +5515,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -9063,7 +9063,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -9590,7 +9590,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -13138,7 +13138,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -13210,7 +13210,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -13260,7 +13260,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -13310,7 +13310,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -13383,7 +13383,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -13453,7 +13453,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -13562,7 +13562,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -13635,7 +13635,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:
@@ -13660,7 +13660,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -13699,7 +13699,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -13746,7 +13746,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -13771,7 +13771,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -13818,7 +13818,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -13840,7 +13840,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13863,7 +13863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13886,7 +13886,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13909,7 +13909,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13932,7 +13932,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13955,7 +13955,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13978,7 +13978,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14001,7 +14001,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14024,7 +14024,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14047,7 +14047,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14070,7 +14070,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -14104,7 +14104,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -14137,7 +14137,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 rules:
@@ -14162,7 +14162,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -14196,7 +14196,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -14220,7 +14220,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -14244,7 +14244,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 roleRef:
@@ -14268,7 +14268,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -14292,7 +14292,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14318,7 +14318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14345,7 +14345,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14376,7 +14376,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14397,7 +14397,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14419,7 +14419,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.19.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.19.5
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         ports:
@@ -14459,7 +14459,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14480,7 +14480,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14498,7 +14498,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.2
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.5
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -14506,7 +14506,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.19.2
+        image: quay.io/jetstack/cert-manager-controller:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
@@ -14559,7 +14559,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14580,7 +14580,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14607,7 +14607,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.19.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -14675,7 +14675,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -14714,7 +14714,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 64db0508a040d0d4a8bee266169966ce02b8520679d856c96205b166f7683bc1
+    manifestHash: 17db9ccb408cc6e020ba494e0fbfb5a25e773a836799dd28f46852d0bb6234d9
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -470,7 +470,7 @@ spec:
                             description: |-
                               The IP address or hostname of an authoritative DNS server supporting
                               RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                              enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                              enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                               This field is required.
                             type: string
                           protocol:
@@ -3543,7 +3543,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -3825,7 +3825,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4152,7 +4152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4987,7 +4987,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5515,7 +5515,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -9063,7 +9063,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -9590,7 +9590,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -13138,7 +13138,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -13210,7 +13210,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -13260,7 +13260,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -13310,7 +13310,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -13383,7 +13383,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -13453,7 +13453,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -13562,7 +13562,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -13635,7 +13635,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:
@@ -13660,7 +13660,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -13699,7 +13699,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -13746,7 +13746,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -13771,7 +13771,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -13818,7 +13818,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -13840,7 +13840,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13863,7 +13863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13886,7 +13886,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13909,7 +13909,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13932,7 +13932,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13955,7 +13955,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13978,7 +13978,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14001,7 +14001,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14024,7 +14024,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14047,7 +14047,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14070,7 +14070,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -14104,7 +14104,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -14137,7 +14137,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 rules:
@@ -14162,7 +14162,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -14196,7 +14196,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -14220,7 +14220,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -14244,7 +14244,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 roleRef:
@@ -14268,7 +14268,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -14292,7 +14292,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14318,7 +14318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14345,7 +14345,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14376,7 +14376,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14397,7 +14397,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14419,7 +14419,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.19.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.19.5
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         ports:
@@ -14459,7 +14459,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14480,7 +14480,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14498,7 +14498,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.2
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.5
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         - --feature-gates=AdditionalCertificateOutputFormats=true
@@ -14507,7 +14507,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.19.2
+        - name: AWS_REGION
+          value: us-test-1
+        image: quay.io/jetstack/cert-manager-controller:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
@@ -14560,7 +14562,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14581,7 +14583,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14608,7 +14610,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.19.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -14676,7 +14678,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -14715,7 +14717,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 89c8798d6650ec7ff12281d6c6d98b4dbaca8901ec1ec714ef3fce416222cdad
+    manifestHash: 11a84ee13e25fd8bbcff57a21d822cef8951be71c673ed2960cdbb25d5037b70
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -470,7 +470,7 @@ spec:
                             description: |-
                               The IP address or hostname of an authoritative DNS server supporting
                               RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                              enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                              enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                               This field is required.
                             type: string
                           protocol:
@@ -3543,7 +3543,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -3825,7 +3825,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4152,7 +4152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -4987,7 +4987,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5515,7 +5515,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -9063,7 +9063,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -9590,7 +9590,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:
@@ -13138,7 +13138,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -13210,7 +13210,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -13260,7 +13260,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -13310,7 +13310,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -13383,7 +13383,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -13453,7 +13453,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -13562,7 +13562,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -13635,7 +13635,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:
@@ -13660,7 +13660,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -13699,7 +13699,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -13746,7 +13746,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -13771,7 +13771,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -13818,7 +13818,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -13840,7 +13840,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13863,7 +13863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13886,7 +13886,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13909,7 +13909,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13932,7 +13932,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13955,7 +13955,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13978,7 +13978,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14001,7 +14001,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14024,7 +14024,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14047,7 +14047,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14070,7 +14070,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -14104,7 +14104,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -14137,7 +14137,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 rules:
@@ -14162,7 +14162,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -14196,7 +14196,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -14220,7 +14220,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -14244,7 +14244,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-tokenrequest
   namespace: kube-system
 roleRef:
@@ -14268,7 +14268,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -14292,7 +14292,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14318,7 +14318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14345,7 +14345,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14376,7 +14376,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -14397,7 +14397,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14419,7 +14419,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.19.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.19.5
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         ports:
@@ -14459,7 +14459,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager
   namespace: kube-system
 spec:
@@ -14480,7 +14480,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14498,7 +14498,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.2
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.5
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -14506,7 +14506,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.19.2
+        - name: AWS_REGION
+          value: us-test-1
+        image: quay.io/jetstack/cert-manager-controller:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
@@ -14559,7 +14561,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -14580,7 +14582,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.19.2
+        app.kubernetes.io/version: v1.19.5
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -14607,7 +14609,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.19.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.19.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -14675,7 +14677,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -14714,7 +14716,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.5
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 ---
 # Source: cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -39,7 +39,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 ---
 # Source: cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   group: acme.cert-manager.io
   names:
@@ -450,7 +450,7 @@ spec:
                               description: |-
                                 The IP address or hostname of an authoritative DNS server supporting
                                 RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                 This field is required.
                               type: string
                             protocol:
@@ -3334,7 +3334,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   group: acme.cert-manager.io
   names:
@@ -3609,7 +3609,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   group: cert-manager.io
   names:
@@ -3929,7 +3929,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   group: cert-manager.io
   names:
@@ -4746,7 +4746,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   group: cert-manager.io
   names:
@@ -5257,7 +5257,7 @@ spec:
                                     description: |-
                                       The IP address or hostname of an authoritative DNS server supporting
                                       RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                       This field is required.
                                     type: string
                                   protocol:
@@ -8562,7 +8562,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   group: cert-manager.io
   names:
@@ -9072,7 +9072,7 @@ spec:
                                     description: |-
                                       The IP address or hostname of an authoritative DNS server supporting
                                       RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                       This field is required.
                                     type: string
                                   protocol:
@@ -12376,7 +12376,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -12408,7 +12408,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -12434,7 +12434,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -12460,7 +12460,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -12495,7 +12495,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -12533,7 +12533,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -12593,7 +12593,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -12630,7 +12630,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -12647,7 +12647,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -12670,7 +12670,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -12695,7 +12695,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -12717,7 +12717,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -12743,7 +12743,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -12759,7 +12759,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12779,7 +12779,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12799,7 +12799,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12819,7 +12819,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12839,7 +12839,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12859,7 +12859,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12879,7 +12879,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12899,7 +12899,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12919,7 +12919,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12939,7 +12939,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12961,7 +12961,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -12987,7 +12987,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -13008,7 +13008,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
@@ -13026,7 +13026,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -13051,7 +13051,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13074,7 +13074,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13096,7 +13096,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13117,7 +13117,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13138,7 +13138,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   type: ClusterIP
   ports:
@@ -13161,7 +13161,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   type: ClusterIP
   ports:
@@ -13185,7 +13185,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   type: ClusterIP
   ports:
@@ -13213,7 +13213,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   replicas: 1
   selector:
@@ -13228,7 +13228,7 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.19.2"
+        app.kubernetes.io/version: "v1.19.5"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -13243,7 +13243,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.19.2"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.19.5"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -13292,7 +13292,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   replicas: 1
   selector:
@@ -13307,7 +13307,7 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.19.2"
+        app.kubernetes.io/version: "v1.19.5"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -13330,13 +13330,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.19.2"
+          image: "quay.io/jetstack/cert-manager-controller:v1.19.5"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.2
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.5
           - --max-concurrent-challenges=60
           - --enable-certificate-owner-ref=true
           {{ if .CertManager.DefaultIssuer }}
@@ -13413,7 +13413,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
 spec:
   replicas: 1
   selector:
@@ -13428,7 +13428,7 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.19.2"
+        app.kubernetes.io/version: "v1.19.5"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -13443,7 +13443,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.19.2"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.19.5"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -13522,7 +13522,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
   annotations:
     cert-manager.io/inject-ca-from-secret: "kube-system/cert-manager-webhook-ca"
 webhooks:
@@ -13561,7 +13561,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.5"
   annotations:
     cert-manager.io/inject-ca-from-secret: "kube-system/cert-manager-webhook-ca"
 webhooks:

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -13365,6 +13365,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{ if (eq GetCloudProvider "aws") }}
+          # Set the region so the Route53 dns-01 solver can resolve the regional
+          # STS endpoint when using IRSA, where no region is otherwise provided.
+          - name: AWS_REGION
+            value: "{{ Region }}"
+          {{ end }}
           # LivenessProbe settings are based on those used for the Kubernetes
           # controller-manager. See:
           # https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 89c8798d6650ec7ff12281d6c6d98b4dbaca8901ec1ec714ef3fce416222cdad
+    manifestHash: f618f52c944d9ec1b016fb131c776cbd88033f640b4072d19b4bbafee498cfcf
     name: certmanager.io
     prune:
       kinds:


### PR DESCRIPTION
Cherry pick of #18428 on release-1.35.

#18428: cert-manager: upgrade to v1.19.5 and set AWS_REGION for Route53 dns-01

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```