### PR TITLE
Make cloud-controller-manager pods tolerate all taints

### DIFF
--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: dc6be0c5013574096329dabe0d6d17c2d72612261465d5b87fe5d5a4348f11f1
+    manifestHash: 15006609a7898026f87810402911936af6d2edc8d95903449b4d3e2078b7b5d6
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -62,15 +62,7 @@ spec:
         fsGroup: 10001
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -199,7 +199,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9de6c9b260180507ee94922630ac7e6f80e6c71cbc365ac1e0e2192f3680a854
+    manifestHash: 69492a91fde143770836032baba838f346787af29d7299053a336720752ab287
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e787322f496b05956d1d54e6c32a14a4590587c301682d647f9296709f6ba66c
+    manifestHash: f2f9d21f55213f224a4a2c029e1499f7251bc9213ff584ba7088abaed1a0c5dc
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -97,7 +97,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7be78497b071308570fe3713b52eabd6333592d05bc11a32148e39d102f2c4a6
+    manifestHash: f69f480893c1ef8f36b6b12c7542d87ddfe86716232ef119825f7da3edff9ed9
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -97,7 +97,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 55c8bb9f8e6985b40c8b009f4a78cd21dc74997c50615645d0d74f0c1aac56cd
+    manifestHash: 267d3c45193c89bc133f1db4b377a4dfe376db8528703a69a5cd3682bd340c24
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -55,15 +55,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -97,7 +97,7 @@ spec:
       role.kubernetes.io/authentication: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9c58545e8729ec86ab40ad062d37791f78bdc168c982d2487e417b2ca08902fb
+    manifestHash: fbbecdd5fb742599a0cea2af6251dccf7769cd73a327ec40a4d7f2aaab7ea844
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9b9824e64a58d001a21641f43e076578b8e44533fb67314fcf9994521d6b6da1
+    manifestHash: 697de55684f78367375b72a8fd8308953f4e36604637549bfb407fb65bf2ac39
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3c4ee296add1925160cba61a3399321a342c92d9c7d11b2c98e18bde28a47fe6
+    manifestHash: c1d6a6fba240e1c2f9c187015965306df287a19b21b081697ddc098fea295b65
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3c4ee296add1925160cba61a3399321a342c92d9c7d11b2c98e18bde28a47fe6
+    manifestHash: c1d6a6fba240e1c2f9c187015965306df287a19b21b081697ddc098fea295b65
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8f428b4e73d771170ce036caafb7abf26fb64f04cc16aeb0b5240e81a15142ef
+    manifestHash: f83d7390bc994a88a3096b2099c58b539c8414e6470cf61257a0905eec36b2a8
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 4675c5209ff2c6e56d5c2310a2615205f8d04afa9151223f08ac71169c089edb
+    manifestHash: f719a133948aeb85a0e734d2f1ca8ef44546a1bbd6f62046bc07a24f6eac03a6
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: bbfa672d1bdd4a042f542a3cf80e4d01b8726fde97f44f5954093d4ada9a5224
+    manifestHash: 5907c9458ec1c68b59a408d28f3f1b6e53efa7f99960e75d3c32d0fa8d0a1b6a
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
+    manifestHash: 6bd4941429296da17146136171722c374d41aa135941f2931ac0e42910dcbd25
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -62,15 +62,7 @@ spec:
         fsGroup: 10001
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9de6c9b260180507ee94922630ac7e6f80e6c71cbc365ac1e0e2192f3680a854
+    manifestHash: 69492a91fde143770836032baba838f346787af29d7299053a336720752ab287
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: c163cedaac16a5ad05c6a14b242fec9773f1a14d10197142954a83ad4b67996c
+    manifestHash: 0ca849b5c2b0b1948e7a1d68242c3e494981885e488009a574c0d27458ce71fd
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: ccfd2beeef630d16ce9a15baca52e63b5a1cda53187778d4c84d7865f0a8d45d
+    manifestHash: aa3511732ac0b7ddb3f6863577447854fdb09e9a544a23ef1fd6d449f46994ca
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_gossip.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_gossip.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/gossip-aws/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e0542fa55f1849b4c434335f6c68c8993cba934cdadbfe858c64902a0fda0d5b
+    manifestHash: 72125de812e233fd91caa3afb44561cfc953466d3361a0b1ad51e692a073aaff
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
@@ -304,12 +304,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoExecute
-        key: node-role.kubernetes.io/etcd
+      - operator: Exists
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -389,13 +384,4 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: cloud-node-manager
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoExecute
-        operator: Exists
-      - effect: NoSchedule
-        operator: Exists
+      - operator: Exists

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
@@ -85,7 +85,7 @@ spec:
       k8s-addon: azure-cloud-config.addons.k8s.io
   - id: k8s-1.31
     manifest: azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml
