### PR TITLE
feat(api): add storageInitializationTimeout to KubeAPIServerConfig

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2407,6 +2407,12 @@ spec:
                   storageBackend:
                     description: StorageBackend is the backend storage
                     type: string
+                  storageInitializationTimeout:
+                    description: |-
+                      StorageInitializationTimeout is the maximum amount of time to wait for the storage layer to initialize before declaring kube-apiserver ready.
+                      Increasing this value allows etcd more time to become ready on new control-plane nodes before kube-apiserver gives up and crashes.
+                      Default is 1m0s.
+                    type: string
                   tlsCertFile:
                     type: string
                   tlsCipherSuites:

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -515,6 +515,11 @@ type KubeAPIServerConfig struct {
 	// RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
 	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty" flag:"request-timeout"`
 
+	// StorageInitializationTimeout is the maximum amount of time to wait for the storage layer to initialize before declaring kube-apiserver ready.
+	// Increasing this value allows etcd more time to become ready on new control-plane nodes before kube-apiserver gives up and crashes.
+	// Default is 1m0s.
+	StorageInitializationTimeout *metav1.Duration `json:"storageInitializationTimeout,omitempty" flag:"storage-initialization-timeout"`
+
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -513,6 +513,11 @@ type KubeAPIServerConfig struct {
 	// RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
 	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty" flag:"request-timeout"`
 
+	// StorageInitializationTimeout is the maximum amount of time to wait for the storage layer to initialize before declaring kube-apiserver ready.
+	// Increasing this value allows etcd more time to become ready on new control-plane nodes before kube-apiserver gives up and crashes.
+	// Default is 1m0s.
+	StorageInitializationTimeout *metav1.Duration `json:"storageInitializationTimeout,omitempty" flag:"storage-initialization-timeout"`
+
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5333,6 +5333,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
+	out.StorageInitializationTimeout = in.StorageInitializationTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.WatchCache = in.WatchCache
 	out.WatchCacheSizes = in.WatchCacheSizes
@@ -5448,6 +5449,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
+	out.StorageInitializationTimeout = in.StorageInitializationTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.WatchCache = in.WatchCache
 	out.WatchCacheSizes = in.WatchCacheSizes

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3542,6 +3542,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.StorageInitializationTimeout != nil {
+		in, out := &in.StorageInitializationTimeout, &out.StorageInitializationTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MinRequestTimeout != nil {
 		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
 		*out = new(int32)

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -504,6 +504,11 @@ type KubeAPIServerConfig struct {
 	// RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
 	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty" flag:"request-timeout"`
 
+	// StorageInitializationTimeout is the maximum amount of time to wait for the storage layer to initialize before declaring kube-apiserver ready.
+	// Increasing this value allows etcd more time to become ready on new control-plane nodes before kube-apiserver gives up and crashes.
+	// Default is 1m0s.
+	StorageInitializationTimeout *metav1.Duration `json:"storageInitializationTimeout,omitempty" flag:"storage-initialization-timeout"`
+
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5759,6 +5759,7 @@ func autoConvert_v1alpha3_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
+	out.StorageInitializationTimeout = in.StorageInitializationTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.WatchCache = in.WatchCache
 	out.WatchCacheSizes = in.WatchCacheSizes
@@ -5879,6 +5880,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha3_KubeAPIServerConfig(in *ko
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
+	out.StorageInitializationTimeout = in.StorageInitializationTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.WatchCache = in.WatchCache
 	out.WatchCacheSizes = in.WatchCacheSizes

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3526,6 +3526,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.StorageInitializationTimeout != nil {
+		in, out := &in.StorageInitializationTimeout, &out.StorageInitializationTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MinRequestTimeout != nil {
 		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
 		*out = new(int32)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3705,6 +3705,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.StorageInitializationTimeout != nil {
+		in, out := &in.StorageInitializationTimeout, &out.StorageInitializationTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MinRequestTimeout != nil {
 		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
 		*out = new(int32)


### PR DESCRIPTION
Adds `storageInitializationTimeout` to `KubeAPIServerConfig`, mapping to `--storage-initialization-timeout` on kube-apiserver.

**Problem:** The default of 1m0s is too short for etcd to become ready on new control-plane nodes joining an existing cluster. etcd-manager needs time to discover peers via gossip DNS and replay the raft log. When kube-apiserver times out it enters CrashLoopBackOff with exponential backoff, leaving the node permanently broken until an operator runs `systemctl restart kubelet`.

**Fix:** Setting `storageInitializationTimeout: 10m0s` lets kube-apiserver wait for etcd rather than crashing, so nodes self-heal on first boot without manual intervention.

Changes follow the existing pattern of `requestTimeout` / `runtimeRequestTimeout`.
