### PR TITLE
Title: feat(gce): add regional MIG support for multi-AZ instance groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ charts/
 
 # Ignore asdf .tool-versions file
 .tool-versions
+go1.26.3.linux-amd64.tar.gz

--- a/cloudmock/gce/mockcompute/api.go
+++ b/cloudmock/gce/mockcompute/api.go
@@ -41,6 +41,7 @@ type MockClient struct {
 
 	instanceTemplateClient     *instanceTemplateClient
 	instanceGroupManagerClient *instanceGroupManagerClient
+	regionInstanceGroupManagerClient *regionInstanceGroupManagerClient
 	targetPoolClient           *targetPoolClient
 
 	diskClient *diskClient
@@ -70,6 +71,7 @@ func NewMockClient(project string) *MockClient {
 
 		instanceTemplateClient:     newInstanceTemplateClient(),
 		instanceGroupManagerClient: newInstanceGroupManagerClient(instanceClient),
+			regionInstanceGroupManagerClient: newRegionInstanceGroupManagerClient(),
 		targetPoolClient:           newTargetPoolClient(),
 
 		diskClient: newDiskClient(),
@@ -171,6 +173,10 @@ func (c *MockClient) InstanceTemplates() gce.InstanceTemplateClient {
 
 func (c *MockClient) InstanceGroupManagers() gce.InstanceGroupManagerClient {
 	return c.instanceGroupManagerClient
+}
+
+func (c *MockClient) RegionInstanceGroupManagers() gce.RegionInstanceGroupManagerClient {
+	return c.regionInstanceGroupManagerClient
 }
 
 func (c *MockClient) TargetPools() gce.TargetPoolClient {

--- a/cloudmock/gce/mockcompute/region_instance_group_manager.go
+++ b/cloudmock/gce/mockcompute/region_instance_group_manager.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockcompute
+
+import (
+"context"
+"fmt"
+"sync"
+
+compute "google.golang.org/api/compute/v1"
+"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+)
+
+type regionInstanceGroupManagerClient struct {
+// regionInstanceGroupManagers keyed by project, region, and name.
+regionInstanceGroupManagers map[string]map[string]map[string]*compute.InstanceGroupManager
+sync.Mutex
+}
+
+var _ gce.RegionInstanceGroupManagerClient = &regionInstanceGroupManagerClient{}
+
+func newRegionInstanceGroupManagerClient() *regionInstanceGroupManagerClient {
+return &regionInstanceGroupManagerClient{
+regionInstanceGroupManagers: map[string]map[string]map[string]*compute.InstanceGroupManager{},
+}
+}
+
+func (c *regionInstanceGroupManagerClient) All() map[string]interface{} {
+c.Lock()
+defer c.Unlock()
+m := map[string]interface{}{}
+for _, regions := range c.regionInstanceGroupManagers {
+for _, igms := range regions {
+for n, igm := range igms {
+m[n] = igm
+}
+}
+}
+return m
+}
+
+func (c *regionInstanceGroupManagerClient) Insert(project, region string, igm *compute.InstanceGroupManager) (*compute.Operation, error) {
+c.Lock()
+defer c.Unlock()
+igmRegions, ok := c.regionInstanceGroupManagers[project]
+if !ok {
+igmRegions = map[string]map[string]*compute.InstanceGroupManager{}
+c.regionInstanceGroupManagers[project] = igmRegions
+}
+igms, ok := igmRegions[region]
+if !ok {
+igms = map[string]*compute.InstanceGroupManager{}
+igmRegions[region] = igms
+}
+igm.SelfLink = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/instanceGroupManagers/%s", project, region, igm.Name)
+igms[igm.Name] = igm
+return doneOperation(), nil
+}
+
+func (c *regionInstanceGroupManagerClient) Delete(project, region, name string) (*compute.Operation, error) {
+c.Lock()
+defer c.Unlock()
+regions, ok := c.regionInstanceGroupManagers[project]
+if !ok {
+return nil, notFoundError()
+}
+igms, ok := regions[region]
+if !ok {
+return nil, notFoundError()
+}
+if _, ok := igms[name]; !ok {
+return nil, notFoundError()
+}
+delete(igms, name)
+return doneOperation(), nil
+}
+
+func (c *regionInstanceGroupManagerClient) Get(project, region, name string) (*compute.InstanceGroupManager, error) {
+c.Lock()
+defer c.Unlock()
+regions, ok := c.regionInstanceGroupManagers[project]
+if !ok {
+return nil, notFoundError()
+}
+igms, ok := regions[region]
+if !ok {
+return nil, notFoundError()
+}
+igm, ok := igms[name]
+if !ok {
+return nil, notFoundError()
+}
+return igm, nil
+}
+
+func (c *regionInstanceGroupManagerClient) List(ctx context.Context, project, region string) ([]*compute.InstanceGroupManager, error) {
+c.Lock()
+defer c.Unlock()
+regions, ok := c.regionInstanceGroupManagers[project]
+if !ok {
+return nil, nil
+}
+igms, ok := regions[region]
+if !ok {
+return nil, nil
+}
+var l []*compute.InstanceGroupManager
+for _, d := range igms {
+l = append(l, d)
+}
+return l, nil
+}
+
+func (c *regionInstanceGroupManagerClient) SetTargetPools(project, region, name string, targetPools []string) (*compute.Operation, error) {
+return doneOperation(), nil
+}
+
+func (c *regionInstanceGroupManagerClient) SetInstanceTemplate(project, region, name, instanceTemplateURL string) (*compute.Operation, error) {
+return doneOperation(), nil
+}
+
+func (c *regionInstanceGroupManagerClient) Resize(project, region, name string, newSize int64) (*compute.Operation, error) {
+return doneOperation(), nil
+}

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -69,6 +69,7 @@ var (
 	SpotinstController = new("SpotinstController", Bool(true))
 	// VPCSkipEnableDNSSupport if set will make that a VPC does not need DNSSupport enabled.
 	VPCSkipEnableDNSSupport = new("VPCSkipEnableDNSSupport", Bool(false))
+	GCERegionalMIG = new("GCERegionalMIG", Bool(false))
 	// SkipEtcdVersionCheck will bypass the check that etcd-manager is using a supported etcd version
 	SkipEtcdVersionCheck = new("SkipEtcdVersionCheck", Bool(false))
 	// EtcdEventsHTTP enables HTTP (non-TLS) for the events etcd cluster.

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/defaults"
 	"k8s.io/kops/pkg/model/iam"
@@ -334,26 +335,34 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 		}
 		c.AddTask(instanceTemplate)
 
-		instanceCountByZone, err := b.splitToZones(ig)
-		if err != nil {
-			return err
-		}
+		if featureflag.GCERegionalMIG.Enabled() {
+			// Use a single regional MIG spanning all zones
+			zones, err := b.FindZonesForInstanceGroup(ig)
+			if err != nil {
+				return err
+			}
 
-		for zone, targetSize := range instanceCountByZone {
-			name := gce.NameForInstanceGroupManager(b.Cluster.ObjectMeta.Name, ig.ObjectMeta.Name, zone)
+			minSize := 1
+			if ig.Spec.MinSize != nil {
+				minSize = int(fi.ValueOf(ig.Spec.MinSize))
+			} else if ig.Spec.Role == kops.InstanceGroupRoleNode {
+				minSize = 2
+			}
 
-			t := &gcetasks.InstanceGroupManager{
+			name := gce.NameForRegionInstanceGroupManager(b.Cluster.ObjectMeta.Name, ig.ObjectMeta.Name)
+
+			t := &gcetasks.RegionInstanceGroupManager{
 				Name:                        s(name),
 				Lifecycle:                   b.Lifecycle,
-				Zone:                        s(zone),
-				TargetSize:                  fi.PtrTo(int64(targetSize)),
+				Region:                      s(b.Region),
+				TargetSize:                  fi.PtrTo(int64(minSize)),
 				UpdatePolicy:                &gcetasks.UpdatePolicy{MinimalAction: "REPLACE", Type: "OPPORTUNISTIC"},
 				BaseInstanceName:            s(ig.ObjectMeta.Name),
 				InstanceTemplate:            instanceTemplate,
 				ListManagedInstancesResults: "PAGINATED",
+				DistributionPolicyZones:     zones,
 			}
 
-			// Attach API server instances to load balancer if we're using one
 			if ig.HasAPIServer() {
 				if b.UseLoadBalancerForAPI() {
 					lbSpec := b.Cluster.Spec.API.LoadBalancer
@@ -369,6 +378,42 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 			}
 
 			c.AddTask(t)
+		} else {
+			instanceCountByZone, err := b.splitToZones(ig)
+			if err != nil {
+				return err
+			}
+
+			for zone, targetSize := range instanceCountByZone {
+				name := gce.NameForInstanceGroupManager(b.Cluster.ObjectMeta.Name, ig.ObjectMeta.Name, zone)
+
+				t := &gcetasks.InstanceGroupManager{
+					Name:                        s(name),
+					Lifecycle:                   b.Lifecycle,
+					Zone:                        s(zone),
+					TargetSize:                  fi.PtrTo(int64(targetSize)),
+					UpdatePolicy:                &gcetasks.UpdatePolicy{MinimalAction: "REPLACE", Type: "OPPORTUNISTIC"},
+					BaseInstanceName:            s(ig.ObjectMeta.Name),
+					InstanceTemplate:            instanceTemplate,
+					ListManagedInstancesResults: "PAGINATED",
+				}
+
+				if ig.HasAPIServer() {
+					if b.UseLoadBalancerForAPI() {
+						lbSpec := b.Cluster.Spec.API.LoadBalancer
+						if lbSpec != nil {
+							switch lbSpec.Type {
+							case kops.LoadBalancerTypePublic:
+								t.TargetPools = append(t.TargetPools, b.LinkToTargetPool("api"))
+							case kops.LoadBalancerTypeInternal:
+								klog.Warningf("Not hooking the instance group manager up to anything.")
+							}
+						}
+					}
+				}
+
+				c.AddTask(t)
+			}
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/gce/compute.go
+++ b/upup/pkg/fi/cloudup/gce/compute.go
@@ -39,6 +39,7 @@ type ComputeClient interface {
 	Instances() InstanceClient
 	InstanceTemplates() InstanceTemplateClient
 	InstanceGroupManagers() InstanceGroupManagerClient
+	RegionInstanceGroupManagers() RegionInstanceGroupManagerClient
 	TargetPools() TargetPoolClient
 	Disks() DiskClient
 	RegionBackendServices() RegionBackendServiceClient
@@ -842,4 +843,68 @@ func (c *diskClientImpl) AggregatedList(ctx context.Context, project string) ([]
 func (c *diskClientImpl) SetLabels(project, zone, name string, req *compute.ZoneSetLabelsRequest) error {
 	_, err := c.srv.SetLabels(project, zone, name, req).Do()
 	return err
+}
+
+// RegionInstanceGroupManagerClient wraps the GCE RegionInstanceGroupManagers API.
+type RegionInstanceGroupManagerClient interface {
+Insert(project, region string, i *compute.InstanceGroupManager) (*compute.Operation, error)
+Delete(project, region, name string) (*compute.Operation, error)
+Get(project, region, name string) (*compute.InstanceGroupManager, error)
+List(ctx context.Context, project, region string) ([]*compute.InstanceGroupManager, error)
+SetTargetPools(project, region, name string, targetPools []string) (*compute.Operation, error)
+SetInstanceTemplate(project, region, name, instanceTemplateURL string) (*compute.Operation, error)
+Resize(project, region, name string, newSize int64) (*compute.Operation, error)
+}
+
+type regionInstanceGroupManagerClientImpl struct {
+srv *compute.RegionInstanceGroupManagersService
+}
+
+var _ RegionInstanceGroupManagerClient = (*regionInstanceGroupManagerClientImpl)(nil)
+
+func (c *regionInstanceGroupManagerClientImpl) Insert(project, region string, i *compute.InstanceGroupManager) (*compute.Operation, error) {
+return c.srv.Insert(project, region, i).Do()
+}
+
+func (c *regionInstanceGroupManagerClientImpl) Delete(project, region, name string) (*compute.Operation, error) {
+return c.srv.Delete(project, region, name).Do()
+}
+
+func (c *regionInstanceGroupManagerClientImpl) Get(project, region, name string) (*compute.InstanceGroupManager, error) {
+return c.srv.Get(project, region, name).Do()
+}
+
+func (c *regionInstanceGroupManagerClientImpl) List(ctx context.Context, project, region string) ([]*compute.InstanceGroupManager, error) {
+var ms []*compute.InstanceGroupManager
+if err := c.srv.List(project, region).Pages(ctx, func(page *compute.RegionInstanceGroupManagerList) error {
+ms = append(ms, page.Items...)
+return nil
+}); err != nil {
+return nil, err
+}
+return ms, nil
+}
+
+func (c *regionInstanceGroupManagerClientImpl) SetTargetPools(project, region, name string, targetPools []string) (*compute.Operation, error) {
+req := &compute.RegionInstanceGroupManagersSetTargetPoolsRequest{
+TargetPools: targetPools,
+}
+return c.srv.SetTargetPools(project, region, name, req).Do()
+}
+
+func (c *regionInstanceGroupManagerClientImpl) SetInstanceTemplate(project, region, name, instanceTemplateURL string) (*compute.Operation, error) {
+req := &compute.RegionInstanceGroupManagersSetTemplateRequest{
+InstanceTemplate: instanceTemplateURL,
+}
+return c.srv.SetInstanceTemplate(project, region, name, req).Do()
+}
+
+func (c *regionInstanceGroupManagerClientImpl) Resize(project, region, name string, newSize int64) (*compute.Operation, error) {
+return c.srv.Resize(project, region, name, newSize).Do()
+}
+
+func (c *computeClientImpl) RegionInstanceGroupManagers() RegionInstanceGroupManagerClient {
+return &regionInstanceGroupManagerClientImpl{
+srv: c.srv.RegionInstanceGroupManagers,
+}
 }

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -322,3 +322,9 @@ func addCloudInstanceData(cm *cloudinstances.CloudInstance, instance *compute.In
 		}
 	}
 }
+
+// NameForRegionInstanceGroupManager builds a name for a regional InstanceGroupManager.
+func NameForRegionInstanceGroupManager(clusterName, instanceGroupName string) string {
+	name := SafeObjectName(instanceGroupName, clusterName)
+	return name
+}

--- a/upup/pkg/fi/cloudup/gcetasks/regioninstancegroupmanager.go
+++ b/upup/pkg/fi/cloudup/gcetasks/regioninstancegroupmanager.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcetasks
+
+import (
+"fmt"
+"reflect"
+
+compute "google.golang.org/api/compute/v1"
+"k8s.io/kops/upup/pkg/fi"
+"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
+)
+
+// +kops:fitask
+type RegionInstanceGroupManager struct {
+Name      *string
+Lifecycle fi.Lifecycle
+
+Region                      *string
+BaseInstanceName            *string
+InstanceTemplate            *InstanceTemplate
+ListManagedInstancesResults string
+TargetSize                  *int64
+UpdatePolicy                *UpdatePolicy
+DistributionPolicyZones     []string
+
+TargetPools []*TargetPool
+}
+
+var _ fi.CompareWithID = (*RegionInstanceGroupManager)(nil)
+
+func (e *RegionInstanceGroupManager) CompareWithID() *string {
+return e.Name
+}
+
+func (e *RegionInstanceGroupManager) Find(c *fi.CloudupContext) (*RegionInstanceGroupManager, error) {
+cloud := c.T.Cloud.(gce.GCECloud)
+
+r, err := cloud.Compute().RegionInstanceGroupManagers().Get(cloud.Project(), *e.Region, *e.Name)
+if err != nil {
+if gce.IsNotFound(err) {
+return nil, nil
+}
+return nil, fmt.Errorf("error getting RegionInstanceGroupManager: %v", err)
+}
+
+actual := &RegionInstanceGroupManager{}
+actual.Name = &r.Name
+actual.Region = fi.PtrTo(lastComponent(r.Region))
+actual.BaseInstanceName = &r.BaseInstanceName
+actual.TargetSize = e.TargetSize
+actual.InstanceTemplate = &InstanceTemplate{ID: fi.PtrTo(lastComponent(r.InstanceTemplate))}
+actual.ListManagedInstancesResults = r.ListManagedInstancesResults
+
+if policy := r.UpdatePolicy; policy != nil {
+actual.UpdatePolicy = &UpdatePolicy{MinimalAction: policy.MinimalAction, Type: policy.Type}
+}
+
+if r.DistributionPolicy != nil {
+for _, zone := range r.DistributionPolicy.Zones {
+actual.DistributionPolicyZones = append(actual.DistributionPolicyZones, lastComponent(zone.Zone))
+}
+}
+
+for _, targetPool := range r.TargetPools {
+actual.TargetPools = append(actual.TargetPools, &TargetPool{
+Name: fi.PtrTo(lastComponent(targetPool)),
+})
+}
+
+// Ignore "system" fields
+actual.Lifecycle = e.Lifecycle
+
+return actual, nil
+}
+
+func (e *RegionInstanceGroupManager) Run(c *fi.CloudupContext) error {
+return fi.CloudupDefaultDeltaRunMethod(e, c)
+}
+
+func (_ *RegionInstanceGroupManager) CheckChanges(a, e, changes *RegionInstanceGroupManager) error {
+return nil
+}
+
+func (_ *RegionInstanceGroupManager) RenderGCE(t *gce.GCEAPITarget, a, e, changes *RegionInstanceGroupManager) error {
+project := t.Cloud.Project()
+
+instanceTemplateURL, err := e.InstanceTemplate.URL(project)
+if err != nil {
+return err
+}
+
+i := &compute.InstanceGroupManager{
+Name:                        *e.Name,
+Region:                      *e.Region,
+BaseInstanceName:            *e.BaseInstanceName,
+TargetSize:                  *e.TargetSize,
+InstanceTemplate:            instanceTemplateURL,
+ListManagedInstancesResults: e.ListManagedInstancesResults,
+}
+
+if len(e.DistributionPolicyZones) > 0 {
+dp := &compute.DistributionPolicy{}
+for _, zone := range e.DistributionPolicyZones {
+dp.Zones = append(dp.Zones, &compute.DistributionPolicyZoneConfiguration{
+Zone: fmt.Sprintf("zones/%s", zone),
+})
+}
+i.DistributionPolicy = dp
+}
+
+if policy := e.UpdatePolicy; policy != nil {
+i.UpdatePolicy = &compute.InstanceGroupManagerUpdatePolicy{
+MinimalAction: policy.MinimalAction,
+Type:          policy.Type,
+}
+}
+
+for _, targetPool := range e.TargetPools {
+i.TargetPools = append(i.TargetPools, targetPool.URL(t.Cloud))
+}
+
+if a == nil {
+op, err := t.Cloud.Compute().RegionInstanceGroupManagers().Insert(project, *e.Region, i)
+if err != nil {
+return fmt.Errorf("error creating RegionInstanceGroupManager: %v", err)
+}
+if err := t.Cloud.WaitForOp(op); err != nil {
+return fmt.Errorf("error creating RegionInstanceGroupManager: %v", err)
+}
+} else {
+if changes.TargetPools != nil {
+op, err := t.Cloud.Compute().RegionInstanceGroupManagers().SetTargetPools(project, *e.Region, i.Name, i.TargetPools)
+if err != nil {
+return fmt.Errorf("error updating TargetPools for RegionInstanceGroupManager: %v", err)
+}
+if err := t.Cloud.WaitForOp(op); err != nil {
+return fmt.Errorf("error updating TargetPools for RegionInstanceGroupManager: %v", err)
+}
+changes.TargetPools = nil
+}
+
+if changes.InstanceTemplate != nil {
+op, err := t.Cloud.Compute().RegionInstanceGroupManagers().SetInstanceTemplate(project, *e.Region, i.Name, instanceTemplateURL)
+if err != nil {
+return fmt.Errorf("error updating InstanceTemplate for RegionInstanceGroupManager: %v", err)
+}
+if err := t.Cloud.WaitForOp(op); err != nil {
+return fmt.Errorf("error updating InstanceTemplate for RegionInstanceGroupManager: %v", err)
+}
+changes.InstanceTemplate = nil
+}
+
+if changes.TargetSize != nil {
+newSize := int64(0)
+if i.TargetSize != 0 {
+newSize = int64(i.TargetSize)
+}
+op, err := t.Cloud.Compute().RegionInstanceGroupManagers().Resize(project, *e.Region, i.Name, newSize)
+if err != nil {
+return fmt.Errorf("error resizing RegionInstanceGroupManager: %v", err)
+}
+if err := t.Cloud.WaitForOp(op); err != nil {
+return fmt.Errorf("error resizing RegionInstanceGroupManager: %v", err)
+}
+changes.TargetSize = nil
+}
+
+empty := &RegionInstanceGroupManager{}
+if !reflect.DeepEqual(empty, changes) {
+return fmt.Errorf("cannot apply changes to RegionInstanceGroupManager: %v", changes)
+}
+}
+
+return nil
+}
+
+type terraformRegionInstanceGroupManager struct {
+Lifecycle                   *terraform.Lifecycle       `cty:"lifecycle"`
+Name                        *string                    `cty:"name"`
+Region                      *string                    `cty:"region"`
+BaseInstanceName            *string                    `cty:"base_instance_name"`
+ListManagedInstancesResults string                     `cty:"list_managed_instances_results"`
+Version                     *terraformVersion          `cty:"version"`
+TargetSize                  *int64                     `cty:"target_size"`
+UpdatePolicy                *terraformUpdatePolicy     `cty:"update_policy"`
+TargetPools                 []*terraformWriter.Literal `cty:"target_pools"`
+DistributionPolicyZones     []string                   `cty:"distribution_policy_zones"`
+}
+
+func (_ *RegionInstanceGroupManager) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *RegionInstanceGroupManager) error {
+tf := &terraformRegionInstanceGroupManager{
+Name:                        e.Name,
+Region:                      e.Region,
+BaseInstanceName:            e.BaseInstanceName,
+TargetSize:                  e.TargetSize,
+ListManagedInstancesResults: e.ListManagedInstancesResults,
+DistributionPolicyZones:     e.DistributionPolicyZones,
+}
+tf.Lifecycle = &terraform.Lifecycle{
+IgnoreChanges: []*terraformWriter.Literal{{String: "target_size"}},
+}
+if policy := e.UpdatePolicy; policy != nil {
+tf.UpdatePolicy = &terraformUpdatePolicy{
+MinimalAction: policy.MinimalAction,
+Type:          policy.Type,
+}
+}
+tf.Version = &terraformVersion{
+InstanceTemplate: e.InstanceTemplate.TerraformLink(),
+}
+
+for _, targetPool := range e.TargetPools {
+tf.TargetPools = append(tf.TargetPools, targetPool.TerraformLink())
+}
+
+return t.RenderResource("google_compute_region_instance_group_manager", *e.Name, tf)
+}


### PR DESCRIPTION
> **Note:** This PR was developed with AI assistance during code exploration and drafting. I reviewed the code, ran builds and tests locally, and take responsibility for the implementation. Currently being revised based on maintainer feedback ,,,,moved to draft pending design direction.

Fixes #18411

## tl;dr

There's been a TODO in `AutoscalingGroupModelBuilder` since 2017 about switching to Regional MIGs instead of splitting one InstanceGroup into separate per-zone zonal MIGs. The two blockers (no Terraform support, no zone steering) are both resolved now, so this PR does the thing.

## what's in here

- New `RegionInstanceGroupManager` task — handles GCE API calls + renders as `google_compute_region_instance_group_manager` in Terraform with `distribution_policy_zones`
- New `RegionInstanceGroupManagerClient` in the compute client layer + mock for tests
- `Build()` refactored — when `GCERegionalMIG` feature flag is on, creates one regional MIG spanning all zones instead of N zonal MIGs
- Feature flag defaults to **off** so nothing changes for existing clusters

## not breaking anything

Whole thing is behind `KOPS_FEATURE_FLAGS=GCERegionalMIG`. Flag off = old behavior, zero migration needed.

## still todo

- Unit test for the regional path with flag enabled
- Would love maintainer input on the backwards compat approach before moving out of draft
