### PR TITLE
Automated cherry pick of #18529: azure: Bump azure-cloud-controller-manager to v1.36.2

### DIFF
--- a/pkg/model/components/azurecloudcontrollermanager.go
+++ b/pkg/model/components/azurecloudcontrollermanager.go
@@ -42,11 +42,11 @@ func (b *AzureCloudControllerManagerOptionsBuilder) BuildOptions(cluster *kops.C
 	eccm := cluster.Spec.ExternalCloudControllerManager
 
 	if eccm.Image == "" {
-		eccm.Image = "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.3"
+		eccm.Image = "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.36.2"
 	}
 
 	if eccm.AzureNodeManagerImage == "" {
-		eccm.AzureNodeManagerImage = "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.34.3"
+		eccm.AzureNodeManagerImage = "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.36.2"
 	}
 
 	eccm.LeaderElection = &kops.LeaderElectionConfiguration{LeaderElect: fi.PtrTo(true)}

--- a/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/kustomization.yaml
+++ b/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 helmCharts:
   - name: cloud-provider-azure
     repo: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
-    version: "1.34.5"
+    version: "1.36.0"
     releaseName: cloud-provider-azure
     namespace: kube-system
     valuesFile: helm-values.yaml


### PR DESCRIPTION
Cherry pick of #18529 on release-1.36.

#18529: azure: Bump azure-cloud-controller-manager to v1.36.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```