### PR TITLE
Allow setting missing slice elements from the command line

### DIFF
--- a/channels/pkg/channels/addons.go
+++ b/channels/pkg/channels/addons.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blang/semver/v4"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/channels/pkg/api"
+	"k8s.io/kops/pkg/kubemanifest"
 	"k8s.io/kops/upup/pkg/fi/utils"
 	"k8s.io/kops/util/pkg/vfs"
 )
@@ -45,16 +46,41 @@ func LoadAddons(vfsContext *vfs.VFSContext, name string, location *url.URL) (*Ad
 }
 
 func ParseAddons(name string, location *url.URL, data []byte) (*Addons, error) {
-	// Yaml can't parse empty strings
-	configString := string(data)
-	configString = strings.TrimSpace(configString)
+	configString := strings.TrimSpace(string(data))
+
+	objects, err := kubemanifest.LoadObjectsFrom([]byte(configString))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing addons or manifest: %v", err)
+	}
 
 	apiObject := &api.Addons{}
-	if configString != "" {
-		err := utils.YamlUnmarshal([]byte(configString), apiObject)
-		if err != nil {
+	if len(objects) == 0 {
+		// No objects (empty, whitespace, or comment-only content): nothing to apply.
+	} else if gvk := objects[0].GroupVersionKind(); gvk.Kind == "Addons" && gvk.Group == "" && gvk.Version == "" {
+		// Reuse the document already parsed by LoadObjectsFrom instead of parsing it again.
+		if err := objects[0].Reparse(apiObject); err != nil {
 			return nil, fmt.Errorf("error parsing addons: %v", err)
 		}
+	} else {
+		manifest := location.String()
+		manifestHash, err := utils.HashString(configString)
+		if err != nil {
+			return nil, fmt.Errorf("error hashing manifest: %v", err)
+		}
+		manifestLocationHash, err := utils.HashString(manifest)
+		if err != nil {
+			return nil, fmt.Errorf("error hashing manifest location: %v", err)
+		}
+		addonName := "manifest-" + manifestLocationHash[:12]
+		addonSpec := &api.AddonSpec{
+			Name:         &addonName,
+			Manifest:     &manifest,
+			ManifestHash: manifestHash,
+		}
+
+		apiObject.Kind = "Addons"
+		apiObject.ObjectMeta.Name = addonName
+		apiObject.Spec.Addons = []*api.AddonSpec{addonSpec}
 	}
 
 	return &Addons{ChannelName: name, ChannelLocation: *location, APIObject: apiObject}, nil

--- a/channels/pkg/channels/addons_test.go
+++ b/channels/pkg/channels/addons_test.go
@@ -18,6 +18,8 @@ package channels
 
 import (
 	"context"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -28,7 +30,209 @@ import (
 	fakekubernetes "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kops/channels/pkg/api"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/utils"
 )
+
+func TestParseAddons(t *testing.T) {
+	location := mustParseURL(t, "https://example.com/addons/addon.yaml")
+
+	data := []byte(`
+kind: Addons
+metadata:
+  name: example
+spec:
+  addons:
+  - name: example.addons.k8s.io
+    manifest: example.yaml
+    manifestHash: abc123
+`)
+
+	addons, err := ParseAddons("channel", location, data)
+	if err != nil {
+		t.Fatalf("ParseAddons returned error: %v", err)
+	}
+
+	if addons.APIObject.ObjectMeta.Name != "example" {
+		t.Fatalf("expected Addons object name %q, got %q", "example", addons.APIObject.ObjectMeta.Name)
+	}
+	if len(addons.APIObject.Spec.Addons) != 1 {
+		t.Fatalf("expected one addon, got %d", len(addons.APIObject.Spec.Addons))
+	}
+	addon := addons.APIObject.Spec.Addons[0]
+	if addon.Name == nil || *addon.Name != "example.addons.k8s.io" {
+		t.Fatalf("expected addon name %q, got %v", "example.addons.k8s.io", addon.Name)
+	}
+}
+
+// A kOps Addons index may contain more than one YAML document; it must still be
+// parsed as an index (from the first document) rather than wrapped as a raw manifest.
+func TestParseAddonsMultiDocIndex(t *testing.T) {
+	location := mustParseURL(t, "https://example.com/addons/addon.yaml")
+
+	data := []byte(`
+kind: Addons
+metadata:
+  name: example
+spec:
+  addons:
+  - name: example.addons.k8s.io
+    manifest: example.yaml
+    manifestHash: abc123
+---
+kind: Addons
+metadata:
+  name: other
+spec:
+  addons:
+  - name: other.addons.k8s.io
+    manifest: other.yaml
+    manifestHash: def456
+`)
+
+	addons, err := ParseAddons("channel", location, data)
+	if err != nil {
+		t.Fatalf("ParseAddons returned error: %v", err)
+	}
+
+	if addons.APIObject.ObjectMeta.Name != "example" {
+		t.Fatalf("expected Addons index to be parsed (name %q), got %q", "example", addons.APIObject.ObjectMeta.Name)
+	}
+	if len(addons.APIObject.Spec.Addons) != 1 {
+		t.Fatalf("expected one addon, got %d", len(addons.APIObject.Spec.Addons))
+	}
+	addon := addons.APIObject.Spec.Addons[0]
+	if addon.Name == nil || *addon.Name != "example.addons.k8s.io" {
+		t.Fatalf("expected addon name %q, got %v", "example.addons.k8s.io", addon.Name)
+	}
+}
+
+func TestParseAddonsWrapsDirectManifest(t *testing.T) {
+	location := mustParseURL(t, "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml")
+	data := []byte(`
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: gateways.gateway.networking.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: gateway-system
+`)
+
+	addons, err := ParseAddons("channel", location, data)
+	if err != nil {
+		t.Fatalf("ParseAddons returned error: %v", err)
+	}
+
+	expectedHash, err := utils.HashString(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("HashString returned error: %v", err)
+	}
+	expectedLocationHash, err := utils.HashString(location.String())
+	if err != nil {
+		t.Fatalf("HashString returned error: %v", err)
+	}
+	expectedName := "manifest-" + expectedLocationHash[:12]
+
+	if addons.APIObject.ObjectMeta.Name != expectedName {
+		t.Fatalf("expected Addons object name %q, got %q", expectedName, addons.APIObject.ObjectMeta.Name)
+	}
+	if len(addons.APIObject.Spec.Addons) != 1 {
+		t.Fatalf("expected one addon, got %d", len(addons.APIObject.Spec.Addons))
+	}
+	addon := addons.APIObject.Spec.Addons[0]
+	if addon.Name == nil || *addon.Name != expectedName {
+		t.Fatalf("expected addon name %q, got %v", expectedName, addon.Name)
+	}
+	if addon.Manifest == nil || *addon.Manifest != location.String() {
+		t.Fatalf("expected manifest %q, got %v", location.String(), addon.Manifest)
+	}
+	if addon.ManifestHash != expectedHash {
+		t.Fatalf("expected manifest hash %q, got %q", expectedHash, addon.ManifestHash)
+	}
+}
+
+func TestParseAddonsDirectManifestNameUsesLocationHash(t *testing.T) {
+	location := mustParseURL(t, "https://example.com/addons/direct.yaml")
+
+	data1 := []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: version-1
+`)
+	data2 := []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: version-2
+`)
+
+	addons1, err := ParseAddons("channel", location, data1)
+	if err != nil {
+		t.Fatalf("ParseAddons returned error: %v", err)
+	}
+	addons2, err := ParseAddons("channel", location, data2)
+	if err != nil {
+		t.Fatalf("ParseAddons returned error: %v", err)
+	}
+
+	addon1 := addons1.APIObject.Spec.Addons[0]
+	addon2 := addons2.APIObject.Spec.Addons[0]
+	if addon1.Name == nil || addon2.Name == nil {
+		t.Fatalf("expected addon names, got %v and %v", addon1.Name, addon2.Name)
+	}
+	if *addon1.Name != *addon2.Name {
+		t.Fatalf("expected stable addon name, got %q and %q", *addon1.Name, *addon2.Name)
+	}
+	if addon1.ManifestHash == addon2.ManifestHash {
+		t.Fatalf("expected content hash to change, got %q", addon1.ManifestHash)
+	}
+}
+
+func TestParseAddonsRejectsInvalidYAML(t *testing.T) {
+	location := mustParseURL(t, "https://example.com/addons/not-yaml.yaml")
+
+	_, err := ParseAddons("channel", location, []byte("not: [valid"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "error parsing addons or manifest") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+// Content with no objects (empty, whitespace, or comment-only) is a no-op, not an error.
+func TestParseAddonsEmpty(t *testing.T) {
+	location := mustParseURL(t, "https://example.com/addons/addon.yaml")
+
+	for name, data := range map[string][]byte{
+		"empty":        []byte(""),
+		"whitespace":   []byte("\n  \n"),
+		"comment only": []byte("# nothing to see here\n"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			addons, err := ParseAddons("channel", location, data)
+			if err != nil {
+				t.Fatalf("ParseAddons returned error: %v", err)
+			}
+			if len(addons.APIObject.Spec.Addons) != 0 {
+				t.Fatalf("expected no addons, got %d", len(addons.APIObject.Spec.Addons))
+			}
+		})
+	}
+}
+
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("failed to parse URL %q: %v", rawURL, err)
+	}
+	return u
+}
 
 func Test_Filtering(t *testing.T) {
 	grid := []struct {

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -407,16 +407,19 @@ spec:
 
 ## Custom addons
 
-The command `kops create cluster` does not support specifying addons to be added to the cluster when it is created. Instead they can be added after cluster creation using kubectl. Alternatively when creating a cluster from a yaml manifest, addons can be specified using `spec.addons`.
+Static addons are configured with `spec.addons`. Each entry points to a manifest that the control plane can read.
 
 ```yaml
 spec:
   addons:
-  - manifest: s3://my-kops-addons/addon.yaml
+  - manifest: https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
 ```
 
-The docs about the [addon management](contributing/addons.md#addon-management) describe in more detail how to define a addon resource with regards to versioning.
-Here is a minimal example of an addon manifest that would install two different addons.
+Starting with kOps 1.36, that file can be a regular Kubernetes resource manifest. For example, the manifest above installs the Gateway API CRDs. kOps applies the resources as-is.
+
+It can also be a kOps `Addons` index. Use this when one entry in `spec.addons` should point at multiple versioned manifests. The [addon management](contributing/addons.md#addon-management) docs describe versioned addon indexes in more detail.
+
+Here is a minimal `Addons` index that installs two addons.
 
 ```yaml
 kind: Addons
@@ -436,7 +439,7 @@ spec:
     manifest: bar.addons.org.io/v0.0.1.yaml
 ```
 
-In this example the folder structure should look like this;
+In this example, the file structure should look like this:
 
 ```
 addon.yaml
@@ -446,7 +449,7 @@ addon.yaml
     v0.0.1.yaml
 ```
 
-The yaml files in the foo/bar folders can be any kubernetes resource. Typically this file structure would be pushed to S3 or another of the supported backends and then referenced as above in `spec.addons`. In order for master nodes to be able to access the S3 bucket containing the addon manifests, one might have to add additional iam policies to the master nodes using `spec.additionalPolicies`, like so:
+The YAML files in the foo/bar folders can be any Kubernetes resource manifest. Typically this file structure would be pushed to S3 or another supported backend and then referenced from `spec.addons`. If master nodes need access to an S3 bucket containing addon manifests, add IAM policies using `spec.additionalPolicies`, like so:
 
 ```yaml
 spec:

--- a/tests/e2e/scenarios/ai-conformance/run-test.sh
+++ b/tests/e2e/scenarios/ai-conformance/run-test.sh
@@ -63,6 +63,7 @@ cp "${KOPS}" "${BIN_DIR}/kops"
 # - Metrics Server: For HPA support
 OVERRIDES="${OVERRIDES-} --networking=cilium"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.networking.cilium.gatewayAPI.enabled=true"
+OVERRIDES="${OVERRIDES} --set=cluster.spec.addons[0].manifest=https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml"
 OVERRIDES="${OVERRIDES} --node-size=c5.large"
 OVERRIDES="${OVERRIDES} --node-count=2"
 OVERRIDES="${OVERRIDES} --zones=us-east-2a,us-east-2b,us-east-2c"
@@ -102,10 +103,6 @@ kubectl get nodes --show-labels
 echo "----------------------------------------------------------------"
 echo "Deploying AI Conformance Components"
 echo "----------------------------------------------------------------"
-
-# 0. Gateway API CRDs (Required for Cilium)
-echo "Installing Gateway API CRDs v1.2.0..."
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
 
 # cert-manager
 echo "Installing cert-manager..."
@@ -232,10 +229,7 @@ helm install kueue https://github.com/kubernetes-sigs/kueue/releases/download/v0
   --create-namespace \
   --wait --timeout 300s
 
-# Gateway API
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.5.0" | kubectl apply -f -
-
-# Gateway API Implenmentation - Istio
+# Gateway API Implementation - Istio
 helm repo add istio https://istio-release.storage.googleapis.com/charts
 helm repo update
 
@@ -339,13 +333,13 @@ kubectl -n default logs job/test-gpu-pod || echo "Failed to get logs"
 echo "Verifying GPU Metrics in Prometheus..."
 # Wait for DCGM exporter to start collecting metrics
 # Query Prometheus for DCGM GPU metrics with retries
-PROM_POD=$(kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
+PROM_POD=$(kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
 if [ -n "${PROM_POD}" ]; then
   echo "Querying Prometheus for DCGM_FI_DEV_GPU_UTIL metric (retrying up to 5 times)..."
   for i in {1..5}; do
     echo "Attempt $i..."
     METRICS=$(kubectl exec -n monitoring "${PROM_POD}" -c prometheus -- \
-      wget -qO- 'http://localhost:9090/api/v1/query?query=DCGM_FI_DEV_GPU_UTIL' 2>/dev/null)
+      wget -qO- 'http://localhost:9090/api/v1/query?query=DCGM_FI_DEV_GPU_UTIL' 2>/dev/null || true)
     if echo "${METRICS}" | grep -q "result"; then
       echo "Successfully retrieved GPU metrics:"
       echo "${METRICS}" | head -c 500

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -9,6 +9,8 @@ spec:
   - 10.2.0.0/16
   - 10.3.0.0/16
   - 10.4.0.0/16
+  addons:
+  - manifest: https://example.com/addon.yaml
   api:
     loadBalancer:
       class: Network

--- a/tests/integration/create_cluster/complex/options.yaml
+++ b/tests/integration/create_cluster/complex/options.yaml
@@ -17,3 +17,5 @@ KubernetesVersion: v1.32.0
 # We specify SSHAccess but _not_ AdminAccess
 SSHAccess:
 - 1.2.3.4/32
+Sets:
+- cluster.spec.addons[0].manifest=https://example.com/addon.yaml

--- a/util/pkg/reflectutils/access.go
+++ b/util/pkg/reflectutils/access.go
@@ -56,6 +56,23 @@ func SetString(target interface{}, targetPath string, newValue string) error {
 			return nil
 		}
 
+		// Partial match, append the next explicitly indexed slice element.
+		if v.Kind() == reflect.Slice {
+			if len(targetFieldPath.elements) > len(path.elements) {
+				next := targetFieldPath.elements[len(path.elements)]
+				if next.Type == FieldPathElementTypeArrayIndex && next.number == v.Len() {
+					if !v.CanSet() {
+						return fmt.Errorf("cannot set field %q (marked immutable)", path)
+					}
+
+					newLen := v.Len() + 1
+					grown := reflect.MakeSlice(v.Type(), newLen, newLen)
+					reflect.Copy(grown, v)
+					v.Set(grown)
+				}
+			}
+		}
+
 		// Partial match, check for nil struct and auto-populate
 		if v.Kind() == reflect.Ptr && v.IsNil() {
 			if !v.CanSet() {

--- a/util/pkg/reflectutils/tests/access_test.go
+++ b/util/pkg/reflectutils/tests/access_test.go
@@ -117,6 +117,20 @@ func TestSet(t *testing.T) {
 			Value:    "allowed",
 		},
 		{
+			Name:     "creating missing slice element",
+			Input:    "{}",
+			Expected: "{ 'spec': { 'containers': [ { 'policy': { 'name': 'allowed' } } ] } }",
+			Path:     "spec.containers[0].policy.name",
+			Value:    "allowed",
+		},
+		{
+			Name:     "growing missing slice element",
+			Input:    "{ 'spec': { 'containers': [ { 'image': 'existing' } ] } }",
+			Expected: "{ 'spec': { 'containers': [ { 'image': 'existing' }, { 'image': 'hello-world' } ] } }",
+			Path:     "spec.containers[1].image",
+			Value:    "hello-world",
+		},
+		{
 			Name:     "set int",
 			Input:    "{ 'spec': { 'containers': [ {} ] } }",
 			Expected: "{ 'spec': { 'containers': [ { 'int': 123 } ] } }",
@@ -180,6 +194,13 @@ func TestSet(t *testing.T) {
 			Value:    "GHI,JKL",
 		},
 		{
+			Name:     "set enum slice element",
+			Input:    "{ 'spec': { 'containers': [ {} ] } }",
+			Expected: "{ 'spec': { 'containers': [ { 'enumSlice': [ 'ABC' ] } ] } }",
+			Path:     "spec.containers[0].enumSlice[0]",
+			Value:    "ABC",
+		},
+		{
 			Name:     "set env var",
 			Input:    "{ 'spec': { 'containers': [ {} ] } }",
 			Expected: "{ 'spec': { 'containers': [ { 'env': [ { 'name': 'ABC' } ] } ] } }",
@@ -221,14 +242,6 @@ func TestSet(t *testing.T) {
 			Path:     "spec.containers[0].stringMap",
 			Value:    "GHI=JKL",
 		},
-		// Not sure if we should do this...
-		// {
-		// 	Name:     "creating missing array elements",
-		// 	Input:    "{}",
-		// 	Expected: "{ 'spec': { 'containers': [ { 'policy': { 'name': 'allowed' } } ] } }",
-		// 	Path:     "spec.containers[0].policy.name",
-		// 	Value:    "allowed",
-		// },
 	}
 
 	for _, g := range grid {
@@ -302,6 +315,13 @@ func TestSetInvalidPath(t *testing.T) {
 			Value:         "123",
 			ExpectedError: "field wrong.path.check not found in *fakeObject",
 		},
+		{
+			Name:          "creating missing slice gap",
+			Input:         "{}",
+			Path:          "spec.containers[1].image",
+			Value:         "hello-world",
+			ExpectedError: "field spec.containers[1].image not found in *fakeObject",
+		},
 	}
 
 	for _, g := range grid {
@@ -322,6 +342,20 @@ func TestSetInvalidPath(t *testing.T) {
 				t.Fatalf("Expected Error: %s\n Actual Error: %s", g.ExpectedError, err.Error())
 			}
 		})
+	}
+}
+
+func TestSetHugeSliceIndexDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("SetString panicked: %v", r)
+		}
+	}()
+
+	c := &fakeObject{}
+	err := reflectutils.SetString(c, "spec.containers[9223372036854775807].image", "hello-world")
+	if err == nil {
+		t.Fatal("expected error")
 	}
 }
 


### PR DESCRIPTION
Grow slices for explicit indexes while processing `--set` paths, so paths like `cluster.spec.addons[0].manifest` can create the first element. This is an alternative to https://github.com/kubernetes/kops/pull/18473.

Configure the scenario to install Gateway API CRDs via `cluster.spec.addons`, using the Gateway API version documented by Istio 1.29.

/cc @rifelpet @ameukam 

Assisted by Claude Opus