### PR TITLE
Automated cherry pick of #18498: Remove namespace from DO ClusterRole

### DIFF
--- a/upup/models/cloudup/resources/addons/digitalocean-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
@@ -1455,7 +1455,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-do-node-driver-registrar-role
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["events"]


### PR DESCRIPTION
Cherry pick of #18498 on release-1.36.

#18498: Remove namespace from DO ClusterRole

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```