### PR TITLE
Default omitted authorization to RBAC instead of AlwaysAllow

### DIFF
--- a/docs/releases/1.36-NOTES.md
+++ b/docs/releases/1.36-NOTES.md
@@ -196,6 +196,7 @@ kOps 1.36 adds Kubernetes 1.36 support, completes the move away from the in-tree
 * The in-tree `cloud-provider-aws` and `cloud-provider-gcp` dependencies have been dropped from kOps; external cloud providers are required (already mandatory for Kubernetes 1.33+) ([#18336](https://github.com/kubernetes/kops/pull/18336), [#18274](https://github.com/kubernetes/kops/pull/18274))
 * The legacy `azureblob://{container}/{key}` URL form (paired with the `AZURE_STORAGE_ACCOUNT` environment variable) is no longer accepted; state-store paths must use the new `azureblob://{account}/{container}/{key}` form ([#18260](https://github.com/kubernetes/kops/pull/18260))
 * Users who set `spec.containerd.configAdditions` must update those entries to the containerd config TOML v3 schema before upgrading to kOps 1.36 ([#18291](https://github.com/kubernetes/kops/pull/18291))
+* A cluster spec applied with the top-level `authorization` field omitted (`kops create -f` / `kops replace -f`) now defaults to RBAC instead of `AlwaysAllow`, matching `kops create cluster`. This takes effect when such a manifest is (re-)applied; clusters whose stored spec already sets `authorization` are unchanged. Set `spec.authorization.alwaysAllow: {}` to keep `AlwaysAllow`.
 
 # Known Issues
 

--- a/nodeup/pkg/model/tests/golden/audit/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/audit/tasks-kube-apiserver.yaml
@@ -28,7 +28,7 @@ contents: |
       - --audit-webhook-batch-max-wait=5s
       - --audit-webhook-config-file=/etc/kubernetes/audit/webhook-config.yaml
       - --authentication-config=/etc/kubernetes/authentication-config.yaml
-      - --authorization-mode=AlwaysAllow
+      - --authorization-mode=Node,RBAC
       - --bind-address=0.0.0.0
       - --client-ca-file=/srv/kubernetes/ca.crt
       - --enable-admission-plugins=DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,ResourceQuota,RuntimeClass,ServiceAccount,ValidatingAdmissionPolicy,ValidatingAdmissionWebhook

--- a/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
@@ -42,7 +42,7 @@ contents: |
       - --api-audiences=kubernetes.svc.default
       - --apiserver-count=1
       - --authentication-token-webhook-config-file=/etc/kubernetes/authn.config
-      - --authorization-mode=AlwaysAllow
+      - --authorization-mode=Node,RBAC
       - --bind-address=0.0.0.0
       - --client-ca-file=/srv/kubernetes/ca.crt
       - --enable-admission-plugins=DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,ResourceQuota,RuntimeClass,ServiceAccount,ValidatingAdmissionPolicy,ValidatingAdmissionWebhook

--- a/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
@@ -20,7 +20,7 @@ contents: |
       - --anonymous-auth=false
       - --api-audiences=kubernetes.svc.default
       - --apiserver-count=1
-      - --authorization-mode=AlwaysAllow
+      - --authorization-mode=Node,RBAC
       - --bind-address=0.0.0.0
       - --client-ca-file=/srv/kubernetes/ca.crt
       - --enable-admission-plugins=DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,ResourceQuota,RuntimeClass,ServiceAccount,ValidatingAdmissionPolicy,ValidatingAdmissionWebhook

--- a/nodeup/pkg/model/tests/golden/envvars/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/envvars/tasks-kube-apiserver.yaml
@@ -20,7 +20,7 @@ contents: |
       - --anonymous-auth=false
       - --api-audiences=kubernetes.svc.default
       - --apiserver-count=1
-      - --authorization-mode=AlwaysAllow
+      - --authorization-mode=Node,RBAC
       - --bind-address=0.0.0.0
       - --client-ca-file=/srv/kubernetes/ca.crt
       - --enable-admission-plugins=DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,ResourceQuota,RuntimeClass,ServiceAccount,ValidatingAdmissionPolicy,ValidatingAdmissionWebhook

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
@@ -20,7 +20,7 @@ contents: |
       - --anonymous-auth=false
       - --api-audiences=kubernetes.svc.default
       - --apiserver-count=1
-      - --authorization-mode=AlwaysAllow
+      - --authorization-mode=Node,RBAC
       - --bind-address=0.0.0.0
       - --client-ca-file=/srv/kubernetes/ca.crt
       - --enable-admission-plugins=DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,ResourceQuota,RuntimeClass,ServiceAccount,ValidatingAdmissionPolicy,ValidatingAdmissionWebhook

--- a/nodeup/pkg/model/tests/golden/oidc/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/oidc/tasks-kube-apiserver.yaml
@@ -20,7 +20,7 @@ contents: |
       - --anonymous-auth=false
       - --api-audiences=kubernetes.svc.default
       - --apiserver-count=1
-      - --authorization-mode=AlwaysAllow
+      - --authorization-mode=Node,RBAC
       - --bind-address=0.0.0.0
       - --client-ca-file=/srv/kubernetes/ca.crt
       - --enable-admission-plugins=DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,ResourceQuota,RuntimeClass,ServiceAccount,ValidatingAdmissionPolicy,ValidatingAdmissionWebhook

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
@@ -20,7 +20,7 @@ contents: |
       - --anonymous-auth=false
       - --api-audiences=kubernetes.svc.default
       - --apiserver-count=1
-      - --authorization-mode=AlwaysAllow
+      - --authorization-mode=Node,RBAC
       - --bind-address=0.0.0.0
       - --client-ca-file=/srv/kubernetes/ca.crt
       - --enable-admission-plugins=DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,ResourceQuota,RuntimeClass,ServiceAccount,ValidatingAdmissionPolicy,ValidatingAdmissionWebhook

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
@@ -20,7 +20,7 @@ contents: |
       - --anonymous-auth=false
       - --api-audiences=kubernetes.svc.default
       - --apiserver-count=1
-      - --authorization-mode=AlwaysAllow
+      - --authorization-mode=Node,RBAC
       - --bind-address=0.0.0.0
       - --client-ca-file=/srv/kubernetes/ca.crt
       - --enable-admission-plugins=DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,ResourceQuota,RuntimeClass,ServiceAccount,ValidatingAdmissionPolicy,ValidatingAdmissionWebhook

--- a/nodeup/pkg/model/tests/golden/without-etcd-events/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/without-etcd-events/tasks-kube-apiserver.yaml
@@ -20,7 +20,7 @@ contents: |
       - --anonymous-auth=false
       - --api-audiences=kubernetes.svc.default
       - --apiserver-count=1
-      - --authorization-mode=AlwaysAllow
+      - --authorization-mode=Node,RBAC
       - --bind-address=0.0.0.0
       - --client-ca-file=/srv/kubernetes/ca.crt
       - --enable-admission-plugins=DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,ResourceQuota,RuntimeClass,ServiceAccount,ValidatingAdmissionPolicy,ValidatingAdmissionWebhook

--- a/pkg/apis/kops/v1alpha2/defaults.go
+++ b/pkg/apis/kops/v1alpha2/defaults.go
@@ -55,8 +55,9 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 		obj.Authorization = &AuthorizationSpec{}
 	}
 	if obj.Authorization.IsEmpty() {
-		// Before the Authorization field was introduced, the behaviour was alwaysAllow
-		obj.Authorization.AlwaysAllow = &AlwaysAllowAuthorizationSpec{}
+		// Default an omitted authorization to RBAC, matching "kops create cluster".
+		// AlwaysAllow is still honored when set explicitly.
+		obj.Authorization.RBAC = &RBACAuthorizationSpec{}
 	}
 
 	if obj.LegacyNetworking != nil {

--- a/pkg/apis/kops/v1alpha2/defaults_test.go
+++ b/pkg/apis/kops/v1alpha2/defaults_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import "testing"
+
+// TestSetDefaultsClusterSpecAuthorization checks that an omitted or empty
+// authorization defaults to RBAC, and that an explicit AlwaysAllow is preserved.
+func TestSetDefaultsClusterSpecAuthorization(t *testing.T) {
+	grid := []struct {
+		name            string
+		authorization   *AuthorizationSpec
+		wantRBAC        bool
+		wantAlwaysAllow bool
+	}{
+		{
+			name:          "omitted defaults to RBAC",
+			authorization: nil,
+			wantRBAC:      true,
+		},
+		{
+			name:          "empty defaults to RBAC",
+			authorization: &AuthorizationSpec{},
+			wantRBAC:      true,
+		},
+		{
+			name:            "explicit AlwaysAllow is preserved",
+			authorization:   &AuthorizationSpec{AlwaysAllow: &AlwaysAllowAuthorizationSpec{}},
+			wantAlwaysAllow: true,
+		},
+		{
+			name:          "explicit RBAC is preserved",
+			authorization: &AuthorizationSpec{RBAC: &RBACAuthorizationSpec{}},
+			wantRBAC:      true,
+		},
+	}
+	for _, g := range grid {
+		t.Run(g.name, func(t *testing.T) {
+			spec := &ClusterSpec{Authorization: g.authorization}
+
+			SetDefaults_ClusterSpec(spec)
+
+			if spec.Authorization == nil {
+				t.Fatalf("Authorization was not defaulted")
+			}
+			if got := spec.Authorization.RBAC != nil; got != g.wantRBAC {
+				t.Errorf("Authorization.RBAC set = %v, want %v", got, g.wantRBAC)
+			}
+			if got := spec.Authorization.AlwaysAllow != nil; got != g.wantAlwaysAllow {
+				t.Errorf("Authorization.AlwaysAllow set = %v, want %v", got, g.wantAlwaysAllow)
+			}
+		})
+	}
+}

--- a/pkg/apis/kops/v1alpha3/defaults.go
+++ b/pkg/apis/kops/v1alpha3/defaults.go
@@ -45,8 +45,9 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 		obj.Authorization = &AuthorizationSpec{}
 	}
 	if obj.Authorization.IsEmpty() {
-		// Before the Authorization field was introduced, the behaviour was alwaysAllow
-		obj.Authorization.AlwaysAllow = &AlwaysAllowAuthorizationSpec{}
+		// Default an omitted authorization to RBAC, matching "kops create cluster".
+		// AlwaysAllow is still honored when set explicitly.
+		obj.Authorization.RBAC = &RBACAuthorizationSpec{}
 	}
 
 	if obj.Networking.Flannel != nil {

--- a/pkg/apis/kops/v1alpha3/defaults_test.go
+++ b/pkg/apis/kops/v1alpha3/defaults_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import "testing"
+
+// TestSetDefaultsClusterSpecAuthorization checks that an omitted or empty
+// authorization defaults to RBAC, and that an explicit AlwaysAllow is preserved.
+func TestSetDefaultsClusterSpecAuthorization(t *testing.T) {
+	grid := []struct {
+		name            string
+		authorization   *AuthorizationSpec
+		wantRBAC        bool
+		wantAlwaysAllow bool
+	}{
+		{
+			name:          "omitted defaults to RBAC",
+			authorization: nil,
+			wantRBAC:      true,
+		},
+		{
+			name:          "empty defaults to RBAC",
+			authorization: &AuthorizationSpec{},
+			wantRBAC:      true,
+		},
+		{
+			name:            "explicit AlwaysAllow is preserved",
+			authorization:   &AuthorizationSpec{AlwaysAllow: &AlwaysAllowAuthorizationSpec{}},
+			wantAlwaysAllow: true,
+		},
+		{
+			name:          "explicit RBAC is preserved",
+			authorization: &AuthorizationSpec{RBAC: &RBACAuthorizationSpec{}},
+			wantRBAC:      true,
+		},
+	}
+	for _, g := range grid {
+		t.Run(g.name, func(t *testing.T) {
+			spec := &ClusterSpec{Authorization: g.authorization}
+
+			SetDefaults_ClusterSpec(spec)
+
+			if spec.Authorization == nil {
+				t.Fatalf("Authorization was not defaulted")
+			}
+			if got := spec.Authorization.RBAC != nil; got != g.wantRBAC {
+				t.Errorf("Authorization.RBAC set = %v, want %v", got, g.wantRBAC)
+			}
+			if got := spec.Authorization.AlwaysAllow != nil; got != g.wantAlwaysAllow {
+				t.Errorf("Authorization.AlwaysAllow set = %v, want %v", got, g.wantAlwaysAllow)
+			}
+		})
+	}
+}

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -81,8 +81,8 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(cluster *kops.Cluster) error 
 	}
 
 	if clusterSpec.Authorization == nil || clusterSpec.Authorization.IsEmpty() {
-		// Do nothing - use the default as defined by the apiserver
-		// (this won't happen anyway because of our default logic)
+		// Do nothing - use the default as defined by the apiserver.
+		// In practice unreachable: defaulting sets RBAC when authorization is omitted.
 	} else if clusterSpec.Authorization.AlwaysAllow != nil {
 		clusterSpec.KubeAPIServer.AuthorizationMode = fi.PtrTo("AlwaysAllow")
 	} else if clusterSpec.Authorization.RBAC != nil {

--- a/pkg/model/components/kubescheduler/tests/kubeschedulerconfig/completed-cluster.yaml
+++ b/pkg/model/components/kubescheduler/tests/kubeschedulerconfig/completed-cluster.yaml
@@ -3,7 +3,7 @@ metadata:
 spec:
   api: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   cloudProvider: {}
   configStore: {}
   kubernetesVersion: v1.24.0

--- a/pkg/model/components/kubescheduler/tests/minimal/completed-cluster.yaml
+++ b/pkg/model/components/kubescheduler/tests/minimal/completed-cluster.yaml
@@ -3,7 +3,7 @@ metadata:
 spec:
   api: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   cloudProvider: {}
   configStore: {}
   kubernetesVersion: v1.26.0

--- a/pkg/model/components/kubescheduler/tests/mixing/completed-cluster.yaml
+++ b/pkg/model/components/kubescheduler/tests/mixing/completed-cluster.yaml
@@ -3,7 +3,7 @@ metadata:
 spec:
   api: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   cloudProvider: {}
   configStore: {}
   kubeScheduler:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: apiserver
 InstanceGroupRole: APIServer
-NodeupConfigHash: iGSx8xmvaxKfn/6wGkpNdJ7h+X8e5Pl88s/OqkJqo5k=
+NodeupConfigHash: fiUzZzSxK7ITUGXhK5U2Xa7pe9t3qkQkAq9CCARo4qo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: JUKaGq5/1AiNJjDTK2VJIrcWDuIx+mKn57uoJaz1x48=
+NodeupConfigHash: UnEbA7nSb9vZpzfmdoHsGZGZaabfwvfCXoMaRz3IIZk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -61,7 +61,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     enableAdmissionPlugins:
     - DefaultStorageClass

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-apiserver_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-apiserver_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     enableAdmissionPlugins:
     - DefaultStorageClass

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     enableAdmissionPlugins:
     - DefaultStorageClass

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: adUEImG0hCz/3a0F1j2z39selyzUNgn4KnCB50INwu8=
+NodeupConfigHash: znHlgooKASsah+sJQutefFjSeT/wVPVu6PMu08ftHGA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   awsLoadBalancerController:
     enabled: true
   certManager:
@@ -66,7 +66,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: bastionuserdata.example.com
 ConfigBase: memfs://clusters.example.com/bastionuserdata.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: qGHIU9VUTpfjjoHKb3fWZ9ntpQvDNKGu8oBywuyPVy4=
+NodeupConfigHash: grEQavaNHRfaLsFC1yTq5J7kXaElQzRWGmOFadJnZP4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander-custom.example.com_user_data
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander-custom.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: cas-priority-expander-custom.example.com
 ConfigBase: memfs://clusters.example.com/cas-priority-expander-custom.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 2FDH+y0OLZhgOfaW1fU7T1GPiann55m8nwhopBbtfqg=
+NodeupConfigHash: CppvzoU/fD0ws7Ct715whNdOc6X37/fx65Sc6gn3pe8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -85,7 +85,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander.example.com_user_data
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: cas-priority-expander.example.com
 ConfigBase: memfs://clusters.example.com/cas-priority-expander.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: nMYwMnonjnne3JC+uvi1/nGYdtBJpK4eCHDg88Nmx9E=
+NodeupConfigHash: PJMjVV93F3ZhzaGdIjY15T4um+JttRTG9ZjCkvDw6Uc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -78,7 +78,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -135,7 +135,7 @@ ClusterName: complex.example.com
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: ZRal098lSSMLl4cCEjMIQGSaSJKdl/3A6Dm36xor+TU=
+NodeupConfigHash: OwzGeToBSioLnJHxFdCnnQhlvcVBGvy3W0COkqrT4XE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -25,7 +25,7 @@ spec:
   authentication:
     aws: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -85,7 +85,7 @@ spec:
     - kubernetes.svc.default
     apiServerCount: 1
     auditWebhookBatchThrottleQps: 3140m
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     cpuLimit: 500m

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -11,7 +11,7 @@ APIServerConfig:
     - kubernetes.svc.default
     apiServerCount: 1
     auditWebhookBatchThrottleQps: 3140m
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     cpuLimit: 500m

--- a/tests/integration/update_cluster/compress/data/aws_launch_template_master-us-test-1a.masters.compress.example.com_user_data
+++ b/tests/integration/update_cluster/compress/data/aws_launch_template_master-us-test-1a.masters.compress.example.com_user_data
@@ -129,7 +129,7 @@ function download-release() {
 echo "== nodeup node config starting =="
 ensure-install-dir
 
-echo "H4sIAAAAAAAA/2zOwUoDMRDG8XueIi+wXSu4YMCD5tCmYN1WBK9DdtYGMpmQSbS+vcieFnr///g+G7lNY+HvMGExGn5E2dikYjkCodGeKRcU2eAVKEfceCZlOc3h6wUEjSakWUzf+0Wtwv6mdkkqJI+7wi0vKwT/tmvSVZTabWEdnTmi0ZZTLRzHCAnVkSdseTmyB7kYPR7c/GkPj2/A4Aa3f5bTLn4Mr9fzSS7Dwx39vodwLzZs+Un9AQAA//8BAAD//1ABtIb3AAAA" | base64 -d | gzip -d > conf/kube_env.yaml
+echo "H4sIAAAAAAAA/2zOzU4DIRTF8T1PwQtMRxM/KomLlphqFxPqwujsbuEWq8AlXNCJT2/MrCZx///lHB2oOVPo6+ywKAnfLHRoXLEMEFFJSzEXZF7hBDEHXFmKQlM6nf0WGJWMGE+s+t7OahH2/+qnxBWSxV2hlueVCH+2a9xV5NpdwjJ6poBKakq1UDABEoqBHLY8H3kEflfS3R79em9ey2Y71MMDffyYt5uLz6v1zozTeLz24+bFTvt8d/D34hcAAP//AQAA//+k2k5F9wAAAA==" | base64 -d | gzip -d > conf/kube_env.yaml
 
 download-release
 echo "== nodeup node config done =="

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -61,7 +61,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: containerd.example.com
 ConfigBase: memfs://clusters.example.com/containerd.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Xvr8UYD/VXBE/DZNeX1o51Vpwdz3eTnntaXNTb7xols=
+NodeupConfigHash: SxMJSaip0yRwWB0IovNzdNTCHqfziYKBPbuwVGJ/DSs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -71,7 +71,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/containerd/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
+++ b/tests/integration/update_cluster/containerd/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: containerd.example.com
 ConfigBase: memfs://clusters.example.com/containerd.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: tL8RoIKKTMa1nR4x3m+Wy5LYjIFSa4fjxt8MSIsz8ww=
+NodeupConfigHash: 6uf4x3guLQlCHbi78NbPTj/q7vwVhFzWm5mq87h6VfI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -61,7 +61,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
+++ b/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: 123.example.com
 ConfigBase: memfs://clusters.example.com/123.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: MdROp1oLpwQQJZkZzrGv7V1lVwvW1zyjbLt7Yaik3rc=
+NodeupConfigHash: z6R1mgrRzVDbvX6dGkuCqrgjJXLidoUKVOrSc8dTKwY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -83,7 +83,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existing-iam.example.com
 ConfigBase: memfs://tests/existing-iam.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: QgqhjLW5pagg77fZ4exXOWm36h3xYVrqUKXrOiHLjb4=
+NodeupConfigHash: QRsSJINgvGF5T+2CWZiEmN4w44T32v5csEHNbBLfHXw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existing-iam.example.com
 ConfigBase: memfs://tests/existing-iam.example.com
 InstanceGroupName: master-us-test-1b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: B96S6Jr3of1ttp4VWII2Unq12YCSk/6ER3UBBpyNqc4=
+NodeupConfigHash: pMcW0Zp3W2mszpgyL/3qpTm690NPONXdDdq+xBPdb68=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existing-iam.example.com
 ConfigBase: memfs://tests/existing-iam.example.com
 InstanceGroupName: master-us-test-1c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 9v0Bkbkp+RALUA1ZdHPKWxpCMkDKG/ueHhufKnR4J/Q=
+NodeupConfigHash: N+8kXyfp2L+XTHncfigmba07OOrvfiJjUUDrYm/fufU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -69,7 +69,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existingsg.example.com
 ConfigBase: memfs://clusters.example.com/existingsg.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: nbNezmKMiqgsFAKSeYI1v7dQR/U/hqSwYJmLiA/phdM=
+NodeupConfigHash: 8+zDx1OPpU5zikrk4lVT1XOppeTf6Rwf4NS9BPdMado=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existingsg.example.com
 ConfigBase: memfs://clusters.example.com/existingsg.example.com
 InstanceGroupName: master-us-test-1b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Ps40v1vzYptB/OyK/moEFI7g72xK9rJ5qJy5cY+mCqw=
+NodeupConfigHash: 9J09MIG00RO9TFdS4IshZp2++SOZPZ8bjUf0WKNZetw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: existingsg.example.com
 ConfigBase: memfs://clusters.example.com/existingsg.example.com
 InstanceGroupName: master-us-test-1c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: d1sipMqe2ELnFAErc9u9DZsuZSYXqP1eLeUJaBoIL6o=
+NodeupConfigHash: sBYXgk6N+DSAIgVZSicTPi/QUHzxFGvPC6P+dDzRJkM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
@@ -10,7 +10,7 @@ spec:
       securityGroupOverride: sg-elb
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -72,7 +72,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/external_dns/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/external_dns/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: +VhmrssmpmPVnc3H0oxO9Lipi8JDNQXxzZONXMRBzwI=
+NodeupConfigHash: bpeLY8/nNzAjbQ+OVxg7JCN8KhfMXyPWmS6TahLOyuw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -61,7 +61,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: adUEImG0hCz/3a0F1j2z39selyzUNgn4KnCB50INwu8=
+NodeupConfigHash: znHlgooKASsah+sJQutefFjSeT/wVPVu6PMu08ftHGA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -62,7 +62,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
+++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: externallb.example.com
 ConfigBase: memfs://clusters.example.com/externallb.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: zUiuDij/WMRMdHF4Er6ALRrIEVzS3ufZbt+bmSZo/4M=
+NodeupConfigHash: tD8KPzn0yweCnDxzDW1csdvFkI5+2hT1lwHNZcI8irA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -61,7 +61,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: externalpolicies.example.com
 ConfigBase: memfs://clusters.example.com/externalpolicies.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: xA7ajMOwAv9Kzyez5RSTNtrWWPqD+xrzmxVzIYMi9SA=
+NodeupConfigHash: URnBIAeq6gEnsT0vlYJ50zvnBdzKpwQ90vxLF793IEY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
@@ -12,7 +12,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -77,7 +77,7 @@ spec:
     - kubernetes.svc.default
     apiServerCount: 1
     auditWebhookBatchThrottleQps: 3140m
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     - kubernetes.svc.default
     apiServerCount: 1
     auditWebhookBatchThrottleQps: 3140m
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: ha.example.com
 ConfigBase: memfs://tests/ha.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Cd5Y+TmMg2dWWoDOwvjvdOt8bXZqwcSa+Am5mFmNTrY=
+NodeupConfigHash: MIYZl+LDqrbMfc0ipGEanLUKEfRQWINds2f7yeySFSw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: ha.example.com
 ConfigBase: memfs://tests/ha.example.com
 InstanceGroupName: master-us-test-1b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: pSiGUniCXEw8O6vW6MuSbewm36NzvC2z3+E7W8iWMKU=
+NodeupConfigHash: C+IYcLKAMrAZI1mXHgJKAoW2AHsBBVwnMiv/r311y0M=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: ha.example.com
 ConfigBase: memfs://tests/ha.example.com
 InstanceGroupName: master-us-test-1c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: NkBKh4P2bIJYQWwWv7JbCJQPBlbWL+Me3wuFI6ksmRo=
+NodeupConfigHash: p/Li9eiV1b22JQNLyd6t7I6rWa7dcly8VYFKjaA9DgU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -69,7 +69,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: adUEImG0hCz/3a0F1j2z39selyzUNgn4KnCB50INwu8=
+NodeupConfigHash: znHlgooKASsah+sJQutefFjSeT/wVPVu6PMu08ftHGA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   certManager:
     enabled: true
   channel: stable
@@ -90,7 +90,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: adUEImG0hCz/3a0F1j2z39selyzUNgn4KnCB50INwu8=
+NodeupConfigHash: znHlgooKASsah+sJQutefFjSeT/wVPVu6PMu08ftHGA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -71,7 +71,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: bRpATqWz9Dbb3Ggd1wa14lhBScHyGbZBQSqcrdXIKjY=
+NodeupConfigHash: ypwM7U+M+qpGt/FQYZjW7S3WLVzMCjr+crSCSWxzGso=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   awsLoadBalancerController:
     cpuLimit: 300m
     cpuRequest: 150m
@@ -88,7 +88,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: /jpfisbXgG4Pdc/mybdH+9rqttTGEpN42kKeJrV9vh8=
+NodeupConfigHash: SOta0JyYa0BShBzjriQpPvCdtjZrecE0ABC2LVd3eH4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   awsLoadBalancerController:
     cpuLimit: 300m
     cpuRequest: 150m
@@ -88,7 +88,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.many-addons.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.many-addons.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: many-addons.example.com
 ConfigBase: memfs://tests/many-addons.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: XALetUqlsUWI3uIBaZYTb8xDbp0vg9YMYHd08SdluPQ=
+NodeupConfigHash: SIOiWbqoNmCO9TckQaIrC9+17zaNxPW+KTE0aOok0z8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   awsLoadBalancerController:
     enabled: true
   certManager:
@@ -86,7 +86,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_master-us-test-1a.masters.minimal-aws.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_master-us-test-1a.masters.minimal-aws.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-aws.example.com
 ConfigBase: memfs://clusters.example.com/minimal-aws.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 28etZKU6seNuXx0Yni/0M8WpwtSMIS+7yqUblsjQrl0=
+NodeupConfigHash: KRfgk7Bs2IhoH1YkVRQPVk/w0+MuySUSdfeL5gVBiSk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -59,7 +59,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     enableAdmissionPlugins:
     - DefaultStorageClass

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     enableAdmissionPlugins:
     - DefaultStorageClass

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_master-us-test-1a.masters.minimal-etcd.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_master-us-test-1a.masters.minimal-etcd.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-etcd.example.com
 ConfigBase: memfs://clusters.example.com/minimal-etcd.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: yVV7x+jBDGF5x1W5/gLsbsVVeW3Yw8gIqbt9PsK/aXw=
+NodeupConfigHash: whwe8MdgW3x6QpIOoo+PVVMWnbs/GtbmQW5OLnooimA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -69,7 +69,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: +VhmrssmpmPVnc3H0oxO9Lipi8JDNQXxzZONXMRBzwI=
+NodeupConfigHash: bpeLY8/nNzAjbQ+OVxg7JCN8KhfMXyPWmS6TahLOyuw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -67,7 +67,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: /QtaXDH49LbrnlqvmAMKHmXxDy8rCqwaYposwHCxli0=
+NodeupConfigHash: DfqhgdwdpkFTF1AfVf5UfCVtRONw+zd6h5x+RcIEq7Y=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Network
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -65,7 +65,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: eqKu8/qq6M5bIoIoIC5jJA0WGiE04oSu6+0mXo8ioHQ=
+NodeupConfigHash: oH8ZmBNIpMHs6Y1gyF0WyQZWzrrCg3M7LiFhxT9uWJ0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Network
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -65,7 +65,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 1lKAG95ciMRCBvxPl8V6QlW8dBY9sZnHqDLnN46aHGU=
+NodeupConfigHash: gBZLIJLg9PO8OP53Bpl41CPI73ED+Xh6UW6dK/jhGpU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Network
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -65,7 +65,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: EJ8s5gupweupaVKbv39O4ppmcvvXIwF7m1JiB82T1NY=
+NodeupConfigHash: abovx3XzmQ8xL1YUMMACdiT8Q7JyRS9d46X8jPQH9NM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Network
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -65,7 +65,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: EJ8s5gupweupaVKbv39O4ppmcvvXIwF7m1JiB82T1NY=
+NodeupConfigHash: abovx3XzmQ8xL1YUMMACdiT8Q7JyRS9d46X8jPQH9NM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Network
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -65,7 +65,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_master-us-test-1a.masters.this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_master-us-test-1a.masters.this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: this.is.truly.a.really.really.really.really.really.long.cluster-nam
 ConfigBase: memfs://clusters.example.com/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: FL6dK2VdhYeMAZxfOMv7PSC0wTQObBlGBpGS8lojsC8=
+NodeupConfigHash: lcIcz+XGNnlKnOlLfIvVpo5bixlZEI9PltMh0w+Zx9k=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -59,7 +59,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-warmpool.example.com
 ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: H2JO6JPDGKCnofPQA7rT6gwsEMp7xzQu2p0lUHp7nKA=
+NodeupConfigHash: BmaYfe+ZloWxNifcz6fsa8nReT0srU34pZ4RjUF+ywM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
   assets:
     containerProxy: kops.k8s.io/remapped-image
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.k8s.local
 ConfigBase: memfs://clusters.example.com/minimal.k8s.local
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: fvroaH3GKxHbcj/4CDjAJTcnj9Njl6PlFs4Jtcmnujw=
+NodeupConfigHash: 661e2KxaC1VkiDUO+QtLSBZY6u2sAh2GUdhjYrjnhY0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -60,7 +60,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.k8s.local
 ConfigBase: memfs://clusters.example.com/minimal.k8s.local
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: KL9UdVLJ3OHoPDYHnPxkx+0EsFRFSKGO81fiySPUhiI=
+NodeupConfigHash: PAoaDZl1HZGwSxH57A5sBU+yXfge6ZcUDWSz/hXJcnA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -61,7 +61,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: DZ0GF8Svcb5eK9gYxvdC+ak5L9v07ZIyKKlsw9wucYM=
+NodeupConfigHash: 3BYyPv4KMujTfMOlWQI9SL+t/XcqTlYvUYi0zBRqNVE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: M19xcucHjpFTAQjf345WpGXdhB2quX6cPhqirzpBD7Y=
+NodeupConfigHash: 5+t/EouQXfSHhZROBj5UYtgYdIrjDaCIwyphfhWL3Mo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: duN7/uMq3B7B6fm+CV1MBKJWo18j8pSW0oSlEFXuU+8=
+NodeupConfigHash: cyvvmFh8R+yn88WH4bWPMHaKZTubGPMhjT2rPiv+7M4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -69,7 +69,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: DZ0GF8Svcb5eK9gYxvdC+ak5L9v07ZIyKKlsw9wucYM=
+NodeupConfigHash: 3BYyPv4KMujTfMOlWQI9SL+t/XcqTlYvUYi0zBRqNVE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1b
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: M19xcucHjpFTAQjf345WpGXdhB2quX6cPhqirzpBD7Y=
+NodeupConfigHash: 5+t/EouQXfSHhZROBj5UYtgYdIrjDaCIwyphfhWL3Mo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: mixedinstances.example.com
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: master-us-test-1c
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: duN7/uMq3B7B6fm+CV1MBKJWo18j8pSW0oSlEFXuU+8=
+NodeupConfigHash: cyvvmFh8R+yn88WH4bWPMHaKZTubGPMhjT2rPiv+7M4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -69,7 +69,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 3
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: nthimdsprocessor.longclustername.example.com
 ConfigBase: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: +9TWHP6jwEFwD/l0dGetQJJxeoapWTaVU1KRf+2i3bU=
+NodeupConfigHash: ZBsQe+k0AM7QKghHRnwFQqfcJfLlnB91I4gFjn8d5fM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -62,7 +62,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: nthimdsprocessor.longclustername.example.com
 ConfigBase: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 7QpDGP/SEx0jmvpq4fdCHe8F32PMp28SU/dtOL6dqvo=
+NodeupConfigHash: TPdhBcfEP8WyhJssm1eY7VxZDom2higldq38na/9jsY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -61,7 +61,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: u2N3eCJ58mp8RNETyjvQJ1UJe4I/NwV7N73IgaIHjo4=
+NodeupConfigHash: thS9CJHR4a4+jREYCeI8zXP4aqWtdV8N60EEtx+Ehxg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -65,7 +65,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: private-shared-ip.example.com
 ConfigBase: memfs://clusters.example.com/private-shared-ip.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: XDNey1JaoNAu5tGc33O3e/zsHJwxEAGdtLuzPpEtx/M=
+NodeupConfigHash: rwzD+vWgZWwXdyxz4cDHXHdPZOhJ8G0dLNekZkIaMEY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: private-shared-subnet.example.com
 ConfigBase: memfs://clusters.example.com/private-shared-subnet.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: U9tsu1X2qeBgG5Jr18j6a1Rt9W4ml5qoyRwwkwMRv7I=
+NodeupConfigHash: q9VOaVc/z2/WYxIcm7j3HSGFjUp9gOWPXqnUYLoR7iM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatecalico.example.com
 ConfigBase: memfs://clusters.example.com/privatecalico.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 8OANRo7DY1YgILAisM2tMLc0Oh9rHhTg4SFZXeOl4lM=
+NodeupConfigHash: vfqe4ZAGAhdkjsbPt5KNLwGaXvm/kkuvAa9ZeFoII4w=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -64,7 +64,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatecilium.example.com
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: u9XttkBojjwSip+1OGwJBOKYL0W6V7AmCGUne/H0Xfw=
+NodeupConfigHash: RWKfxSEZ3cbT23xGVd4fHPOeTMra0l0YueOaiBva6IQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatecilium.example.com
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: ddzV5qiA0cqrowpqQj6isRLZdRoTTy54TnuEUC953Zs=
+NodeupConfigHash: KjESQPu3W4saJ6Mf7gfk/Ntn3gKYu+Ca43Tr5vJmp9I=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatecilium.example.com
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: qY7k7aVHbNYG0KnMqbktFBr70N71SZtK3RTryRHXkXw=
+NodeupConfigHash: i0ohcgcp9ZC5/IPyrNcqYSOzq7kdrkbM1eMxyApMAFA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   certManager:
     enabled: true
   channel: stable
@@ -65,7 +65,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privateciliumadvanced.example.com
 ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: a70RkHTb3lw6JVty0EUrw0LUkLmEItx6mBA7/uw2oX4=
+NodeupConfigHash: nAzRxn9aRN/UcVngDgfM4YwWnAH97jAK8NTEbHTRwZ8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -72,7 +72,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatedns1.example.com
 ConfigBase: memfs://clusters.example.com/privatedns1.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: zsCS10xWSqb488fXFvJNce6pQg3dUo3iyiWjEsCii3o=
+NodeupConfigHash: qb3n8K3gTXjF6r0Y2F+fDljhbQZZpHhd8DZgTRxXdl4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -66,7 +66,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     enableAdmissionPlugins:
     - DefaultStorageClass

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     enableAdmissionPlugins:
     - DefaultStorageClass

--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatedns2.example.com
 ConfigBase: memfs://clusters.example.com/privatedns2.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: bveDNoB6hgtSqijZITBi73qLaFFcEjsvEG4HhKnU/k8=
+NodeupConfigHash: Nuqh/phLKINKu+l2p07ufY7SwFA9NTBO46bpZGnjBMs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privateflannel.example.com
 ConfigBase: memfs://clusters.example.com/privateflannel.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: v7A/4uqP7xn5SZMnITM3dQnxm9tfw9mHY37GaV7B674=
+NodeupConfigHash: Lv7SInjWhiGNM8hVx3kk7mQe+7i2Z8j/Iwmtxq8pZNU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     enableAdmissionPlugins:
     - DefaultStorageClass

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     enableAdmissionPlugins:
     - DefaultStorageClass

--- a/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_master-us-test-1a.masters.privatekindnet.example.com_user_data
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_master-us-test-1a.masters.privatekindnet.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatekindnet.example.com
 ConfigBase: memfs://clusters.example.com/privatekindnet.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 724al15VLiaSEUnKaoK+CVosVTvxpslJZ9lA0jgfRzM=
+NodeupConfigHash: XeOUkvRhsSIGZjP3s+ZUc7Skm7YQ2FIU5zCYNB3/m/k=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: privatekopeio.example.com
 ConfigBase: memfs://clusters.example.com/privatekopeio.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: fKP8p3Ed58tdllbM5/i0Y/nMav/oLuYZbtIEO+Ni8y4=
+NodeupConfigHash: yFt4UKxR92p5gpGFC6kmztzQM+Bv8F4f0+bOpyL13NE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 4jTjrxaSwY0HDmRydNNsLKhCfTgiJf5+JkjFMvEecg8=
+NodeupConfigHash: Xcjhdjck8rpNPL7oTEZvHFk/jiP7i8r+utB8kfOTv5g=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -62,7 +62,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: sharedsubnet.example.com
 ConfigBase: memfs://clusters.example.com/sharedsubnet.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: AHOG25vdiePqp4+LUWK28yf34pOsbws4VlnKfd1d9vs=
+NodeupConfigHash: 0L/Dhlp0V4sx/mv0G2tEwOghsZJnEQueOwWqb/QBTUE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -61,7 +61,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: sharedvpc.example.com
 ConfigBase: memfs://clusters.example.com/sharedvpc.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: AF410vysKkEyAS3Yu6yOzzO1Mf8ZfSJc6FJ2vAsl6YA=
+NodeupConfigHash: kMxqRAauEGV50Af8Lxv2JcmymTiwiKaNz1kIGZvcCtk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -61,7 +61,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal-ipv6.example.com
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: EJ8s5gupweupaVKbv39O4ppmcvvXIwF7m1JiB82T1NY=
+NodeupConfigHash: abovx3XzmQ8xL1YUMMACdiT8Q7JyRS9d46X8jPQH9NM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Network
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -65,7 +65,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: '::'
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
+++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: unmanaged.example.com
 ConfigBase: memfs://clusters.example.com/unmanaged.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: QNoe7gMrBEev7XwLBrrK/aEA6YI0prDCm3Sxx5VhBZQ=
+NodeupConfigHash: ztCSRHO1Ku+MpdDLtWRJNbcg75wYJ23gkfrnxCftubw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
@@ -9,7 +9,7 @@ spec:
       class: Classic
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -63,7 +63,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -8,7 +8,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: adUEImG0hCz/3a0F1j2z39selyzUNgn4KnCB50INwu8=
+NodeupConfigHash: znHlgooKASsah+sJQutefFjSeT/wVPVu6PMu08ftHGA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
@@ -7,7 +7,7 @@ spec:
   api:
     dns: {}
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudConfig:
     awsEBSCSIDriver:
@@ -61,7 +61,7 @@ spec:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -9,7 +9,7 @@ APIServerConfig:
     apiAudiences:
     - kubernetes.svc.default
     apiServerCount: 1
-    authorizationMode: AlwaysAllow
+    authorizationMode: Node,RBAC
     bindAddress: 0.0.0.0
     cloudProvider: external
     enableAdmissionPlugins:


### PR DESCRIPTION
A cluster spec applied with the top-level `authorization` field omitted (kops create -f / replace -f) defaulted to AlwaysAllow, while `kops create cluster` has always defaulted to RBAC. Align the v1alpha2 and v1alpha3 SetDefaults_ClusterSpec with the CLI: an omitted or empty authorization now defaults to RBAC. AlwaysAllow is still honored when set explicitly.

/cc @rifelpet @ameukam 