### PR TITLE
tests/e2e: skip implement-NodePort ETP=Local test on calico+Azure

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -103,12 +103,15 @@ func (t *Tester) setSkipRegexFlag() error {
 	// test requires externalTrafficPolicy=Local source-IP preservation, which is broken on these
 	// CNIs: the client IP is SNATed to a pod IP instead of being preserved (kube-router instead
 	// times out reaching the local endpoint). Confirmed failing on cilium, flannel, kopeio and
-	// kube-router on all clouds, and on calico on GCE (calico preserves the source IP on AWS).
-	// amazon-vpc and kindnet preserve it and keep running the test.
+	// kube-router on all clouds, and on calico on GCE and Azure, where the underlay cannot route
+	// the pod CIDR so calico encapsulates inter-node pod traffic (IPIP tunl0 on GCE, VXLAN
+	// vxlan.calico on Azure) and the masquerade rewrites the source to the node's tunnel address.
+	// Calico preserves the source IP only on AWS, where kOps disables the source/dest check and
+	// routes pod traffic natively. amazon-vpc and kindnet preserve it and keep running the test.
 	// < 38 so we look at this again
 	if k8sVersion.Minor < 38 &&
 		(networking.Cilium != nil || networking.Flannel != nil || networking.Kopeio != nil || networking.KubeRouter != nil ||
-			(networking.Calico != nil && cluster.Spec.LegacyCloudProvider == "gce")) {
+			(networking.Calico != nil && (cluster.Spec.LegacyCloudProvider == "gce" || cluster.Spec.LegacyCloudProvider == "azure"))) {
 		skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
 	}
 


### PR DESCRIPTION
The "Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes" test fails on calico on Azure for the same reason it does on GCE: the underlay cannot route the pod CIDR, so calico must encapsulate inter-node pod traffic (VXLAN vxlan.calico on Azure, IPIP tunl0 on GCE). On the node-local ExternalTrafficPolicy=Local NodePort short-circuit path the masquerade then rewrites the client source IP to the node's tunnel address (a pod-CIDR IP) instead of preserving it, so the test fails on every run once the cluster comes up.

/cc @rifelpet 