### PR TITLE
Increase storage test timeouts for the Azure disk CSI driver

### DIFF
--- a/tests/e2e/csi-manifests/azure-disk/driver.yaml
+++ b/tests/e2e/csi-manifests/azure-disk/driver.yaml
@@ -28,3 +28,16 @@ DriverInfo:
     pvcDataSource: false
     RWX: false
     readWriteOncePod: true
+# The disk.csi.azure.com driver's attach/detach operations are ARM control-plane
+# calls that routinely take longer than the framework's default TimeoutContext
+# values, causing PersistentVolume e2e flakes (pods stuck Pending on volume mount,
+# slow PV deletion). These keys map to framework.TimeoutContext fields and override
+# the defaults for the external storage tests only.
+Timeouts:
+  PodStart: 15m
+  PodStartSlow: 20m
+  ClaimProvision: 10m
+  ClaimBound: 10m
+  PVDelete: 15m
+  PVDeleteSlow: 30m
+  PodDelete: 10m


### PR DESCRIPTION
## What

Add a `Timeouts:` block to the external-storage testdriver manifest for `disk.csi.azure.com` (`tests/e2e/csi-manifests/azure-disk/driver.yaml`), overriding several `framework.TimeoutContext` defaults for the Azure disk storage e2e tests.

## Why

The `e2e-kops-azure-gossip-ha` job flakes on PersistentVolume tests because `disk.csi.azure.com` attach/detach/provision are ARM control-plane operations that routinely exceed the e2e framework's default timeouts. Observed failures in the `External Storage [Driver: disk.csi.azure.com]` suite:

- `subPath should support readOnly file specified in the volumeMount`
- `subPath should support non-existent path`
- `volumes should allow exec of files on the volume`

All fail identically: the test pod is scheduled but stays `Pending` / `PodInitializing` waiting on the volume to attach+mount, then trips the default `PodStart` timeout (`Timed out after 300.001s`). The root cause is Azure disk attach latency, not a product bug — confirmed against the failing runs:

- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-azure-gossip-ha/2066392075493969920
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-azure-gossip-ha/2065908887327870976
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-azure-gossip-ha/2065063307588407296

## How

The Kubernetes external-storage test harness supports a per-driver `Timeouts` map that overrides `framework.TimeoutContext`. This is the supported, configuration-only knob — no changes to `k8s.io/kubernetes/test/e2e` code. kops already passes this manifest via `--storage.testdriver` (`tests/e2e/pkg/tester/tester.go`).

### Consuming code in kubernetes/kubernetes

These settings are read by the external storage test driver:

- [`driverDefinition.Timeouts` field](https://github.com/kubernetes/kubernetes/blob/17e2eda6119170e6ce1a065716432b1d37d028dd/test/e2e/storage/external/external.go#L178-L181) — the manifest field these YAML keys map to.
- [`driverDefinition.GetTimeouts()`](https://github.com/kubernetes/kubernetes/blob/17e2eda6119170e6ce1a065716432b1d37d028dd/test/e2e/storage/external/external.go#L363) — parses each value with `time.ParseDuration` and overlays it onto the default `framework.TimeoutContext`.
- [`GetDriverTimeouts()` / `CustomTimeoutsTestDriver`](https://github.com/kubernetes/kubernetes/blob/17e2eda6119170e6ce1a065716432b1d37d028dd/test/e2e/storage/framework/testdriver.go#L153-L165) — how the storage suites obtain the (possibly overridden) timeouts.
- [`TimeoutContext` / `defaultTimeouts`](https://github.com/kubernetes/kubernetes/blob/17e2eda6119170e6ce1a065716432b1d37d028dd/test/e2e/framework/timeouts.go) — the struct whose Go field names these keys must match, and the defaults being overridden.

New values (defaults in parentheses):

| Key            | New   | Default |
|----------------|-------|---------|
| PodStart       | 15m   | 5m      |
| PodStartSlow   | 20m   | 15m     |
| ClaimProvision | 10m   | 5m      |
| ClaimBound     | 10m   | 3m      |
| PVDelete       | 15m   | 5m      |
| PVDeleteSlow   | 30m   | 20m     |
| PodDelete      | 10m   | 5m      |

## Scope / not addressed

This only affects the `External Storage [Driver: disk.csi.azure.com]` tests. The two `[sig-apps] StatefulSet` flakes on the same job ([2067116858862997504](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-azure-gossip-ha/2067116858862997504), [2065546496547229696](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-azure-gossip-ha/2065546496547229696)) share the same Azure-latency root cause but use hardcoded constants (`StatefulSetTimeout = 10m`) in upstream `test/e2e` and cannot be tuned via configuration; they would need a separate upstream change.

---
Assisted by Opus 4.8
