### PR TITLE
Automated cherry pick of #18529: azure: Bump azure-cloud-controller-manager to v1.36.2

### DIFF
--- a/pkg/model/components/azurecloudcontrollermanager.go
+++ b/pkg/model/components/azurecloudcontrollermanager.go
@@ -42,11 +42,11 @@ func (b *AzureCloudControllerManagerOptionsBuilder) BuildOptions(cluster *kops.C
 	eccm := cluster.Spec.ExternalCloudControllerManager
 
 	if eccm.Image == "" {
-		eccm.Image = "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.3"
+		eccm.Image = "mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.36.2"
 	}
 
 	if eccm.AzureNodeManagerImage == "" {
-		eccm.AzureNodeManagerImage = "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.34.3"
+		eccm.AzureNodeManagerImage = "mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager:v1.36.2"
 	}
 
 	eccm.LeaderElection = &kops.LeaderElectionConfiguration{LeaderElect: fi.PtrTo(true)}

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_cluster-completed.spec_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_cluster-completed.spec_source
@@ -18,9 +18,9 @@ spec:
       tenantId: ""
     manageStorageClasses: true
   cloudControllerManager:
-    azureNodeManagerImage: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.34.3
+    azureNodeManagerImage: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager:v1.36.2
     configureCloudRoutes: false
-    image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.3
+    image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.36.2
     leaderElection:
       leaderElect: true
     logLevel: 2

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
@@ -268,7 +268,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.3
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.36.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -373,7 +373,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.34.3
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager:v1.36.2
         imagePullPolicy: IfNotPresent
         name: cloud-node-manager
         resources:

--- a/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
+++ b/tests/integration/update_cluster/gossip-azure/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source
@@ -85,7 +85,7 @@ spec:
       k8s-addon: azure-cloud-config.addons.k8s.io
   - id: k8s-1.31
     manifest: azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml
-    manifestHash: 539bf5e117db1a903ff8c4dae393b197f140cc57b003687a91aa8e5b3d17b3f4
+    manifestHash: e1cd50f45a795474e38f44aebf07c51d0aa4bfedb9dbec3b2549fa76038e057a
     name: azure-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: azure-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_cluster-completed.spec_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_cluster-completed.spec_source
@@ -19,9 +19,9 @@ spec:
       tenantId: tenant-123
     manageStorageClasses: true
   cloudControllerManager:
-    azureNodeManagerImage: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.34.3
+    azureNodeManagerImage: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager:v1.36.2
     configureCloudRoutes: false
-    image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.3
+    image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.36.2
     leaderElection:
       leaderElect: true
     logLevel: 2

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source
@@ -268,7 +268,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.3
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.36.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -373,7 +373,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.34.3
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager:v1.36.2
         imagePullPolicy: IfNotPresent
         name: cloud-node-manager
         resources:

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
@@ -79,7 +79,7 @@ spec:
       k8s-addon: azure-cloud-config.addons.k8s.io
   - id: k8s-1.31
     manifest: azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml
-    manifestHash: bc6ea012c9a6fc50042ef36bd3bb5a0e6aa1a9de9b79f518e149e67265970ea0
+    manifestHash: bd851558984698b20cd112515ae63882328a98ad9a8231164e1671e29f1aa971
     name: azure-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: azure-cloud-controller.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/kustomization.yaml
+++ b/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/kustomization.yaml
@@ -32,6 +32,11 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
         value: '{{ or .ExternalCloudControllerManager.CPURequest "100m" }}'
+      # kOps schedules the CCM on control-plane nodes that may carry arbitrary taints; tolerate all.
+      - op: replace
+        path: /spec/template/spec/tolerations
+        value:
+          - operator: Exists
   - target:
       kind: DaemonSet
       name: cloud-node-manager
@@ -39,6 +44,11 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/image
         value: '{{ .ExternalCloudControllerManager.AzureNodeManagerImage }}'
+      # node-manager runs on every node; tolerate all taints.
+      - op: replace
+        path: /spec/template/spec/tolerations
+        value:
+          - operator: Exists
   # Remove Windows resources.
   - target:
       kind: DaemonSet

--- a/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/kustomization.yaml
+++ b/upup/models/cloudup/resources/addons/azure-cloud-controller.addons.k8s.io/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 helmCharts:
   - name: cloud-provider-azure
     repo: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
-    version: "1.34.5"
+    version: "1.36.0"
     releaseName: cloud-provider-azure
     namespace: kube-system
     valuesFile: helm-values.yaml


### PR DESCRIPTION
Cherry pick of #18529 on release-1.36.

#18529: azure: Bump azure-cloud-controller-manager to v1.36.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```