### PR TITLE
Enable gosec and gocritic

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,8 +4,52 @@ run:
 linters:
   default: none
   enable:
+    - gocritic
+    - gosec
     - misspell
   settings:
+    gocritic:
+      # Keep gocritic focused on correctness checks for the initial adoption.
+      # These checks are mostly style churn in the existing codebase.
+      disabled-checks:
+        - appendAssign
+        - assignOp
+        - captLocal
+        - commentFormatting
+        - deprecatedComment
+        - elseif
+        - ifElseChain
+        - singleCaseSwitch
+        - sloppyLen
+    gosec:
+      # Keep the initial gosec adoption to high-signal checks. The broader
+      # default set reports many legacy taint, weak hash, math/rand, and
+      # integer conversion findings that need separate audits.
+      includes:
+        - G101
+        - G103
+        - G104
+        - G106
+        - G108
+        - G109
+        - G110
+        - G111
+        - G201
+        - G202
+        - G203
+        - G301
+        - G302
+        - G303
+        - G304
+        - G305
+        - G306
+        - G307
+        - G403
+        - G502
+        - G503
+        - G504
+        - G601
+        - G602
     misspell:
       mode: default
       # Leave locale unset so both US and UK English spellings are accepted.
@@ -16,6 +60,12 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        # Test fixtures intentionally contain fake keys and tokens.
+        path: _test\.go$
+        text: "G101:"
     paths:
       - ^zz_generated.*
       - third_party$

--- a/cmd/kops/distrust_keypair.go
+++ b/cmd/kops/distrust_keypair.go
@@ -125,7 +125,7 @@ func RunDistrustKeypair(ctx context.Context, f *util.Factory, out io.Writer, opt
 	}
 
 	if options.Keyset != "all" {
-		return distrustKeypair(ctx, out, options.Keyset, options.KeypairIDs[:], keyStore)
+		return distrustKeypair(ctx, out, options.Keyset, options.KeypairIDs, keyStore)
 	}
 
 	keysets, err := keyStore.ListKeysets()

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -1979,7 +1979,7 @@ func (i *integrationTest) runTestTerraformScaleway(t *testing.T) {
 }
 
 func MakeSSHKeyPair(publicKeyPath string, privateKeyPath string) error {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return err
 	}
