### PR TITLE
Calico: add NFTablesMode setting

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5304,6 +5304,11 @@ spec:
                         description: MTU to be set in the cni-network-config for calico.
                         format: int32
                         type: integer
+                      nftablesMode:
+                        description: |-
+                          NFTablesMode configures nftables support in Felix
+                          Options: Disabled, Enabled, Auto
+                        type: string
                       prometheusGoMetricsEnabled:
                         description: PrometheusGoMetricsEnabled enables Prometheus
                           Go runtime metrics collection

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -246,6 +246,9 @@ type CalicoNetworkingSpec struct {
 	LogSeverityScreen string `json:"logSeverityScreen,omitempty"`
 	// MTU to be set in the cni-network-config for calico.
 	MTU *int32 `json:"mtu,omitempty"`
+	// NFTablesMode configures nftables support in Felix
+	// Options: Disabled, Enabled, Auto
+	NFTablesMode string `json:"nftablesMode,omitempty"`
 	// PrometheusMetricsEnabled can be set to enable the experimental Prometheus
 	// metrics server (default: false)
 	PrometheusMetricsEnabled bool `json:"prometheusMetricsEnabled,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -201,6 +201,9 @@ type CalicoNetworkingSpec struct {
 	LogSeverityScreen string `json:"logSeverityScreen,omitempty"`
 	// MTU to be set in the cni-network-config for calico.
 	MTU *int32 `json:"mtu,omitempty"`
+	// NFTablesMode configures nftables support in Felix
+	// Options: Disabled, Enabled, Auto
+	NFTablesMode string `json:"nftablesMode,omitempty"`
 	// PrometheusMetricsEnabled can be set to enable the experimental Prometheus
 	// metrics server (default: false)
 	PrometheusMetricsEnabled bool `json:"prometheusMetricsEnabled,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1881,6 +1881,7 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.IptablesBackend = in.IptablesBackend
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
+	out.NFTablesMode = in.NFTablesMode
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
@@ -1918,6 +1919,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.IptablesBackend = in.IptablesBackend
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
+	out.NFTablesMode = in.NFTablesMode
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -210,6 +210,9 @@ type CalicoNetworkingSpec struct {
 	LogSeverityScreen string `json:"logSeverityScreen,omitempty"`
 	// MTU to be set in the cni-network-config for calico.
 	MTU *int32 `json:"mtu,omitempty"`
+	// NFTablesMode configures nftables support in Felix
+	// Options: Disabled, Enabled, Auto
+	NFTablesMode string `json:"nftablesMode,omitempty"`
 	// PrometheusMetricsEnabled can be set to enable the experimental Prometheus
 	// metrics server (default: false)
 	PrometheusMetricsEnabled bool `json:"prometheusMetricsEnabled,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2068,6 +2068,7 @@ func autoConvert_v1alpha3_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.IptablesBackend = in.IptablesBackend
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
+	out.NFTablesMode = in.NFTablesMode
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled
@@ -2104,6 +2105,7 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha3_CalicoNetworkingSpec(in *
 	out.IptablesBackend = in.IptablesBackend
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
+	out.NFTablesMode = in.NFTablesMode
 	out.PrometheusMetricsEnabled = in.PrometheusMetricsEnabled
 	out.PrometheusMetricsPort = in.PrometheusMetricsPort
 	out.PrometheusGoMetricsEnabled = in.PrometheusGoMetricsEnabled

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.25.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.25.yaml.template
@@ -7352,6 +7352,11 @@ spec:
             # Set Felix iptables binary variant, Legacy or NFT
             - name: FELIX_IPTABLESBACKEND
               value: "{{- or .Networking.Calico.IptablesBackend "Auto" }}"
+            {{ if .Networking.Calico.NFTablesMode -}}
+            # Configures nftables support in Felix (Disabled, Enabled, Auto)
+            - name: FELIX_NFTABLESMODE
+              value: "{{ .Networking.Calico.NFTablesMode }}"
+            {{ end -}}
             # Controls the log level
             - name: FELIX_LOGSEVERITYSCREEN
               value: "{{- or .Networking.Calico.LogSeverityScreen "info" }}"


### PR DESCRIPTION
Surface Calico's Felix NFTablesMode (Disabled, Enabled, Auto) as a field on CalicoNetworkingSpec and propagate it to the calico-node DaemonSet via FELIX_NFTABLESMODE. When left unset, the upstream Calico chart default applies, preserving existing behavior.

On distributions where iptables is only present as a shim over nftables (e.g. RHEL10+, Rocky10+), routing Felix's data plane through iptables-nft / nft_compat has produced BGP session flapping and broken pod networking on GCE. This field lets clusters opt their Calico install into native nftables on those nodes.