### PR TITLE
tests/e2e: also skip implement-NodePort ETP=Local test on calico+GCE

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -103,10 +103,12 @@ func (t *Tester) setSkipRegexFlag() error {
 	// test requires externalTrafficPolicy=Local source-IP preservation, which is broken on these
 	// CNIs: the client IP is SNATed to a pod IP instead of being preserved (kube-router instead
 	// times out reaching the local endpoint). Confirmed failing on cilium, flannel, kopeio and
-	// kube-router; amazon-vpc, calico and kindnet preserve the source IP and keep running it.
+	// kube-router on all clouds, and on calico on GCE (calico preserves the source IP on AWS).
+	// amazon-vpc and kindnet preserve it and keep running the test.
 	// < 38 so we look at this again
 	if k8sVersion.Minor < 38 &&
-		(networking.Cilium != nil || networking.Flannel != nil || networking.Kopeio != nil || networking.KubeRouter != nil) {
+		(networking.Cilium != nil || networking.Flannel != nil || networking.Kopeio != nil || networking.KubeRouter != nil ||
+			(networking.Calico != nil && cluster.Spec.LegacyCloudProvider == "gce")) {
 		skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
 	}
 


### PR DESCRIPTION
## What

Follow-up to the recent change that runs `Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes` on non-Cilium CNIs (https://github.com/kubernetes/kops/pull/18515). The test fails on **calico on GCE** but passes on **calico on AWS**:

- ❌ [e2e-kops-gce-cni-calico #2070816086277754880](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-gce-cni-calico/2070816086277754880) — fails all recent builds (client IP `100.117.161.64` (pod) != `10.0.16.6` (node))
- ✅ [e2e-kops-aws-cni-calico #2070768263305891840](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-cni-calico/2070768263305891840) — passes

## Root cause

The test runs a hostNetwork pod on node A that curls node B's NodePort with the source bound to node A's IP; with `externalTrafficPolicy=Local`, node B must deliver to a local backend without SNAT so the client IP is preserved.

| | GCE calico | AWS calico |
|---|---|---|
| Inter-node pod routes | `... via <nodeIP> **dev tunl0** proto bird onlink` | `... via <nodeIP> **dev ens5** proto bird` |
| Encapsulation | **IPIP (tunl0)** | none — native VPC |
| MTU | 1440 (IPIP overhead) | 8981 |

The bad source `100.117.161.64` is exactly node A's `/26` IPIP block base (`100.117.161.64/26 via 10.0.16.6 dev tunl0`) — its tunl0 tunnel address. The IPIP/masquerade path rewrites the source, losing the client IP.

kops sets calico to IPIP CrossSubnet on both clouds. The difference:
- **AWS**: kops disables the EC2 source/dest check, so the VPC forwards calico pod-CIDR packets → calico routes natively (no encap) → source IP preserved.
- **GCE**: the VPC drops packets with arbitrary pod-CIDR source/dest (anti-spoofing), so calico must IPIP-encapsulate all inter-node pod traffic → source IP rewritten.

This is a fundamental calico-IPIP-overlay-on-GCE limitation (same SNAT class as Cilium's overlay), not a kops bug. Corroborated by the rest of the GCE matrix: `ipalias` (alias IPs), `kindnet` and `kubenet` (GCE routes) all route natively and **pass**; only the calico overlay fails.

## Change

Extend the skip to calico when the cloud provider is GCE. amazon-vpc and kindnet keep running the test on both clouds, and calico keeps running it on AWS (where it passes).