### PR TITLE
Add serathius as scalability test owner

### DIFF
--- a/tests/e2e/scenarios/scalability/OWNERS
+++ b/tests/e2e/scenarios/scalability/OWNERS
@@ -4,7 +4,9 @@ approvers:
   - hakman
   - dims
   - hakuna-matatah
+  - serathius
 reviewers:
   - hakman
   - dims
   - hakuna-matatah
+  - serathius


### PR DESCRIPTION
The kops scalability test run is owned by SIG Scalability, so this directory should have a SIG Scalability owner. Adds serathius to approvers and reviewers of tests/e2e/scenarios/scalability/OWNERS.