### PR TITLE
azure: Bump azuredisk-csi-driver to v1.34.4

### DIFF
--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: csi-azuredisk-controller-sa
   namespace: kube-system
@@ -22,8 +22,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: csi-azuredisk-node-sa
   namespace: kube-system
@@ -38,8 +38,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-external-attacher-role
 rules:
@@ -117,8 +117,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-external-provisioner-role
 rules:
@@ -214,8 +214,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-external-resizer-role
 rules:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-external-snapshotter-role
 rules:
@@ -422,8 +422,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-csi-attacher-binding
 roleRef:
@@ -445,8 +445,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-csi-provisioner-binding
 roleRef:
@@ -468,8 +468,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-csi-resizer-role
 roleRef:
@@ -491,8 +491,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-csi-snapshotter-binding
 roleRef:
@@ -552,8 +552,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: csi-azuredisk-controller
   namespace: kube-system
@@ -569,8 +569,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.34.0
-        helm.sh/chart: azuredisk-csi-driver-1.34.0
+        app.kubernetes.io/version: 1.34.4
+        helm.sh/chart: azuredisk-csi-driver-1.34.4
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -582,7 +582,7 @@ spec:
                 operator: Exists
       containers:
       - args:
-        - --feature-gates=Topology=true,HonorPVReclaimPolicy=true,VolumeAttributesClass=true
+        - --feature-gates=Topology=true,VolumeAttributesClass=true
         - --csi-address=$(ADDRESS)
         - --v=2
         - --timeout=30s
@@ -597,7 +597,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.1.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.2.0
         name: csi-provisioner
         resources:
           limits:
@@ -624,7 +624,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-attacher:v4.10.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-attacher:v4.11.0
         name: csi-attacher
         resources:
           limits:
@@ -651,7 +651,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.4.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.5.0
         name: csi-snapshotter
         resources:
           limits:
@@ -678,7 +678,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.0.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.1.0
         name: csi-resizer
         resources:
           limits:
@@ -698,7 +698,7 @@ spec:
         - --probe-timeout=3s
         - --http-endpoint=localhost:29602
         - --v=2
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0
         name: liveness-probe
         resources:
           limits:
@@ -726,6 +726,8 @@ spec:
         - --user-agent-suffix=kops
         - --allow-empty-cloud-config=false
         - --vmss-cache-ttl-seconds=60
+        - --kube-api-qps=0
+        - --kube-api-burst=0
         - --enable-traffic-manager=false
         - --traffic-manager-port=7788
         - --enable-otel-tracing=false
@@ -742,7 +744,7 @@ spec:
           value: unix:///csi/csi.sock
         - name: AZURE_GO_SDK_LOG_LEVEL
           value: null
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -812,8 +814,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: csi-azuredisk-node
   namespace: kube-system
@@ -828,8 +830,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.34.0
-        helm.sh/chart: azuredisk-csi-driver-1.34.0
+        app.kubernetes.io/version: 1.34.4
+        helm.sh/chart: azuredisk-csi-driver-1.34.4
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -847,7 +849,7 @@ spec:
         - --probe-timeout=10s
         - --health-port=29603
         - --v=2
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0
         name: liveness-probe
         resources:
           limits:
@@ -866,13 +868,27 @@ spec:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
         - --v=2
+        - --http-endpoint=localhost:29607
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/disk.csi.azure.com/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.15.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.16.0
+        livenessProbe:
+          failureThreshold: 2
+          httpGet:
+            host: localhost
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 20
+          periodSeconds: 20
+          timeoutSeconds: 10
         name: node-driver-registrar
+        ports:
+        - containerPort: 29607
+          name: healthz
+          protocol: TCP
         resources:
           limits:
             memory: 100Mi
@@ -923,7 +939,7 @@ spec:
               fieldPath: spec.nodeName
         - name: AZURE_GO_SDK_LOG_LEVEL
           value: null
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1020,8 +1036,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   annotations:
-    csiDriver: v1.34.0
-    snapshot: v8.4.0
+    csiDriver: v1.34.4
+    snapshot: v8.5.0
   labels:
     addon.kops.k8s.io/name: azuredisk-csi-driver.addons.k8s.io
     app.kubernetes.io/managed-by: kops

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
@@ -91,7 +91,7 @@ spec:
       k8s-addon: azure-cloud-controller.addons.k8s.io
   - id: k8s-1.31
     manifest: azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml
-    manifestHash: c4e39eea11e49c4ae1dbf981e9d98256de3183c496becbb1f175306a6c354eb3
+    manifestHash: 743cb817f7db9e63cdff793d07dd043b226b0de5c3a37ccdd4af4943e67176db
     name: azuredisk-csi-driver.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: csi-azuredisk-controller-sa
   namespace: kube-system
@@ -22,8 +22,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: csi-azuredisk-node-sa
   namespace: kube-system
