### PR TITLE
chore(channels): promote to stable, bump node images, update recommended kOps versions

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -206,31 +206,31 @@ spec:
     #requiredVersion: 1.36.0
     kubernetesVersion: 1.36.2
   - range: ">=1.35.0-alpha.1"
-    recommendedVersion: "1.35.0-beta.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.35.0
     kubernetesVersion: 1.35.6
   - range: ">=1.34.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.34.0
     kubernetesVersion: 1.34.9
   - range: ">=1.33.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.33.0
     kubernetesVersion: 1.33.13
   - range: ">=1.32.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.32.0
     kubernetesVersion: 1.32.13
   - range: ">=1.31.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.31.0
     kubernetesVersion: 1.31.14
   - range: ">=1.30.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.30.0
     kubernetesVersion: 1.30.14
   - range: ">=1.29.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.34.3"
     #requiredVersion: 1.29.0
     kubernetesVersion: 1.29.15
   - range: ">=1.28.0-alpha.1"

--- a/channels/alpha
+++ b/channels/alpha
@@ -66,19 +66,19 @@ spec:
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0 <1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260410
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260610
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.32.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260218
+    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260610
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.32.0"
@@ -94,23 +94,23 @@ spec:
       providerID: gce
       architectureID: amd64
       kubernetesVersion: ">=1.18.0 <1.27.0"
-    - name: ubuntu-os-cloud/ubuntu-2204-jammy-v20250615
+    - name: ubuntu-os-cloud/ubuntu-2204-jammy-v20260612
       providerID: gce
       architectureID: amd64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+    - name: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
       providerID: gce
       architectureID: amd64
       kubernetesVersion: ">=1.32.0"
-    - name: Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202406060
+    - name: Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202505200
       providerID: azure
       architectureID: amd64
       kubernetesVersion: ">=1.20.0 <1.27.0"
-    - name: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202506120
+    - name: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202606110
       providerID: azure
       architectureID: amd64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: Canonical:ubuntu-24_04-lts:server:24.04.202507010
+    - name: Canonical:ubuntu-24_04-lts:server:24.04.202606120
       providerID: azure
       architectureID: amd64
       kubernetesVersion: ">=1.32.0"

--- a/channels/alpha
+++ b/channels/alpha
@@ -102,6 +102,10 @@ spec:
       providerID: gce
       architectureID: amd64
       kubernetesVersion: ">=1.32.0"
+    - name: ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260615
+      providerID: gce
+      architectureID: arm64
+      kubernetesVersion: ">=1.32.0"
     - name: Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202505200
       providerID: azure
       architectureID: amd64
@@ -113,6 +117,10 @@ spec:
     - name: Canonical:ubuntu-24_04-lts:server:24.04.202606120
       providerID: azure
       architectureID: amd64
+      kubernetesVersion: ">=1.32.0"
+    - name: Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606110
+      providerID: azure
+      architectureID: arm64
       kubernetesVersion: ">=1.32.0"
   cluster:
     kubernetesVersion: v1.5.8

--- a/channels/stable
+++ b/channels/stable
@@ -66,19 +66,19 @@ spec:
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0 <1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260410
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260610
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.32.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260218
+    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260610
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.32.0"
@@ -94,23 +94,23 @@ spec:
       providerID: gce
       architectureID: amd64
       kubernetesVersion: ">=1.18.0 <1.27.0"
-    - name: ubuntu-os-cloud/ubuntu-2204-jammy-v20250615
+    - name: ubuntu-os-cloud/ubuntu-2204-jammy-v20260612
       providerID: gce
       architectureID: amd64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+    - name: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
       providerID: gce
       architectureID: amd64
       kubernetesVersion: ">=1.32.0"
-    - name: Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202406060
+    - name: Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202505200
       providerID: azure
       architectureID: amd64
       kubernetesVersion: ">=1.20.0 <1.27.0"
