### PR TITLE
tests/e2e/scalability: add CONTROL_PLANE_LB_TYPE env variable

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -129,6 +129,9 @@ fi
 create_args+=("--node-count=${KUBE_NODE_COUNT:-100}")
 create_args+=("--control-plane-count=${CONTROL_PLANE_COUNT:-1}")
 create_args+=("--control-plane-size=${CONTROL_PLANE_SIZE:-c5.2xlarge}")
+if [[ -n "${CONTROL_PLANE_LB_TYPE:-}" ]]; then
+  create_args+=("--api-loadbalancer-type=${CONTROL_PLANE_LB_TYPE}")
+fi
 
 # Enable HTTP for events etcd to reduce TLS overhead in scale tests
 KOPS_FEATURE_FLAGS="EtcdEventsHTTP,${KOPS_FEATURE_FLAGS:-}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Appends `--api-loadbalancer-type` to the scalability test's create args when `CONTROL_PLANE_LB_TYPE` is set; unset leaves existing jobs unchanged.

We need this to run master in HA for scalability tests.

Saw it being used in other kops tests: https://github.com/kubernetes/test-infra/blob/441abe18f71bee7c03ae2286f0fc8ba2822b7267/config/jobs/kubernetes/kops/kops-presubmits-gossip.yaml#L344C23-L344C120