### PR TITLE
cilium: allow disabling masquerade in ENI IPAM mode

### DIFF
--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -122,7 +122,7 @@ Enable this by setting `--networking=cilium-eni` (as of kOps 1.26) or by specify
       ipam: eni
 ```
 
-In kOps versions before 1.22, when using ENI IPAM you need to explicitly disable masquerading in Cilium as well.
+When using ENI IPAM, kOps enables masquerading by default. If pods in your cluster can reach external destinations without it — for example, nodes in private subnets behind a NAT gateway, or via VPC endpoints — you can disable masquerading to match Cilium's upstream default for ENI IPAM:
 
 ```yaml
   networking:
@@ -130,6 +130,8 @@ In kOps versions before 1.22, when using ENI IPAM you need to explicitly disable
       disableMasquerade: true
       ipam: eni
 ```
+
+Do not disable masquerading if pods rely on the node's address to reach external destinations (for example, nodes in public subnets without a NAT gateway), as their traffic would otherwise be dropped.
 
 Note that since Cilium Operator is the entity that interacts with the EC2 API to provision and attaching ENIs, we force it to run on the master nodes when this IPAM is used.
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1411,9 +1411,6 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 			if cluster.GetCloudProvider() != kops.CloudProviderAWS {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("ipam"), "Cilum ENI IPAM is supported only in AWS"))
 			}
-			if v.Masquerade != nil && !*v.Masquerade {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Child("masquerade"), "Masquerade must be enabled when ENI IPAM is used"))
-			}
 			if c.IsIPv6Only() {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("ipam"), "Cilium ENI IPAM does not support IPv6"))
 			}

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -1220,7 +1220,6 @@ func Test_Validate_Cilium(t *testing.T) {
 					AWS: &kops.AWSSpec{},
 				},
 			},
-			ExpectedErrors: []string{"Forbidden::cilium.masquerade"},
 		},
 		{
 			Cilium: kops.CiliumNetworkingSpec{


### PR DESCRIPTION
kOps forbids setting masquerade (disableMasquerade) when Cilium ENI IPAM is used, erroring with "Masquerade must be enabled when ENI IPAM is used". This blocks users who want Cilium's upstream no-masquerade behavior for ENI (e.g. private-topology clusters with NAT-gateway egress, or clusters using VPC endpoints), forcing them to patch the cilium-config ConfigMap after the fact, which races new nodes during rolling updates.

Remove the validation so masquerade can be set in either direction for ENI. The default is intentionally left unchanged (masquerade stays on): flipping it off by default breaks pod egress to external endpoints (e.g. IRSA -> STS) on public-topology clusters whose pod ENI IPs have no public address, as shown by a red pull-kops-e2e-cni-cilium-eni run. Users who can route pod egress without masquerading opt in via `masquerade: false` (or via `extraConfig`).

Fixes #18427

/cc @rifelpet @ameukam 