### PR TITLE
Expose GCP project as PROJECT env for ClusterLoader2 on GCE

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -295,6 +295,9 @@ func (d *deployer) env() []string {
 	case "gce":
 		if d.GCPProject != "" {
 			vars = append(vars, fmt.Sprintf("GCP_PROJECT=%v", d.GCPProject))
+			// ClusterLoader2's managed Prometheus client reads the GCP project
+			// from the PROJECT env var, so also expose it under that name.
+			vars = append(vars, fmt.Sprintf("PROJECT=%v", d.GCPProject))
 		}
 	}
 


### PR DESCRIPTION
## What

In the kubetest2-kops deployer, export `PROJECT` alongside `GCP_PROJECT` (both from `d.GCPProject`) when running the test command on GCE.

## Why

ClusterLoader2's managed Prometheus client ([`clusterloader2/pkg/prometheus/clients/gcp_managed.go`](https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/pkg/prometheus/clients/gcp_managed.go)) reads the GCP project from the `PROJECT` env var to build the Cloud Monitoring query URL:

```go
uri: fmt.Sprintf("https://monitoring.googleapis.com/v1/projects/%s/location/global/prometheus/api/v1/query", os.Getenv("PROJECT"))
```

The deployer only exported `GCP_PROJECT`, so for scalability jobs that enable the "Quotas total usage" measurement (via `preset-e2e-scalability-common`'s `CL2_ENABLE_QUOTAS_USAGE_MEASUREMENT=true`) the query URL had an empty project and Cloud Monitoring rejected it with `HTTP 400 INVALID_ARGUMENT`, failing the load test.

Setting `PROJECT` in the deployer (rather than in `run-test.sh`) is required because these jobs acquire their project from boskos, so `GCP_PROJECT` is empty at scenario start — `d.GCPProject` is where the resolved project value is guaranteed populated.

## Failing job

`ci-kubernetes-kops-gce-small-scale-kindnet-using-cl2` fails on the `Quotas total usage` measurement:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-kops-gce-small-scale-kindnet-using-cl2/2073413226502033408

```
E0704 15:04:51 prometheus_measurement.go:112] Quotas total usage gathering error:
  query error: response failed with status code 400 [body: {"status": "INVALID_ARGUMENT"}]
```