### PR TITLE
channels: surface addon apply failures via a readiness probe

### DIFF
--- a/channels/pkg/cmd/apply_channel.go
+++ b/channels/pkg/cmd/apply_channel.go
@@ -94,6 +94,15 @@ func runApplyChannelIteration(ctx context.Context, f *ChannelsFactory, out io.Wr
 // ChannelsFactory per iteration drops cached REST configs and the discovery
 // cache, picking up cert rotation and new CRDs without a restart.
 func runApplyChannelLoop(ctx context.Context, out io.Writer, options *ApplyChannelOptions, args []string) error {
+	// In daemon mode kops-channels runs as a system-node-critical static pod; serve a
+	// readiness probe reporting the last apply outcome, so a persistent failure surfaces
+	// as NotReady (failing `kops validate cluster`, which gates rolling updates) instead
+	// of only being logged. Starts NotReady until the first successful apply.
+	readiness, err := serveReadiness(ctx)
+	if err != nil {
+		return fmt.Errorf("serving readiness probe: %w", err)
+	}
+
 	// Retry quickly until the first success: the apiserver is usually
 	// unreachable while the control plane is still coming up.
 	const startupRetryInterval = 5 * time.Second
@@ -101,7 +110,9 @@ func runApplyChannelLoop(ctx context.Context, out io.Writer, options *ApplyChann
 	settled := false
 	for {
 		interval := options.Interval
-		if err := runApplyChannelIteration(ctx, NewChannelsFactory(), out, options, args); err != nil {
+		err := runApplyChannelIteration(ctx, NewChannelsFactory(), out, options, args)
+		readiness.recordApplyResult(err)
+		if err != nil {
 			if !settled {
 				interval = min(startupRetryInterval, options.Interval)
 			}

--- a/channels/pkg/cmd/readiness.go
+++ b/channels/pkg/cmd/readiness.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"k8s.io/kops/pkg/wellknownports"
+)
+
+type applyChannelReadiness struct {
+	ready atomic.Bool
+	addr  string // resolved listen address; read only by tests (which bind :0)
+}
+
+func (r *applyChannelReadiness) recordApplyResult(err error) {
+	r.ready.Store(err == nil)
+}
+
+// serveReadiness serves /readyz on loopback for the kubelet readiness probe until ctx is cancelled:
+// 200 when ready is true, 503 otherwise. The pod runs with hostNetwork, so the kubelet reaches it
+// via 127.0.0.1 in the host network namespace.
+func serveReadiness(ctx context.Context) (*applyChannelReadiness, error) {
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(wellknownports.KopsChannelsHealthCheck))
+	return serveReadinessOnAddr(ctx, addr)
+}
+
+func serveReadinessOnAddr(ctx context.Context, addr string) (*applyChannelReadiness, error) {
+	readiness := &applyChannelReadiness{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if readiness.ready.Load() {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok\n"))
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("apply iterations are failing\n"))
+		}
+	})
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listening on %s: %w", addr, err)
+	}
+	readiness.addr = listener.Addr().String()
+
+	server := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = server.Close()
+	}()
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			klog.Fatalf("kops-channels readiness server stopped: %v", err)
+		}
+	}()
+	return readiness, nil
+}

