### PR TITLE
scaletest: Report experiment variant into scalability run metadata

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -17,6 +17,11 @@
 set -e
 set -x
 
+# Report the experiment variant so TestGrid can show it as a column header.
+if [[ -n "${ARTIFACTS:-}" ]]; then
+  echo "{\"variant\":\"${EXPERIMENT_VARIANT:-base}\"}" > "${ARTIFACTS}/metadata.json"
+fi
+
 make test-e2e-install
 
 REPO_ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
Write `variant` (from `EXPERIMENT_VARIANT`, default `base`) into `${ARTIFACTS}/metadata.json` so TestGrid can distinguish runs of the experimental scale job. Tracking issue: https://github.com/kubernetes/test-infra/issues/37273