### PR TITLE
Automated cherry pick of #18543: gce: register all zonal MIGs of a multi-zone instance group with cluster-autoscaler

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -554,6 +554,7 @@ func TestHA(t *testing.T) {
 func TestHighAvailabilityGCE(t *testing.T) {
 	newIntegrationTest("ha-gce.example.com", "ha_gce").withZones(3).
 		withAddons(
+			clusterAutoscalerAddon,
 			dnsControllerAddon,
 			gcpCCMAddon,
 			gcpPDCSIAddon,

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -288,29 +288,41 @@ func (b *AutoscalingGroupModelBuilder) splitToZones(ig *kops.InstanceGroup) (map
 		// 1) no support in terraform
 		// 2) we can't steer to specific zones AFAICT, only to all zones in the region
 
-		targetSizes := make([]int, len(zones))
-		totalSize := 0
-		for i := range zones {
-			targetSizes[i] = minSize / len(zones)
-			totalSize += targetSizes[i]
-		}
-		i := 0
-		for totalSize < minSize {
-			targetSizes[i]++
-			totalSize++
-
-			i++
-			if i >= len(targetSizes) {
-				i = 0
-			}
-		}
-
-		instanceCountByZone := make(map[string]int)
-		for i, zone := range zones {
-			instanceCountByZone[zone] = targetSizes[i]
-		}
-		return instanceCountByZone, nil
+		return SplitCountAcrossZones(minSize, zones), nil
 	}
+}
+
+// SplitCountAcrossZones distributes count across zones as evenly as possible,
+// assigning the remainder to zones in the order given. Both the target sizes
+// of the per-zone InstanceGroupManagers and the min/max sizes registered with
+// cluster-autoscaler are derived from this split, so they stay consistent.
+func SplitCountAcrossZones(count int, zones []string) map[string]int {
+	if len(zones) == 0 {
+		return map[string]int{}
+	}
+
+	targetSizes := make([]int, len(zones))
+	totalSize := 0
+	for i := range zones {
+		targetSizes[i] = count / len(zones)
+		totalSize += targetSizes[i]
+	}
+	i := 0
+	for totalSize < count {
+		targetSizes[i]++
+		totalSize++
+
+		i++
+		if i >= len(targetSizes) {
+			i = 0
+		}
+	}
+
+	countByZone := make(map[string]int)
+	for i, zone := range zones {
+		countByZone[zone] = targetSizes[i]
+	}
+	return countByZone
 }
 
 func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -29,6 +29,23 @@ spec:
     leaderElection:
       leaderElect: true
   cloudProvider: gce
+  clusterAutoscaler:
+    awsUseStaticInstanceList: false
+    balanceSimilarNodeGroups: false
+    emitPerNodegroupMetrics: false
+    enabled: true
+    expander: random
+    ignoreDaemonSetsUtilization: false
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
+    maxNodeProvisionTime: 15m0s
+    newPodScaleUpDelay: 0s
+    scaleDownDelayAfterAdd: 10m0s
+    scaleDownUnneededTime: 10m0s
+    scaleDownUnreadyTime: 20m0s
+    scaleDownUtilizationThreshold: "0.5"
+    skipNodesWithCustomControllerPods: true
+    skipNodesWithLocalStorage: true
+    skipNodesWithSystemPods: true
   clusterDNSDomain: cluster.local
   configBase: memfs://tests/ha-gce.example.com
   containerd:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -33,6 +33,12 @@ spec:
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
+  - id: k8s-1.15
+    manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
+    manifestHash: eea5ac03bd4329b74f89b20615a8035cbd86f6db857a01cd2394f5d3d9d811ad
+    name: cluster-autoscaler.addons.k8s.io
+    selector:
+      k8s-addon: cluster-autoscaler.addons.k8s.io
   - id: v1.7.0
     manifest: storage-gce.addons.k8s.io/v1.7.0.yaml
     manifestHash: 4f73c7d683f04e61d60e90053a6db1fd82272dc0c13790390740f5e207181c77

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -35,7 +35,7 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: eea5ac03bd4329b74f89b20615a8035cbd86f6db857a01cd2394f5d3d9d811ad
+    manifestHash: d5520ffa5552a7f2cfc659fa19472299ef8e58d1fbc8117b8c33ade21157cc0f
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -333,7 +333,8 @@ spec:
         - --emit-per-nodegroup-metrics=false
         - --cloud-provider=gce
         - --expander=random
-        - --nodes=2:2:https://www.googleapis.com/compute/v1/projects/testproject/zones/us-test1-a/instanceGroups/a-nodes-ha-gce-example-com
+        - --nodes=1:1:https://www.googleapis.com/compute/v1/projects/testproject/zones/us-test1-a/instanceGroups/a-nodes-ha-gce-example-com
+        - --nodes=1:1:https://www.googleapis.com/compute/v1/projects/testproject/zones/us-test1-b/instanceGroups/b-nodes-ha-gce-example-com
         - --ignore-daemonsets-utilization=false
         - --scale-down-utilization-threshold=0.5
         - --skip-nodes-with-custom-controller-pods=true

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -1,0 +1,393 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: cluster-autoscaler
+
+---
+
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - endpoints
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resourceNames:
+  - cluster-autoscaler
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - watch
+  - list
+  - get
+  - update
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  - deviceclasses
+  - resourceclaims
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  - services
+  - replicationcontrollers
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - batch
+  - extensions
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - replicasets
+  - daemonsets
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - watch
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - csinodes
+  - csidrivers
+  - csistoragecapacities
+  - volumeattachments
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - cluster-autoscaler
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - cluster-autoscaler-status
+  resources:
+  - configmaps
+  verbs:
+  - delete
+  - get
+  - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: kube-system
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  ports:
+  - name: http
+    port: 8085
+    protocol: TCP
+    targetPort: 8085
+  selector:
+    app.kubernetes.io/name: cluster-autoscaler
+  type: ClusterIP
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
+      labels:
+        app: cluster-autoscaler
+        app.kubernetes.io/name: cluster-autoscaler
+        k8s-addon: cluster-autoscaler.addons.k8s.io
+        k8s-app: cluster-autoscaler
+        kops.k8s.io/managed-by: kops
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      containers:
+      - command:
+        - ./cluster-autoscaler
+        - --balance-similar-node-groups=false
+        - --emit-per-nodegroup-metrics=false
+        - --cloud-provider=gce
+        - --expander=random
+        - --nodes=2:2:https://www.googleapis.com/compute/v1/projects/testproject/zones/us-test1-a/instanceGroups/a-nodes-ha-gce-example-com
+        - --ignore-daemonsets-utilization=false
+        - --scale-down-utilization-threshold=0.5
+        - --skip-nodes-with-custom-controller-pods=true
+        - --skip-nodes-with-local-storage=true
+        - --skip-nodes-with-system-pods=true
+        - --scale-down-delay-after-add=10m0s
+        - --scale-down-unneeded-time=10m0s
+        - --scale-down-unready-time=20m0s
+        - --new-pod-scale-up-delay=0s
+        - --max-node-provision-time=15m0s
+        - --cordon-node-before-terminating=true
+        - --logtostderr=true
+        - --stderrthreshold=info
+        - --v=4
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.7
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health-check
+            port: http
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cluster-autoscaler
+        ports:
+        - containerPort: 8085
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      nodeSelector: null
+      priorityClassName: system-cluster-critical
+      serviceAccountName: cluster-autoscaler
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule

--- a/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   api:
     dns: {}
+  clusterAutoscaler:
+    enabled: true
   authorization:
     rbac: {}
   channel: stable

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -58,6 +58,14 @@ resource "aws_s3_object" "ha-gce-example-com-addons-bootstrap" {
   server_side_encryption = "AES256"
 }
 
+resource "aws_s3_object" "ha-gce-example-com-addons-cluster-autoscaler-addons-k8s-io-k8s-1-15" {
+  bucket                 = "testingBucket"
+  content                = file("${path.module}/data/aws_s3_object_ha-gce.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content")
+  key                    = "tests/ha-gce.example.com/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml"
+  provider               = aws.files
+  server_side_encryption = "AES256"
+}
+
 resource "aws_s3_object" "ha-gce-example-com-addons-coredns-addons-k8s-io-k8s-1-12" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_ha-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/kops/pkg/kubemanifest"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/components/kopscontroller"
+	"k8s.io/kops/pkg/model/gcemodel"
 	"k8s.io/kops/pkg/model/iam"
 	"k8s.io/kops/pkg/nodelabels"
 	"k8s.io/kops/pkg/resources/spotinst"
@@ -1136,7 +1137,7 @@ type ClusterAutoscalerNodeGroup struct {
 }
 
 // GetClusterAutoscalerNodeGroups returns a map containing ClusterAutoscaler info for each instance group of type Node.
-func (tf *TemplateFunctions) GetClusterAutoscalerNodeGroups() map[string]ClusterAutoscalerNodeGroup {
+func (tf *TemplateFunctions) GetClusterAutoscalerNodeGroups() (map[string]ClusterAutoscalerNodeGroup, error) {
 	cluster := tf.Cluster
 	groups := make(map[string]ClusterAutoscalerNodeGroup)
 	for _, ig := range tf.KopsModelContext.InstanceGroups {
@@ -1147,9 +1148,37 @@ func (tf *TemplateFunctions) GetClusterAutoscalerNodeGroups() map[string]Cluster
 				MaxSize:   fi.ValueOf(ig.Spec.MaxSize),
 			}
 			if cluster.GetCloudProvider() == kops.CloudProviderGCE {
+				// On GCE, kOps creates one zonal InstanceGroupManager per zone of the
+				// instance group, so each zonal MIG must be registered with
+				// cluster-autoscaler as its own node group. The min/max sizes are
+				// split across zones the same way the MIG target sizes are.
 				cloud := tf.cloud.(gce.GCECloud)
+				zones, err := apiModel.FindZonesForInstanceGroup(cluster, ig)
+				if err != nil {
+					return nil, err
+				}
+				if len(zones) == 0 {
+					return nil, fmt.Errorf("no zones found for instance group %q", ig.ObjectMeta.Name)
+				}
+				minSizeByZone := gcemodel.SplitCountAcrossZones(int(group.MinSize), zones)
+				maxSizeByZone := gcemodel.SplitCountAcrossZones(int(group.MaxSize), zones)
 				format := "https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instanceGroups/%s"
-				group.Other = fmt.Sprintf(format, cloud.Project(), ig.Spec.Zones[0], gce.NameForInstanceGroupManager(cluster.ObjectMeta.Name, ig.ObjectMeta.Name, ig.Spec.Zones[0]))
+				for _, zone := range zones {
+					// A zone whose max size is zero can never hold an instance.
+					if len(zones) > 1 && maxSizeByZone[zone] == 0 {
+						continue
+					}
+					zoneGroup := group
+					zoneGroup.MinSize = int32(minSizeByZone[zone])
+					zoneGroup.MaxSize = int32(maxSizeByZone[zone])
+					zoneGroup.Other = fmt.Sprintf(format, cloud.Project(), zone, gce.NameForInstanceGroupManager(cluster.ObjectMeta.Name, ig.ObjectMeta.Name, zone))
+					key := ig.Name
+					if len(zones) > 1 {
+						key = ig.Name + "-" + zone
+					}
+					groups[key] = zoneGroup
+				}
+				continue
 			} else if cluster.GetCloudProvider() == kops.CloudProviderHetzner {
 				// Hetzner autoscaler expects --nodes=min:max:instanceType:region:name.
 				// The subnet name for Hetzner is the location (e.g. "hel1"), which is
@@ -1162,7 +1191,7 @@ func (tf *TemplateFunctions) GetClusterAutoscalerNodeGroups() map[string]Cluster
 			groups[ig.Name] = group
 		}
 	}
-	return groups
+	return groups, nil
 }
 
 // HCloudClusterConfig returns HCLOUD_CLUSTER_CONFIG as JSON.

--- a/upup/pkg/fi/cloudup/template_functions_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_test.go
@@ -24,6 +24,7 @@ import (
 	"text/template"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gcemock "k8s.io/kops/cloudmock/gce"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
@@ -508,5 +509,80 @@ func TestTemplateFunctions_TaskHelpers(t *testing.T) {
 
 	if actual := buf.String(); actual != "ManagedFile/alpha|ManagedFile/alpha;ManagedFile/zeta;" {
 		t.Fatalf("unexpected rendered template %q", actual)
+	}
+}
+
+func TestGetClusterAutoscalerNodeGroupsGCE(t *testing.T) {
+	cloud := gcemock.InstallMockGCECloud("us-test1", "testproject")
+
+	cluster := &kops.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "minimal.example.com"},
+		Spec: kops.ClusterSpec{
+			CloudProvider: kops.CloudProviderSpec{
+				GCE: &kops.GCESpec{},
+			},
+		},
+	}
+
+	newIG := func(name string, minSize, maxSize int32, zones []string) *kops.InstanceGroup {
+		return &kops.InstanceGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: kops.InstanceGroupSpec{
+				Role:    kops.InstanceGroupRoleNode,
+				MinSize: fi.PtrTo(minSize),
+				MaxSize: fi.PtrTo(maxSize),
+				Zones:   zones,
+			},
+		}
+	}
+
+	migURL := func(zone, name string) string {
+		return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/testproject/zones/%s/instanceGroups/%s", zone, name)
+	}
+
+	grid := []struct {
+		desc     string
+		ig       *kops.InstanceGroup
+		expected map[string]ClusterAutoscalerNodeGroup
+	}{
+		{
+			desc: "single zone",
+			ig:   newIG("nodes", 1, 10, []string{"us-test1-a"}),
+			expected: map[string]ClusterAutoscalerNodeGroup{
+				"nodes": {MinSize: 1, MaxSize: 10, Other: migURL("us-test1-a", "a-nodes-minimal-example-com")},
+			},
+		},
+		{
+			desc: "multiple zones split min and max",
+			ig:   newIG("nodes", 1, 3, []string{"us-test1-a", "us-test1-b", "us-test1-c"}),
+			expected: map[string]ClusterAutoscalerNodeGroup{
+				"nodes-us-test1-a": {MinSize: 1, MaxSize: 1, Other: migURL("us-test1-a", "a-nodes-minimal-example-com")},
+				"nodes-us-test1-b": {MinSize: 0, MaxSize: 1, Other: migURL("us-test1-b", "b-nodes-minimal-example-com")},
+				"nodes-us-test1-c": {MinSize: 0, MaxSize: 1, Other: migURL("us-test1-c", "c-nodes-minimal-example-com")},
+			},
+		},
+		{
+			desc: "max size smaller than zone count skips empty zones",
+			ig:   newIG("nodes", 1, 1, []string{"us-test1-a", "us-test1-b", "us-test1-c"}),
+			expected: map[string]ClusterAutoscalerNodeGroup{
+				"nodes-us-test1-a": {MinSize: 1, MaxSize: 1, Other: migURL("us-test1-a", "a-nodes-minimal-example-com")},
+			},
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.desc, func(t *testing.T) {
+			tf := &TemplateFunctions{cloud: cloud}
+			tf.Cluster = cluster
+			tf.InstanceGroups = []*kops.InstanceGroup{g.ig}
+
+			actual, err := tf.GetClusterAutoscalerNodeGroups()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(actual, g.expected) {
+				t.Errorf("expected %+v, got %+v", g.expected, actual)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #18543 on release-1.36.

#18543: gce: register all zonal MIGs of a multi-zone instance group with cluster-autoscaler

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```