### PR TITLE
chore: downgrade containerd to v2.2.4

### DIFF
--- a/docs/releases/1.36-NOTES.md
+++ b/docs/releases/1.36-NOTES.md
@@ -4,7 +4,7 @@
 
 This is a document to gather the release notes prior to the release.
 
-kOps 1.36 adds Kubernetes 1.36 support, completes the move away from the in-tree cloud providers, refreshes the bundled components (containerd v2.3, etcd-manager, AWS Load Balancer Controller, EBS CSI driver, Cilium options, CoreDNS, etc.), reworks how the `kops-channels` addon manager is built and deployed, introduces a hybrid bootstrap path for gossip clusters, expands Azure and Hetzner support, and lays the groundwork for Linode (Akamai) as a new cloud provider.
+kOps 1.36 adds Kubernetes 1.36 support, completes the move away from the in-tree cloud providers, refreshes the bundled components (containerd v2.2, etcd-manager, AWS Load Balancer Controller, EBS CSI driver, Cilium options, CoreDNS, etc.), reworks how the `kops-channels` addon manager is built and deployed, introduces a hybrid bootstrap path for gossip clusters, expands Azure and Hetzner support, and lays the groundwork for Linode (Akamai) as a new cloud provider.
 
 # Significant changes
 
@@ -20,7 +20,7 @@ kOps 1.36 adds Kubernetes 1.36 support, completes the move away from the in-tree
 * Remove the unused in-tree cloud config plumbing ([#18347](https://github.com/kubernetes/kops/pull/18347))
 
 ## Container Runtime
-* Default containerd to v2.3.0 (with runc 1.4.2) for Kubernetes 1.36+; v2.2.3 remains the default for 1.32–1.35, and v1.7.31 for older clusters ([#18364](https://github.com/kubernetes/kops/pull/18364))
+* Default containerd to v2.2.4 (with runc 1.3.5) for Kubernetes 1.32+, and v1.7.32 for older clusters ([#18364](https://github.com/kubernetes/kops/pull/18364))
 * Support containerd config TOML v3, with clearer config-file version behavior and dead-code cleanup from 1.6 ([#18291](https://github.com/kubernetes/kops/pull/18291)). Users who set `spec.containerd.configAdditions` on a cluster or instance group must update those entries to match the TOML v3 schema before upgrading.
 * Map the containerd registry mirror wildcard to the `_default` directory ([#18291](https://github.com/kubernetes/kops/pull/18291))
 * Stream verified container image bytes directly into `ctr import` from nodeup and drop the containerized-mounter Archive task ([#18278](https://github.com/kubernetes/kops/pull/18278), [#18277](https://github.com/kubernetes/kops/pull/18277))

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -51,15 +51,12 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 			containerd.Runc = &kops.Runc{
 				Version: fi.PtrTo("1.3.5"),
 			}
-		case b.IsKubernetesLT("1.36"):
+		default:
+			// Stay on containerd 2.2.x rather than 2.3.x to avoid a sandbox-image
+			// regression in 2.3 (https://github.com/containerd/containerd/issues/13529).
 			containerd.Version = fi.PtrTo("2.2.4")
 			containerd.Runc = &kops.Runc{
 				Version: fi.PtrTo("1.3.5"),
-			}
-		default:
-			containerd.Version = fi.PtrTo("2.3.1")
-			containerd.Runc = &kops.Runc{
-				Version: fi.PtrTo("1.4.2"),
 			}
 		}
 	}

--- a/tests/integration/update_cluster/gossip-aws/data/aws_launch_template_master-us-test-1a.masters.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_launch_template_master-us-test-1a.masters.gossip.k8s.local_user_data
@@ -126,7 +126,7 @@ ClusterName: gossip.k8s.local
 ConfigBase: memfs://tests/gossip.k8s.local
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 1pm6BY+ab63mQSW1/ZfgYGfsRDIbvCccuDYqsEg08XA=
+NodeupConfigHash: VbjEp+Axj82oms4GyHO1IGs/59j+pfNTVn36MeUsKdc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-aws/data/aws_launch_template_nodes.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_launch_template_nodes.gossip.k8s.local_user_data
@@ -149,7 +149,7 @@ ConfigServer:
   - https://kops-controller.internal.gossip.k8s.local:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: tGolsQcYa7KvneHf+KnOHWd9/Ke0kjnjH25hscbOwms=
+NodeupConfigHash: Jw3JarWmyueHHS7VHTP4RAZNaiaf24s1upXmQ49rC1Q=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_cluster-completed.spec_content
@@ -29,9 +29,9 @@ spec:
   containerd:
     logLevel: info
     runc:
-      version: 1.4.2
+      version: 1.3.5
     sandboxImage: registry.k8s.io/pause:3.10.1
-    version: 2.3.1
+    version: 2.2.4
   etcdClusters:
   - backups:
       backupStore: memfs://tests/gossip.k8s.local/backups/etcd/main

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -59,16 +59,16 @@ Assets:
   - 123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubectl
   - 7644623e4ec9ad443ab352a8a5800a5180ee28741288be805286ba72bb8e7164@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/amd64/ecr-credential-provider-linux-amd64
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 628448bd973610c656c1cbea8e88b32fafd85b23cc1aa4a3372eb7198478c054@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-amd64.tar.gz
-  - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
   - 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - 46a83603a850f3916ca7c942310daaf82ed17773a85b1d431e92d4a541e46d0d@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-arm64.tar.gz
-  - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
@@ -302,9 +302,9 @@ configStore:
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.4.2
+    version: 1.3.5
   sandboxImage: registry.k8s.io/pause:3.10.1
-  version: 2.3.1
+  version: 2.2.4
 etcdManifests:
 - memfs://tests/gossip.k8s.local/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://tests/gossip.k8s.local/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_nodeupconfig-nodes_content
@@ -4,16 +4,16 @@ Assets:
   - 123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubectl
   - 7644623e4ec9ad443ab352a8a5800a5180ee28741288be805286ba72bb8e7164@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/amd64/ecr-credential-provider-linux-amd64
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 628448bd973610c656c1cbea8e88b32fafd85b23cc1aa4a3372eb7198478c054@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-amd64.tar.gz
-  - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
   - 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - 46a83603a850f3916ca7c942310daaf82ed17773a85b1d431e92d4a541e46d0d@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-arm64.tar.gz
-  - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
 CAs: {}
 ClusterName: gossip.k8s.local
@@ -53,8 +53,8 @@ UpdatePolicy: automatic
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.4.2
+    version: 1.3.5
   sandboxImage: registry.k8s.io/pause:3.10.1
-  version: 2.3.1
+  version: 2.2.4
 usesLegacyGossip: true
 usesNoneDNS: false

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_control-plane-eastus-1.masters.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_control-plane-eastus-1.masters.gossip.k8s.local_user_data
@@ -125,7 +125,7 @@ ClusterName: gossip.k8s.local
 ConfigBase: memfs://tests/gossip.k8s.local
 InstanceGroupName: control-plane-eastus-1
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: GVPe15FsTb0G6rulm6qR7OITa3vQg/34YWSWSPALFLQ=
+NodeupConfigHash: z1OZw05UQ+XjMqrk5kgIzAVSA0zyeF1IenEdJn2uxJw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_nodes-eastus-1.gossip.k8s.local_user_data
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_linux_virtual_machine_scale_set_nodes-eastus-1.gossip.k8s.local_user_data
@@ -148,7 +148,7 @@ ConfigServer:
   - https://kops-controller.internal.gossip.k8s.local:3988/
 InstanceGroupName: nodes-eastus-1
 InstanceGroupRole: Node
-NodeupConfigHash: teimdkCoryzf7FnmfP/s5jTiJQsROFiivBSlMNO0Yfc=
+NodeupConfigHash: NoKZKNORV22wdh/hvAlBVpt0DLx2FvhzqPzqabtFznM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_cluster-completed.spec_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_cluster-completed.spec_source
@@ -30,9 +30,9 @@ spec:
   containerd:
     logLevel: info
     runc:
-      version: 1.4.2
+      version: 1.3.5
     sandboxImage: registry.k8s.io/pause:3.10.1
-    version: 2.3.1
+    version: 2.2.4
   etcdClusters:
   - backups:
       backupStore: memfs://tests/gossip.k8s.local/backups/etcd/main

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source
@@ -58,15 +58,15 @@ Assets:
   - d857082946c28493e8fdc52227feabd962e0e0900b6c6e4f6510168043b79dd4@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubelet
   - 123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubectl
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 628448bd973610c656c1cbea8e88b32fafd85b23cc1aa4a3372eb7198478c054@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-amd64.tar.gz
-  - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - 46a83603a850f3916ca7c942310daaf82ed17773a85b1d431e92d4a541e46d0d@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-arm64.tar.gz
-  - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
 AzureAdminUser: kops
 CAs:
@@ -301,9 +301,9 @@ configStore:
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.4.2
+    version: 1.3.5
   sandboxImage: registry.k8s.io/pause:3.10.1
-  version: 2.3.1
+  version: 2.2.4
 etcdManifests:
 - memfs://tests/gossip.k8s.local/manifests/etcd/main-control-plane-eastus-1.yaml
 - memfs://tests/gossip.k8s.local/manifests/etcd/events-control-plane-eastus-1.yaml

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-nodes-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_nodeupconfig-nodes-eastus-1_source
@@ -3,15 +3,15 @@ Assets:
   - d857082946c28493e8fdc52227feabd962e0e0900b6c6e4f6510168043b79dd4@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubelet
   - 123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubectl
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 628448bd973610c656c1cbea8e88b32fafd85b23cc1aa4a3372eb7198478c054@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-amd64.tar.gz
-  - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - 46a83603a850f3916ca7c942310daaf82ed17773a85b1d431e92d4a541e46d0d@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-arm64.tar.gz
-  - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
 AzureAdminUser: kops
 CAs: {}
@@ -52,8 +52,8 @@ UpdatePolicy: automatic
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.4.2
+    version: 1.3.5
   sandboxImage: registry.k8s.io/pause:3.10.1
-  version: 2.3.1
+  version: 2.2.4
 usesLegacyGossip: true
 usesNoneDNS: false

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -34,9 +34,9 @@ spec:
   containerd:
     logLevel: info
     runc:
-      version: 1.4.2
+      version: 1.3.5
     sandboxImage: registry.k8s.io/pause:3.10.1
-    version: 2.3.1
+    version: 2.2.4
   etcdClusters:
   - backups:
       backupStore: memfs://tests/gossip.k8s.local/backups/etcd/main

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -59,16 +59,16 @@ Assets:
   - 123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubectl
   - b5852509ab5c950485794afd49a3fd1c3d6166db988c15b683d2373b7055300f@https://artifacts.k8s.io/binaries/cloud-provider-gcp/v35.0.0/auth-provider-gcp/linux/amd64/auth-provider-gcp
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 628448bd973610c656c1cbea8e88b32fafd85b23cc1aa4a3372eb7198478c054@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-amd64.tar.gz
-  - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
   - 510aee27ef32a27b76e461e9084719365210d56166057b37db290a72dfecbffa@https://artifacts.k8s.io/binaries/cloud-provider-gcp/v35.0.0/auth-provider-gcp/linux/arm64/auth-provider-gcp
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - 46a83603a850f3916ca7c942310daaf82ed17773a85b1d431e92d4a541e46d0d@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-arm64.tar.gz
-  - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
@@ -303,9 +303,9 @@ configStore:
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.4.2
+    version: 1.3.5
   sandboxImage: registry.k8s.io/pause:3.10.1
-  version: 2.3.1
+  version: 2.2.4
 etcdManifests:
 - memfs://tests/gossip.k8s.local/manifests/etcd/main-master-us-test1-a.yaml
 - memfs://tests/gossip.k8s.local/manifests/etcd/events-master-us-test1-a.yaml

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_nodeupconfig-nodes_content
@@ -4,16 +4,16 @@ Assets:
   - 123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubectl
   - b5852509ab5c950485794afd49a3fd1c3d6166db988c15b683d2373b7055300f@https://artifacts.k8s.io/binaries/cloud-provider-gcp/v35.0.0/auth-provider-gcp/linux/amd64/auth-provider-gcp
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 628448bd973610c656c1cbea8e88b32fafd85b23cc1aa4a3372eb7198478c054@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-amd64.tar.gz
-  - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
   - 510aee27ef32a27b76e461e9084719365210d56166057b37db290a72dfecbffa@https://artifacts.k8s.io/binaries/cloud-provider-gcp/v35.0.0/auth-provider-gcp/linux/arm64/auth-provider-gcp
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - 46a83603a850f3916ca7c942310daaf82ed17773a85b1d431e92d4a541e46d0d@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-arm64.tar.gz
-  - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
 CAs: {}
 ClusterName: gossip.k8s.local
@@ -54,9 +54,9 @@ UpdatePolicy: automatic
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.4.2
+    version: 1.3.5
   sandboxImage: registry.k8s.io/pause:3.10.1
-  version: 2.3.1
+  version: 2.2.4
 multizone: true
 nodeTags: gossip-k8s-local-k8s-io-role-node
 usesLegacyGossip: true

--- a/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_master-us-test1-a-gossip-k8s-local_metadata_user-data
+++ b/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_master-us-test1-a-gossip-k8s-local_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: gossip.k8s.local
 ConfigBase: memfs://tests/gossip.k8s.local
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: EubhQVNMS1YP+fBAYKPhsV/gJ1LFGc1SDruu7jvJHoQ=
+NodeupConfigHash: PaBAJ8ur9LyTwfP/HuTcCRraGWW03Er9J808tQ3j2lQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_nodes-gossip-k8s-local_metadata_user-data
+++ b/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_nodes-gossip-k8s-local_metadata_user-data
@@ -148,7 +148,7 @@ ConfigServer:
   - https://kops-controller.internal.gossip.k8s.local:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 6dedVNJEvl4rl1rjlVJ8ai1EB4ZQYj5+4mIOiW/qr4Y=
+NodeupConfigHash: kwSYMDtnpjC4Xz9G2XZNWNvmhWRVGrn8S4Npf9X2OK4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -27,9 +27,9 @@ spec:
   containerd:
     logLevel: info
     runc:
-      version: 1.4.2
+      version: 1.3.5
     sandboxImage: registry.k8s.io/pause:3.10.1
-    version: 2.3.1
+    version: 2.2.4
   etcdClusters:
   - backups:
       backupStore: memfs://tests/gossip.k8s.local/backups/etcd/main

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
@@ -58,15 +58,15 @@ Assets:
   - d857082946c28493e8fdc52227feabd962e0e0900b6c6e4f6510168043b79dd4@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubelet
   - 123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubectl
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 628448bd973610c656c1cbea8e88b32fafd85b23cc1aa4a3372eb7198478c054@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-amd64.tar.gz
-  - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - 46a83603a850f3916ca7c942310daaf82ed17773a85b1d431e92d4a541e46d0d@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-arm64.tar.gz
-  - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
@@ -300,9 +300,9 @@ configStore:
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.4.2
+    version: 1.3.5
   sandboxImage: registry.k8s.io/pause:3.10.1
-  version: 2.3.1
+  version: 2.2.4
 etcdManifests:
 - memfs://tests/gossip.k8s.local/manifests/etcd/main-master-fsn1.yaml
 - memfs://tests/gossip.k8s.local/manifests/etcd/events-master-fsn1.yaml

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_nodeupconfig-nodes-fsn1_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_nodeupconfig-nodes-fsn1_content
@@ -3,15 +3,15 @@ Assets:
   - d857082946c28493e8fdc52227feabd962e0e0900b6c6e4f6510168043b79dd4@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubelet
   - 123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e@https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubectl
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 628448bd973610c656c1cbea8e88b32fafd85b23cc1aa4a3372eb7198478c054@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-amd64.tar.gz
-  - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
   arm64:
   - 049d95107361583e64f3ac9b8c9bdaf73fc7e512a838972b13b423a33ece87e9@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubelet
   - 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f@https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - 46a83603a850f3916ca7c942310daaf82ed17773a85b1d431e92d4a541e46d0d@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-arm64.tar.gz
-  - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
 CAs: {}
 ClusterName: gossip.k8s.local
@@ -51,8 +51,8 @@ UpdatePolicy: automatic
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.4.2
+    version: 1.3.5
   sandboxImage: registry.k8s.io/pause:3.10.1
-  version: 2.3.1
+  version: 2.2.4
 usesLegacyGossip: true
 usesNoneDNS: false

--- a/tests/integration/update_cluster/gossip-hetzner/data/hcloud_server_master-fsn1_user_data
+++ b/tests/integration/update_cluster/gossip-hetzner/data/hcloud_server_master-fsn1_user_data
@@ -126,7 +126,7 @@ ClusterName: gossip.k8s.local
 ConfigBase: memfs://tests/gossip.k8s.local
 InstanceGroupName: master-fsn1
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: alSe245GY4rH3OA1yhyudm5h7wdSLWq92+RhTKxlaBI=
+NodeupConfigHash: /6wkUnR6BPQngIwwJyAEs60hkGFIP5vyjBS7IaRXWBQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/gossip-hetzner/data/hcloud_server_nodes-fsn1_user_data
+++ b/tests/integration/update_cluster/gossip-hetzner/data/hcloud_server_nodes-fsn1_user_data
@@ -148,7 +148,7 @@ ConfigServer:
   - https://kops-controller.internal.gossip.k8s.local:3988/
 InstanceGroupName: nodes-fsn1
 InstanceGroupRole: Node
-NodeupConfigHash: BTNl24skqWYsfvIbW6LR89onCfTBcQntbgSXye6Px+o=
+NodeupConfigHash: lUAomlDa1RzbvX7pKmGbLYZpWpAwZ59HSQm37jb/qxk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 2e5O4nAxCZvqZMFpQ1qHRUMYSy3QdscVnM+bbC0zHB4=
+NodeupConfigHash: ORMtzgjGdxgtgDEC1APdCcAFigGUU5rHPUI4Aywl0FA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -149,7 +149,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: uyJ1VOgWrEflUFhhCXdVWERTufxBqixVVgrXSbTWcMI=
+NodeupConfigHash: myrLE8m0MSF5ccIOV/X989E0ZL9kg3rU6JSmFQ0Tfwo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_cluster-completed.spec_content
@@ -27,9 +27,9 @@ spec:
   containerd:
     logLevel: info
     runc:
-      version: 1.4.2
+      version: 1.3.5
     sandboxImage: registry.k8s.io/pause:3.10.1
-    version: 2.3.1
+    version: 2.2.4
   dnsZone: Z1AFAKE1ZON3YO
   etcdClusters:
   - backups:

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -61,16 +61,16 @@ Assets:
   - 837bb39bfdf84d6b63f2d53e1f73bc6034bc2b2393641c8d2ba69d2b3b174092@https://dl.k8s.io/release/v1.36.0-rc.1/bin/linux/amd64/kubectl
   - 7644623e4ec9ad443ab352a8a5800a5180ee28741288be805286ba72bb8e7164@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/amd64/ecr-credential-provider-linux-amd64
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 628448bd973610c656c1cbea8e88b32fafd85b23cc1aa4a3372eb7198478c054@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-amd64.tar.gz
-  - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
   arm64:
   - c7fd6b5d5af23079afb98695d9b2e2ed764c1b5581c43a994f8ca062fd154139@https://dl.k8s.io/release/v1.36.0-rc.1/bin/linux/arm64/kubelet
   - 626d71ed21b05fedd56a1dc49ebee8e7217d170d75496f7cd8ee1f0721262e59@https://dl.k8s.io/release/v1.36.0-rc.1/bin/linux/arm64/kubectl
   - 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - 46a83603a850f3916ca7c942310daaf82ed17773a85b1d431e92d4a541e46d0d@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-arm64.tar.gz
-  - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
   - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
 CAs:
   apiserver-aggregator-ca: |
@@ -306,9 +306,9 @@ configStore:
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.4.2
+    version: 1.3.5
   sandboxImage: registry.k8s.io/pause:3.10.1
-  version: 2.3.1
+  version: 2.2.4
 etcdManifests:
 - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://tests/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_nodeupconfig-nodes_content
@@ -4,15 +4,15 @@ Assets:
   - 837bb39bfdf84d6b63f2d53e1f73bc6034bc2b2393641c8d2ba69d2b3b174092@https://dl.k8s.io/release/v1.36.0-rc.1/bin/linux/amd64/kubectl
   - 7644623e4ec9ad443ab352a8a5800a5180ee28741288be805286ba72bb8e7164@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/amd64/ecr-credential-provider-linux-amd64
   - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 628448bd973610c656c1cbea8e88b32fafd85b23cc1aa4a3372eb7198478c054@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-amd64.tar.gz
-  - ac8a90f9e225bb9322189937b230cdc5478d5753f0e31e1bda98a5cf06bd9539@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.amd64
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   arm64:
   - c7fd6b5d5af23079afb98695d9b2e2ed764c1b5581c43a994f8ca062fd154139@https://dl.k8s.io/release/v1.36.0-rc.1/bin/linux/arm64/kubelet
   - 626d71ed21b05fedd56a1dc49ebee8e7217d170d75496f7cd8ee1f0721262e59@https://dl.k8s.io/release/v1.36.0-rc.1/bin/linux/arm64/kubectl
   - 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
   - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - 46a83603a850f3916ca7c942310daaf82ed17773a85b1d431e92d4a541e46d0d@https://github.com/containerd/containerd/releases/download/v2.3.1/containerd-2.3.1-linux-arm64.tar.gz
-  - ea54032310588e115633aa2f4bba8bf9500257f657e1deca88df5778775138db@https://github.com/opencontainers/runc/releases/download/v1.4.2/runc.arm64
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
 CAs: {}
 ClusterName: minimal.example.com
 Hooks:
@@ -52,8 +52,8 @@ UpdatePolicy: automatic
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.4.2
+    version: 1.3.5
   sandboxImage: registry.k8s.io/pause:3.10.1
-  version: 2.3.1
+  version: 2.2.4
 usesLegacyGossip: false
 usesNoneDNS: false


### PR DESCRIPTION
https://github.com/containerd/containerd/issues/13529 breaks kOps, and would rather not do some weird workaround.

/cc @rifelpet @ameukam 