-    manifestHash: 539bf5e117db1a903ff8c4dae393b197f140cc57b003687a91aa8e5b3d17b3f4
+    manifestHash: 58049a7a5484ca352989083239e90b4c9958d197af4abdee1b023ef2ce8cccac
     name: azure-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: azure-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_gossip.k8s.local-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 568f8884929033af7641896093ad710a4c2028f8b636f7d9f1b4de971737bc78
+    manifestHash: f3b4d424e5366b204e1840d624b7b318e7ad4612354e07a58fab77c76cf42a19
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_gossip.k8s.local-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/gossip-gce/data/aws_s3_object_gossip.k8s.local-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 33921669f32907504d8c0edf4c9e668cae0e01ffdecef4d0928ba0d8d2152a93
+    manifestHash: f9007dc3545acf8a13dc36624e34302e5690844a6a612cc63915f4ec10a06556
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 1554f0791b0fccd6a925f552b2443036bc78207c9c5817d88d550c1fb14b6373
+    manifestHash: c98bbd8dc46276aa8ad095ff6ec6d7309a011592107d80e427a102d1862dbc44
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -151,7 +151,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
+    manifestHash: 6bd4941429296da17146136171722c374d41aa135941f2931ac0e42910dcbd25
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -62,15 +62,7 @@ spec:
         fsGroup: 10001
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9de6c9b260180507ee94922630ac7e6f80e6c71cbc365ac1e0e2192f3680a854
+    manifestHash: 69492a91fde143770836032baba838f346787af29d7299053a336720752ab287
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -62,15 +62,7 @@ spec:
         fsGroup: 10001
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -219,7 +219,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 46f55667a95ccec288215d288ef861441e24de6e76aad7fc9f813c4ceebf5031
+    manifestHash: f8cc91a991b786a976896720fd5fa67172956aed96f6cbc916fa740cb30f8bd1
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -219,7 +219,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 1a2c169ec8d130322c15099de960ca91b26ef9a3db1a5aa19191df0366f4447f
+    manifestHash: bc3ca4d1fff81a75328932e62b0f3f6daa98e599eb01921b9a84c17e2568da02
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 9cfc783cae862fd638bd57cb54c68e368ddf164a57e7b6602168d0a95a45de4f
+    manifestHash: a2f62812a76c78d88820673859e171b6f2f1da88cc3332f034cb0859d54736ff
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -267,7 +267,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9a6f4a1224eef8becdd5deea7939381b4c769911cb2cfe98b1da420fb32b9e8c
+    manifestHash: 2ec80eeecb221184d2c06ee3910700e13ea111ca23eef1332d5ba9598d3e0cf1
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e314c8d485c43e8adc57edd7396533c505219c118ceb34900b71a81e9974bd43
+    manifestHash: ee3f6aa52e4896e88112f3600a084ca9db52412a1cc5d1cbc3364304607265cd
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
+    manifestHash: 6bd4941429296da17146136171722c374d41aa135941f2931ac0e42910dcbd25
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b1ba8eea3a03829597c565ce6f572f231bb86d02ac415a57a144931ce25ce494
+    manifestHash: 38c07002155afff4ca7a1f51a8edd086fb2a88403aa06c6c08eecbaeb66b7a09
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2f83bacafe128f6f75e35f3105cdb7570741d55ebc51ba55df36d54e474cddaa
+    manifestHash: 6460fb5b63e5e9a8a788b7ac041b13bb37010877978c4460f2d33faa509641f2
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -85,7 +85,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
+    manifestHash: 6bd4941429296da17146136171722c374d41aa135941f2931ac0e42910dcbd25
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 6106220a3d3be573897abac912daa8afc65fd905fe4339ca60e077f6f530a6bc
+    manifestHash: f29391c6622164c1cb9815feaf60d726e4941b60efe2a58baced88a010235578
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
+    manifestHash: 6bd4941429296da17146136171722c374d41aa135941f2931ac0e42910dcbd25
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -53,15 +53,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -145,7 +145,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
+    manifestHash: f3e855748eb8172127795db2e23d2a8be65f8aeedb647ad6b72bcc408d9e7099
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -53,15 +53,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
+    manifestHash: f3e855748eb8172127795db2e23d2a8be65f8aeedb647ad6b72bcc408d9e7099
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -53,15 +53,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
+    manifestHash: f3e855748eb8172127795db2e23d2a8be65f8aeedb647ad6b72bcc408d9e7099
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -53,15 +53,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
+    manifestHash: f3e855748eb8172127795db2e23d2a8be65f8aeedb647ad6b72bcc408d9e7099
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -53,15 +53,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
+    manifestHash: f3e855748eb8172127795db2e23d2a8be65f8aeedb647ad6b72bcc408d9e7099
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9e8341d28e567c7c1af877e9304ff36ae69daa382e7639e08a35dff2be2407c3
+    manifestHash: 2dbaa25377454a9f17b388bfd4d0a8bda6a00a453741e7dda3f370ad95104ecf
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 25001fd43a14ae33c91663eb7122a8556b0258c62b03dca3fbdbe2271c49f62f
+    manifestHash: 9266c7bc89474c13897f90fda68803c86ba903e900b8ecfd4a8550c69d477b32
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
@@ -304,12 +304,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoExecute
-        key: node-role.kubernetes.io/etcd
+      - operator: Exists
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -389,13 +384,4 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: cloud-node-manager
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoExecute
-        operator: Exists
-      - effect: NoSchedule
-        operator: Exists
+      - operator: Exists

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
@@ -79,7 +79,7 @@ spec:
       k8s-addon: azure-cloud-config.addons.k8s.io
   - id: k8s-1.31
     manifest: azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml
