### PR TITLE
channels: defer apply when CRD is not yet registered

### DIFF
--- a/pkg/applylib/applyset/applyset.go
+++ b/pkg/applylib/applyset/applyset.go
@@ -118,6 +118,16 @@ func (a *ApplySet) ApplyOnce(ctx context.Context) (*ApplyResults, error) {
 
 		currentObj, err := client.Get(ctx, gvk, nn)
 		if err != nil {
+			if meta.IsNoMatchError(err) {
+				// The CRD for this object is not registered yet. This is common during
+				// bootstrap when an operator or a separate addon installs the CRD on its
+				// own schedule (e.g. Cilium's GatewayClass before the Gateway API CRDs
+				// are installed). Defer the object so a single missing CRD does not
+				// fail the whole channel apply; the next reconcile will retry it once
+				// the CRD lands.
+				results.applyDeferred(gvk, nn, err)
+				continue
+			}
 			if !apierrors.IsNotFound(err) {
 				results.applyError(gvk, nn, err)
 				continue

--- a/pkg/applylib/applyset/results.go
+++ b/pkg/applylib/applyset/results.go
@@ -24,14 +24,17 @@ import (
 
 // ApplyResults contains the results of an Apply operation.
 type ApplyResults struct {
-	total             int
-	applySuccessCount int
-	applyFailCount    int
-	healthyCount      int
-	unhealthyCount    int
+	total              int
+	applySuccessCount  int
+	applyFailCount     int
+	applyDeferredCount int
+	healthyCount       int
+	unhealthyCount     int
 }
 
 // AllApplied is true if the desired state has been successfully applied for all objects.
+// Objects whose CRD is not yet registered are reported as deferred (not failed): the
+// reconcile loop will retry them once the CRD lands, so they should not block readiness.
 // Note: you likely also want to check AllHealthy, if you want to be sure the objects are "ready".
 func (r *ApplyResults) AllApplied() bool {
 	r.checkInvariants()
@@ -49,10 +52,10 @@ func (r *ApplyResults) AllHealthy() bool {
 
 // checkInvariants is an internal function that warns if the object doesn't match the expected invariants.
 func (r *ApplyResults) checkInvariants() {
-	if r.total != (r.applySuccessCount + r.applyFailCount) {
+	if r.total != (r.applySuccessCount + r.applyFailCount + r.applyDeferredCount) {
 		klog.Warningf("consistency error (apply counts): %#v", r)
-	} else if r.total != (r.healthyCount + r.unhealthyCount) {
-		// This "invariant" only holds when all objects could be applied
+	} else if r.applySuccessCount != (r.healthyCount + r.unhealthyCount) {
+		// Health is only reported for objects that applied successfully.
 		klog.Warningf("consistency error (healthy counts): %#v", r)
 	}
 }
@@ -61,6 +64,14 @@ func (r *ApplyResults) checkInvariants() {
 func (r *ApplyResults) applyError(gvk schema.GroupVersionKind, nn types.NamespacedName, err error) {
 	r.applyFailCount++
 	klog.Warningf("error from apply on %s %s: %v", gvk, nn, err)
+}
+
+// applyDeferred records that an object was skipped because its CRD is not yet
+// registered. This is not a failure: a subsequent reconcile will retry once the
+// CRD is installed.
+func (r *ApplyResults) applyDeferred(gvk schema.GroupVersionKind, nn types.NamespacedName, err error) {
+	r.applyDeferredCount++
+	klog.V(2).Infof("deferring apply of %s %s until CRD is registered: %v", gvk, nn, err)
 }
 
 // applySuccess records that an object was applied and this succeeded.

--- a/pkg/applylib/applyset/results_test.go
+++ b/pkg/applylib/applyset/results_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applyset
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestAllAppliedTreatsDeferredAsApplied covers the e2e-kops-ai-conformance failure:
+// Cilium's GatewayClass cannot be applied until the Gateway API CRDs are installed,
+// but that should not pin the kops-channels readiness probe to NotReady forever.
+func TestAllAppliedTreatsDeferredAsApplied(t *testing.T) {
+	r := &ApplyResults{total: 2}
+	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "GatewayClass"}
+	nn := types.NamespacedName{Name: "cilium"}
+
+	r.applySuccess(schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}, types.NamespacedName{Namespace: "kube-system", Name: "cilium-config"})
+	r.reportHealth(schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}, types.NamespacedName{Namespace: "kube-system", Name: "cilium-config"}, true)
+	r.applyDeferred(gvk, nn, &meta.NoKindMatchError{GroupKind: gvk.GroupKind(), SearchedVersions: []string{gvk.Version}})
+
+	if !r.AllApplied() {
+		t.Errorf("AllApplied() = false, want true when only failure is a deferred missing CRD; got %#v", r)
+	}
+	if !r.AllHealthy() {
+		t.Errorf("AllHealthy() = false, want true; got %#v", r)
+	}
+}
+
+func TestApplyDeferredDetectsNoMatchError(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "GatewayClass"}
+	noMatch := &meta.NoKindMatchError{GroupKind: gvk.GroupKind(), SearchedVersions: []string{gvk.Version}}
+	// The applyset.go change wraps the error with fmt.Errorf("error getting rest mapping for %v: %w", ...).
+	// Make sure the wrapping does not defeat meta.IsNoMatchError.
+	wrapped := errors.Join(errors.New("error getting rest mapping for v1, Kind=GatewayClass: "), noMatch)
+	if !meta.IsNoMatchError(wrapped) {
+		t.Fatalf("meta.IsNoMatchError(wrapped) = false, want true")
+	}
+}


### PR DESCRIPTION
The kops-channels static pod's readiness probe goes NotReady whenever the last channel apply reported a failure, and that NotReady state blocks `kops validate cluster`. With Cilium's GatewayAPI enabled, the rendered addon includes a GatewayClass whose CRD is installed out-of-band (by an operator or a follow-up addon), so the first reconciles fail with "no matches for kind GatewayClass" and the cluster never validates.

Treat NoKindMatchError as a deferred apply rather than a failure: the reconcile loop already builds a fresh discovery cache each iteration, so the object will be picked up on a later pass once the CRD lands.

Fixes this prow job failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-ai-conformance/2066636438186758144

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-ai-conformance/2066636438186758144/artifacts/cluster-info/kube-system/kops-channels-i-0671771727eda8250/kops-channels.log

```
W0615 22:01:40.104400       1 results.go:63] error from apply on gateway.networking.k8s.io/v1, Kind=GatewayClass /cilium: error getting rest mapping for gateway.networking.k8s.io/v1, Kind=GatewayClass: no matches for kind "GatewayClass" in version "gateway.networking.k8s.io/v1"
W0615 22:01:40.104416       1 results.go:56] consistency error (healthy counts): &applyset.ApplyResults{total:19, applySuccessCount:18, applyFailCount:1, healthyCount:18, unhealthyCount:0}
I0615 22:01:40.104432       1 prune.go:40] Prune spec: <nil>
I0615 22:01:41.008762       1 health.go:64] status conditions not found for DaemonSet.apps:kube-system/cilium
W0615 22:01:41.099990       1 results.go:63] error from apply on gateway.networking.k8s.io/v1, Kind=GatewayClass /cilium: error getting rest mapping for gateway.networking.k8s.io/v1, Kind=GatewayClass: no matches for kind "GatewayClass" in version "gateway.networking.k8s.io/v1"
W0615 22:01:41.100010       1 results.go:56] consistency error (healthy counts): &applyset.ApplyResults{total:19, applySuccessCount:18, applyFailCount:1, healthyCount:18, unhealthyCount:0}
W0615 22:01:41.100041       1 apply_channel.go:119] error in apply iteration (will retry in 5s): applying "s3://k8s-kops-ci-prow-state-store/e2e-7e3760a104-521b7.tests-kops-aws.k8s.io/addons/bootstrap-channel.yaml": updating "networking.cilium.io": error updating addon from "s3://k8s-kops-ci-prow-state-store/e2e-7e3760a104-521b7.tests-kops-aws.k8s.io/addons/networking.cilium.io/k8s-1.16-v1.15.yaml": error applying update: not all objects were applied; error applying update after prune: not all objects were applied
```

Assisted by Claude Opus 4.8