### PR TITLE
tests/e2e: refine externalTrafficPolicy=Local and hostNetwork skips

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -87,10 +87,13 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|should.check.kube-proxy.urls"
 
 		if k8sVersion.Minor < 38 {
-			// This seems to be specific to the kube-proxy replacement
+			// Cilium fails the externalTrafficPolicy=Local sig-network tests: the client source IP is
+			// SNATed to a pod IP instead of being preserved (long-standing, every build in the retention
+			// window). Tracked in https://github.com/cilium/cilium/issues/37613, which Cilium's own CI
+			// cites to skip the whole externalTrafficPolicy family.
 			// < 38 so we look at this again
 			skipRegex += "|Services.should.support.externalTrafficPolicy.Local.for.type.NodePort"
-			// https://github.com/kubernetes/kubernetes/issues/129221
+			skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
 		}
 	} else if networking.KubeRouter != nil {
 		skipRegex += "|should set TCP CLOSE_WAIT timeout|should check kube-proxy urls"
@@ -105,7 +108,6 @@ func (t *Tester) setSkipRegexFlag() error {
 	if cluster.Spec.LegacyCloudProvider == "azure" {
 		// Azure Disk CSI fsgroupchangepolicy tests are flaky due to SCSI device discovery
 		// latency during rapid attach/detach cycles on VMSS nodes.
-		// See https://github.com/kubernetes/kops/issues/17146
 		skipRegex += "|fsgroupchangepolicy"
 		// Skipped upstream in azuredisk-csi-driver external E2E:
 		// https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/test/external-e2e/run.sh
@@ -120,16 +122,14 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|should.be.mountable.when.non-attachable"
 	}
 
-	// This test fails on RHEL-based distros because they return fully qualified hostnames yet the k8s node names are not fully qualified.
-	// Dedicated job testing this: https://testgrid.k8s.io/kops-misc#kops-aws-k28-hostname-bug123255
-	// ref: https://github.com/kubernetes/kops/issues/16349
-	// ref: https://github.com/kubernetes/kubernetes/issues/123255
-	// ref: https://github.com/kubernetes/kubernetes/issues/121018
-	// ref: https://github.com/kubernetes/kubernetes/pull/126896
-	// < 38 so we look at this again
-	if k8sVersion.Minor < 38 {
+	if k8sVersion.Minor < 37 {
+		// Services.should.function.for.service.endpoints.using.hostNetwork fails only on distros that
+		// return fully qualified hostnames (e.g. RHEL) where the k8s node name is not fully qualified;
+		// it already passes where the system hostname matches the node name. Fixed in k8s 1.37 by
+		// kubernetes/kubernetes#139819 (compares spec.nodeName instead of os.Hostname()); the
+		// dedicated reproduction jobs have been removed.
+		// refs: https://github.com/kubernetes/kops/issues/16349, https://github.com/kubernetes/kubernetes/issues/123255
 		skipRegex += "|Services.should.function.for.service.endpoints.using.hostNetwork"
-		skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
 	}
 
 	for _, subnet := range cluster.Spec.Subnets {


### PR DESCRIPTION
Identified this opportunity for cleanup as a part of https://github.com/kubernetes/test-infra/pull/37337

## What

Two corrections to the kubetest2-tester-kops auto skip-regex, plus comment cleanup, based on triage of the (now-removed) `e2e-kops-aws-hostname-bug121018` job.

### 1. `externalTrafficPolicy=Local` source-IP tests are Cilium-only

`Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes` was skipped for **all** CNIs on k8s `< 1.38`, but it only fails on Cilium — the client source IP is SNATed to a pod IP instead of being preserved (failed every build in the retention window). This is the same root cause as its sibling `Services should support externalTrafficPolicy=Local for type=NodePort`, which is already Cilium-gated.

Moved it into the `networking.Cilium != nil` block next to the sibling so kubenet / kube-router / calico / amazonvpc clusters run the test again. Both now reference the canonical upstream tracker **cilium/cilium#37613** (which Cilium's own CI cites to skip the entire `externalTrafficPolicy` family).

### 2. hostNetwork test was fixed in k8s 1.37

`Services should function for service endpoints using hostNetwork` was fixed upstream by **kubernetes/kubernetes#139819** (milestone v1.37) — it now reads `spec.nodeName` via the Downward API instead of `os.Hostname()`. Dropped its skip gate from `< 1.38` to `< 1.37` so 1.37+ runs it.

### 3. Comment cleanup

Removed stale/incorrect issue references: the wrong Azure CSI link (was pointing at an unrelated `kops reconcile` issue), the superseded hostname WIP PR #126896, and the unrelated/closed #129221 (a HealthCheckNodePort port-allocation flake, not the current source-IP failure).

## Behavior changes

- Non-Cilium clusters on k8s `< 1.38` will now run `implement NodePort and HealthCheckNodePort` (assumed Cilium-specific; if it fails on another CNI we re-broaden).
- All distros on k8s `1.37` will now run `function for service endpoints using hostNetwork`, relying on #139819.