### PR TITLE
tests/e2e: skip implement-NodePort ETP=Local test on more CNIs

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -87,18 +87,27 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|should.check.kube-proxy.urls"
 
 		if k8sVersion.Minor < 38 {
-			// Cilium fails the externalTrafficPolicy=Local sig-network tests: the client source IP is
-			// SNATed to a pod IP instead of being preserved (long-standing, every build in the retention
-			// window). Tracked in https://github.com/cilium/cilium/issues/37613, which Cilium's own CI
-			// cites to skip the whole externalTrafficPolicy family.
+			// Cilium SNATs the client source IP to a pod IP instead of preserving it, so it fails the
+			// externalTrafficPolicy=Local for type=NodePort test. This test passes on every other CNI,
+			// so it stays gated to Cilium.
 			// < 38 so we look at this again
 			skipRegex += "|Services.should.support.externalTrafficPolicy.Local.for.type.NodePort"
-			skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
 		}
 	} else if networking.KubeRouter != nil {
 		skipRegex += "|should set TCP CLOSE_WAIT timeout|should check kube-proxy urls"
 	} else if networking.Kubenet != nil {
 		skipRegex += "|Services.*affinity"
+	}
+
+	// The "implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes"
+	// test requires externalTrafficPolicy=Local source-IP preservation, which is broken on these
+	// CNIs: the client IP is SNATed to a pod IP instead of being preserved (kube-router instead
+	// times out reaching the local endpoint). Confirmed failing on cilium, flannel, kopeio and
+	// kube-router; amazon-vpc, calico and kindnet preserve the source IP and keep running it.
+	// < 38 so we look at this again
+	if k8sVersion.Minor < 38 &&
+		(networking.Cilium != nil || networking.Flannel != nil || networking.Kopeio != nil || networking.KubeRouter != nil) {
+		skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
 	}
 
 	if cluster.Spec.LegacyCloudProvider == "digitalocean" {


### PR DESCRIPTION
followup to https://github.com/kubernetes/kops/pull/18509

## What

Follow-up to the recently merged change that moved the `Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes` skip into the Cilium block.

Inspecting the latest `e2e-kops-aws-cni-*` periodic runs shows that gating it to Cilium alone was **too narrow** — the test also fails on **flannel, kopeio, and kube-router**, and it is the *sole* failure in each of those three jobs' latest runs (i.e. it turned them red):

| CNI | this test | symptom | example failing run |
|-----|-----------|---------|---------------------|
| amazon-vpc, calico, kindnet | ✅ PASS | source IP preserved | — |
| cilium | ⏭️ skipped | — | — |
| **flannel** | ❌ FAIL | client IP SNATed to pod IP (`100.96.3.0` != node `172.20.200.197`) | [e2e-kops-aws-cni-flannel #2070646604699799552](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-cni-flannel/2070646604699799552) |
| **kopeio** | ❌ FAIL | client IP SNATed to pod IP (`100.96.2.0` != node `172.20.113.68`) | [e2e-kops-aws-cni-kopeio #2070571105239699456](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-cni-kopeio/2070571105239699456) |
| **kube-router** | ❌ FAIL | request to local NodePort times out (`context deadline exceeded`) | [e2e-kops-aws-cni-kuberouter #2070651133289828352](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-cni-kuberouter/2070651133289828352) |

All three share the same root cause: `externalTrafficPolicy=Local` source-IP preservation is not implemented (kube-router fails one step earlier with a connectivity timeout).

## Change

Move the skip out of the Cilium-only block into a condition covering **cilium, flannel, kopeio, and kube-router**. amazon-vpc, calico, and kindnet preserve the source IP and keep running the test.

The sibling `externalTrafficPolicy=Local for type=NodePort` test **passes on every non-Cilium CNI**, so it stays gated to Cilium only.