### PR TITLE
gce: emit kops.k8s.io/instancegroup node label

### DIFF
--- a/pkg/nodeidentity/gce/identify.go
+++ b/pkg/nodeidentity/gce/identify.go
@@ -138,6 +138,7 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 		capiMachine = m
 	}
 
+	var igName string
 	if capiMachine == nil {
 		// The metadata itself is potentially mutable from the instance
 		// We instead look at the MIG configuration
@@ -170,7 +171,7 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 			return nil, err
 		}
 
-		igName := getMetadataValue(instanceTemplate.Properties.Metadata, MetadataKeyInstanceGroupName)
+		igName = getMetadataValue(instanceTemplate.Properties.Metadata, MetadataKeyInstanceGroupName)
 		if igName == "" {
 			return nil, fmt.Errorf("ig name not set on instance template %s", instanceTemplate.Name)
 		}
@@ -200,6 +201,9 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 				klog.Warningf("unknown node role %q for server %q", role, instance.SelfLink)
 			}
 		}
+	}
+	if igName != "" {
+		labels[kops.NodeLabelInstanceGroup] = igName
 	}
 	info.Labels = labels
 	return info, nil


### PR DESCRIPTION
The GCE node identifier reads the instance-group name from the MIG instance template metadata but never adds it to the returned labels, so kops-controller never patches kops.k8s.io/instancegroup onto GCE nodes. The label has been missing since the cluster-api refactor in a7f1b4f510 which landed in kops 1.35.

Fixes https://github.com/kubernetes/kops/issues/18474

assisted by Opus 4.8