### PR TITLE
gce: fix backend service ownership filtering during delete

### DIFF
--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -1049,6 +1049,10 @@ func deleteServiceAccount(cloud fi.Cloud, r *resources.Resource) error {
 // containsOnlyListedIGMs returns true if all the given backend service's backends
 // are contained in the provided list of IGM resources.
 func containsOnlyListedIGMs(svc *compute.BackendService, igms []*resources.Resource) bool {
+	if len(svc.Backends) == 0 {
+		return false
+	}
+
 	for _, be := range svc.Backends {
 		listed := false
 		for _, igm := range igms {

--- a/pkg/resources/gce/gce_test.go
+++ b/pkg/resources/gce/gce_test.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package gce
 
-import "testing"
+import (
+	"testing"
+
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/kops/pkg/resources"
+)
 
 func TestNameMatch(t *testing.T) {
 	grid := []struct {
@@ -110,5 +115,64 @@ func TestMatchesClusterNameWithUUID(t *testing.T) {
 		if got != g.Want {
 			t.Errorf("{clusterName=%q}.matchesClusterNameWithUUID(%q) got %v, want %v", g.ClusterName, g.Name, got, g.Want)
 		}
+	}
+}
+
+func TestContainsOnlyListedIGMs(t *testing.T) {
+	igms := []*resources.Resource{
+		{Name: "nodes-igm"},
+		{Name: "master-igm"},
+	}
+
+	tests := []struct {
+		name    string
+		service *compute.BackendService
+		want    bool
+	}{
+		{
+			name: "empty backends",
+			service: &compute.BackendService{
+				Backends: nil,
+			},
+			want: false,
+		},
+		{
+			name: "all backends match listed igms",
+			service: &compute.BackendService{
+				Backends: []*compute.Backend{
+					{Group: "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/instanceGroups/nodes-igm"},
+					{Group: "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-b/instanceGroups/master-igm"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "contains backend from non listed igm",
+			service: &compute.BackendService{
+				Backends: []*compute.Backend{
+					{Group: "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/instanceGroups/nodes-igm"},
+					{Group: "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-b/instanceGroups/gke-default-igm"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "NEG backends from GKE Gateway do not match any IGM",
+			service: &compute.BackendService{
+				Backends: []*compute.Backend{
+					{Group: "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/networkEndpointGroups/gkegw1-serve404-neg"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containsOnlyListedIGMs(tt.service, igms)
+			if got != tt.want {
+				t.Fatalf("containsOnlyListedIGMs() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
What this PR does / why we need it:

containsOnlyListedIGMs returned true for backend services with zero backends (vacuous truth over an empty slice). This caused listBackendServices to incorrectly claim unrelated regional backend services in the same GCP project, which cascaded into listHealthchecks selecting their health checks too. The delete loop then retried those foreign resources indefinitely, requiring Ctrl-C to escape.

This is reproducible when a kOps cluster and a GKE cluster coexist in the same project. The GKE Gateway controller creates regional backend services (e.g. serve404 default backends) that can have no instance-group-based backends. The empty Backends slice caused the ownership check to match them to the kOps cluster.

The fix returns false when Backends is empty, so only backend services whose backends actually reference cluster IGMs are selected for deletion. A new unit test covers the empty-backends case and a NEG-backend case reflecting the GKE Gateway scenario from the issue.

Which issue(s) this PR fixes:

Fixes #18440

Special notes for your reviewer:

The change is a 4-line guard in containsOnlyListedIGMs plus 4 unit test cases covering: empty backends, all-match, partial-mismatch, and NEG-style backends from GKE Gateway. No behavior change for backend services that have at least one backend (the existing loop handles those correctly). kOps-created backend services always have at least one backend pointing at a cluster IGM, so this guard only filters out foreign services.