-    manifestHash: bc6ea012c9a6fc50042ef36bd3bb5a0e6aa1a9de9b79f518e149e67265970ea0
+    manifestHash: b3b5a7bfc6d537af282f11d14b7ece6926fe6a42b9ba98e3c145c4bad0e44f8d
     name: azure-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: azure-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
       k8s-addon: storage-gce.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: bacc5c742f681989b23eb9855d213c6041150636902dae9ffaf70afd08632e61
+    manifestHash: efd860e9f256bf13ef8b46d4fa111bb411e762e7d68af05a3d321957d620fa45
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: bacc5c742f681989b23eb9855d213c6041150636902dae9ffaf70afd08632e61
+    manifestHash: efd860e9f256bf13ef8b46d4fa111bb411e762e7d68af05a3d321957d620fa45
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 906ac11ea1c815fcdac165b0e851f1e77e2636201de3fa09c2d37d22bfc47aef
+    manifestHash: c27922dd31b4f61832a6d3a3fc1607092a8ba016478ae41e6327fe178b5a8c24
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: defbd944608641e77a855fa16ad1cf395ee32d2eeecf7ec08c2946e4ffb388a0
+    manifestHash: 636e8e2070f1442f016924e2e26eee4b29dfe0749e880cdcc71e19854f7bb191
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: e7c12ef7cfc853a278f62f2c6d4d961ce9a782941c50a5366ab8a3f8d7324253
+    manifestHash: 20412e8fe0c0f3cb1a709a1f6f4fe7ef45bc6e34cce70b5603ca133c4ecad0ac
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: e7c12ef7cfc853a278f62f2c6d4d961ce9a782941c50a5366ab8a3f8d7324253
+    manifestHash: 20412e8fe0c0f3cb1a709a1f6f4fe7ef45bc6e34cce70b5603ca133c4ecad0ac
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 6c7ec905f94c0c4ff0f970b8b134c606db75b5ee08e4f7bb44d311780c1668f1
+    manifestHash: 19eeb9e0ac4f1721e82f048929c6c7f09c1925165adf082398ca04dc21a79ef4
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 0214b9fbcc723d5c2778429574f870d9f463db96a47abbada20770dac395dbb2
+    manifestHash: b9ba7baaa83f9a93b946ca0a4109001ac7553caad9928d16953d0cdb1c59f56e
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: cf67f240bfa7ee458533349c9a00b324a65a88ed5d132c821a787a54d9a4f053
+    manifestHash: 75ff82cb053e65f7ed3bf5fe8707bd519997b43b1cd44e8fc796f7dda3229e6a
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -70,15 +70,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b7d715a340d3bdaaa4706f63ea6c8c789aa1971a1e3492ce0e925c95e53172a7
+    manifestHash: 2142f049761041304c46a46b4afe3756a69b9da0c6dccdfc1aac4e3f045541c1
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -62,15 +62,7 @@ spec:
         fsGroup: 10001
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: d384e093bce79b1f30d17adbc6cef9df479b8397f9882663304d011c1755140f
+    manifestHash: cd7fa2e029df58ff8a82fdb501b5c96fc2c5712cec37bfa0d6d980ad6e074ebc
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -35,7 +35,7 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.24
     manifest: scaleway-cloud-controller.addons.k8s.io/k8s-1.24.yaml