-    - name: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202506120
+    - name: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202606110
       providerID: azure
       architectureID: amd64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: Canonical:ubuntu-24_04-lts:server:24.04.202507010
+    - name: Canonical:ubuntu-24_04-lts:server:24.04.202606120
       providerID: azure
       architectureID: amd64
       kubernetesVersion: ">=1.32.0"

--- a/channels/stable
+++ b/channels/stable
@@ -206,31 +206,31 @@ spec:
     #requiredVersion: 1.36.0
     kubernetesVersion: 1.36.2
   - range: ">=1.35.0-alpha.1"
-    recommendedVersion: "1.34.3"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.34.0
     kubernetesVersion: 1.35.6
   - range: ">=1.34.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.34.0
     kubernetesVersion: 1.34.9
   - range: ">=1.33.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.33.0
     kubernetesVersion: 1.33.13
   - range: ">=1.32.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.32.0
     kubernetesVersion: 1.32.13
   - range: ">=1.31.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.31.0
     kubernetesVersion: 1.31.14
   - range: ">=1.30.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.35.1"
     #requiredVersion: 1.30.0
     kubernetesVersion: 1.30.14
   - range: ">=1.29.0-alpha.1"
-    recommendedVersion: "1.34.1"
+    recommendedVersion: "1.34.3"
     #requiredVersion: 1.29.0
     kubernetesVersion: 1.29.15
   - range: ">=1.28.0-alpha.1"

--- a/channels/stable
+++ b/channels/stable
@@ -123,13 +123,13 @@ spec:
     recommendedVersion: 1.36.2
     requiredVersion: 1.36.0
   - range: ">=1.35.0"
-    recommendedVersion: 1.35.5
+    recommendedVersion: 1.35.6
     requiredVersion: 1.35.0
   - range: ">=1.34.0"
-    recommendedVersion: 1.34.8
+    recommendedVersion: 1.34.9
     requiredVersion: 1.34.0
   - range: ">=1.33.0"
-    recommendedVersion: 1.33.12
+    recommendedVersion: 1.33.13
     requiredVersion: 1.33.0
   - range: ">=1.32.0"
     recommendedVersion: 1.32.13
@@ -208,15 +208,15 @@ spec:
   - range: ">=1.35.0-alpha.1"
     recommendedVersion: "1.34.3"
     #requiredVersion: 1.34.0
-    kubernetesVersion: 1.35.5
+    kubernetesVersion: 1.35.6
   - range: ">=1.34.0-alpha.1"
     recommendedVersion: "1.34.1"
     #requiredVersion: 1.34.0
-    kubernetesVersion: 1.34.8
+    kubernetesVersion: 1.34.9
   - range: ">=1.33.0-alpha.1"
     recommendedVersion: "1.34.1"
     #requiredVersion: 1.33.0
-    kubernetesVersion: 1.33.12
+    kubernetesVersion: 1.33.13
   - range: ">=1.32.0-alpha.1"
     recommendedVersion: "1.34.1"
     #requiredVersion: 1.32.0

--- a/channels/stable
+++ b/channels/stable
@@ -102,6 +102,10 @@ spec:
       providerID: gce
       architectureID: amd64
       kubernetesVersion: ">=1.32.0"
+    - name: ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260615
+      providerID: gce
+      architectureID: arm64
+      kubernetesVersion: ">=1.32.0"
     - name: Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202505200
       providerID: azure
       architectureID: amd64
@@ -113,6 +117,10 @@ spec:
     - name: Canonical:ubuntu-24_04-lts:server:24.04.202606120
       providerID: azure
       architectureID: amd64
