### PR TITLE
pkg/assets: keep container registry clients out of runtime binaries

### DIFF
--- a/cmd/kops/get_assets.go
+++ b/cmd/kops/get_assets.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io"
 
-	"k8s.io/kops/pkg/assets"
+	"k8s.io/kops/pkg/assets/assetcopy"
 	"k8s.io/kops/pkg/commands/commandutils"
 	"k8s.io/kops/pkg/pretty"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -143,7 +143,7 @@ func RunGetAssets(ctx context.Context, f *util.Factory, out io.Writer, options *
 	}
 
 	if options.Copy {
-		err := assets.Copy(updateClusterResults.ImageAssets, updateClusterResults.FileAssets, f.VFSContext(), updateClusterResults.Cluster)
+		err := assetcopy.Copy(updateClusterResults.ImageAssets, updateClusterResults.FileAssets, f.VFSContext(), updateClusterResults.Cluster)
 		if err != nil {
 			return err
 		}

--- a/cmd/kops/main.go
+++ b/cmd/kops/main.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
 	"k8s.io/kops"
+	"k8s.io/kops/pkg/assets"
 )
 
 func main() {
@@ -32,6 +35,12 @@ func main() {
 }
 
 func run(ctx context.Context) error {
+	// Resolving image digests queries container registries, so only the CLI wires it up; runtime
+	// binaries (kops-controller, nodeup) deliberately do not link the registry client libraries.
+	assets.SetImageDigestResolver(func(image string) (string, error) {
+		return crane.Digest(image, crane.WithAuthFromKeychain(authn.DefaultKeychain))
+	})
+
 	// Set up OpenTelemetry.
 	serviceName := "kops"
 	serviceVersion := kops.Version

--- a/pkg/assets/assetcopy/copy.go
+++ b/pkg/assets/assetcopy/copy.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package assets
+// Package assetcopy copies cluster assets to a private file repository or container registry
+// (`kops get assets --copy`). It is separate from pkg/assets so that only the kops CLI links
+// the container registry client libraries; runtime binaries (kops-controller, nodeup) import
+// pkg/assets without inheriting those dependencies.
+package assetcopy
 
 import (
 	"fmt"
@@ -22,6 +26,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/assets"
 	"k8s.io/kops/util/pkg/vfs"
 )
 
@@ -29,7 +34,7 @@ type assetTask interface {
 	Run() error
 }
 
-func Copy(imageAssets []*ImageAsset, fileAssets []*FileAsset, vfsContext *vfs.VFSContext, cluster *kops.Cluster) error {
+func Copy(imageAssets []*assets.ImageAsset, fileAssets []*assets.FileAsset, vfsContext *vfs.VFSContext, cluster *kops.Cluster) error {
 	tasks := map[string]assetTask{}
 
 	for _, imageAsset := range imageAssets {

--- a/pkg/assets/assetcopy/copyfile.go
+++ b/pkg/assets/assetcopy/copyfile.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package assets
+package assetcopy
 
 import (
 	"bytes"

--- a/pkg/assets/assetcopy/copyfile_test.go
+++ b/pkg/assets/assetcopy/copyfile_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package assets
+package assetcopy
 
 import (
 	"testing"

--- a/pkg/assets/assetcopy/copyimage.go
+++ b/pkg/assets/assetcopy/copyimage.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package assets
+package assetcopy
 
 import (
 	"fmt"

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -27,8 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/crane"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
@@ -39,6 +37,22 @@ import (
 	"k8s.io/kops/util/pkg/hashing"
 	"k8s.io/kops/util/pkg/vfs"
 )
+
+// ImageDigestResolver looks up the manifest digest for an image, returning it in the form
+// "sha256:...".
+type ImageDigestResolver func(image string) (string, error)
+
+// imageDigestResolver is set (during startup) only by binaries that should resolve image digests
+// by querying container registries, i.e. the kops CLI. Runtime binaries (kops-controller, nodeup)
+// leave it unset, both because digest resolution is a cluster-configuration concern and so that
+// they do not link the registry client libraries it requires.
+var imageDigestResolver ImageDigestResolver
+
+// SetImageDigestResolver installs the function RemapImage uses to resolve image digests. When no
+// resolver is set, images are not pinned by digest.
+func SetImageDigestResolver(resolver ImageDigestResolver) {
+	imageDigestResolver = resolver
+}
 
 // AssetBuilder discovers and remaps assets.
 type AssetBuilder struct {
@@ -277,7 +291,7 @@ func (a *AssetBuilder) RemapImage(image string) string {
 
 	a.addImageAsset(asset)
 
-	if !featureflag.ImageDigest.Enabled() || os.Getenv("KOPS_BASE_URL") != "" {
+	if imageDigestResolver == nil || !featureflag.ImageDigest.Enabled() || os.Getenv("KOPS_BASE_URL") != "" {
 		return image
 	}
 
@@ -285,7 +299,7 @@ func (a *AssetBuilder) RemapImage(image string) string {
 		return image
 	}
 
-	digest, err := crane.Digest(image, crane.WithAuthFromKeychain(authn.DefaultKeychain))
+	digest, err := imageDigestResolver(image)
 	if err != nil {
 		klog.Warningf("failed to digest image %q: %s", image, err)
 		return image


### PR DESCRIPTION
`pkg/assets` is linked into `kops-controller` and `nodeup`, but it also carried two CLI-only pieces that pull in `go-containerregistry` and, transitively, `docker/cli`:

- the `kops get assets --copy` image/file copy machinery
- the `crane.Digest()` call that pins images by digest

This moves the copy machinery into a new `pkg/assets/assetcopy` package (imported only by the CLI) and turns digest resolution into an injectable hook that only `cmd/kops` wires up. When no resolver is set, `RemapImage` skips digest pinning, which already matched behavior whenever `ImageDigest` was off or `KOPS_BASE_URL` was set.

Result: `go-containerregistry` and `docker/cli` are gone from the `kops-controller` and `nodeup` binaries and their SBOMs, so registry client CVEs (e.g. CVE-2025-15558 in `docker/cli`) stop showing up in scans of binaries that never talk to a registry. Binaries shrink about 1.5MB (kops-controller) and 1.2MB (nodeup).

/cc @rifelpet @ameukam 

Assisted by Claude Fable