### PR TITLE
gce: allow TCP metrics ports in GCE firewall

### DIFF
--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -138,6 +138,11 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				fmt.Sprintf("tcp:%d", wellknownports.KubeAPIServer),
 				fmt.Sprintf("tcp:%d", wellknownports.KubeletAPI),
 				fmt.Sprintf("tcp:%d", wellknownports.KopsControllerPort),
+				// Metrics ports for control plane components, so they can be scraped from nodes.
+				fmt.Sprintf("tcp:%d", wellknownports.KubeControllerManagerMetricsPort),
+				fmt.Sprintf("tcp:%d", wellknownports.KubeSchedulerMetricsPort),
+				fmt.Sprintf("tcp:%d", wellknownports.KubeProxyMetricsPort),
+				fmt.Sprintf("tcp:%d", wellknownports.EtcdMetricsPort),
 			},
 		}
 		if b.Cluster.UsesLegacyGossip() {
@@ -155,12 +160,6 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			if model.UseCiliumEtcd(b.Cluster) {
 				t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.EtcdCiliumClientPort))
 			}
-		}
-		if b.NetworkingIsIPAlias() {
-			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.KubeControllerManagerMetricsPort))
-			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.KubeSchedulerMetricsPort))
-			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.KubeProxyMetricsPort))
-			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.EtcdMetricsPort))
 		}
 		c.AddTask(t)
 	}

--- a/tests/integration/update_cluster/gossip-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-gce/kubernetes.tf
@@ -338,6 +338,22 @@ resource "google_compute_firewall" "node-to-master-gossip-k8s-local" {
     protocol = "tcp"
   }
   allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["3993"]
     protocol = "udp"
   }

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -395,6 +395,22 @@ resource "google_compute_firewall" "node-to-master-ha-gce-example-com" {
     ports    = ["3988"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-ha-gce-example-com"
   network     = google_compute_network.ha-gce-example-com.name

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -315,6 +315,22 @@ resource "google_compute_firewall" "node-to-master-minimal-example-com" {
     ports    = ["3988"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-example-com"
   network     = google_compute_network.minimal-example-com.name

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -283,6 +283,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
     ports    = ["3988"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-example-com"
   network     = google_compute_network.minimal-gce-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -325,6 +325,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
     ports    = ["3988"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-example-com"
   network     = google_compute_network.minimal-gce-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -309,6 +309,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-ilb-example-com" 
     ports    = ["3988"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-ilb-example-com"
   network     = google_compute_network.minimal-gce-ilb-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/kubernetes.tf
@@ -370,6 +370,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-ilb-cilium-etcd-e
     protocol = "tcp"
   }
   allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["8472"]
     protocol = "udp"
   }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -309,6 +309,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-
     ports    = ["3988"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-with-a-very-very-very-very-ve-96dqvi"
   network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -291,6 +291,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-
     ports    = ["3988"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-with-a-very-very-very-very-ve-96dqvi"
   network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -313,6 +313,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-plb-example-com" 
     ports    = ["3988"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-plb-example-com"
   network     = google_compute_network.minimal-gce-plb-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
@@ -321,6 +321,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-plb-apiserver-exa
     ports    = ["3988"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-plb-apiserver-example-com"
   network     = google_compute_network.minimal-gce-plb-apiserver-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -291,6 +291,22 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-private-example-c
     ports    = ["3988"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["10257"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10259"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["10249"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["2382"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-private-example-com"
   network     = google_compute_network.minimal-gce-private-example-com.name


### PR DESCRIPTION
# Description

This PR opens the GCE ingress firewall ports required for **Prometheus metrics collection** in Calico-based clusters.

### Why is this change needed?
When the Prometheus server is enabled in a kOps cluster on GCE, it attempts to scrape metrics from control plane components (Kubelet, Kube-Controller-Manager, Kube-Scheduler, Kube-Proxy, Etcd) on TCP ports `10249`, `10257`, `10259`, and `2382`.

Historically, kOps only opened these metrics ports for GCE IP Alias / Kindnet networks. However, this created a gap for Calico-based clusters, where these ports remained blocked, causing Prometheus scraping to fail with connection timeouts.