### PR TITLE
etcd-manager: switch to go-runner-based distroless image

### DIFF
--- a/pkg/flagbuilder/build_flags.go
+++ b/pkg/flagbuilder/build_flags.go
@@ -29,10 +29,10 @@ import (
 	"k8s.io/kops/util/pkg/reflectutils"
 )
 
-// BuildFlags returns a space separated list arguments
+// BuildFlags returns a space-separated list of arguments.
 // @deprecated: please use BuildFlagsList
 func BuildFlags(options interface{}) (string, error) {
-	flags, err := BuildFlagsList(options)
+	flags, err := buildFlagsList(options, maybeQuote)
 	if err != nil {
 		return "", err
 	}
@@ -40,8 +40,12 @@ func BuildFlags(options interface{}) (string, error) {
 	return strings.Join(flags, " "), nil
 }
 
-// BuildFlagsList reflects the options interface and extracts the flags from struct tags
+// BuildFlagsList reflects the options interface and extracts the flags from struct tags.
 func BuildFlagsList(options interface{}) ([]string, error) {
+	return buildFlagsList(options, neverQuote)
+}
+
+func buildFlagsList(options interface{}, quote func(string) string) ([]string, error) {
 	var flags []string
 
 	walker := func(path *reflectutils.FieldPath, field *reflect.StructField, val reflect.Value) error {
@@ -143,7 +147,7 @@ func BuildFlagsList(options interface{}) ([]string, error) {
 		case string:
 			vString := fmt.Sprintf("%v", v)
 			if vString != "" && vString != flagEmpty {
-				flag = fmt.Sprintf("--%s=%s", flagName, maybeQuote(vString))
+				flag = fmt.Sprintf("--%s=%s", flagName, quote(vString))
 			}
 
 		case *string:
@@ -152,10 +156,10 @@ func BuildFlagsList(options interface{}) ([]string, error) {
 				// just like the string case above.
 				vString := fmt.Sprintf("%v", *v)
 				if flagIncludeEmpty {
-					flag = fmt.Sprintf("--%s=%s", flagName, maybeQuote(vString))
+					flag = fmt.Sprintf("--%s=%s", flagName, quote(vString))
 				} else {
 					if vString != "" && vString != flagEmpty {
-						flag = fmt.Sprintf("--%s=%s", flagName, maybeQuote(vString))
+						flag = fmt.Sprintf("--%s=%s", flagName, quote(vString))
 					}
 				}
 			}
@@ -214,9 +218,16 @@ func BuildFlagsList(options interface{}) ([]string, error) {
 	return flags, nil
 }
 
+// maybeQuote quotes s when it contains a double quote, so values survive the space-separated
+// string form that a shell or systemd may parse. argv values use neverQuote instead.
 func maybeQuote(s string) string {
 	if strings.Contains(s, "\"") {
 		return fmt.Sprintf("%q", s)
 	}
+	return s
+}
+
+// neverQuote returns s unchanged, for values used directly as exec argv.
+func neverQuote(s string) string {
 	return s
 }

--- a/pkg/flagbuilder/buildflags_test.go
+++ b/pkg/flagbuilder/buildflags_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package flagbuilder
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -209,6 +210,44 @@ func TestBuildAPIServerFlags(t *testing.T) {
 		if actual != test.Expected {
 			t.Errorf("unexpected flags.  actual=%q expected=%q", actual, test.Expected)
 			continue
+		}
+	}
+}
+
+// TestBuildFlagsQuoting checks that the quote function is applied: neverQuote leaves argv values
+// verbatim while maybeQuote quotes those containing a double quote. Regression for etcd-manager's
+// --static-config JSON, executes directly via go-runner with no shell to strip quotes.
+func TestBuildFlagsQuoting(t *testing.T) {
+	options := &struct {
+		StaticConfig string `flag:"static-config"`
+	}{
+		StaticConfig: `{"etcdVersion":"3.6.12"}`,
+	}
+
+	grid := []struct {
+		Quote    func(string) string
+		Expected string
+	}{
+		{
+			Quote:    neverQuote,
+			Expected: `--static-config={"etcdVersion":"3.6.12"}`,
+		},
+		{
+			Quote:    maybeQuote,
+			Expected: `--static-config="{\"etcdVersion\":\"3.6.12\"}"`,
+		},
+	}
+
+	for _, test := range grid {
+		flags, err := buildFlagsList(options, test.Quote)
+		if err != nil {
+			t.Errorf("error from buildFlagsList: %v", err)
+			continue
+		}
+
+		actual := strings.Join(flags, " ")
+		if actual != test.Expected {
+			t.Errorf("unexpected flags.  actual=%q expected=%q", actual, test.Expected)
 		}
 	}
 }

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -45,7 +45,6 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/scaleway"
 	"k8s.io/kops/upup/pkg/fi/fitasks"
 	"k8s.io/kops/util/pkg/env"
-	"k8s.io/kops/util/pkg/exec"
 	"k8s.io/kops/util/pkg/vfs"
 )
 
@@ -210,7 +209,7 @@ metadata:
 spec:
   containers:
   - name: etcd-manager
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     resources:
       requests:
         cpu: 100m
@@ -637,7 +636,13 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 	}
 
 	{
-		container.Command = exec.WithTee("/ko-app/etcd-manager", args, "/var/log/etcd.log")
+		container.Command = []string{"/go-runner"}
+		container.Args = []string{
+			"--log-file=/var/log/etcd.log",
+			"--also-stdout",
+			"/ko-app/etcd-manager",
+		}
+		container.Args = append(container.Args, args...)
 
 		cpuRequest := resource.MustParse("200m")
 		if etcdCluster.CPURequest != nil {

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -74,21 +74,31 @@ Contents: |
     namespace: kube-system
   spec:
     containers:
-    - command:
-      - /bin/sh
-      - -c
-      - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-        --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-        --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-        --discovery-poll-interval=1m15s --dns-suffix=.internal.minimal.example.com --grpc-port=3997
-        --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-        --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-        --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-        > /tmp/pipe 2>&1
+    - args:
+      - --log-file=/var/log/etcd.log
+      - --also-stdout
+      - /ko-app/etcd-manager
+      - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+      - --client-urls=https://__name__:4002
+      - --cluster-name=etcd-events
+      - --containerized=true
+      - --discovery-poll-interval=1m15s
+      - --dns-suffix=.internal.minimal.example.com
+      - --grpc-port=3997
+      - --peer-urls=https://__name__:2381
+      - --quarantine-client-urls=https://__name__:3995
+      - --v=6
+      - --volume-name-tag=k8s.io/etcd/events
+      - --volume-provider=aws
+      - --volume-tag=k8s.io/etcd/events
+      - --volume-tag=k8s.io/role/control-plane=1
+      - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      command:
+      - /go-runner
       env:
       - name: AWS_REGION
         value: us-test-1
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
       name: etcd-manager
       resources:
         requests:
@@ -252,21 +262,32 @@ Contents: |
     namespace: kube-system
   spec:
     containers:
-    - command:
-      - /bin/sh
-      - -c
-      - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-        --backup-interval=1h0m0s --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
-        --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-        --discovery-poll-interval=1m15s --dns-suffix=.internal.minimal.example.com --grpc-port=3996
-        --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-        --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-        --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-        > /tmp/pipe 2>&1
+    - args:
+      - --log-file=/var/log/etcd.log
+      - --also-stdout
+      - /ko-app/etcd-manager
+      - --backup-interval=1h0m0s
+      - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+      - --client-urls=https://__name__:4001
+      - --cluster-name=etcd
+      - --containerized=true
+      - --discovery-poll-interval=1m15s
+      - --dns-suffix=.internal.minimal.example.com
+      - --grpc-port=3996
+      - --peer-urls=https://__name__:2380
+      - --quarantine-client-urls=https://__name__:3994
+      - --v=6
+      - --volume-name-tag=k8s.io/etcd/main
+      - --volume-provider=aws
+      - --volume-tag=k8s.io/etcd/main
+      - --volume-tag=k8s.io/role/control-plane=1
+      - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      command:
+      - /go-runner
       env:
       - name: AWS_REGION
         value: us-test-1
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -74,20 +74,30 @@ Contents: |
     namespace: kube-system
   spec:
     containers:
-    - command:
-      - /bin/sh
-      - -c
-      - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-        --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-        --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-        --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-        --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-        --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+    - args:
+      - --log-file=/var/log/etcd.log
+      - --also-stdout
+      - /ko-app/etcd-manager
+      - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+      - --client-urls=https://__name__:4002
+      - --cluster-name=etcd-events
+      - --containerized=true
+      - --dns-suffix=.internal.minimal.example.com
+      - --grpc-port=3997
+      - --peer-urls=https://__name__:2381
+      - --quarantine-client-urls=https://__name__:3995
+      - --v=6
+      - --volume-name-tag=k8s.io/etcd/events
+      - --volume-provider=aws
+      - --volume-tag=k8s.io/etcd/events
+      - --volume-tag=k8s.io/role/control-plane=1
+      - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      command:
+      - /go-runner
       env:
       - name: AWS_REGION
         value: us-test-1
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
       name: etcd-manager
       resources:
         requests:
@@ -246,20 +256,30 @@ Contents: |
     namespace: kube-system
   spec:
     containers:
-    - command:
-      - /bin/sh
-      - -c
-      - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-        --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
-        --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-        --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-        --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-        --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+    - args:
+      - --log-file=/var/log/etcd.log
+      - --also-stdout
+      - /ko-app/etcd-manager
+      - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+      - --client-urls=https://__name__:4001
+      - --cluster-name=etcd
+      - --containerized=true
+      - --dns-suffix=.internal.minimal.example.com
+      - --grpc-port=3996
+      - --peer-urls=https://__name__:2380
+      - --quarantine-client-urls=https://__name__:3994
+      - --v=6
+      - --volume-name-tag=k8s.io/etcd/main
+      - --volume-provider=aws
+      - --volume-tag=k8s.io/etcd/main
+      - --volume-tag=k8s.io/role/control-plane=1
+      - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      command:
+      - /go-runner
       env:
       - name: AWS_REGION
         value: us-test-1
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -74,22 +74,32 @@ Contents: |
     namespace: kube-system
   spec:
     containers:
-    - command:
-      - /bin/sh
-      - -c
-      - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-        --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-        --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-        --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-        --quarantine-client-urls=https://__name__:3995 --v=3 --volume-name-tag=k8s.io/etcd/events
-        --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+    - args:
+      - --log-file=/var/log/etcd.log
+      - --also-stdout
+      - /ko-app/etcd-manager
+      - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+      - --client-urls=https://__name__:4002
+      - --cluster-name=etcd-events
+      - --containerized=true
+      - --dns-suffix=.internal.minimal.example.com
+      - --grpc-port=3997
+      - --peer-urls=https://__name__:2381
+      - --quarantine-client-urls=https://__name__:3995
+      - --v=3
+      - --volume-name-tag=k8s.io/etcd/events
+      - --volume-provider=aws
+      - --volume-tag=k8s.io/etcd/events
+      - --volume-tag=k8s.io/role/control-plane=1
+      - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      command:
+      - /go-runner
       env:
       - name: AWS_REGION
         value: us-test-1
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
       name: etcd-manager
       resources:
         requests:
@@ -253,22 +263,32 @@ Contents: |
     namespace: kube-system
   spec:
     containers:
-    - command:
-      - /bin/sh
-      - -c
-      - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-        --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
-        --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-        --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-        --quarantine-client-urls=https://__name__:3994 --v=3 --volume-name-tag=k8s.io/etcd/main
-        --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+    - args:
+      - --log-file=/var/log/etcd.log
+      - --also-stdout
+      - /ko-app/etcd-manager
+      - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+      - --client-urls=https://__name__:4001
+      - --cluster-name=etcd
+      - --containerized=true
+      - --dns-suffix=.internal.minimal.example.com
+      - --grpc-port=3996
+      - --peer-urls=https://__name__:2380
+      - --quarantine-client-urls=https://__name__:3994
+      - --v=3
+      - --volume-name-tag=k8s.io/etcd/main
+      - --volume-provider=aws
+      - --volume-tag=k8s.io/etcd/main
+      - --volume-tag=k8s.io/role/control-plane=1
+      - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      command:
+      - /go-runner
       env:
       - name: AWS_REGION
         value: us-test-1
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -74,16 +74,26 @@ Contents: |
     namespace: kube-system
   spec:
     containers:
-    - command:
-      - /bin/sh
-      - -c
-      - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-        --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-        --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-        --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-        --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-        --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+    - args:
+      - --log-file=/var/log/etcd.log
+      - --also-stdout
+      - /ko-app/etcd-manager
+      - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+      - --client-urls=https://__name__:4002
+      - --cluster-name=etcd-events
+      - --containerized=true
+      - --dns-suffix=.internal.minimal.example.com
+      - --grpc-port=3997
+      - --peer-urls=https://__name__:2381
+      - --quarantine-client-urls=https://__name__:3995
+      - --v=6
+      - --volume-name-tag=k8s.io/etcd/events
+      - --volume-provider=aws
+      - --volume-tag=k8s.io/etcd/events
+      - --volume-tag=k8s.io/role/control-plane=1
+      - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      command:
+      - /go-runner
       env:
       - name: AWS_REGION
         value: us-test-1
@@ -95,7 +105,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
       name: etcd-manager
       resources:
         requests:
@@ -259,16 +269,26 @@ Contents: |
     namespace: kube-system
   spec:
     containers:
-    - command:
-      - /bin/sh
-      - -c
-      - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-        --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
-        --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-        --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-        --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-        --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-        --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+    - args:
+      - --log-file=/var/log/etcd.log
+      - --also-stdout
+      - /ko-app/etcd-manager
+      - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+      - --client-urls=https://__name__:4001
+      - --cluster-name=etcd
+      - --containerized=true
+      - --dns-suffix=.internal.minimal.example.com
+      - --grpc-port=3996
+      - --peer-urls=https://__name__:2380
+      - --quarantine-client-urls=https://__name__:3994
+      - --v=6
+      - --volume-name-tag=k8s.io/etcd/main
+      - --volume-provider=aws
+      - --volume-tag=k8s.io/etcd/main
+      - --volume-tag=k8s.io/role/control-plane=1
+      - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+      command:
+      - /go-runner
       env:
       - name: AWS_REGION
         value: us-test-1
@@ -280,7 +300,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+      image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
       name: etcd-manager
       resources:
         requests:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/additionalobjects.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.additionalobjects.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/additionalobjects.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.additionalobjects.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/additionalobjects.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.additionalobjects.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/additionalobjects.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.additionalobjects.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -9,23 +9,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://events.etcd.internal.minimal.example.com:4002 --cluster-name=etcd-events
-      --containerized=true --dns-suffix=.internal.minimal.example.com --grpc-port=3997
-      --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://events.etcd.internal.minimal.example.com:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -9,23 +9,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://main.etcd.internal.minimal.example.com:4001 --cluster-name=etcd
-      --containerized=true --dns-suffix=.internal.minimal.example.com --grpc-port=3996
-      --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://main.etcd.internal.minimal.example.com:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/bastionuserdata.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.bastionuserdata.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/bastionuserdata.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.bastionuserdata.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/bastionuserdata.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.bastionuserdata.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/bastionuserdata.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.bastionuserdata.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/cas-priority-expander-custom.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.cas-priority-expander-custom.example.com --grpc-port=3997
-      --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/cas-priority-expander-custom.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.cas-priority-expander-custom.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/cas-priority-expander-custom.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.cas-priority-expander-custom.example.com --grpc-port=3996
-      --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/cas-priority-expander-custom.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.cas-priority-expander-custom.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/cas-priority-expander.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.cas-priority-expander.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned >
-      /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/cas-priority-expander.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.cas-priority-expander.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/cas-priority-expander.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.cas-priority-expander.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned >
-      /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/cas-priority-expander.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.cas-priority-expander.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/complex.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.complex.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/complex.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.complex.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/complex.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/complex.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.complex.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/complex.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.complex.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/complex.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/compress.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.compress.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/compress.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.compress.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/compress.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/compress.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.compress.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/compress.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.compress.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/compress.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/containerd.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.containerd.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/containerd.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.containerd.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/containerd.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/containerd.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.containerd.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/containerd.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.containerd.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/containerd.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd/assets.yaml
+++ b/tests/integration/update_cluster/containerd/assets.yaml
@@ -42,8 +42,8 @@ images:
   download: registry.k8s.io/coredns/coredns:v1.14.2
 - canonical: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
   download: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
-- canonical: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
-  download: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+- canonical: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
+  download: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
 - canonical: registry.k8s.io/etcd:v3.5.31
   download: registry.k8s.io/etcd:v3.5.31
 - canonical: registry.k8s.io/etcd:v3.6.12

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/containerd.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.containerd.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/containerd.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.containerd.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/containerd.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/containerd.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.containerd.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/containerd.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.containerd.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/containerd.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/123.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.123.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/123.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.123.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/123.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/123.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.123.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/123.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.123.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/123.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.existing-iam.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.existing-iam.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.existing-iam.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.existing-iam.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.existing-iam.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.existing-iam.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.existing-iam.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.existing-iam.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.existing-iam.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.existing-iam.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.existing-iam.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/existing-iam.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.existing-iam.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.existingsg.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.existingsg.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.existingsg.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.existingsg.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.existingsg.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.existingsg.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.existingsg.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.existingsg.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.existingsg.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.existingsg.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.existingsg.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/existingsg.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.existingsg.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/externallb.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.externallb.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/externallb.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.externallb.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/externallb.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/externallb.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.externallb.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/externallb.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.externallb.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/externallb.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/externalpolicies.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.externalpolicies.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/externalpolicies.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.externalpolicies.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/externalpolicies.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.externalpolicies.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/externalpolicies.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.externalpolicies.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.gossip.k8s.local
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/gossip.k8s.local=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.gossip.k8s.local
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/gossip.k8s.local=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.gossip.k8s.local
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/gossip.k8s.local=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.gossip.k8s.local
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/gossip.k8s.local=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.gossip.k8s.local
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io_etcd_events --volume-provider=azure --volume-tag=k8s.io_etcd_events
-      --volume-tag=k8s.io_role_control-plane=1 --volume-tag=kubernetes.io_cluster_gossip.k8s.local=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.gossip.k8s.local
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io_etcd_events
+    - --volume-provider=azure
+    - --volume-tag=k8s.io_etcd_events
+    - --volume-tag=k8s.io_role_control-plane=1
+    - --volume-tag=kubernetes.io_cluster_gossip.k8s.local=owned
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.gossip.k8s.local
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io_etcd_main --volume-provider=azure --volume-tag=k8s.io_etcd_main
-      --volume-tag=k8s.io_role_control-plane=1 --volume-tag=kubernetes.io_cluster_gossip.k8s.local=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.gossip.k8s.local
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io_etcd_main
+    - --volume-provider=azure
+    - --volume-tag=k8s.io_etcd_main
+    - --volume-tag=k8s.io_role_control-plane=1
+    - --volume-tag=kubernetes.io_cluster_gossip.k8s.local=owned
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.gossip.k8s.local
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=gossip-k8s-local
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.gossip.k8s.local
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=gossip-k8s-local
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.gossip.k8s.local
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=gossip-k8s-local
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.gossip.k8s.local
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=gossip-k8s-local
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -7,22 +7,31 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.gossip.k8s.local
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=kops.k8s.io/instance-group=master-fsn1 --volume-provider=hetzner
-      --volume-tag=kops.k8s.io/cluster=gossip.k8s.local --volume-tag=kops.k8s.io/volume-role=events
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.gossip.k8s.local
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=kops.k8s.io/instance-group=master-fsn1
+    - --volume-provider=hetzner
+    - --volume-tag=kops.k8s.io/cluster=gossip.k8s.local
+    - --volume-tag=kops.k8s.io/volume-role=events
+    command:
+    - /go-runner
     env:
     - name: HCLOUD_TOKEN
       value: REDACTED
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -7,22 +7,31 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.gossip.k8s.local
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=kops.k8s.io/instance-group=master-fsn1 --volume-provider=hetzner
-      --volume-tag=kops.k8s.io/cluster=gossip.k8s.local --volume-tag=kops.k8s.io/volume-role=main
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/gossip.k8s.local/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.gossip.k8s.local
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=kops.k8s.io/instance-group=master-fsn1
+    - --volume-provider=hetzner
+    - --volume-tag=kops.k8s.io/cluster=gossip.k8s.local
+    - --volume-tag=kops.k8s.io/volume-role=main
+    command:
+    - /go-runner
     env:
     - name: HCLOUD_TOKEN
       value: REDACTED
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.ha.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.ha.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/ha.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.ha.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.ha.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/ha.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.ha.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.ha.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/ha.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.ha.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.ha.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/ha.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.ha.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.ha.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/ha.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.ha.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.ha.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/ha.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.ha-gce.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.ha-gce.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=ha-gce-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.ha-gce.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.ha-gce.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=ha-gce-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.ha-gce.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.ha-gce.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=ha-gce-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.ha-gce.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.ha-gce.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=ha-gce-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.ha-gce.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.ha-gce.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=ha-gce-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.ha-gce.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/ha-gce.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.ha-gce.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=ha-gce-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/many-addons.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.many-addons.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/many-addons.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/many-addons.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.many-addons.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/many-addons.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/many-addons.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.many-addons.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/many-addons.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/many-addons.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.many-addons.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/many-addons.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-aws.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-aws.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-aws.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-aws.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-aws.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-aws.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-aws.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-aws.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-aws.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-aws.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-aws.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-aws.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,17 +7,26 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-etcd.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-etcd.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-etcd.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-etcd.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-etcd.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-etcd.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,17 +7,26 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-etcd.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-etcd.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=10 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-etcd.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-etcd.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-etcd.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=10
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-etcd.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-warmpool.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-warmpool.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-warmpool.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-warmpool.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: kops.k8s.io/remapped-image/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: kops.k8s.io/remapped-image/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-warmpool.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-warmpool.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-warmpool.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-warmpool.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: kops.k8s.io/remapped-image/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: kops.k8s.io/remapped-image/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-azure.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal-azure.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io_etcd_events --volume-provider=azure --volume-tag=k8s.io_etcd_events
-      --volume-tag=k8s.io_role_control-plane=1 --volume-tag=kubernetes.io_cluster_minimal-azure.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-azure.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-azure.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io_etcd_events
+    - --volume-provider=azure
+    - --volume-tag=k8s.io_etcd_events
+    - --volume-tag=k8s.io_role_control-plane=1
+    - --volume-tag=kubernetes.io_cluster_minimal-azure.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-azure.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal-azure.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io_etcd_main --volume-provider=azure --volume-tag=k8s.io_etcd_main
-      --volume-tag=k8s.io_role_control-plane=1 --volume-tag=kubernetes.io_cluster_minimal-azure.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-azure.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-azure.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io_etcd_main
+    - --volume-provider=azure
+    - --volume-tag=k8s.io_etcd_main
+    - --volume-tag=k8s.io_role_control-plane=1
+    - --volume-tag=kubernetes.io_cluster_minimal-azure.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal-gce.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal-gce.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal-gce.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal-gce.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-ilb.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-gce-ilb.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s-io-etcd-events
-      --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-ilb.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-ilb.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-ilb.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal-gce-ilb.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-ilb.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-ilb.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-ilb-cilium-etcd.example.com/backups/etcd/cilium
-      --client-urls=https://api.internal.minimal-gce-ilb-cilium-etcd.example.com:4003
-      --cluster-name=etcd-cilium --containerized=true --dns-suffix=.internal.minimal-gce-ilb-cilium-etcd.example.com
-      --grpc-port=3991 --peer-urls=https://__name__:2382 --quarantine-client-urls=https://__name__:3992
-      --v=6 --volume-name-tag=k8s-io-etcd-cilium --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-cilium-etcd-example-com
-      --volume-tag=k8s-io-etcd-cilium --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-ilb-cilium-etcd.example.com/backups/etcd/cilium
+    - --client-urls=https://api.internal.minimal-gce-ilb-cilium-etcd.example.com:4003
+    - --cluster-name=etcd-cilium
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-ilb-cilium-etcd.example.com
+    - --grpc-port=3991
+    - --peer-urls=https://__name__:2382
+    - --quarantine-client-urls=https://__name__:3992
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-cilium
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-cilium-etcd-example-com
+    - --volume-tag=k8s-io-etcd-cilium
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-ilb-cilium-etcd.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-gce-ilb-cilium-etcd.example.com --grpc-port=3997
-      --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-cilium-etcd-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-ilb-cilium-etcd.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-ilb-cilium-etcd.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-cilium-etcd-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-ilb-cilium-etcd.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-gce-ilb-cilium-etcd.example.com --grpc-port=3996
-      --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-cilium-etcd-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-ilb-cilium-etcd.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-ilb-cilium-etcd.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-cilium-etcd-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-gce-with-a-very-very-very-very-very-long-name.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-with-a-very-very-very-very-very-long-name.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-gce-with-a-very-very-very-very-very-long-name.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-with-a-very-very-very-very-very-long-name.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-gce-with-a-very-very-very-very-very-long-name.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-with-a-very-very-very-very-very-long-name.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-gce-with-a-very-very-very-very-very-long-name.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-with-a-very-very-very-very-very-long-name.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-plb.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-gce-plb.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s-io-etcd-events
-      --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-plb-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-plb.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-plb.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-plb-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,20 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-plb.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal-gce-plb.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-plb-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-plb.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-plb.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-plb-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -9,21 +9,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-plb-apiserver.example.com/backups/etcd/events
-      --client-urls=https://events.etcd.internal.minimal-gce-plb-apiserver.example.com:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal-gce-plb-apiserver.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-plb-apiserver-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-plb-apiserver.example.com/backups/etcd/events
+    - --client-urls=https://events.etcd.internal.minimal-gce-plb-apiserver.example.com:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-plb-apiserver.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-plb-apiserver-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -9,21 +9,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-plb-apiserver.example.com/backups/etcd/main
-      --client-urls=https://main.etcd.internal.minimal-gce-plb-apiserver.example.com:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal-gce-plb-apiserver.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-plb-apiserver-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-plb-apiserver.example.com/backups/etcd/main
+    - --client-urls=https://main.etcd.internal.minimal-gce-plb-apiserver.example.com:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-plb-apiserver.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-plb-apiserver-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-private.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-gce-private.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s-io-etcd-events
-      --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-private-example-com
-      --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-private.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-private.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-events
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-private-example-com
+    - --volume-tag=k8s-io-etcd-events
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -7,21 +7,30 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal-gce-private.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-gce-private.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s-io-etcd-main
-      --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-private-example-com
-      --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal-gce-private.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-gce-private.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s-io-etcd-main
+    - --volume-provider=gce
+    - --volume-tag=k8s-io-cluster-name=minimal-gce-private-example-com
+    - --volume-tag=k8s-io-etcd-main
+    - --volume-tag=k8s-io-role-master=master
+    command:
+    - /go-runner
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.k8s.local --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.k8s.local
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.k8s.local --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.k8s.local
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.k8s.local --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.k8s.local
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.k8s.local --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.k8s.local
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -7,22 +7,31 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=kops.k8s.io/instance-group=master-fsn1 --volume-provider=hetzner
-      --volume-tag=kops.k8s.io/cluster=minimal.example.com --volume-tag=kops.k8s.io/volume-role=events
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=kops.k8s.io/instance-group=master-fsn1
+    - --volume-provider=hetzner
+    - --volume-tag=kops.k8s.io/cluster=minimal.example.com
+    - --volume-tag=kops.k8s.io/volume-role=events
+    command:
+    - /go-runner
     env:
     - name: HCLOUD_TOKEN
       value: REDACTED
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -7,22 +7,31 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/minimal.example.com/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=kops.k8s.io/instance-group=master-fsn1 --volume-provider=hetzner
-      --volume-tag=kops.k8s.io/cluster=minimal.example.com --volume-tag=kops.k8s.io/volume-role=main
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=kops.k8s.io/instance-group=master-fsn1
+    - --volume-provider=hetzner
+    - --volume-tag=kops.k8s.io/cluster=minimal.example.com
+    - --volume-tag=kops.k8s.io/volume-role=main
+    command:
+    - /go-runner
     env:
     - name: HCLOUD_TOKEN
       value: REDACTED
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -7,24 +7,33 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/scw-minimal.k8s.local/backups/etcd/events --client-urls=https://__name__:4002
-      --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.scw-minimal.k8s.local
-      --grpc-port=3997 --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=noprefix=kops.k8s.io/instance-group=control-plane-fr-par-1
-      --volume-provider=scaleway --volume-tag=noprefix=kops.k8s.io/cluster=scw-minimal.k8s.local
-      --volume-tag=noprefix=kops.k8s.io/etcd=events --volume-tag=noprefix=kops.k8s.io/role=ControlPlane
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/scw-minimal.k8s.local/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.scw-minimal.k8s.local
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=noprefix=kops.k8s.io/instance-group=control-plane-fr-par-1
+    - --volume-provider=scaleway
+    - --volume-tag=noprefix=kops.k8s.io/cluster=scw-minimal.k8s.local
+    - --volume-tag=noprefix=kops.k8s.io/etcd=events
+    - --volume-tag=noprefix=kops.k8s.io/role=ControlPlane
+    command:
+    - /go-runner
     env:
     - name: SCW_ACCESS_KEY
     - name: SCW_DEFAULT_PROJECT_ID
     - name: SCW_SECRET_KEY
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -7,24 +7,33 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://tests/scw-minimal.k8s.local/backups/etcd/main --client-urls=https://__name__:4001
-      --cluster-name=etcd --containerized=true --dns-suffix=.internal.scw-minimal.k8s.local
-      --grpc-port=3996 --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=noprefix=kops.k8s.io/instance-group=control-plane-fr-par-1
-      --volume-provider=scaleway --volume-tag=noprefix=kops.k8s.io/cluster=scw-minimal.k8s.local
-      --volume-tag=noprefix=kops.k8s.io/etcd=main --volume-tag=noprefix=kops.k8s.io/role=ControlPlane
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://tests/scw-minimal.k8s.local/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.scw-minimal.k8s.local
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=noprefix=kops.k8s.io/instance-group=control-plane-fr-par-1
+    - --volume-provider=scaleway
+    - --volume-tag=noprefix=kops.k8s.io/cluster=scw-minimal.k8s.local
+    - --volume-tag=noprefix=kops.k8s.io/etcd=main
+    - --volume-tag=noprefix=kops.k8s.io/role=ControlPlane
+    command:
+    - /go-runner
     env:
     - name: SCW_ACCESS_KEY
     - name: SCW_DEFAULT_PROJECT_ID
     - name: SCW_SECRET_KEY
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.mixedinstances.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.mixedinstances.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com --grpc-port=3997
-      --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com --grpc-port=3996
-      --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com --grpc-port=3997
-      --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
-      --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com --grpc-port=3996
-      --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
-      --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.nthimdsprocessor.longclustername.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/private-shared-ip.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.private-shared-ip.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/private-shared-ip.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.private-shared-ip.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/private-shared-ip.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.private-shared-ip.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/private-shared-ip.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.private-shared-ip.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/private-shared-subnet.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.private-shared-subnet.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
-      /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/private-shared-subnet.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.private-shared-subnet.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/private-shared-subnet.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.private-shared-subnet.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
-      /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/private-shared-subnet.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.private-shared-subnet.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatecalico.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.privatecalico.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatecalico.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.privatecalico.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatecalico.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.privatecalico.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatecalico.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.privatecalico.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.privatecilium.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.privatecilium.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.privatecilium.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.privatecilium.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.privatecilium.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.privatecilium.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.privatecilium.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.privatecilium.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.privatecilium.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.privatecilium.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.privatecilium.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatecilium.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.privatecilium.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium
-      --client-urls=https://api.internal.privateciliumadvanced.example.com:4003 --cluster-name=etcd-cilium
-      --containerized=true --dns-suffix=.internal.privateciliumadvanced.example.com
-      --grpc-port=3991 --peer-urls=https://__name__:2382 --quarantine-client-urls=https://__name__:3992
-      --v=6 --volume-name-tag=k8s.io/etcd/cilium --volume-provider=aws --volume-tag=k8s.io/etcd/cilium
-      --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
-      > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium
+    - --client-urls=https://api.internal.privateciliumadvanced.example.com:4003
+    - --cluster-name=etcd-cilium
+    - --containerized=true
+    - --dns-suffix=.internal.privateciliumadvanced.example.com
+    - --grpc-port=3991
+    - --peer-urls=https://__name__:2382
+    - --quarantine-client-urls=https://__name__:3992
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/cilium
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/cilium
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.privateciliumadvanced.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
-      /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.privateciliumadvanced.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.privateciliumadvanced.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
-      /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.privateciliumadvanced.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns1/assets.yaml
+++ b/tests/integration/update_cluster/privatedns1/assets.yaml
@@ -42,8 +42,8 @@ images:
   download: registry.k8s.io/coredns/coredns:v1.14.2
 - canonical: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
   download: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
-- canonical: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
-  download: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+- canonical: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
+  download: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
 - canonical: registry.k8s.io/etcd:v3.5.31
   download: registry.k8s.io/etcd:v3.5.31
 - canonical: registry.k8s.io/etcd:v3.6.12

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatedns1.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.privatedns1.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatedns1.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.privatedns1.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatedns1.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.privatedns1.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatedns1.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.privatedns1.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatedns2.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.privatedns2.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatedns2.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.privatedns2.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatedns2.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.privatedns2.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatedns2.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.privatedns2.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privateflannel.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.privateflannel.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privateflannel.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.privateflannel.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privateflannel.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.privateflannel.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privateflannel.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.privateflannel.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatekindnet.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.privatekindnet.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatekindnet.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatekindnet.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.privatekindnet.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatekindnet.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatekindnet.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.privatekindnet.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatekindnet.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatekindnet.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.privatekindnet.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatekindnet.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatekopeio.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.privatekopeio.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatekopeio.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.privatekopeio.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/privatekopeio.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.privatekopeio.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/privatekopeio.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.privatekopeio.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/sharedsubnet.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.sharedsubnet.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/sharedsubnet.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.sharedsubnet.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/sharedsubnet.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.sharedsubnet.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/sharedsubnet.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.sharedsubnet.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/sharedvpc.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.sharedvpc.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/sharedvpc.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.sharedvpc.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/sharedvpc.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.sharedvpc.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/sharedvpc.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.sharedvpc.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,23 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal-ipv6.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
-      2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal-ipv6.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/unmanaged.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.unmanaged.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/unmanaged.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.unmanaged.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/unmanaged.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.unmanaged.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/unmanaged.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.unmanaged.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3997 --peer-urls=https://__name__:2381
-      --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
-      --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
+    - --client-urls=https://__name__:4002
+    - --cluster-name=etcd-events
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3997
+    - --peer-urls=https://__name__:2381
+    - --quarantine-client-urls=https://__name__:3995
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/events
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/events
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -7,22 +7,32 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - command:
-    - /bin/sh
-    - -c
-    - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /ko-app/etcd-manager
-      --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=.internal.minimal.example.com --grpc-port=3996 --peer-urls=https://__name__:2380
-      --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
-      --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
-      --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
+  - args:
+    - --log-file=/var/log/etcd.log
+    - --also-stdout
+    - /ko-app/etcd-manager
+    - --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
+    - --client-urls=https://__name__:4001
+    - --cluster-name=etcd
+    - --containerized=true
+    - --dns-suffix=.internal.minimal.example.com
+    - --grpc-port=3996
+    - --peer-urls=https://__name__:2380
+    - --quarantine-client-urls=https://__name__:3994
+    - --v=6
+    - --volume-name-tag=k8s.io/etcd/main
+    - --volume-provider=aws
+    - --volume-tag=k8s.io/etcd/main
+    - --volume-tag=k8s.io/role/control-plane=1
+    - --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
+    command:
+    - /go-runner
     env:
     - name: AWS_REGION
       value: us-test-1
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
       value: 90d
-    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260531
+    image: registry.k8s.io/etcd-manager/etcd-manager-slim:v3.0.20260608
     name: etcd-manager
     resources:
       requests:


### PR DESCRIPTION
With this, we are moving away from any non-distroless based images.
Based on https://github.com/kubernetes-sigs/etcd-manager/pull/73.

/cc @rifelpet @justinsb @ameukam 

<img width="1354" height="1354" alt="image" src="https://github.com/user-attachments/assets/134bbcab-8c30-415c-b7bd-81d1ab7808ec" />
