### PR TITLE
Automated cherry pick of #18541: Update cluster-autoscaler to v1.36.0

### DIFF
--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -48,11 +48,13 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 			case 32:
 				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7"
 			case 33:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.4"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.5"
 			case 34:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.3"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.4"
+			case 35:
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.1"
 			default:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.36.0"
 			}
 		}
 		cas.Image = fi.PtrTo(image)


### PR DESCRIPTION
Cherry pick of #18541 on release-1.36.

#18541: Update cluster-autoscaler to v1.36.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```