+      kubernetesVersion: ">=1.32.0"
+    - name: Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606110
+      providerID: azure
+      architectureID: arm64
       kubernetesVersion: ">=1.32.0"
   cluster:
     kubernetesVersion: v1.5.8

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -377,7 +377,8 @@ func (c *Channel) HasUpstreamImagePrefix(image string) bool {
 		strings.HasPrefix(image, "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:") ||
 		strings.HasPrefix(image, "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:") ||
 		strings.HasPrefix(image, "Canonical:ubuntu-24_04-lts:server-gen1:") ||
-		strings.HasPrefix(image, "Canonical:ubuntu-24_04-lts:server:")
+		strings.HasPrefix(image, "Canonical:ubuntu-24_04-lts:server:") ||
+		strings.HasPrefix(image, "Canonical:ubuntu-24_04-lts:server-arm64:")
 }
 
 // GetPackageVersion returns the version for the package, or an error if could not be found.

--- a/tests/integration/create_cluster/calico_bpf/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/calico_bpf/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: calico-bpf.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -90,7 +90,7 @@ metadata:
     kops.k8s.io/cluster: calico-bpf.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/cilium-eni/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/cilium-eni/expected-v1alpha2.yaml
@@ -71,7 +71,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -91,7 +91,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
@@ -135,7 +135,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -161,7 +161,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -181,7 +181,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -201,7 +201,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -221,7 +221,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 4
   minSize: 4
@@ -242,7 +242,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 3
   minSize: 3
@@ -262,7 +262,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 3
   minSize: 3

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -107,7 +107,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -127,7 +127,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -147,7 +147,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -167,7 +167,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 4
   minSize: 4
@@ -188,7 +188,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 3
   minSize: 3
@@ -208,7 +208,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 3
   minSize: 3

--- a/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
@@ -66,7 +66,7 @@ metadata:
     kops.k8s.io/cluster: gce.example.com
   name: control-plane-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -88,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: gce.example.com
   name: nodes-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/gossip-aws/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gossip-aws/expected-v1alpha2.yaml
@@ -67,7 +67,7 @@ metadata:
     kops.k8s.io/cluster: gossip.k8s.local
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: gossip.k8s.local
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/gossip-azure/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gossip-azure/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: gossip.k8s.local
   name: control-plane-eastus-1
 spec:
-  image: Canonical:ubuntu-24_04-lts:server:24.04.202507010
+  image: Canonical:ubuntu-24_04-lts:server:24.04.202606120
   machineType: Standard_B2s
   maxSize: 1
   minSize: 1
@@ -92,7 +92,7 @@ metadata:
     kops.k8s.io/cluster: gossip.k8s.local
   name: nodes-eastus-1
 spec:
-  image: Canonical:ubuntu-24_04-lts:server:24.04.202507010
+  image: Canonical:ubuntu-24_04-lts:server:24.04.202606120
   machineType: Standard_B2s
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/gossip-gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gossip-gce/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ metadata:
     kops.k8s.io/cluster: gossip.k8s.local
   name: control-plane-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: gossip.k8s.local
   name: nodes-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -107,7 +107,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -127,7 +127,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -147,7 +147,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -167,7 +167,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -187,7 +187,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -107,7 +107,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -127,7 +127,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -147,7 +147,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -167,7 +167,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -187,7 +187,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -73,7 +73,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: control-plane-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -95,7 +95,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: control-plane-us-test1-b
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -117,7 +117,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: control-plane-us-test1-c
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -139,7 +139,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: nodes-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -161,7 +161,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: nodes-us-test1-b
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -183,7 +183,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: nodes-us-test1-c
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -79,7 +79,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-1
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -99,7 +99,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-2
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -119,7 +119,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-3
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -139,7 +139,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -95,7 +95,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-1
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -115,7 +115,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-2
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -135,7 +135,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-3
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -155,7 +155,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1b-1
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -175,7 +175,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1b-2
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -195,7 +195,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -215,7 +215,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -72,7 +72,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -92,7 +92,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -112,7 +112,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
@@ -78,7 +78,7 @@ metadata:
     kops.k8s.io/cluster: ipv6.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -98,7 +98,7 @@ metadata:
     kops.k8s.io/cluster: ipv6.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
