### PR TITLE
Automated cherry pick of #18556: feat(api): add storageInitializationTimeout to KubeAPIServerConfig

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2371,6 +2371,12 @@ spec:
                   storageBackend:
                     description: StorageBackend is the backend storage
                     type: string
+                  storageInitializationTimeout:
+                    description: |-
+                      StorageInitializationTimeout is the maximum amount of time to wait for the storage layer to initialize before declaring kube-apiserver ready.
+                      Increasing this value allows etcd more time to become ready on new control-plane nodes before kube-apiserver gives up and crashes.
+                      Default is 1m0s.
+                    type: string
                   tlsCertFile:
                     type: string
                   tlsCipherSuites:

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -495,6 +495,11 @@ type KubeAPIServerConfig struct {
 	// RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
 	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty" flag:"request-timeout"`
 
+	// StorageInitializationTimeout is the maximum amount of time to wait for the storage layer to initialize before declaring kube-apiserver ready.
+	// Increasing this value allows etcd more time to become ready on new control-plane nodes before kube-apiserver gives up and crashes.
+	// Default is 1m0s.
+	StorageInitializationTimeout *metav1.Duration `json:"storageInitializationTimeout,omitempty" flag:"storage-initialization-timeout"`
+
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -502,6 +502,11 @@ type KubeAPIServerConfig struct {
 	// RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
 	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty" flag:"request-timeout"`
 
+	// StorageInitializationTimeout is the maximum amount of time to wait for the storage layer to initialize before declaring kube-apiserver ready.
+	// Increasing this value allows etcd more time to become ready on new control-plane nodes before kube-apiserver gives up and crashes.
+	// Default is 1m0s.
+	StorageInitializationTimeout *metav1.Duration `json:"storageInitializationTimeout,omitempty" flag:"storage-initialization-timeout"`
+
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5275,6 +5275,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
+	out.StorageInitializationTimeout = in.StorageInitializationTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.WatchCache = in.WatchCache
 	out.WatchCacheSizes = in.WatchCacheSizes
@@ -5389,6 +5390,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
+	out.StorageInitializationTimeout = in.StorageInitializationTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.WatchCache = in.WatchCache
 	out.WatchCacheSizes = in.WatchCacheSizes

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3496,6 +3496,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.StorageInitializationTimeout != nil {
+		in, out := &in.StorageInitializationTimeout, &out.StorageInitializationTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MinRequestTimeout != nil {
 		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
 		*out = new(int32)

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -493,6 +493,11 @@ type KubeAPIServerConfig struct {
 	// RequestTimeout configures the duration a handler must keep a request open before timing it out. (default 1m0s)
 	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty" flag:"request-timeout"`
 
+	// StorageInitializationTimeout is the maximum amount of time to wait for the storage layer to initialize before declaring kube-apiserver ready.
+	// Increasing this value allows etcd more time to become ready on new control-plane nodes before kube-apiserver gives up and crashes.
+	// Default is 1m0s.
+	StorageInitializationTimeout *metav1.Duration `json:"storageInitializationTimeout,omitempty" flag:"storage-initialization-timeout"`
+
 	// MinRequestTimeout configures the minimum number of seconds a handler must keep a request open before timing it out.
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5672,6 +5672,7 @@ func autoConvert_v1alpha3_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
+	out.StorageInitializationTimeout = in.StorageInitializationTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.WatchCache = in.WatchCache
 	out.WatchCacheSizes = in.WatchCacheSizes
@@ -5791,6 +5792,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha3_KubeAPIServerConfig(in *ko
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
+	out.StorageInitializationTimeout = in.StorageInitializationTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
 	out.WatchCache = in.WatchCache
 	out.WatchCacheSizes = in.WatchCacheSizes

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3475,6 +3475,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.StorageInitializationTimeout != nil {
+		in, out := &in.StorageInitializationTimeout, &out.StorageInitializationTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MinRequestTimeout != nil {
 		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
 		*out = new(int32)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3654,6 +3654,11 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.StorageInitializationTimeout != nil {
+		in, out := &in.StorageInitializationTimeout, &out.StorageInitializationTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MinRequestTimeout != nil {
 		in, out := &in.MinRequestTimeout, &out.MinRequestTimeout
 		*out = new(int32)


### PR DESCRIPTION
Cherry pick of #18556 on release-1.35.

#18556: feat(api): add storageInitializationTimeout to KubeAPIServerConfig

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```