### PR TITLE
e2e: test the PR's own channels, not master's

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	osexec "os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -232,6 +233,12 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 			return err
 		}
 		args = append(args, createArgs...)
+	}
+	// Use the PR's own channels only when kops was built from the checkout. Downloaded
+	// --kops-version[-marker] binaries can land in <cwd>/_rundir under KopsRoot, where path
+	// containment alone wouldn't exclude them.
+	if d.KopsVersionMarker == "" && d.KopsVersion == "" && builtFromKopsRoot(d.KopsBinaryPath, d.KopsRoot) {
+		args = localChannelArgs(args, d.KopsRoot)
 	}
 	args = appendIfUnset(args, "--admin-access", adminAccess)
 
@@ -521,6 +528,49 @@ func extractFlagValues(args, flag string) []string {
 		}
 	}
 	return values
+}
+
+// builtFromKopsRoot reports whether kopsBinaryPath lies inside the repo checkout at kopsRoot.
+// Scenario scripts always pass --kops-root, so its presence alone doesn't imply a source build.
+func builtFromKopsRoot(kopsBinaryPath, kopsRoot string) bool {
+	if kopsBinaryPath == "" || kopsRoot == "" {
+		return false
+	}
+	rel, err := filepath.Rel(kopsRoot, kopsBinaryPath)
+	if err != nil {
+		return false
+	}
+	return filepath.IsLocal(rel)
+}
+
+// localChannelArgs rewrites a bare --channel shorthand (e.g. alpha) to a file:// URL under the
+// checkout's channels/ dir, defaulting to alpha when absent. URLs and "none" are passed through.
+func localChannelArgs(args []string, kopsRoot string) []string {
+	for i, a := range args {
+		if v, ok := strings.CutPrefix(a, "--channel="); ok {
+			if isChannelShorthand(v) {
+				args[i] = "--channel=" + localChannelURL(kopsRoot, v)
+			}
+			return args
+		}
+		if a == "--channel" && i+1 < len(args) {
+			if isChannelShorthand(args[i+1]) {
+				args[i+1] = localChannelURL(kopsRoot, args[i+1])
+			}
+			return args
+		}
+	}
+	return append(args, "--channel="+localChannelURL(kopsRoot, "alpha"))
+}
+
+// isChannelShorthand reports whether v is a bare channel name, not a URL or the "none" sentinel.
+func isChannelShorthand(v string) bool {
+	return v != "" && v != "none" && !strings.Contains(v, "://")
+}
+
+// localChannelURL returns the file:// URL for channel name under the checkout's channels/ dir.
+func localChannelURL(kopsRoot, name string) string {
+	return "file://" + filepath.ToSlash(filepath.Join(kopsRoot, "channels", name))
 }
 
 // prowJobLabel returns a "key=value" cloud-label fragment recording the prow

--- a/tests/e2e/kubetest2-kops/deployer/up_test.go
+++ b/tests/e2e/kubetest2-kops/deployer/up_test.go
@@ -18,6 +18,7 @@ package deployer
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -78,6 +79,74 @@ func TestAppendIfUnset(t *testing.T) {
 			actual := appendIfUnset(tc.args, tc.arg, tc.val)
 			if !reflect.DeepEqual(actual, tc.expected) {
 				t.Errorf("arguments didn't match: %v vs %v", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestBuiltFromKopsRoot(t *testing.T) {
+	const root = "/home/prow/go/src/k8s.io/kops"
+	cases := []struct {
+		name       string
+		binaryPath string
+		kopsRoot   string
+		want       bool
+	}{
+		{"binary built under the checkout", root + "/.build/dist/linux/amd64/kops", root, true},
+		{"binary downloaded to a temp dir", "/tmp/kops.abc123", root, false},
+		{"sibling dir is not under the checkout", "/home/prow/go/src/k8s.io/kops-other/kops", root, false},
+		{"empty kops root", root + "/.build/dist/linux/amd64/kops", "", false},
+		{"empty binary path", "", root, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := builtFromKopsRoot(tc.binaryPath, tc.kopsRoot); got != tc.want {
+				t.Errorf("builtFromKopsRoot(%q, %q) = %v, want %v", tc.binaryPath, tc.kopsRoot, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLocalChannelArgs(t *testing.T) {
+	const kopsRoot = "/home/prow/go/src/k8s.io/kops"
+	base := "file://" + kopsRoot + "/channels/"
+	cases := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{
+			name:     "rewrites shorthand in equals form",
+			args:     []string{"create", "cluster", "--channel=alpha", "--networking=cilium"},
+			expected: []string{"create", "cluster", "--channel=" + base + "alpha", "--networking=cilium"},
+		},
+		{
+			name:     "rewrites shorthand in space form",
+			args:     []string{"--channel", "stable"},
+			expected: []string{"--channel", base + "stable"},
+		},
+		{
+			name:     "leaves absolute channel URL unchanged",
+			args:     []string{"--channel=https://example.com/channels/alpha"},
+			expected: []string{"--channel=https://example.com/channels/alpha"},
+		},
+		{
+			name:     "leaves none unchanged",
+			args:     []string{"--channel=none"},
+			expected: []string{"--channel=none"},
+		},
+		{
+			name:     "absent channel defaults to alpha pointed at the checkout",
+			args:     []string{"create", "cluster", "--networking=cilium"},
+			expected: []string{"create", "cluster", "--networking=cilium", "--channel=" + base + "alpha"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := localChannelArgs(slices.Clone(tc.args), kopsRoot)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("localChannelArgs() = %v, want %v", actual, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
In e2e, `kops create cluster --channel=alpha` reads the channel from the kops master branch, so a PR's edits to channels/alpha or channels/stable are never exercised by its own e2e jobs.

When kops is built from the PR checkout, the deployer now rewrites --channel to a file:// path into that checkout's channels/ directory (defaulting to alpha when --channel is unset), so the build uses the PR's channels. Downloaded release/marker binaries don't match the checkout and keep using master's channels.

/cc @rifelpet @ameukam 