### PR TITLE
azure: Grant control-plane VMSS Contributor instead of Owner

### DIFF
--- a/docs/getting_started/azure.md
+++ b/docs/getting_started/azure.md
@@ -75,6 +75,15 @@ kops delete cluster --name my.k8s
 kops delete cluster --name my.k8s --yes 
 ```
 
+## Managed Identities
+
+kOps assigns a system-assigned managed identity to each VM Scale Set. The control-plane identity is granted the following built-in roles:
+
+* **Contributor** on the cluster resource group, used by cloud-controller-manager, the Azure Disk CSI driver, etcd-manager, kops-controller and protokube.
+* **Storage Blob Data Contributor** on the state-store storage account, used to read cluster configuration and write etcd backups.
+
+Worker node identities are not granted any role.
+
 ## TODO
 
 kOps for Azure currently does not support the following features:

--- a/docs/releases/1.36-NOTES.md
+++ b/docs/releases/1.36-NOTES.md
@@ -77,6 +77,7 @@ This feature is currently supported on Debian-family distributions only (Debian,
 * Use `HeadBucket` to resolve the S3 bucket region, pass the VFS scheme and provider-specific options to the S3 client, and silence warnings when the S3 provider has no supported checksum ([#18335](https://github.com/kubernetes/kops/pull/18335), [#18129](https://github.com/kubernetes/kops/pull/18129), [#18132](https://github.com/kubernetes/kops/pull/18132), [#18128](https://github.com/kubernetes/kops/pull/18128))
 
 ## Azure
+* Grant the control-plane VM Scale Set identity the built-in **Contributor** role instead of **Owner** on the cluster resource group. Existing clusters keep the old Owner role assignment until it is removed with `az role assignment delete` or the cluster is deleted.
 * Deploy `cloud-controller-manager` for node lifecycle and load-balancer support ([#18197](https://github.com/kubernetes/kops/pull/18197))
 * Add experimental Terraform target support ([#18149](https://github.com/kubernetes/kops/pull/18149))
 * Add support for the Azure Disk CSI Driver ([#18141](https://github.com/kubernetes/kops/pull/18141))

--- a/pkg/model/azuremodel/vmscaleset.go
+++ b/pkg/model/azuremodel/vmscaleset.go
@@ -70,12 +70,12 @@ func (b *VMScaleSetModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				b.Cluster.AzureResourceGroupName(),
 			)
 			c.AddTask(&azuretasks.RoleAssignment{
-				Name:       to.Ptr(fmt.Sprintf("%s-%s", *vmss.Name, "owner")),
+				Name:       to.Ptr(fmt.Sprintf("%s-%s", *vmss.Name, "contributor")),
 				Lifecycle:  b.Lifecycle,
 				Scope:      to.Ptr(resourceGroupID),
 				VMScaleSet: vmss,
-				// Owner
-				RoleDefID: to.Ptr("8e3af657-a8ff-443c-a75c-2fe8c4bcb635"),
+				// Contributor
+				RoleDefID: to.Ptr("b24988ac-6180-42a0-ab88-20f7382dd24c"),
 			})
 			c.AddTask(&azuretasks.RoleAssignment{
 				Name:       to.Ptr(fmt.Sprintf("%s-%s", *vmss.Name, "blob")),

--- a/tests/integration/update_cluster/gossip-azure/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-azure/kubernetes.tf
@@ -476,9 +476,9 @@ resource "azurerm_role_assignment" "control-plane-eastus-1-masters-gossip-k8s-lo
   skip_service_principal_aad_check = true
 }
 
-resource "azurerm_role_assignment" "control-plane-eastus-1-masters-gossip-k8s-local-owner" {
+resource "azurerm_role_assignment" "control-plane-eastus-1-masters-gossip-k8s-local-contributor" {
   principal_id                     = azurerm_linux_virtual_machine_scale_set.control-plane-eastus-1-masters-gossip-k8s-local.identity[0].principal_id
-  role_definition_id               = "/subscriptions/sub-123/resourceGroups/gossip.k8s.local/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+  role_definition_id               = "/subscriptions/sub-123/resourceGroups/gossip.k8s.local/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
   scope                            = "/subscriptions/sub-123/resourceGroups/gossip.k8s.local"
   skip_service_principal_aad_check = true
 }

--- a/tests/integration/update_cluster/minimal_azure/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_azure/kubernetes.tf
@@ -476,9 +476,9 @@ resource "azurerm_role_assignment" "control-plane-eastus-1-masters-minimal-azure
   skip_service_principal_aad_check = true
 }
 
-resource "azurerm_role_assignment" "control-plane-eastus-1-masters-minimal-azure-example-com-owner" {
+resource "azurerm_role_assignment" "control-plane-eastus-1-masters-minimal-azure-example-com-contributor" {
   principal_id                     = azurerm_linux_virtual_machine_scale_set.control-plane-eastus-1-masters-minimal-azure-example-com.identity[0].principal_id
-  role_definition_id               = "/subscriptions/sub-123/resourceGroups/minimal-azure.example.com/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+  role_definition_id               = "/subscriptions/sub-123/resourceGroups/minimal-azure.example.com/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
   scope                            = "/subscriptions/sub-123/resourceGroups/minimal-azure.example.com"
   skip_service_principal_aad_check = true
 }


### PR DESCRIPTION
The built-in Owner role includes Microsoft.Authorization/roleAssignments/write, a privilege-escalation path reachable by any pod via the instance metadata endpoint. No cluster component uses Microsoft.Authorization; Contributor covers everything the control plane needs.

Existing clusters keep the old Owner role assignment until it is removed manually or the cluster is deleted; the terraform target prunes it on apply.

/cc @rifelpet @ameukam 