@@ -38,8 +38,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-external-attacher-role
 rules:
@@ -117,8 +117,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-external-provisioner-role
 rules:
@@ -214,8 +214,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-external-resizer-role
 rules:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-external-snapshotter-role
 rules:
@@ -422,8 +422,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-csi-attacher-binding
 roleRef:
@@ -445,8 +445,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-csi-provisioner-binding
 roleRef:
@@ -468,8 +468,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-csi-resizer-role
 roleRef:
@@ -491,8 +491,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: azuredisk-csi-snapshotter-binding
 roleRef:
@@ -552,8 +552,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: csi-azuredisk-controller
   namespace: kube-system
@@ -569,8 +569,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.34.0
-        helm.sh/chart: azuredisk-csi-driver-1.34.0
+        app.kubernetes.io/version: 1.34.4
+        helm.sh/chart: azuredisk-csi-driver-1.34.4
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -582,7 +582,7 @@ spec:
                 operator: Exists
       containers:
       - args:
-        - --feature-gates=Topology=true,HonorPVReclaimPolicy=true,VolumeAttributesClass=true
+        - --feature-gates=Topology=true,VolumeAttributesClass=true
         - --csi-address=$(ADDRESS)
         - --v=2
         - --timeout=30s
@@ -597,7 +597,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.1.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.2.0
         name: csi-provisioner
         resources:
           limits:
@@ -624,7 +624,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-attacher:v4.10.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-attacher:v4.11.0
         name: csi-attacher
         resources:
           limits:
@@ -651,7 +651,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.4.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.5.0
         name: csi-snapshotter
         resources:
           limits:
@@ -678,7 +678,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.0.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.1.0
         name: csi-resizer
         resources:
           limits:
@@ -698,7 +698,7 @@ spec:
         - --probe-timeout=3s
         - --http-endpoint=localhost:29602
         - --v=2
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0
         name: liveness-probe
         resources:
           limits:
@@ -726,6 +726,8 @@ spec:
         - --user-agent-suffix=kops
         - --allow-empty-cloud-config=false
         - --vmss-cache-ttl-seconds=60
+        - --kube-api-qps=0
+        - --kube-api-burst=0
         - --enable-traffic-manager=false
         - --traffic-manager-port=7788
         - --enable-otel-tracing=false
@@ -742,7 +744,7 @@ spec:
           value: unix:///csi/csi.sock
         - name: AZURE_GO_SDK_LOG_LEVEL
           value: null
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -812,8 +814,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
     k8s-addon: azuredisk-csi-driver.addons.k8s.io
   name: csi-azuredisk-node
   namespace: kube-system
@@ -828,8 +830,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.34.0
-        helm.sh/chart: azuredisk-csi-driver-1.34.0
+        app.kubernetes.io/version: 1.34.4
+        helm.sh/chart: azuredisk-csi-driver-1.34.4
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -847,7 +849,7 @@ spec:
         - --probe-timeout=10s
         - --health-port=29603
         - --v=2
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0
         name: liveness-probe
         resources:
           limits:
@@ -866,13 +868,27 @@ spec:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
         - --v=2
+        - --http-endpoint=localhost:29607
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/disk.csi.azure.com/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.15.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.16.0
+        livenessProbe:
+          failureThreshold: 2
+          httpGet:
+            host: localhost
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 20
+          periodSeconds: 20
+          timeoutSeconds: 10
         name: node-driver-registrar
+        ports:
+        - containerPort: 29607
+          name: healthz
+          protocol: TCP
         resources:
           limits:
             memory: 100Mi
@@ -923,7 +939,7 @@ spec:
               fieldPath: spec.nodeName
         - name: AZURE_GO_SDK_LOG_LEVEL
           value: null
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1020,8 +1036,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   annotations:
-    csiDriver: v1.34.0
-    snapshot: v8.4.0
+    csiDriver: v1.34.4
+    snapshot: v8.5.0
   labels:
     addon.kops.k8s.io/name: azuredisk-csi-driver.addons.k8s.io
     app.kubernetes.io/managed-by: kops

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
@@ -85,7 +85,7 @@ spec:
       k8s-addon: azure-cloud-controller.addons.k8s.io
   - id: k8s-1.31
     manifest: azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml
-    manifestHash: c4e39eea11e49c4ae1dbf981e9d98256de3183c496becbb1f175306a6c354eb3
+    manifestHash: 743cb817f7db9e63cdff793d07dd043b226b0de5c3a37ccdd4af4943e67176db
     name: azuredisk-csi-driver.addons.k8s.io
     prune:
       kinds:

--- a/upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml.template
+++ b/upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml.template
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-controller-sa
   namespace: kube-system
 ---
@@ -17,8 +17,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-node-sa
   namespace: kube-system
 ---
@@ -29,8 +29,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-attacher-role
 rules:
 - apiGroups:
@@ -104,8 +104,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-provisioner-role
 rules:
 - apiGroups:
@@ -197,8 +197,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-resizer-role
 rules:
 - apiGroups:
@@ -272,8 +272,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-snapshotter-role
 rules:
 - apiGroups:
@@ -385,8 +385,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-attacher-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -404,8 +404,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-provisioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -423,8 +423,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-resizer-role
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -442,8 +442,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-snapshotter-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -487,8 +487,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-controller
   namespace: kube-system
 spec:
@@ -503,8 +503,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.34.0
-        helm.sh/chart: azuredisk-csi-driver-1.34.0
+        app.kubernetes.io/version: 1.34.4
+        helm.sh/chart: azuredisk-csi-driver-1.34.4
     spec:
       affinity:
         nodeAffinity:
@@ -515,7 +515,7 @@ spec:
                 operator: Exists
       containers:
       - args:
-        - --feature-gates=Topology=true,HonorPVReclaimPolicy=true,VolumeAttributesClass=true
+        - --feature-gates=Topology=true,VolumeAttributesClass=true
         - --csi-address=$(ADDRESS)
         - --v=2
         - --timeout=30s
@@ -530,7 +530,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.1.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.2.0
         name: csi-provisioner
         resources:
           limits:
@@ -557,7 +557,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-attacher:v4.10.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-attacher:v4.11.0
         name: csi-attacher
         resources:
           limits:
@@ -584,7 +584,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.4.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.5.0
         name: csi-snapshotter
         resources:
           limits:
@@ -611,7 +611,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.0.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.1.0
         name: csi-resizer
         resources:
           limits:
@@ -631,7 +631,7 @@ spec:
         - --probe-timeout=3s
         - --http-endpoint=localhost:29602
         - --v=2
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0
         name: liveness-probe
         resources:
           limits:
@@ -659,6 +659,8 @@ spec:
         - --user-agent-suffix=kops
         - --allow-empty-cloud-config=false
         - --vmss-cache-ttl-seconds=60
+        - --kube-api-qps=0
+        - --kube-api-burst=0
         - --enable-traffic-manager=false
         - --traffic-manager-port=7788
         - --enable-otel-tracing=false
@@ -675,7 +677,7 @@ spec:
           value: unix:///csi/csi.sock
         - name: AZURE_GO_SDK_LOG_LEVEL
           value: null
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -742,8 +744,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.0
-    helm.sh/chart: azuredisk-csi-driver-1.34.0
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-node
   namespace: kube-system
 spec:
@@ -757,8 +759,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.34.0
-        helm.sh/chart: azuredisk-csi-driver-1.34.0
+        app.kubernetes.io/version: 1.34.4
+        helm.sh/chart: azuredisk-csi-driver-1.34.4
     spec:
       affinity:
         nodeAffinity:
@@ -775,7 +777,7 @@ spec:
         - --probe-timeout=10s
         - --health-port=29603
         - --v=2
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0
         name: liveness-probe
         resources:
           limits:
@@ -794,13 +796,27 @@ spec:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
         - --v=2
+        - --http-endpoint=localhost:29607
         env:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/disk.csi.azure.com/csi.sock
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.15.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.16.0
+        livenessProbe:
+          failureThreshold: 2
+          httpGet:
+            host: localhost
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 20
+          periodSeconds: 20
+          timeoutSeconds: 10
         name: node-driver-registrar
+        ports:
+        - containerPort: 29607
+          name: healthz
+          protocol: TCP
         resources:
           limits:
             memory: 100Mi
@@ -851,7 +867,7 @@ spec:
               fieldPath: spec.nodeName
         - name: AZURE_GO_SDK_LOG_LEVEL
           value: null
-        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.0
+        image: mcr.microsoft.com/oss/v2/kubernetes-csi/azuredisk-csi:v1.34.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -946,8 +962,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   annotations:
-    csiDriver: v1.34.0
-    snapshot: v8.4.0
+    csiDriver: v1.34.4
+    snapshot: v8.5.0
   name: disk.csi.azure.com
 spec:
   attachRequired: true

--- a/upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io/kustomization.yaml
+++ b/upup/models/cloudup/resources/addons/azuredisk-csi-driver.addons.k8s.io/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 helmCharts:
   - name: azuredisk-csi-driver
     repo: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
-    version: "1.34.0"
+    version: "1.34.4"
     releaseName: azuredisk-csi-driver
     namespace: kube-system
     valuesFile: helm-values.yaml


### PR DESCRIPTION
The kops Azure e2e jobs (e.g. e2e-kops-azure-gossip-ha) flake on slow Azure disk attach/detach. The v1.34.x patch stream fixes that path:

- https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/3481
  (v1.34.1): fix: handling dangling detaches in a better way
- https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/3547
  (v1.34.3): fix: incorrect node attached on waitingForDetached call

/cc @rifelpet @ameukam 