### PR TITLE
test: avoid kubeconfig access in golden tests

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -1284,6 +1284,7 @@ func (i *integrationTest) runTest(t *testing.T, ctx context.Context, h *testutil
 
 		// We don't test it here, and it adds a dependency on kubectl
 		options.CreateKubecfg = false
+		options.IgnoreKubeletVersionSkew = true
 		options.ClusterName = i.clusterName
 		options.LifecycleOverrides = i.lifecycleOverrides
 

--- a/hack/update-expected.sh
+++ b/hack/update-expected.sh
@@ -40,5 +40,8 @@ unset SCW_ACCESS_KEY SCW_SECRET_KEY SCW_DEFAULT_PROJECT_ID SCW_PROFILE
 unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_SUBSCRIPTION_ID AZURE_TENANT_ID
 unset DIGITALOCEAN_ACCESS_TOKEN
 
+# Avoid reading a developer's default kubeconfig while regenerating golden files.
+export KUBECONFIG=/dev/null
+
 # Run the tests in "autofix mode"
 HACK_UPDATE_EXPECTED_IN_PLACE=1 go test "${PKG}" "${RUN_FILTER[@]}" -count=1


### PR DESCRIPTION
This should speed things up a little...

/cc @rifelpet @ameukam 