### PR TITLE
Support etcd 3.7.0-rc.0 and allow overriding the etcd version in the scalability scenario

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -31,6 +31,8 @@ var _ loader.ClusterOptionsBuilder = &EtcdOptionsBuilder{}
 const (
 	LatestEtcd35Version = "3.5.31"
 	LatestEtcd36Version = "3.6.12"
+	// TODO: replace with the released etcd 3.7 version before the Kubernetes 1.37 release.
+	LatestEtcd37Version = "3.7.0-rc.0"
 )
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -96,6 +96,7 @@ type etcdVersion struct {
 var etcdLatestImages = []etcdVersion{
 	{Version: components.LatestEtcd35Version, Image: "registry.k8s.io/etcd:v" + components.LatestEtcd35Version},
 	{Version: components.LatestEtcd36Version, Image: "registry.k8s.io/etcd:v" + components.LatestEtcd36Version},
+	{Version: components.LatestEtcd37Version, Image: "registry.k8s.io/etcd:v" + components.LatestEtcd37Version},
 }
 
 func etcdSupportedVersions() []etcdVersion {

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -146,6 +146,18 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - --target-dir=/opt/etcd-v3.7.0-rc.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/etcd:v3.7.0-rc.0
+      name: init-etcd-3-7-0-rc-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
@@ -319,6 +331,18 @@ Contents: |
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:v3.6.12
       name: init-etcd-3-6-12
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - --target-dir=/opt/etcd-v3.7.0-rc.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/etcd:v3.7.0-rc.0
+      name: init-etcd-3-7-0-rc-0
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -194,6 +194,8 @@ Contents: |
         name: etcd-v3-6-12
       - mountPath: /opt/etcd-v3.6.12
         name: etcd-v3-6-12
+      - mountPath: /opt/etcd-v3.7.0-rc.0
+        name: etcd-v3-7-0-rc-0
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
@@ -225,6 +227,10 @@ Contents: |
         pullPolicy: IfNotPresent
         reference: registry.k8s.io/etcd:v3.6.12
       name: etcd-v3-6-12
+    - image:
+        pullPolicy: IfNotPresent
+        reference: registry.k8s.io/etcd:v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - hostPath:
         path: /var/log/etcd-events.log
         type: FileOrCreate
@@ -366,6 +372,8 @@ Contents: |
         name: etcd-v3-6-12
       - mountPath: /opt/etcd-v3.6.12
         name: etcd-v3-6-12
+      - mountPath: /opt/etcd-v3.7.0-rc.0
+        name: etcd-v3-7-0-rc-0
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
@@ -397,6 +405,10 @@ Contents: |
         pullPolicy: IfNotPresent
         reference: registry.k8s.io/etcd:v3.6.12
       name: etcd-v3-6-12
+    - image:
+        pullPolicy: IfNotPresent
+        reference: registry.k8s.io/etcd:v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - hostPath:
         path: /var/log/etcd.log
         type: FileOrCreate

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -147,6 +147,18 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - --target-dir=/opt/etcd-v3.7.0-rc.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/etcd:v3.7.0-rc.0
+      name: init-etcd-3-7-0-rc-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
@@ -321,6 +333,18 @@ Contents: |
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:v3.6.12
       name: init-etcd-3-6-12
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - --target-dir=/opt/etcd-v3.7.0-rc.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/etcd:v3.7.0-rc.0
+      name: init-etcd-3-7-0-rc-0
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -153,6 +153,18 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - --target-dir=/opt/etcd-v3.7.0-rc.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/etcd:v3.7.0-rc.0
+      name: init-etcd-3-7-0-rc-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
       - --symlink
       - --target-dir=/opt/etcd-v3.5.0
       - --target-dir=/opt/etcd-v3.5.1
@@ -333,6 +345,18 @@ Contents: |
       - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:v3.6.12
       name: init-etcd-3-6-12
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - --target-dir=/opt/etcd-v3.7.0-rc.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/etcd:v3.7.0-rc.0
+      name: init-etcd-3-7-0-rc-0
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -89,6 +89,9 @@ create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_QUOTA_BACKEND_BYTES=$
 create_args+=("--set spec.etcdClusters[*].manager.env=ETCD_ENABLE_PPROF=true")
 create_args+=("--set spec.etcdClusters[0].manager.listenClientHTTPURLs=http://localhost:2385")
 create_args+=("--set spec.etcdClusters[1].manager.listenClientHTTPURLs=http://localhost:2386")
+if [[ -n "${ETCD_VERSION:-}" ]]; then
+  create_args+=("--set spec.etcdClusters[*].version=${ETCD_VERSION}")
+fi
 create_args+=("--set spec.cloudControllerManager.concurrentNodeSyncs=10")
 create_args+=("--set spec.kubelet.maxPods=96")
 create_args+=("--set spec.kubelet.kubeAPIQPS=100")

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -130,6 +130,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -161,6 +163,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -130,6 +130,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -161,6 +163,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -132,6 +132,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -163,6 +165,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -132,6 +132,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -163,6 +165,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/containerd/assets.yaml
+++ b/tests/integration/update_cluster/containerd/assets.yaml
@@ -48,6 +48,8 @@ images:
   download: registry.k8s.io/etcd:v3.5.31
 - canonical: registry.k8s.io/etcd:v3.6.12
   download: registry.k8s.io/etcd:v3.6.12
+- canonical: registry.k8s.io/etcd:v3.7.0-rc.0
+  download: registry.k8s.io/etcd:v3.7.0-rc.0
 - canonical: registry.k8s.io/kops/channels:1.34.0-beta.1
   download: registry.k8s.io/kops/channels:1.34.0-beta.1
 - canonical: registry.k8s.io/kops/dns-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
@@ -127,6 +127,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -158,6 +160,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
@@ -127,6 +127,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -158,6 +160,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -127,6 +127,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -158,6 +160,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -127,6 +127,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -158,6 +160,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/gossip-hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -129,6 +129,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -160,6 +162,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -130,6 +130,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -161,6 +163,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -130,6 +130,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -161,6 +163,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -83,6 +83,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: kops.k8s.io/remapped-image/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: kops.k8s.io/remapped-image/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source
@@ -127,6 +127,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -158,6 +160,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source
@@ -127,6 +127,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -158,6 +160,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -78,6 +78,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -79,6 +79,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -82,6 +82,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -82,6 +82,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatedns1/assets.yaml
+++ b/tests/integration/update_cluster/privatedns1/assets.yaml
@@ -48,6 +48,8 @@ images:
   download: registry.k8s.io/etcd:v3.5.31
 - canonical: registry.k8s.io/etcd:v3.6.12
   download: registry.k8s.io/etcd:v3.6.12
+- canonical: registry.k8s.io/etcd:v3.7.0-rc.0
+  download: registry.k8s.io/etcd:v3.7.0-rc.0
 - canonical: registry.k8s.io/kops/channels:1.34.0-beta.1
   download: registry.k8s.io/kops/channels:1.34.0-beta.1
 - canonical: registry.k8s.io/kops/dns-controller:1.34.0-beta.1

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -130,6 +130,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -161,6 +163,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -130,6 +130,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -161,6 +163,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -130,6 +130,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -161,6 +163,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -130,6 +130,8 @@ spec:
       name: etcd-v3-6-12
     - mountPath: /opt/etcd-v3.6.12
       name: etcd-v3-6-12
+    - mountPath: /opt/etcd-v3.7.0-rc.0
+      name: etcd-v3-7-0-rc-0
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
@@ -161,6 +163,10 @@ spec:
       pullPolicy: IfNotPresent
       reference: registry.k8s.io/etcd:v3.6.12
     name: etcd-v3-6-12
+  - image:
+      pullPolicy: IfNotPresent
+      reference: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: etcd-v3-7-0-rc-0
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -81,6 +81,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -80,6 +80,18 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - --target-dir=/opt/etcd-v3.7.0-rc.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/etcd:v3.7.0-rc.0
+    name: init-etcd-3-7-0-rc-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
     - --symlink
     - --target-dir=/opt/etcd-v3.5.0
     - --target-dir=/opt/etcd-v3.5.1


### PR DESCRIPTION
Adds etcd 3.7.0-rc.0 as a supported version and an optional ETCD_VERSION override in the scalability scenario so scale jobs can test rc candidate.

Opted not to blanket default the 3.7 for all scalability jobs as this is rc candidate, but maybe we should for proper soak.

We are soaking etcd 3.7 ahead of the release. The best way to do that is to integrate with kubernetes scalability test and ensure that we do not find regressions/bugs. Kubernetes is already using the 3.7-rc client library ([ref](https://github.com/kubernetes/kubernetes/blob/544a4612cd73250f69e6a95f4b3de8b94112e594/go.mod#L56-L58)),
The timeline is roughly 
- June 1: Release etcd 3.7-rc.0
- July 1: Release etcd 3.7 and switch all CI to 3.7
- End of July: Release Kubernetes 1.37