### PR TITLE
chore(channels): pin Azure noble image to a deployable version

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -114,11 +114,11 @@ spec:
       providerID: azure
       architectureID: amd64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: Canonical:ubuntu-24_04-lts:server:24.04.202606120
+    - name: Canonical:ubuntu-24_04-lts:server:24.04.202606060
       providerID: azure
       architectureID: amd64
       kubernetesVersion: ">=1.32.0"
-    - name: Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606110
+    - name: Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606060
       providerID: azure
       architectureID: arm64
       kubernetesVersion: ">=1.32.0"

--- a/channels/stable
+++ b/channels/stable
@@ -114,11 +114,11 @@ spec:
       providerID: azure
       architectureID: amd64
       kubernetesVersion: ">=1.27.0 <1.32.0"
-    - name: Canonical:ubuntu-24_04-lts:server:24.04.202606120
+    - name: Canonical:ubuntu-24_04-lts:server:24.04.202606060
       providerID: azure
       architectureID: amd64
       kubernetesVersion: ">=1.32.0"
-    - name: Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606110
+    - name: Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606060
       providerID: azure
       architectureID: arm64
       kubernetesVersion: ">=1.32.0"

--- a/tests/integration/create_cluster/gossip-azure/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gossip-azure/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: gossip.k8s.local
   name: control-plane-eastus-1
 spec:
-  image: Canonical:ubuntu-24_04-lts:server:24.04.202606120
+  image: Canonical:ubuntu-24_04-lts:server:24.04.202606060
   machineType: Standard_B2s
   maxSize: 1
   minSize: 1
@@ -92,7 +92,7 @@ metadata:
     kops.k8s.io/cluster: gossip.k8s.local
   name: nodes-eastus-1
 spec:
-  image: Canonical:ubuntu-24_04-lts:server:24.04.202606120
+  image: Canonical:ubuntu-24_04-lts:server:24.04.202606060
   machineType: Standard_B2s
   maxSize: 1
   minSize: 1


### PR DESCRIPTION
Azure retired the pinned Ubuntu 24.04 daily images from the uksouth marketplace, so VMSS creation fails with PlatformImageNotFound and every Azure e2e job dies in the Up phase:
> The platform image 'Canonical:ubuntu-24_04-lts:server:24.04.202606120' is not available.

`az vm image show` (the query path a deployment uses) confirms 24.04.202606120 (amd64) and 24.04.202606110 (arm64) are no longer available, while `az vm image list` still lists them from a stale catalog. 24.04.202606060 is the newest version that `az vm image show` confirms deployable for both server and server-arm64, so pin both arches to it.

/cc @rifelpet @ameukam 