### PR TITLE
Automated cherry pick of #18478: nodeup: load ip_set module and disable firewalld on RHEL10

### DIFF
--- a/nodeup/pkg/model/firewall.go
+++ b/nodeup/pkg/model/firewall.go
@@ -36,6 +36,29 @@ func (b *FirewallBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	c.AddTask(b.buildFirewallScript())
 	c.AddTask(b.buildSystemdService())
 
+	// On distros where Kubernetes CNIs (notably Calico) document firewalld
+	// as incompatible, stop and mask it. firewalld's default-reject
+	// filter_INPUT/filter_FORWARD policies and periodic-reload behavior
+	// conflict with the iptables/nftables rules CNIs install for pod and
+	// service traffic. Most cloud images in the RHEL family already ship
+	// firewalld off (AWS RHEL/Rocky AMIs, upstream Rocky GenericCloud); the
+	// GCE-optimized Rocky 10 image is the known outlier. The disable/mask
+	// sequence is idempotent and a no-op where firewalld isn't installed.
+	// See: https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements
+	if b.Distribution.ForceNftables() {
+		c.AddTask(&nodetasks.File{
+			Path:     "/etc/kops/firewalld-disabled",
+			Contents: fi.NewStringResource("# Marker: firewalld disabled by kops to avoid conflicts with the Kubernetes CNI dataplane.\n"),
+			Type:     nodetasks.FileType_File,
+			OnChangeExecute: [][]string{
+				// Stop and disable so it can't restart at boot.
+				{"bash", "-c", "systemctl disable --now firewalld.service 2>/dev/null; true"},
+				// Mask so package updates or preset reloads can't bring it back.
+				{"bash", "-c", "systemctl mask firewalld.service 2>/dev/null; true"},
+			},
+		})
+	}
+
 	return nil
 }
 

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -592,9 +592,15 @@ func loadKernelModules(context *model.NodeupModelContext, distribution distribut
 		}
 	}
 	if distribution.ForceNftables() {
-		// Distributions like RHEL10+ use nftables exclusively
-		// Load nf_tables and nf_conntrack to fix CNI plugins that use iptables-nft
-		for _, mod := range []string{"nf_tables", "nf_conntrack"} {
+		// Distributions like RHEL10+ use nftables exclusively.
+		// - nf_tables / nf_conntrack: required by CNI plugins that shell out
+		//   to iptables-nft.
+		// - ip_set: Calico's Felix unconditionally starts an `ipsetsManager`
+		//   that shells out to `ipset list -name` during dataplane resync,
+		//   even when NFTablesMode=Enabled. On RHEL10 family kernels the
+		//   ip_set module isn't auto-loaded, so the ipset call returns
+		//   EINVAL and Felix panics, crashlooping calico-node.
+		for _, mod := range []string{"nf_tables", "nf_conntrack", "ip_set"} {
 			if err := modprobe(mod); err != nil {
 				klog.Warningf("error loading %s module: %v", mod, err)
 			}


### PR DESCRIPTION
Cherry pick of #18478 on release-1.36.

#18478: nodeup: load ip_set module and disable firewalld on RHEL10

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```