--- a/channels/pkg/cmd/readiness_test.go
+++ b/channels/pkg/cmd/readiness_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestServeReadinessReportsApplyOutcome(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	readiness, err := serveReadinessOnAddr(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("serveReadinessOnAddr returned error: %v", err)
+	}
+
+	assertReadinessStatus(t, readiness.addr, http.StatusServiceUnavailable)
+
+	readiness.recordApplyResult(nil)
+	assertReadinessStatus(t, readiness.addr, http.StatusOK)
+
+	readiness.recordApplyResult(errors.New("apply failed"))
+	assertReadinessStatus(t, readiness.addr, http.StatusServiceUnavailable)
+}
+
+func TestServeReadinessReturnsBindError(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve test port: %v", err)
+	}
+	defer listener.Close()
+
+	_, err = serveReadinessOnAddr(context.Background(), listener.Addr().String())
+	if err == nil {
+		t.Fatalf("expected bind error")
+	}
+}
+
+func assertReadinessStatus(t *testing.T, addr string, expectedStatus int) {
+	t.Helper()
+
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Get("http://" + addr + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != expectedStatus {
+		t.Fatalf("expected status %d, got %d", expectedStatus, resp.StatusCode)
+	}
+}

--- a/pkg/model/components/channels/model.go
+++ b/pkg/model/components/channels/model.go
@@ -23,12 +23,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	kopsroot "k8s.io/kops"
 	"k8s.io/kops/pkg/assets"
 	"k8s.io/kops/pkg/k8scodecs"
 	"k8s.io/kops/pkg/kubemanifest"
 	"k8s.io/kops/pkg/model"
+	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/pkg/wellknownusers"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/fitasks"
@@ -155,6 +157,23 @@ func (b *ChannelsBuilder) buildPod(channels []string) (*v1.Pod, error) {
 				v1.ResourceCPU:    resource.MustParse("50m"),
 				v1.ResourceMemory: resource.MustParse("50Mi"),
 			},
+		},
+		// kops-channels is system-node-critical, so a NotReady container fails `kops validate
+		// cluster`. The apply loop serves /readyz on loopback, publishing the most recent apply
+		// outcome. failureThreshold 2 (~20s at periodSeconds 10) trips within one apply
+		// interval (channelsInterval, 60s), so a single failed apply surfaces as NotReady; 2
+		// (not 1) rides out one flaky probe sample.
+		ReadinessProbe: &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				HTTPGet: &v1.HTTPGetAction{
+					Host: "127.0.0.1",
+					Path: "/readyz",
+					Port: intstr.FromInt(wellknownports.KopsChannelsHealthCheck),
+				},
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       10,
+			FailureThreshold:    2,
 		},
 		// ko-distroless's default nonroot uid can't read /var/lib/kops/kubeconfig.
 		SecurityContext: &v1.SecurityContext{

--- a/pkg/model/components/channels/tests/container_registry/tasks.yaml
+++ b/pkg/model/components/channels/tests/container_registry/tasks.yaml
@@ -30,6 +30,14 @@ Contents: |
         value: us-test-1
       image: my-mirror.example.com/kops-channels:1.36.0-alpha.1
       name: kops-channels
+      readinessProbe:
+        failureThreshold: 2
+        httpGet:
+          host: 127.0.0.1
+          path: /readyz
+          port: 3986
+        initialDelaySeconds: 30
+        periodSeconds: 10
       resources:
         requests:
           cpu: 50m

--- a/pkg/model/components/channels/tests/minimal/tasks.yaml
+++ b/pkg/model/components/channels/tests/minimal/tasks.yaml
@@ -30,6 +30,14 @@ Contents: |
         value: us-test-1
       image: registry.k8s.io/kops/channels:1.36.0-alpha.1
       name: kops-channels
+      readinessProbe:
+        failureThreshold: 2
+        httpGet:
+          host: 127.0.0.1
+          path: /readyz
+          port: 3986
+        initialDelaySeconds: 30
+        periodSeconds: 10
       resources:
         requests:
           cpu: 50m

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -26,6 +26,9 @@ const (
 	// EtcdMetricsPort is used to serve etcd metrics
 	EtcdMetricsPort = 2382
 
+	// KopsChannelsHealthCheck is the loopback port the kops-channels static pod serves /readyz on.
+	KopsChannelsHealthCheck = 3986
+
 	// NodeupChallenge is the port where nodeup listens for challenges.
 	NodeupChallenge = 3987
 

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-channels-kops-channels_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-channels-kops-channels_source
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: REDACTED
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: kops.k8s.io/remapped-image/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-channels-kops-channels_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-channels-kops-channels_source
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -26,6 +26,14 @@ spec:
       value: /tmp
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: REDACTED
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -29,6 +29,14 @@ spec:
     - name: SCW_SECRET_KEY
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-channels-kops-channels_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-channels-kops-channels_content
@@ -28,6 +28,14 @@ spec:
       value: us-test-1
     image: registry.k8s.io/kops/channels:1.34.0-beta.1
     name: kops-channels
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 3986
+      initialDelaySeconds: 30
+      periodSeconds: 10
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
Apply errors were only logged, so a manifest the apiserver rejects (e.g. an immutable Deployment selector) left the cluster silently broken. /readyz now reflects the last apply outcome; the pod is system-node-critical, so a NotReady fails `kops validate cluster` and halts the rolling update before workers roll.