### PR TITLE
fix: remap v1alpha2 field paths in instance group set/unset commands

### DIFF
--- a/pkg/apis/kops/fieldmap.go
+++ b/pkg/apis/kops/fieldmap.go
@@ -85,3 +85,27 @@ var clusterFieldMappings = []struct {
 	{V1Alpha2: "spec.externalDns.provider", V1Alpha3: "spec.externalDNS.provider"},
 	{V1Alpha2: "spec.externalDns.priorityClassName", V1Alpha3: "spec.externalDNS.priorityClassName"},
 }
+
+// InternalPathForInstanceGroupField returns the path for a given instance group field, as it appears in the internal API.
+func InternalPathForInstanceGroupField(fieldPath string) string {
+	for _, mapping := range instanceGroupFieldMappings {
+		if mapping.V1Alpha2 == fieldPath {
+			return mapping.Internal
+		}
+	}
+	return fieldPath
+}
+
+// instanceGroupFieldMappings maps v1alpha2 instance group field paths to their internal equivalents.
+var instanceGroupFieldMappings = []struct {
+	V1Alpha2 string
+	Internal string
+}{
+	{V1Alpha2: "spec.rootVolumeSize", Internal: "spec.rootVolume.size"},
+	{V1Alpha2: "spec.rootVolumeType", Internal: "spec.rootVolume.type"},
+	{V1Alpha2: "spec.rootVolumeIops", Internal: "spec.rootVolume.iops"},
+	{V1Alpha2: "spec.rootVolumeThroughput", Internal: "spec.rootVolume.throughput"},
+	{V1Alpha2: "spec.rootVolumeOptimization", Internal: "spec.rootVolume.optimization"},
+	{V1Alpha2: "spec.rootVolumeEncryption", Internal: "spec.rootVolume.encryption"},
+	{V1Alpha2: "spec.rootVolumeEncryptionKey", Internal: "spec.rootVolume.encryptionKey"},
+}

--- a/pkg/apis/kops/fieldmap_test.go
+++ b/pkg/apis/kops/fieldmap_test.go
@@ -34,3 +34,23 @@ func TestClusterFieldHumanPath(t *testing.T) {
 		}
 	}
 }
+
+func TestInternalPathForInstanceGroupField(t *testing.T) {
+	grid := []struct {
+		In       string
+		Expected string
+	}{
+		{In: "spec.rootVolumeType", Expected: "spec.rootVolume.type"},
+		{In: "spec.rootVolumeSize", Expected: "spec.rootVolume.size"},
+		{In: "spec.rootVolumeIops", Expected: "spec.rootVolume.iops"},
+		{In: "spec.rootVolumeEncryptionKey", Expected: "spec.rootVolume.encryptionKey"},
+		{In: "spec.machineType", Expected: "spec.machineType"},
+	}
+
+	for _, g := range grid {
+		actual := InternalPathForInstanceGroupField(g.In)
+		if actual != g.Expected {
+			t.Errorf("InternalPathForInstanceGroupField(%q) = %q; expected %q", g.In, actual, g.Expected)
+		}
+	}
+}

--- a/pkg/commands/set_instancegroups.go
+++ b/pkg/commands/set_instancegroups.go
@@ -34,6 +34,7 @@ func SetInstancegroupFields(fields []string, instanceGroup *api.InstanceGroup) e
 
 		key := kv[0]
 		key = strings.TrimPrefix(key, "instancegroup.")
+		key = api.InternalPathForInstanceGroupField(key)
 
 		if err := reflectutils.SetString(instanceGroup, key, kv[1]); err != nil {
 			return err

--- a/pkg/commands/set_instancegroups_test.go
+++ b/pkg/commands/set_instancegroups_test.go
@@ -102,6 +102,30 @@ func TestSetInstanceGroupsFields(t *testing.T) {
 				},
 			},
 		},
+		{
+			Fields: []string{
+				"spec.rootVolumeType=gp3",
+			},
+			Output: kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					RootVolume: &kops.InstanceRootVolumeSpec{
+						Type: fi.PtrTo("gp3"),
+					},
+				},
+			},
+		},
+		{
+			Fields: []string{
+				"spec.rootVolumeSize=64",
+			},
+			Output: kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					RootVolume: &kops.InstanceRootVolumeSpec{
+						Size: fi.PtrTo(int32(64)),
+					},
+				},
+			},
+		},
 	}
 
 	for _, g := range grid {

--- a/pkg/commands/unset_instancegroups.go
+++ b/pkg/commands/unset_instancegroups.go
@@ -27,6 +27,7 @@ import (
 func UnsetInstancegroupFields(fields []string, instanceGroup *api.InstanceGroup) error {
 	for _, field := range fields {
 		key := strings.TrimPrefix(field, "instancegroup.")
+		key = api.InternalPathForInstanceGroupField(key)
 
 		if err := reflectutils.Unset(instanceGroup, key); err != nil {
 			return err

--- a/pkg/commands/unset_instancegroups_test.go
+++ b/pkg/commands/unset_instancegroups_test.go
@@ -99,6 +99,40 @@ func TestUnsetInstanceGroupsFields(t *testing.T) {
 				Spec: kops.InstanceGroupSpec{},
 			},
 		},
+		{
+			Fields: []string{
+				"spec.rootVolumeType",
+			},
+			Input: kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					RootVolume: &kops.InstanceRootVolumeSpec{
+						Type: fi.PtrTo("gp3"),
+					},
+				},
+			},
+			Output: kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					RootVolume: &kops.InstanceRootVolumeSpec{},
+				},
+			},
+		},
+		{
+			Fields: []string{
+				"spec.rootVolumeSize",
+			},
+			Input: kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					RootVolume: &kops.InstanceRootVolumeSpec{
+						Size: fi.PtrTo(int32(64)),
+					},
+				},
+			},
+			Output: kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					RootVolume: &kops.InstanceRootVolumeSpec{},
+				},
+			},
+		},
 	}
 
 	for _, g := range grid {


### PR DESCRIPTION
**What this PR does / why we need it**:

`kops edit instancegroup --set spec.rootVolumeType=gp3` fails with "field not found" because the internal struct uses the nested path `spec.rootVolume.type`. Users naturally copy field names from the YAML they see in `kops edit instancegroup`, which uses the v1alpha2 flat names. This adds a field mapping that translates the seven legacy `rootVolume*` field names to their internal `rootVolume.*` equivalents in both `--set` and `--unset` commands.

**Which issue(s) this PR fixes**:

Fixes #17622

**Special notes for your reviewer**:

This mirrors how `SetClusterFields` already remaps legacy cluster field paths via `InternalPathForClusterField`.