@@ -1989,7 +1989,7 @@ func MakeSSHKeyPair(publicKeyPath string, privateKeyPath string) error {
 	if err := pem.Encode(&privateKeyBytes, privateKeyPEM); err != nil {
 		return err
 	}
-	if err := os.WriteFile(privateKeyPath, privateKeyBytes.Bytes(), os.FileMode(0o700)); err != nil {
+	if err := os.WriteFile(privateKeyPath, privateKeyBytes.Bytes(), os.FileMode(0o600)); err != nil {
 		return err
 	}
 
@@ -1998,7 +1998,7 @@ func MakeSSHKeyPair(publicKeyPath string, privateKeyPath string) error {
 		return err
 	}
 	publicKeyBytes := ssh.MarshalAuthorizedKey(publicKey)
-	if err := os.WriteFile(publicKeyPath, publicKeyBytes, os.FileMode(0o744)); err != nil {
+	if err := os.WriteFile(publicKeyPath, publicKeyBytes, os.FileMode(0o644)); err != nil {
 		return err
 	}
 

--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -202,7 +202,7 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 			Auth: []ssh.AuthMethod{
 				ssh.PublicKeys(signer),
 			},
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // toolbox dump connects to cluster nodes without managed host keys.
 		}
 
 		klog.Infof("will SSH using username %q", sshConfig.User)

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -58,7 +58,7 @@ const (
 	kubeletService = "kubelet.service"
 
 	kubeletConfigFilePath            = "/var/lib/kubelet/kubelet.conf"
-	credentialProviderConfigFilePath = "/var/lib/kubelet/credential-provider.conf"
+	credentialProviderConfigFilePath = "/var/lib/kubelet/credential-provider.conf" //nolint:gosec // This is a config file path, not a credential.
 )
 
 // Scheme registration is shared across all calls in this file because the

--- a/pkg/assets/builder_test.go
+++ b/pkg/assets/builder_test.go
@@ -131,7 +131,7 @@ func TestValidate_RemapImage_ContainerRegistry_MappingMultipleTimesConverges(t *
 func TestRemapEmptySection(t *testing.T) {
 	builder := buildAssetBuilder(t)
 
-	testdir := filepath.Join("testdata")
+	testdir := "testdata"
 
 	key := "emptysection"
 

--- a/pkg/bootstrap/pkibootstrap/options.go
+++ b/pkg/bootstrap/pkibootstrap/options.go
@@ -23,4 +23,4 @@ type Options struct {
 }
 
 // AuthenticationTokenPrefix is the prefix used for authentication using PKI
-const AuthenticationTokenPrefix = "x-pki-tpm "
+const AuthenticationTokenPrefix = "x-pki-tpm " //nolint:gosec // This is an authentication scheme prefix, not a credential.

--- a/pkg/controllers/clusterapi/cluster_controller.go
+++ b/pkg/controllers/clusterapi/cluster_controller.go
@@ -276,7 +276,7 @@ func (s *clusterScope) createKopsControlPlane(ctx context.Context, kube client.C
 			"users": []map[string]any{
 				{
 					"name": "in-cluster",
-					"user": map[string]any{
+					"user": map[string]any{ //nolint:gosec // This is a kubeconfig field name, not a credential.
 						"tokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
 					},
 				},

--- a/pkg/model/iam/subject.go
+++ b/pkg/model/iam/subject.go
@@ -124,7 +124,7 @@ func addServiceAccountRoleForAWS(context *IAMModelContext, podSpec *corev1.PodSp
 	}
 
 	awsRoleARN := "arn:" + context.AWSPartition + ":iam::" + context.AWSAccountID + ":role/" + roleName
-	tokenDir := "/var/run/secrets/amazonaws.com/"
+	tokenDir := "/var/run/secrets/amazonaws.com/" //nolint:gosec // This is the projected token directory path, not a credential.
 	tokenName := "token"
 
 	volume := corev1.Volume{

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -235,9 +235,7 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 			return string(bootConfigData), nil
 		},
 
-		"GzipBase64": func(data string) (string, error) {
-			return gzipBase64(data)
-		},
+		"GzipBase64": gzipBase64,
 
 		"CompressUserData": func() bool {
 			return b.CompressUserData

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -30,10 +30,10 @@ func TestLoadTemplatesTracksTemplateSources(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dir, "addons", "example"), 0755); err != nil {
 		t.Fatalf("creating addon dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "addons", "example", "plain.yaml"), []byte("plain"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "addons", "example", "plain.yaml"), []byte("plain"), 0o600); err != nil {
 		t.Fatalf("writing plain resource: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "addons", "example", "rendered.yaml.template"), []byte("template"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "addons", "example", "rendered.yaml.template"), []byte("template"), 0o600); err != nil {
 		t.Fatalf("writing template resource: %v", err)
 	}
 

--- a/pkg/testutils/golden/compare.go
+++ b/pkg/testutils/golden/compare.go
@@ -68,7 +68,7 @@ func AssertMatchesFile(t *testing.T, actual string, p string) {
 		if err := os.MkdirAll(path.Dir(p), 0o755); err != nil {
 			t.Errorf("error creating directory %s: %v", path.Dir(p), err)
 		}
-		if err := os.WriteFile(p, []byte(actual), 0o644); err != nil {
+		if err := os.WriteFile(p, []byte(actual), 0o644); err != nil { //nolint:gosec // Updated golden files should be readable in the worktree.
 			t.Errorf("error writing expected output %s: %v", p, err)
 		}
 

--- a/protokube/pkg/gossip/dns/hosts/hosts_test.go
+++ b/protokube/pkg/gossip/dns/hosts/hosts_test.go
@@ -121,7 +121,7 @@ func runTest(t *testing.T, in string, expected string) {
 		"c": {},
 	}
 
-	if err := os.WriteFile(p, []byte(in), 0o755); err != nil {
+	if err := os.WriteFile(p, []byte(in), 0o600); err != nil {
 		t.Fatalf("error writing hosts file: %v", err)
 	}
 

--- a/upup/pkg/fi/cloudup/awsup/aws_authenticator.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_authenticator.go
@@ -37,8 +37,8 @@ import (
 	"k8s.io/kops/pkg/bootstrap"
 )
 
-const AWSAuthenticationTokenPrefixV1 = "x-aws-sts "
-const AWSAuthenticationTokenPrefixV2 = "x-aws-sts-v2 "
+const AWSAuthenticationTokenPrefixV1 = "x-aws-sts "    //nolint:gosec // This is an authentication scheme prefix, not a credential.
+const AWSAuthenticationTokenPrefixV2 = "x-aws-sts-v2 " //nolint:gosec // This is an authentication scheme prefix, not a credential.
 
 type awsAuthenticator struct {
 	// sts holds the AWS STS client, for signing V2 requests

--- a/upup/pkg/fi/cloudup/awsup/aws_verifier_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_verifier_test.go
@@ -525,7 +525,11 @@ func computeSignatureV4(req *http.Request, region string, service string, secret
 	}
 	timeStampISO8601Format := reqTime
 
-	today := reqTime[:strings.Index(reqTime, "T")]
+	tIndex := strings.Index(reqTime, "T")
+	if tIndex < 0 {
+		return "", fmt.Errorf("cannot determine signature day")
+	}
+	today := reqTime[:tIndex]
 
 	scope := today + "/" + region + "/" + service + "/aws4_request"
 

--- a/upup/pkg/fi/cloudup/azure/authenticator.go
+++ b/upup/pkg/fi/cloudup/azure/authenticator.go
@@ -26,7 +26,7 @@ import (
 
 // AzureAuthenticationTokenPrefix prefixes bootstrap tokens created from Azure IMDS instance
 // identity data.
-const AzureAuthenticationTokenPrefix = "x-azure-id "
+const AzureAuthenticationTokenPrefix = "x-azure-id " //nolint:gosec // This is an authentication scheme prefix, not a credential.
 
 type azureAuthenticator struct{}
 

--- a/upup/pkg/fi/cloudup/gce/tpm/token.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/token.go
@@ -48,7 +48,7 @@ type AuthTokenData struct {
 }
 
 // GCETPMAuthenticationTokenPrefix is the prefix used for authentication using the GCE TPM
-const GCETPMAuthenticationTokenPrefix = "x-gce-tpm "
+const GCETPMAuthenticationTokenPrefix = "x-gce-tpm " //nolint:gosec // This is an authentication scheme prefix, not a credential.
 
 // AudienceNodeAuthentication is used in case we have multiple audiences using the TPM in future
 const AudienceNodeAuthentication = "kops.k8s.io/node-bootstrap"

--- a/upup/pkg/fi/cloudup/hetzner/authenticator.go
+++ b/upup/pkg/fi/cloudup/hetzner/authenticator.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/pkg/bootstrap"
 )
 
-const HetznerAuthenticationTokenPrefix = "x-hetzner-id "
+const HetznerAuthenticationTokenPrefix = "x-hetzner-id " //nolint:gosec // This is an authentication scheme prefix, not a credential.
 
 type hetznerAuthenticator struct {
 }

--- a/upup/pkg/fi/cloudup/linode/authenticator.go
+++ b/upup/pkg/fi/cloudup/linode/authenticator.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kops/pkg/bootstrap"
 )
 
-const LinodeAuthenticationTokenPrefix = "x-linode-instance-id "
+const LinodeAuthenticationTokenPrefix = "x-linode-instance-id " //nolint:gosec // This is an authentication scheme prefix, not a credential.
 
 const (
 	linodeMetadataBaseURL  = "http://169.254.169.254"

--- a/upup/pkg/fi/cloudup/openstack/authenticator.go
+++ b/upup/pkg/fi/cloudup/openstack/authenticator.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/kops/pkg/bootstrap"
 )
 
-const OpenstackAuthenticationTokenPrefix = "x-openstack-id "
+const OpenstackAuthenticationTokenPrefix = "x-openstack-id " //nolint:gosec // This is an authentication scheme prefix, not a credential.
 
 type openstackAuthenticator struct {
 }

--- a/upup/pkg/fi/cloudup/scaleway/authenticator.go
+++ b/upup/pkg/fi/cloudup/scaleway/authenticator.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kops/pkg/bootstrap"
 )
 
-const ScalewayAuthenticationTokenPrefix = "x-scaleway-instance-server-id "
+const ScalewayAuthenticationTokenPrefix = "x-scaleway-instance-server-id " //nolint:gosec // This is an authentication scheme prefix, not a credential.
 
 type scalewayAuthenticator struct{}
 

--- a/upup/pkg/fi/cloudup/scaleway/utils_test.go
+++ b/upup/pkg/fi/cloudup/scaleway/utils_test.go
@@ -49,7 +49,7 @@ func createScalewayConfigFile() error {
 	if err != nil {
 		return fmt.Errorf("error marshalling yaml file: %w", err)
 	}
-	err = os.WriteFile("./scw_config_test.yaml", out, 0644)
+	err = os.WriteFile("./scw_config_test.yaml", out, 0o600)
 	if err != nil {
 		return fmt.Errorf("error writing yaml file: %w", err)
 	}

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -147,9 +147,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 
 	dest["SharedVPC"] = tf.SharedVPC
 	// Remember that we may be on a different arch from the target.  Hard-code for now.
-	dest["replace"] = func(s, find, replace string) string {
-		return strings.ReplaceAll(s, find, replace)
-	}
+	dest["replace"] = strings.ReplaceAll
 	dest["joinHostPort"] = net.JoinHostPort
 
 	sprigTxtFuncMap := sprig.TxtFuncMap()
@@ -482,7 +480,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 
 	dest["KopsFeatureEnabled"] = tf.kopsFeatureEnabled
 	dest["KopsVersion"] = func() string { return kopsroot.Version }
-	dest["KopsVersionImageTag"] = func() string { return kopsroot.KopsVersionImageTag() }
+	dest["KopsVersionImageTag"] = kopsroot.KopsVersionImageTag
 	dest["KopsVersionForLabel"] = func() string {
 		// Labels follow strict rules: a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
 		// By convention we use a v prefix here

--- a/upup/pkg/fi/http_test.go
+++ b/upup/pkg/fi/http_test.go
@@ -35,7 +35,7 @@ func TestDownloadURLRejectsNon2xxAndPreservesDestination(t *testing.T) {
 	defer server.Close()
 
 	dest := filepath.Join(t.TempDir(), "download")
-	if err := os.WriteFile(dest, []byte("original"), 0o644); err != nil {
+	if err := os.WriteFile(dest, []byte("original"), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -517,7 +517,7 @@ func evaluateHostnameOverride(cloudProvider api.CloudProviderID) (string, error)
 
 		// Linode cloud-init does not set the OS hostname.
 		// Set it here so the OS hostname matches the kubelet hostname override.
-		if err := os.WriteFile("/etc/hostname", []byte(label+"\n"), 0644); err != nil {
+		if err := os.WriteFile("/etc/hostname", []byte(label+"\n"), 0o644); err != nil { //nolint:gosec // /etc/hostname is conventionally world-readable system configuration.
 			klog.Warningf("Failed to write /etc/hostname: %v", err)
 		} else if err := exec.Command("hostname", label).Run(); err != nil {
 			klog.Warningf("Failed to set runtime hostname %q: %v", label, err)

--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -330,9 +330,8 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 
 		// If the package manager update was less than 10 minutes ago, skip updating the package list.
 		if d.IsDebianFamily() && time.Since(packageManagerLastUpdated) > 10*time.Minute {
-			args := []string{"apt-get", "update"}
-			klog.Infof("Running command %s", args)
-			cmd := exec.Command(args[0], args[1:]...)
+			klog.Infof("Running command apt-get update")
+			cmd := exec.Command("apt-get", "update")
 			cmd.Env = env
 			output, err := cmd.CombinedOutput()
 			if err != nil {

--- a/util/pkg/reflectutils/access.go
+++ b/util/pkg/reflectutils/access.go
@@ -181,21 +181,32 @@ func setType(v reflect.Value, newValue string) error {
 		newV = reflect.ValueOf(b)
 
 	case "int64", "int32", "int16", "int":
-		v, err := strconv.Atoi(newValue)
-		if err != nil {
-			return fmt.Errorf("cannot interpret %q value as integer", newValue)
-		}
-
 		switch t {
 		case "int":
+			v, err := strconv.Atoi(newValue)
+			if err != nil {
+				return fmt.Errorf("cannot interpret %q value as integer", newValue)
+			}
 			newV = reflect.ValueOf(v)
 		case "int16":
+			v, err := strconv.ParseInt(newValue, 10, 16)
+			if err != nil {
+				return fmt.Errorf("cannot interpret %q value as int16", newValue)
+			}
 			v16 := int16(v)
 			newV = reflect.ValueOf(v16)
 		case "int32":
+			v, err := strconv.ParseInt(newValue, 10, 32)
+			if err != nil {
+				return fmt.Errorf("cannot interpret %q value as int32", newValue)
+			}
 			v32 := int32(v)
 			newV = reflect.ValueOf(v32)
 		case "int64":
+			v, err := strconv.ParseInt(newValue, 10, 64)
+			if err != nil {
+				return fmt.Errorf("cannot interpret %q value as int64", newValue)
+			}
 			v64 := int64(v)
 			newV = reflect.ValueOf(v64)
 		default:


### PR DESCRIPTION
Changes are fixes from running 'make verify-golangci-lint'