### PR TITLE
dump: add --node-dump-timeout flag for per-node dump timeout

### DIFF
--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
@@ -62,11 +63,12 @@ type ToolboxDumpOptions struct {
 
 	ClusterName string
 
-	Dir          string
-	PrivateKey   string
-	SSHUser      string
-	MaxNodes     int
-	K8sResources bool
+	Dir             string
+	PrivateKey      string
+	SSHUser         string
+	MaxNodes        int
+	NodeDumpTimeout time.Duration
+	K8sResources    bool
 
 	// CloudResources controls whether we dump the cloud resources
 	CloudResources bool
@@ -77,6 +79,7 @@ func (o *ToolboxDumpOptions) InitDefaults() {
 	o.PrivateKey = "~/.ssh/id_rsa"
 	o.SSHUser = "ubuntu"
 	o.MaxNodes = 500
+	o.NodeDumpTimeout = time.Minute
 	o.K8sResources = k8sResources != ""
 	o.CloudResources = true
 }
@@ -107,6 +110,7 @@ func NewCmdToolboxDump(f commandutils.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.K8sResources, "k8s-resources", options.K8sResources, "Include k8s resources in the dump")
 	cmd.Flags().BoolVar(&options.CloudResources, "cloud-resources", options.CloudResources, "Include cloud resources in the dump")
 	cmd.Flags().IntVar(&options.MaxNodes, "max-nodes", options.MaxNodes, "The maximum number of nodes from which to dump logs")
+	cmd.Flags().DurationVar(&options.NodeDumpTimeout, "node-dump-timeout", options.NodeDumpTimeout, "Timeout for connecting to and dumping logs from a single node")
 	cmd.Flags().StringVar(&options.PrivateKey, "private-key", options.PrivateKey, "File containing private key to use for SSH access to instances")
 	cmd.Flags().StringVar(&options.SSHUser, "ssh-user", options.SSHUser, "The remote user for SSH access to instances")
 	cmd.RegisterFlagCompletionFunc("ssh-user", cobra.NoFileCompletions)
@@ -241,7 +245,7 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 			}
 		}
 
