### PR TITLE
Remove namespace from DO ClusterRole

### DIFF
--- a/upup/models/cloudup/resources/addons/digitalocean-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
@@ -1455,7 +1455,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-do-node-driver-registrar-role
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["events"]


### PR DESCRIPTION
DO jobs are failing because the channels container is failing to apply this manifest:

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-do-gossip/2068038730425307136/artifacts/cluster-info/kube-system/kops-channels-10.108.0.4/kops-channels.log

```
W0619 18:55:03.807097       1 results.go:63] error from apply on rbac.authorization.k8s.io/v1, Kind=ClusterRole kube-system/csi-do-node-driver-registrar-role: namespace "kube-system" was provided for cluster-scoped object rbac.authorization.k8s.io/v1, Kind=ClusterRole
I0619 18:55:04.007854       1 health.go:64] status conditions not found for StatefulSet.apps:kube-system/snapshot-controller
W0619 18:55:04.307159       1 results.go:56] consistency error (healthy counts): &applyset.ApplyResults{total:27, applySuccessCount:26, applyFailCount:1, healthyCount:26, unhealthyCount:0}
W0619 18:55:04.307204       1 apply_channel.go:119] error in apply iteration (will retry in 5s): applying "do://e2e-kops-space/e2e-e2e-kops-do-gossip.k8s.local/addons/bootstrap-channel.yaml": updating "digitalocean-csi-driver.addons.k8s.io": error updating addon from "do://e2e-kops-space/e2e-e2e-kops-do-gossip.k8s.local/addons/digitalocean-csi-driver.addons.k8s.io/k8s-1.22.yaml": error applying update: not all objects were applied; error applying update after prune: not all objects were applied
```