### PR TITLE
nodeup: include Ubuntu in markSecondaryENIsUnmanaged guard

### DIFF
--- a/nodeup/pkg/model/networking/eni_networking.go
+++ b/nodeup/pkg/model/networking/eni_networking.go
@@ -121,11 +121,12 @@ MACAddressPolicy=none
 // markSecondaryENIsUnmanaged tells systemd-networkd to ignore secondary ENIs (ens6+).
 // Without this, systemd-networkd fully manages secondary ENIs via DHCP, creating
 // competing routes that interfere with CNI networking.
-// AL2023 and Debian 12+.
+// AL2023, Debian 12+, and Ubuntu 22.04+.
 // ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/3524
 func markSecondaryENIsUnmanaged(c *fi.NodeupModelBuilderContext, dist distributions.Distribution) {
 	if !(dist == distributions.DistributionAmazonLinux2023 ||
-		(dist.IsDebian() && dist.Version() >= 12)) {
+		(dist.IsDebian() && dist.Version() >= 12) ||
+		(dist.IsUbuntu() && dist.Version() >= 22.04)) {
 		return
 	}
 


### PR DESCRIPTION
nodeup: include Ubuntu in markSecondaryENIsUnmanaged guard

Add Ubuntu >= 22.04 to the guard clause so kops writes the
Unmanaged=yes .network file for secondary ENIs on Ubuntu, mirroring
the existing AL2023 / Debian 12+ handling. Without this, systemd-networkd
keeps DHCP-ing on secondary ENIs managed by Cilium / AWS VPC CNI.

Fixes #18564