-		dumper := dump.NewLogDumper(bastionAddress, sshConfig, keyRing, options.Dir)
+		dumper := dump.NewLogDumper(bastionAddress, sshConfig, keyRing, options.Dir, options.NodeDumpTimeout)
 
 		if err := dumper.DumpAllNodes(ctx, nodes, options.MaxNodes, cloudResources); err != nil {
 			klog.Warningf("error dumping nodes: %v", err)

--- a/docs/cli/kops_toolbox_dump.md
+++ b/docs/cli/kops_toolbox_dump.md
@@ -23,14 +23,15 @@ kops toolbox dump [CLUSTER] [flags]
 ### Options
 
 ```
-      --cloud-resources      Include cloud resources in the dump (default true)
-      --dir string           Target directory; if specified will collect logs and other information.
-  -h, --help                 help for dump
-      --k8s-resources        Include k8s resources in the dump
-      --max-nodes int        The maximum number of nodes from which to dump logs (default 500)
-  -o, --output string        Output format.  One of json or yaml (default "yaml")
-      --private-key string   File containing private key to use for SSH access to instances (default "~/.ssh/id_rsa")
-      --ssh-user string      The remote user for SSH access to instances (default "ubuntu")
+      --cloud-resources              Include cloud resources in the dump (default true)
+      --dir string                   Target directory; if specified will collect logs and other information.
+  -h, --help                         help for dump
+      --k8s-resources                Include k8s resources in the dump
+      --max-nodes int                The maximum number of nodes from which to dump logs (default 500)
+      --node-dump-timeout duration   Timeout for connecting to and dumping logs from a single node (default 1m0s)
+  -o, --output string                Output format.  One of json or yaml (default "yaml")
+      --private-key string           File containing private key to use for SSH access to instances (default "~/.ssh/id_rsa")
+      --ssh-user string              The remote user for SSH access to instances (default "ubuntu")
 ```
 
 ### Options inherited from parent commands

--- a/pkg/dump/dumper.go
+++ b/pkg/dump/dumper.go
@@ -40,13 +40,16 @@ type logDumper struct {
 
 	artifactsDir string
 
+	// nodeDumpTimeout bounds the time spent connecting to and dumping a single node.
+	nodeDumpTimeout time.Duration
+
 	services     []string
 	files        []string
 	podSelectors []string
 }
 
 // NewLogDumper is the constructor for a logDumper
-func NewLogDumper(bastionAddress string, sshConfig *ssh.ClientConfig, keyRing agent.Agent, artifactsDir string) *logDumper {
+func NewLogDumper(bastionAddress string, sshConfig *ssh.ClientConfig, keyRing agent.Agent, artifactsDir string, nodeDumpTimeout time.Duration) *logDumper {
 	sshClientFactory := &sshClientFactoryImplementation{
 		keyRing:   keyRing,
 		sshConfig: sshConfig,
@@ -56,9 +59,14 @@ func NewLogDumper(bastionAddress string, sshConfig *ssh.ClientConfig, keyRing ag
 		sshClientFactory.bastion = bastionAddress
 	}
 
+	if nodeDumpTimeout <= 0 {
+		nodeDumpTimeout = defaultNodeDumpTimeout
+	}
+
 	d := &logDumper{
 		sshClientFactory: sshClientFactory,
 		artifactsDir:     artifactsDir,
+		nodeDumpTimeout:  nodeDumpTimeout,
 	}
 
 	d.services = []string{
@@ -245,10 +253,13 @@ func (d *logDumper) dumpNotRegistered(ctx context.Context, node *resources.Insta
 	return "", fmt.Errorf("no known addresses for node %s", node.Name)
 }
 
-// nodeDumpTimeout bounds the time spent connecting to and dumping a single node.
+// defaultNodeDumpTimeout bounds the time spent connecting to and dumping a single node.
 // A healthy node dumps in well under a minute. Without this cap, an SSH operation
 // against an unreachable node blocks until the OS TCP timeout (~15 min) expires.
-const nodeDumpTimeout = time.Minute
+// Large clusters dump multi-GB logs per node and need a higher value, configurable
+// via the --node-dump-timeout flag, because the files are dumped sequentially and a
+// single oversized log can otherwise exhaust the budget before the rest are read.
+const defaultNodeDumpTimeout = time.Minute
 
 // DumpNode connects to a node and dumps the logs.
 func (d *logDumper) dumpNode(ctx context.Context, name string, ip string, useBastion bool) error {
@@ -258,7 +269,7 @@ func (d *logDumper) dumpNode(ctx context.Context, name string, ip string, useBas
 
 	klog.Infof("Dumping node %s", name)
 
-	ctx, cancel := context.WithTimeout(ctx, nodeDumpTimeout)
+	ctx, cancel := context.WithTimeout(ctx, d.nodeDumpTimeout)
 	defer cancel()
 
 	n, err := d.connectToNode(ctx, name, ip, useBastion)

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -70,6 +70,7 @@ type deployer struct {
 	ValidationCount    int           `flag:"validation-count" desc:"how many times should a validation pass"`
 	ValidationInterval time.Duration `flag:"validation-interval" desc:"time in duration to wait between validation attempts"`
 	MaxNodesToDump     string        `flag:"max-nodes-to-dump" desc:"max number of nodes to dump logs from, helpful to set when running scale tests"`
+	NodeDumpTimeout    time.Duration `flag:"node-dump-timeout" desc:"timeout for connecting to and dumping logs from a single node, helpful to raise when running scale tests"`
 
 	TemplatePath string `flag:"template-path" desc:"The path to the manifest template used for cluster creation"`
 

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -47,6 +47,9 @@ func (d *deployer) DumpClusterLogs() error {
 	if d.MaxNodesToDump != "" {
 		args = append(args, "--max-nodes", d.MaxNodesToDump)
 	}
+	if d.NodeDumpTimeout > 0 {
+		args = append(args, "--node-dump-timeout", d.NodeDumpTimeout.String())
+	}
 	klog.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(append(d.env(), "KOPS_TOOLBOX_DUMP_K8S_RESOURCES=1")...)


### PR DESCRIPTION
Make the per-node log dump timeout configurable with a new --node-dump-timeout flag (default unchanged at 1m) so scale tests can raise it

Fixes #18442