-    manifestHash: fb9f1a97680793793c38db19bbfe317b58628b6bc9bca16a4124afe9539aa294
+    manifestHash: 2203789dbfc24d40f55d6bb9d6a7c7a8ad1b9f39ec99ca561ed9302741675c13
     name: scaleway-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: scaleway-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-scaleway-cloud-controller.addons.k8s.io-k8s-1.24_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-scaleway-cloud-controller.addons.k8s.io-k8s-1.24_content
@@ -40,6 +40,16 @@ spec:
         app: scaleway-cloud-controller-manager
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --cloud-provider=scaleway
@@ -59,23 +69,7 @@ spec:
       hostNetwork: true
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoExecute
-        key: node.kubernetes.io/not-ready
-        operator: Exists
-        tolerationSeconds: 300
-      - effect: NoExecute
-        key: node.kubernetes.io/unreachable
-        operator: Exists
-        tolerationSeconds: 300
+      - operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 5fe9fc377054d32f7f903069119f8923f08871fa4c7cd71db40cb97f75f0c828
+    manifestHash: fcfdc4b9a8f7e0d0b7040e5ebe97cc589bf2dd7388390dd610584b9e41ef6303
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 5fe9fc377054d32f7f903069119f8923f08871fa4c7cd71db40cb97f75f0c828
+    manifestHash: fcfdc4b9a8f7e0d0b7040e5ebe97cc589bf2dd7388390dd610584b9e41ef6303
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -62,15 +62,7 @@ spec:
         fsGroup: 10001
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -89,7 +89,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 87c153a8d190d13b30eac66117f56f1124d207b28818e4ed5a222c144a8ad1a1
+    manifestHash: e854f3f57aef3c0624dfb01330f13f978f1aed8cc7656eb109e712589c2f6a5d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -89,7 +89,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 796f038bac2c845bc6f11da1fe6f5c447cbf0ef7708e00e1ea34a0b30384d51a
+    manifestHash: 296398bf3f096d3127ebdd6eb59907dedcc27a4e9816892ccb689a849c294585
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -97,7 +97,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
+    manifestHash: 6bd4941429296da17146136171722c374d41aa135941f2931ac0e42910dcbd25
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 5523aba8aba70c5b68f0b771a3b1fc442e3bf1ea46a6afc5293bb70f597d3dc9
+    manifestHash: 5413eecafd740f6ed21d26fa231fa3685108d2893ea78b0a45b2ea709afb1f93
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 707ddaec3e8eaa8ef8eea07613f0eaceb6820dbd5c2c89027aa9eb71cfa468d4
+    manifestHash: 8349e43bd245b30c60af87ba0f5d1cdf9eafcaed12d998cf9b5a894d3fe5447b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -145,7 +145,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9fbf176db11352011d6b5c378cc7e6625aaebb7e04526cf3c84354a2ead855a8
+    manifestHash: 6623a6825ff1c981cb11267582fb0e50957df0dfcbb8810d7b1241c8d1005283
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8fe93d5de53463def33ae1bc261bb089ae26b9b1d5c96fada4386a4bdb3e2f8f
+    manifestHash: 2db87c2b0d1ebbe980b08c0987cca3a21db2586f5f6e00d8c9b11e96ee32be74
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8fe93d5de53463def33ae1bc261bb089ae26b9b1d5c96fada4386a4bdb3e2f8f
+    manifestHash: 2db87c2b0d1ebbe980b08c0987cca3a21db2586f5f6e00d8c9b11e96ee32be74
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -152,7 +152,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 96137cba2dd45aabd780e54fff06d20bacb1094f18f998b5c49bb4e90aa93855
+    manifestHash: 2f978d4ddb444b6a7867350561b2e0fc0eaefcdee6c2c1a785acf5a6fb4d6959
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 909fae67a7f84fd7a71bd763960f1bfa846014671e98b35d5ff17652fee1078d
+    manifestHash: 367dc7d6e3509805fe56cbfea59753812d9811cfb1bce7d121311ed5a297d671
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: dbbc3527ca3ab0bcb3acb9ffcd94c24650a66c9dbb24890f887870f8a1cc7aa3
+    manifestHash: 8040179d82dc53bc63f81ec5e033fecd8cd6fb04630bfbfb89e35e6a00a9bcc0
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 0c8760e9e730a88658c771ac947e6b471e0e750b39847027dfa125062fd683e6
+    manifestHash: cec7487850fd02141e50e756c66f485fef3b2c08485b0971f3d8e8c0b27be5ca
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -141,7 +141,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: da2e7a9aeaa36e9442110a73a49efa12891d5b1d3db4fa44376e82f534b28c84
+    manifestHash: 9fb5b436183e0788189519c798834bea426a500ab041f2b485be145475868825
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: ac3e0e4295a3782ef4856569cb047e2701fd5f98772a76c478e5c467da461bf8
+    manifestHash: 54047aedcaefd55934e8016676e31a17a132a5ce7ca65f48d371919decfdc717
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -139,7 +139,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 5498fc4ba791012d64ae8a38dcd84b841455a1892b5c0e4980bc1c06ec2357fa
+    manifestHash: 7a77c7031e4793d4a12bee9b1503612d4d4d399f2083285a8255ce8dc516b043
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -62,15 +62,7 @@ spec:
         fsGroup: 10001
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 49df9879eebd02e13adcad2c2fc8014c3aa0e320ec1ddf6ad57451bf7b46d1e9
+    manifestHash: f56912af119cdda97fab85a465b4fa48144f9791764d99909efa4d3788e72b51
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: a7d28b813e7e04e0f024c7712f1de8c81ac93d052497da1b66312b8e11f32e4e
+    manifestHash: 1d86596604d6eb9358b8aa3ce90840173eff501d84e55a751bc629c76a400495
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: ee9cc5a223f9f9176acd4d8fa1e3ef92172786f5fc903a3dc0ffc1da05bdb40d
+    manifestHash: 0155ded4edd6f4bf3accc33b644e4ea4f6751798b4af1361486dae4ab99750af
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -53,15 +53,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b043d1f8a02a0c5e1015ebac2ff1b189f66ac75da8243919ee9ba96ce527644e
+    manifestHash: f3e855748eb8172127795db2e23d2a8be65f8aeedb647ad6b72bcc408d9e7099
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 8e34b44c34f08c5470d3374c0570cb73d7e880df797ad60075dd7a6c6df39e06
+    manifestHash: 92577af35211a65505bd00db8abc24002cc9513a3aef045d9a1a3b6d18d6dc48
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3fccc826d4b7fc9d9558089100535ef41eeffbc3323fe194f732c4bed5cc8a71
+    manifestHash: 6bd4941429296da17146136171722c374d41aa135941f2931ac0e42910dcbd25
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
@@ -26,15 +26,7 @@ spec:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-        effect: NoSchedule
-      - key: node.kubernetes.io/not-ready
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/control-plane
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - operator: Exists
 {{ if ContainerdSELinuxEnabled }}
       securityContext:
         seLinuxOptions:

--- a/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml.template
+++ b/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml.template
@@ -264,12 +264,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoExecute
-        key: node-role.kubernetes.io/etcd
+      - operator: Exists
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -343,13 +338,4 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: cloud-node-manager
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoExecute
-        operator: Exists
-      - effect: NoSchedule
-        operator: Exists
+      - operator: Exists

--- a/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
@@ -39,23 +39,7 @@ spec:
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
-        - key: "node.cloudprovider.kubernetes.io/uninitialized"
-          value: "true"
-          effect: "NoSchedule"
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
-        - key: "node-role.kubernetes.io/master"
-          effect: NoSchedule
-        - key: "node-role.kubernetes.io/control-plane"
-          effect: NoSchedule
-        - effect: NoExecute
-          key: node.kubernetes.io/not-ready
-          operator: Exists
-          tolerationSeconds: 300
-        - effect: NoExecute
-          key: node.kubernetes.io/unreachable
-          operator: Exists
-          tolerationSeconds: 300
+        - operator: Exists
       containers:
       - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.45
         name: digitalocean-cloud-controller-manager

--- a/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
@@ -30,15 +30,7 @@ spec:
               - key: node-role.kubernetes.io/master
                 operator: Exists
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-        effect: NoSchedule
-      - key: node.kubernetes.io/not-ready
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/control-plane
-        effect: NoSchedule
+      - operator: Exists
 {{ if ContainerdSELinuxEnabled }}
       securityContext:
         seLinuxOptions:

--- a/upup/models/cloudup/resources/addons/scaleway-cloud-controller.addons.k8s.io/k8s-1.24.yaml.template
+++ b/upup/models/cloudup/resources/addons/scaleway-cloud-controller.addons.k8s.io/k8s-1.24.yaml.template
@@ -34,28 +34,21 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       dnsPolicy: Default
       hostNetwork: true
       serviceAccountName: cloud-controller-manager
       tolerations:
-        # we sould allow to schedule on uninitialized and master nodes
-        - key: "node.cloudprovider.kubernetes.io/uninitialized"
-          value: "true"
-          effect: "NoSchedule"
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
-        - key: "node-role.kubernetes.io/master"
-          effect: NoSchedule
-        - key: "node-role.kubernetes.io/control-plane"
-          effect: NoSchedule
-        - key: node.kubernetes.io/not-ready
-          effect: NoExecute
-          operator: Exists
-          tolerationSeconds: 300
-        - key: node.kubernetes.io/unreachable
-          effect: NoExecute
-          operator: Exists
-          tolerationSeconds: 300
+        - operator: Exists
       containers:
         - name: scaleway-cloud-controller-manager
           image: scaleway/scaleway-cloud-controller-manager:latest

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -54,15 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
-      - effect: NoSchedule
-        key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /etc/kubernetes/cloud.config

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: bb2aae2f50be553a55945513ac25d68bf656b7a89f21d811eed1d8396c6fe6ec
+    manifestHash: e28788fadb56157996ee775857499e47007147586a6fe3b5f2adf93e86c7fc92
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -97,7 +97,7 @@ spec:
       role.kubernetes.io/authentication: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -97,7 +97,7 @@ spec:
       role.kubernetes.io/authentication: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -98,7 +98,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -104,7 +104,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -158,7 +158,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7fffc651bf20882d8a4d0726872354b225c781d2536cf071a045d29ef9d941f5
+    manifestHash: 77bfa1b6196c212493d3073080ea8c26bdae100859ce772b0af49c74d92bed63
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cefa983df5c1f9d34873989012e5f5d9ae6172ee1a11c7e8ecdcab2377a9809b
+    manifestHash: c36e4ce956c7a47be9fee95dc29d26c520fbde69fa2ed0deba48286297448f35
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
## What

