### PR TITLE
nodeup: load ip_set module and disable firewalld on RHEL10

### DIFF
--- a/nodeup/pkg/model/firewall.go
+++ b/nodeup/pkg/model/firewall.go
@@ -36,6 +36,29 @@ func (b *FirewallBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	c.AddTask(b.buildFirewallScript())
 	c.AddTask(b.buildSystemdService())
 
+	// On distros where Kubernetes CNIs (notably Calico) document firewalld
+	// as incompatible, stop and mask it. firewalld's default-reject
+	// filter_INPUT/filter_FORWARD policies and periodic-reload behavior
+	// conflict with the iptables/nftables rules CNIs install for pod and
+	// service traffic. Most cloud images in the RHEL family already ship
+	// firewalld off (AWS RHEL/Rocky AMIs, upstream Rocky GenericCloud); the
+	// GCE-optimized Rocky 10 image is the known outlier. The disable/mask
+	// sequence is idempotent and a no-op where firewalld isn't installed.
+	// See: https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements
+	if b.Distribution.ForceNftables() {
+		c.AddTask(&nodetasks.File{
+			Path:     "/etc/kops/firewalld-disabled",
+			Contents: fi.NewStringResource("# Marker: firewalld disabled by kops to avoid conflicts with the Kubernetes CNI dataplane.\n"),
+			Type:     nodetasks.FileType_File,
+			OnChangeExecute: [][]string{
+				// Stop and disable so it can't restart at boot.
+				{"bash", "-c", "systemctl disable --now firewalld.service 2>/dev/null; true"},
+				// Mask so package updates or preset reloads can't bring it back.
+				{"bash", "-c", "systemctl mask firewalld.service 2>/dev/null; true"},
+			},
+		})
+	}
+
 	return nil
 }
 

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -592,9 +592,15 @@ func loadKernelModules(context *model.NodeupModelContext, distribution distribut
 		}
 	}
 	if distribution.ForceNftables() {
-		// Distributions like RHEL10+ use nftables exclusively
-		// Load nf_tables and nf_conntrack to fix CNI plugins that use iptables-nft
-		for _, mod := range []string{"nf_tables", "nf_conntrack"} {
+		// Distributions like RHEL10+ use nftables exclusively.
+		// - nf_tables / nf_conntrack: required by CNI plugins that shell out
+		//   to iptables-nft.
+		// - ip_set: Calico's Felix unconditionally starts an `ipsetsManager`
+		//   that shells out to `ipset list -name` during dataplane resync,
+		//   even when NFTablesMode=Enabled. On RHEL10 family kernels the
+		//   ip_set module isn't auto-loaded, so the ipset call returns
+		//   EINVAL and Felix panics, crashlooping calico-node.
+		for _, mod := range []string{"nf_tables", "nf_conntrack", "ip_set"} {
 			if err := modprobe(mod); err != nil {
 				klog.Warningf("error loading %s module: %v", mod, err)
 			}


### PR DESCRIPTION
## Summary

Two related fixes for kops nodeup on the `ForceNftables()` distros (RHEL 10+, Rocky 10+):

1. **Load the `ip_set` kernel module** alongside `nf_tables` / `nf_conntrack` in `loadKernelModules`.
2. **Stop and mask `firewalld.service`** via a new step on `FirewallBuilder`, gated on `Distribution.ForceNftables()`.

Together these unblock the failing Calico cells in the `e2e-kops-grid-calico-{rhel10,rocky10}*` grid, which produce two distinct failure modes today.

## Problem

### Mode 1 — Felix `ipsetsManager` panics (arm64 cells)

Calico v3.31's Felix unconditionally starts an `ipsetsManager` that shells out to `ipset list -name` during dataplane resync, **even when `NFTablesMode: Enabled` is in effect**. On RHEL 10-family arm64 kernels the `ip_set` module isn't auto-loaded, so the netlink request returns `EINVAL` and Felix panics in a tight loop, taking calico-node with it. Every node reports `CrashLoopBackOff`, validation fails after ~25 min, Up returns exit 1.

The relevant Felix log on a failing node:

[ERROR] felix/ipsets.go:758: Bad return code from 'ipset list -name'.                           stderr="ipset v7.11: Kernel error received: Invalid argument"
[PANIC] felix/ipsets.go:416: Failed to update IP sets after multiple retries.

`lsmod` on the same node confirms `ip_set` is absent while `nf_tables` and `nf_conntrack` (already modprobed by kops) are present.

Example failing jobs:

- [AWS Calico rhel10arm64 k8s 1.33 kops 1.35](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-calico-rhel10arm64-k33-ko35/2063915367746506752)
- [AWS Calico rhel10arm64 k8s 1.33 kops master](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-calico-rhel10arm64-k33/2064097821987966976)
- [AWS Calico rocky10arm64 k8s 1.32 kops 1.35](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-calico-rocky10arm64-k32-ko35/2063963183185399808)

### Mode 2 — BGP keepalives killed by firewalld interaction (GCE x86_64 cells)

On the GCE-optimized Rocky Linux 10 image, `firewalld.service` starts at boot: `Starting firewalld.service - firewalld - dynamic firewall daemon...`, and the resulting nft ruleset contains a populated `table inet firewalld` with default-reject `filter_INPUT` and `filter_FORWARD` policies plus a `ct state invalid drop` rule. firewalld's periodic-reload behavior plus that `ct state invalid drop` race against Calico's BPF-mode INPUT chain rule:

```
meta mark & 0x05000000 == 0x05000000 meta l4proto tcp ... reject with tcp reset
```

which TCP-RSTs any BGP keepalive that arrives after the session's conntrack entry has been dropped. BIRD then logs `Error: Hold timer expired` on all peers simultaneously and the mesh never recovers. Cluster validation succeeds but e2e tests time out at the 60-minute kubetest2 cap.

This pattern persists even with `networking.calico.nftablesMode: Enabled` set (the field [added in #18452](https://github.com/kubernetes/kops/pull/18452)), confirming the flap isn't caused by Felix's `nft_compat` usage. the host-level firewalld is the remaining disturbance.

Example failing builds:

- [GCE Calico rocky10 k8s 1.33 kops 1.35](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-calico-rocky10-k33-ko35/2063955381826097152)
- [GCE Calico rocky10 k8s 1.35 kops 1.35 (the original report, pre-`nftablesMode`)](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-calico-rocky10-k35/2060557987310735360)

### Why only the GCE image

Empirical comparison from this investigation's own artifacts:

| Image | `firewalld.service` started? | `table inet firewalld` in nft? |
|---|---|---|
| GCE `rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260526` (x86_64) | yes | yes |
| AWS `309956199498/RHEL-10.1.0_HVM-...arm64-...` (Red Hat AMI) | no | absent |

The CIQ-built GCE-optimized spin ships firewalld active; the Red Hat AWS AMIs and the upstream Rocky `GenericCloud` qcow2 don't. Disabling firewalld in nodeup is therefore a no-op on the AWS path and a fix on the GCE path.

## Fix

**`upup/pkg/fi/nodeup/command.go` — `loadKernelModules`:** append `ip_set` to the `ForceNftables()` modprobe list. `modprobe` already logs warnings on failure rather than aborting nodeup, so the call is safe on hosts where the module package isn't installed.

**`nodeup/pkg/model/firewall.go` — new `disableFirewalld(c)` step:** mirrors the existing `disableNMCloudSetup` pattern. it writes a marker file under `/etc/kops/` and uses `OnChangeExecute` to run `systemctl disable --now firewalld.service` and `systemctl mask firewalld.service`, both wrapped in `bash -c '... 2>/dev/null; true'` so they're safe no-ops on images where firewalld isn't installed. Gated on `b.Distribution.ForceNftables()`.

## Precedent for unconditionally disabling firewalld

- [Calico requirements doc](https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements): *"If your Linux distribution comes with installed Firewalld or another iptables manager it should be disabled."*
- [RKE2 known issues](https://docs.rke2.io/known_issues): *"firewalld should be disabled on systems running RKE2."*
- OpenShift: disables firewalld on every RHEL worker ([openshift-ansible #11824](https://github.com/openshift/openshift-ansible/pull/11824)).
- AWS RHEL/Rocky 10 image team: strips firewalld from the AMI.

