### PR TITLE
Automated cherry pick of #18467: aws: Reconcile target group health check changes on existing target groups

### DIFF
--- a/cloudmock/aws/mockelbv2/targetgroups.go
+++ b/cloudmock/aws/mockelbv2/targetgroups.go
@@ -143,3 +143,37 @@ func (m *MockELBV2) ModifyTargetGroupAttributes(ctx context.Context, request *el
 	m.TargetGroups[arn].attributes = request.Attributes
 	return &elbv2.ModifyTargetGroupAttributesOutput{Attributes: request.Attributes}, nil
 }
+
+func (m *MockELBV2) ModifyTargetGroup(ctx context.Context, request *elbv2.ModifyTargetGroupInput, optFns ...func(*elbv2.Options)) (*elbv2.ModifyTargetGroupOutput, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	klog.Infof("ModifyTargetGroup %v", request)
+
+	// Layer 7 health checks require a path and a return code, matching the AWS API validation.
+	proto := request.HealthCheckProtocol
+	if proto == elbv2types.ProtocolEnumHttp || proto == elbv2types.ProtocolEnumHttps {
+		if request.HealthCheckPath == nil || request.Matcher == nil {
+			return nil, fmt.Errorf("ValidationError: Path and return code are required for layer 7 health checks")
+		}
+	}
+
+	arn := aws.ToString(request.TargetGroupArn)
+	tg := m.TargetGroups[arn]
+	if request.HealthCheckProtocol != "" {
+		tg.description.HealthCheckProtocol = request.HealthCheckProtocol
+	}
+	if request.HealthCheckPath != nil {
+		tg.description.HealthCheckPath = request.HealthCheckPath
+	}
+	if request.Matcher != nil {
+		tg.description.Matcher = request.Matcher
+	}
+	if request.HealthyThresholdCount != nil {
+		tg.description.HealthyThresholdCount = request.HealthyThresholdCount
+	}
+	if request.UnhealthyThresholdCount != nil {
+		tg.description.UnhealthyThresholdCount = request.UnhealthyThresholdCount
+	}
+	return &elbv2.ModifyTargetGroupOutput{TargetGroups: []elbv2types.TargetGroup{tg.description}}, nil
+}

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -392,6 +392,26 @@ func (_ *TargetGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *TargetGrou
 			if err := ModifyTargetGroupAttributes(ctx, t.Cloud, a.ARN, e.Attributes); err != nil {
 				return err
 			}
+			// Health check settings are only applied on create, so reconcile them here for an existing target group.
+			if changes.HealthCheckProtocol != "" || changes.HealthCheckPath != nil ||
+				changes.HealthyThreshold != nil || changes.UnhealthyThreshold != nil {
+				klog.V(2).Infof("Modifying Target Group health check for NLB")
+				proto := e.HealthCheckProtocol
+				request := &elbv2.ModifyTargetGroupInput{
+					TargetGroupArn:          a.ARN,
+					HealthCheckProtocol:     proto,
+					HealthyThresholdCount:   e.HealthyThreshold,
+					UnhealthyThresholdCount: e.UnhealthyThreshold,
+				}
+				// HTTP/HTTPS health checks need a path and matcher, 200-399 matches the NLB create default.
+				if proto == elbv2types.ProtocolEnumHttp || proto == elbv2types.ProtocolEnumHttps {
+					request.HealthCheckPath = e.HealthCheckPath
+					request.Matcher = &elbv2types.Matcher{HttpCode: fi.PtrTo("200-399")}
+				}
+				if _, err := t.Cloud.ELBV2().ModifyTargetGroup(ctx, request); err != nil {
+					return fmt.Errorf("modifying NLB target group health check: %w", err)
+				}
+			}
 		}
 	}
 	return nil

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awstasks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"k8s.io/kops/cloudmock/aws/mockec2"
+	"k8s.io/kops/cloudmock/aws/mockelbv2"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+)
+
+// TestTargetGroupHealthCheckChange verifies that a health check change on an existing target group is applied,
+// instead of recurring as an unapplied change on every run.
+func TestTargetGroupHealthCheckChange(t *testing.T) {
+	ctx := context.TODO()
+
+	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	c := &mockec2.MockEC2{}
+	cloud.MockEC2 = c
+	cloud.MockELBV2 = &mockelbv2.MockELBV2{EC2: c}
+
+	// Pre-create the VPC
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{
+		CidrBlock: aws.String("172.20.0.0/16"),
+	})
+	if err != nil {
+		t.Fatalf("error creating test VPC: %v", err)
+	}
+	_, err = c.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{aws.ToString(vpc.Vpc.VpcId)},
+		Tags: []ec2types.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String("ExistingVPC"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("error tagging test vpc: %v", err)
+	}
+
+	// We define a function so we can rebuild the tasks, because we modify in-place when running
+	buildTasks := func(healthCheckProtocol elbv2types.ProtocolEnum, healthCheckPath *string) map[string]fi.CloudupTask {
+		vpc1 := &VPC{
+			Name:      s("vpc1"),
+			Lifecycle: fi.LifecycleSync,
+			CIDR:      s("172.20.0.0/16"),
+			Tags:      map[string]string{"kubernetes.io/cluster/cluster.example.com": "shared"},
+			Shared:    fi.PtrTo(true),
+			ID:        vpc.Vpc.VpcId,
+		}
+		tg1 := &TargetGroup{
+			Name:                s("tg1"),
+			Lifecycle:           fi.LifecycleSync,
+			VPC:                 vpc1,
+			Tags:                map[string]string{"Name": "tg1"},
+			Protocol:            elbv2types.ProtocolEnumTcp,
+			Port:                fi.PtrTo(int32(3988)),
+			Interval:            fi.PtrTo(int32(10)),
+			HealthyThreshold:    fi.PtrTo(int32(2)),
+			UnhealthyThreshold:  fi.PtrTo(int32(2)),
+			HealthCheckProtocol: healthCheckProtocol,
+			HealthCheckPath:     healthCheckPath,
+			Shared:              fi.PtrTo(false),
+		}
+
+		return map[string]fi.CloudupTask{
+			"vpc1": vpc1,
+			"tg1":  tg1,
+		}
+	}
+
+	// Create the target group with a TCP health check (as an older kOps version would).
+	runTasks(t, cloud, buildTasks(elbv2types.ProtocolEnumTcp, nil))
+
+	// Upgrade to an HTTPS health check with a path.
+	runTasks(t, cloud, buildTasks(elbv2types.ProtocolEnumHttps, s("/healthz")))
+
+	// The change must have been applied, so a subsequent run sees no changes.
+	checkNoChanges(t, ctx, cloud, buildTasks(elbv2types.ProtocolEnumHttps, s("/healthz")))
+}