Set `tolerations: [{operator: Exists}]` on every cloud-controller-manager pod that runs with `hostNetwork: true` (AWS, Azure, DigitalOcean, GCP, Scaleway), so the CCM can always be scheduled onto a node regardless of which taints are currently present. The Scaleway CCM additionally gains a `node-role.kubernetes.io/control-plane` nodeAffinity, since broadening its tolerations means tolerations can no longer keep it off worker nodes.

The Azure `cloud-node-manager` DaemonSet keeps `nodeSelector: kubernetes.io/os: linux` (it is a per-node agent and must run on every node); only its tolerations are broadened.

This matches the pattern already used by node-level DaemonSets that must run everywhere — the Cilium agent, CNI plugins, and CSI node drivers all use `- operator: Exists`.

## Why

`e2e-kops-do-gossip` is intermittently failing cluster validation, e.g.:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-do-gossip/2068280267818143744

### The deadlock

With `--cloud-provider=external`, a node has no `InternalIP` until the cloud-controller-manager initializes it. The Cilium agent needs that node IP — without it the agent dies with `unable to determine direct routing device` (`k8sNodeIP=""`), so it never becomes ready.

Meanwhile the cilium-operator (`set-cilium-node-taints: "true"`) adds `node.cilium.io/agent-not-ready:NoSchedule` to any node whose Cilium agent isn't ready yet. The DO CCM DaemonSet did **not** tolerate that taint. So once the operator taints the control-plane node before the CCM pod is bound there:

1. CCM can no longer schedule onto the control-plane node → node never initialized → no `InternalIP`
2. Cilium agent can't start without the node IP → never becomes ready
3. operator never removes the `agent-not-ready` taint → back to (1)

A permanent deadlock. The CCM pod never appears at all and the cluster fails to validate.

### Why it's a race, and why only some clouds lose it

The `agent-not-ready` taint only blocks *new* scheduling — it never evicts an already-bound pod. So the outcome hinges entirely on whether the CCM pod is bound to the control-plane node **before** the cilium-operator taints it.

This is decided during control-plane bootstrap by which static-pod component wins a restart-timing race:

- The kube-scheduler and kube-controller-manager both crash-loop on startup until the kube-apiserver has published the `extension-apiserver-authentication` configmap (identical behavior on every cloud).
- On a healthy/fast control plane, the scheduler is up and caches-synced *before* the daemonset-controller creates the CCM pod, so the CCM pod binds immediately — well before the operator's taint controller (which has a built-in ~11s leader-election/startup delay) ever runs.
- On a slower/less-stable control plane, the apiserver restarts an extra time, the scheduler crash-loops one or two extra cycles, and CrashLoopBackOff (10s → 20s → 40s → 80s) turns that into a large gap. The CCM/cilium pods sit `Pending` with no scheduler; when the scheduler finally comes up it binds the all-tolerating Cilium pod to the control-plane node first, the operator taints the node, and the CCM pod is locked out.

Observed on the failing DO run vs. a passing AWS run:

| | apiserver starts | scheduler restarts | KCM healthy | scheduler healthy | gap | result |
|---|---|---|---|---|---|---|
| AWS | 2 | 2 | 09:54:44 | 09:54:44 | ~0s | CCM binds, wins |
| DO  | 3 | 4 | 10:38:53 | 10:39:38 | ~45s | operator taints first, deadlock |

Because the margin is environmental (control-plane bring-up speed, not config), the same DO job *passes* on runs where the control plane comes up quickly — which is exactly why it's flaky rather than always-failing. The placement constraints, node-IP handling, Cilium routing mode (`tunnel`/`ipam: kubernetes`), and addon apply order are all identical between the passing and failing clouds, so none of those explain the difference — it is purely the bootstrap restart-timing race.

Every external CCM in kops shares this latent exposure; they just run on clouds whose control planes usually win the race. Making the CCM tolerate all taints removes the dependency on winning that window entirely.

## Testing

- Regenerated integration golden files (`hack/update-expected.sh`); manifestHashes update so existing clusters re-apply the new manifests automatically.
- `go test ./cmd/kops/` and the bootstrapchannelbuilder tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