@@ -82,7 +82,7 @@ metadata:
     kops.k8s.io/cluster: karpenter.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -102,7 +102,7 @@ metadata:
     kops.k8s.io/cluster: karpenter.example.com
   name: nodes
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   manager: Karpenter
   nodeLabels:
     kops.k8s.io/instancegroup: nodes

--- a/tests/integration/create_cluster/minimal-1.31/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.31/expected-v1alpha2.yaml
@@ -67,7 +67,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260410
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-1.32/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.32/expected-v1alpha2.yaml
@@ -67,7 +67,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-1.35/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.35/expected-v1alpha2.yaml
@@ -67,7 +67,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-1.36/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.36/expected-v1alpha2.yaml
@@ -67,7 +67,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-arm64/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-arm64/expected-v1alpha2.yaml
@@ -67,7 +67,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260610
   machineType: m6g.xlarge
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260610
   machineType: m6g.xlarge
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-gce-dns-none/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-gce-dns-none/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-gce/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-irsa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-irsa/expected-v1alpha2.yaml
@@ -71,7 +71,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -91,7 +91,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal_feature-gates/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal_feature-gates/expected-v1alpha2.yaml
@@ -91,7 +91,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -111,7 +111,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -72,7 +72,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -92,7 +92,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -112,7 +112,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -90,7 +90,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -75,7 +75,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -98,7 +98,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid3
   - sg-exampleid4
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -121,7 +121,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid
   - sg-exampleid2
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-micro
   maxSize: 1
   minSize: 1
@@ -95,7 +95,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid3
   - sg-exampleid4
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-standard-2
   maxSize: 1
   minSize: 1
@@ -120,7 +120,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid
   - sg-exampleid2
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -74,7 +74,7 @@ metadata:
     kops.k8s.io/cluster: private-subnets.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -94,7 +94,7 @@ metadata:
     kops.k8s.io/cluster: private-subnets.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -69,7 +69,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -89,7 +89,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -69,7 +69,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -89,7 +89,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -68,7 +68,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -88,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260218
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260610
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/volume_type/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/volume_type/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ metadata:
     kops.k8s.io/cluster: volume-types.example.com
   name: control-plane-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -89,7 +89,7 @@ metadata:
     kops.k8s.io/cluster: volume-types.example.com
   name: nodes-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250606
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: e2-medium
   maxSize: 1
   minSize: 1


### PR DESCRIPTION
### 1. Promote alpha → stable
Copies the k8s patch bumps that have baked in `alpha` into `stable`:
- 1.35: `1.35.5` → `1.35.6`
- 1.34: `1.34.8` → `1.34.9`
- 1.33: `1.33.12` → `1.33.13`

The beta kOps `recommendedVersion` and the alpha-only `packages:` section stay held back as usual.

### 2. Bump node images
Updates the `images:` section in both channels to the latest published Ubuntu images, queried directly from the cloud CLIs (`aws ec2 describe-images`, `gcloud compute images describe-from-family`, `az vm image list`):

| Provider | Image | Version |
|---|---|---|
| AWS | jammy & noble (amd64 + arm64) | `…-server-20260610` |
| GCE | jammy | `v20260612` |
| GCE | noble (amd64) | `v20260615` |
| Azure | focal | `20.04.202505200` |
| Azure | jammy | `22.04.202606110` |
| Azure | noble | `24.04.202606120` |

### 3. Recommended kOps versions
Sets `kopsVersions[].recommendedVersion` to the latest GA kOps that supports each Kubernetes version:
- k8s 1.30–1.35 → `1.35.1`
- k8s 1.29 → `1.34.3` (kOps 1.35 deprecates k8s 1.29)

### 4. arm64 noble images for GCE and Azure
Adds `architectureID: arm64` noble (`>=1.32.0`) defaults so arm64 clusters on GCE/Azure get a default image (previously AWS-only):
- GCE → `ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260615`
- Azure → `Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606110`

/cc @rifelpet @ameukam 

Assisted by Claude Opus