### PR TITLE
e2e: Skip ImageVolume tests on COS 121

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -154,8 +154,11 @@ func (t *Tester) setSkipRegexFlag() error {
 			// https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#implementations-supplementalgroupspolicy
 			// https://github.com/kubernetes/test-infra/blob/0fa3c1f53ee2b715469380f9e50200d6b7612dff/config/jobs/kubernetes/kops/helpers.py#L107-L109
 			skipMap["SupplementalGroupsPolicy"] = nil
+		}
+		if matchesAnySubstrings(ig.Spec.Image, []string{"debian-11", "cos-121", "cos-arm64-121"}) {
 			// ImageVolume requires containerd v2.1
 			// ref: https://github.com/containerd/containerd/releases/tag/v2.1.0
+			// https://docs.cloud.google.com/container-optimized-os/docs/release-notes/m121
 			skipMap["ImageVolume"] = nil
 		}
 		if matchesAnySubstrings(ig.Spec.Image, []string{


### PR DESCRIPTION
COS 121 is pinned to containerd 2.0.X:

https://docs.cloud.google.com/container-optimized-os/docs/release-notes/m121

Whereas newer COS 125 uses containerd 2.1.X:

https://docs.cloud.google.com/container-optimized-os/docs/release-notes/m125

For the same reason we skip this test on Debian 11, we should skip on COS 121.


Fixes these failures:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-gce-nftables-cos121/2067395485424947200

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-gce-nftables-cos121arm64/2067320993709297664