--- a/util/pkg/awsinterfaces/elbv2.go
+++ b/util/pkg/awsinterfaces/elbv2.go
@@ -39,6 +39,7 @@ type ELBV2API interface {
 	DescribeTargetGroups(ctx context.Context, input *elbv2.DescribeTargetGroupsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTargetGroupsOutput, error)
 	DescribeTargetHealth(ctx context.Context, input *elbv2.DescribeTargetHealthInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTargetHealthOutput, error)
 	ModifyLoadBalancerAttributes(ctx context.Context, input *elbv2.ModifyLoadBalancerAttributesInput, optFns ...func(*elbv2.Options)) (*elbv2.ModifyLoadBalancerAttributesOutput, error)
+	ModifyTargetGroup(ctx context.Context, input *elbv2.ModifyTargetGroupInput, optFns ...func(*elbv2.Options)) (*elbv2.ModifyTargetGroupOutput, error)
 	ModifyTargetGroupAttributes(ctx context.Context, input *elbv2.ModifyTargetGroupAttributesInput, optFns ...func(*elbv2.Options)) (*elbv2.ModifyTargetGroupAttributesOutput, error)
 	RemoveTags(ctx context.Context, input *elbv2.RemoveTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.RemoveTagsOutput, error)
 	SetIpAddressType(ctx context.Context, input *elbv2.SetIpAddressTypeInput, optFns ...func(*elbv2.Options)) (*elbv2.SetIpAddressTypeOutput, error)


### PR DESCRIPTION
Cherry pick of #18467 on release-1.36.

#18467: aws: Reconcile target group health check changes on existing target groups

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```