### PR TITLE
Add support for Cilium Bandwidth Manager and BBR

### DIFF
--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -277,6 +277,52 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/downloa
 
 For more information about using the Gateway API with Cilium, see the [Cilium Gateway API documentation](https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/).
 
+## Bandwidth Manager and BBR
+
+Cilium can enforce per-Pod egress bandwidth limits (via the `kubernetes.io/egress-bandwidth` annotation) using its eBPF-based [Bandwidth Manager](https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/), and optionally use [BBR](https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/#bbr-tcp-congestion-control) as the TCP congestion control algorithm for Pod traffic.
+
+You can enable the Bandwidth Manager on its own:
+
+```yaml
+spec:
+  networking:
+    cilium:
+      enableBandwidthManager: true
+```
+
+Or enable Bandwidth Manager **and** BBR together:
+
+```yaml
+spec:
+  networking:
+    cilium:
+      enableBandwidthManager: true
+      enableBBR: true
+```
+
+`enableBBR` requires `enableBandwidthManager` — Cilium's BBR path plugs into the Bandwidth Manager's eBPF EDT scheduler, so without Bandwidth Manager there is nothing for it to attach to. When `enableBBR` is set, kOps also writes the node sysctls `net.core.default_qdisc=fq` and `net.ipv4.tcp_congestion_control=bbr` so the host kernel TCP stack uses BBR as well.
+
+**Requirements**
+
+- Linux kernel **>= 5.18** on every node when `enableBBR` is set (the eBPF BBR pacing path needs a recent kernel). The Bandwidth Manager on its own works on older 5.x kernels.
+- Direct routing or BPF host routing. The default kOps + Cilium setup satisfies this.
+
+**Notes on AWS + Ubuntu**
+
+- Ubuntu 22.04 (kernel 5.15) does not include the BBR pacing path Cilium uses; prefer Ubuntu 24.04 (kernel 6.8) or a newer HWE kernel.
+- The kOps default AWS AMI (Ubuntu) ships with the `tcp_bbr` module; no extra image customization is required.
+
+**When BBR helps in AWS**
+
+BBR's advantage scales with the bandwidth-delay product (BDP). Modern AWS instances have ENA NICs in the 10–100 Gbps range, so even at sub-millisecond intra-AZ RTT — and especially at 1–2 ms cross-AZ — the BDP is large enough that a single CUBIC flow needs seconds to ramp up to line rate and backs off hard on any random loss. BBR converges to the bottleneck bandwidth much faster and is far more resilient to spurious loss. Workloads that typically benefit:
+
+- Large pod-to-pod or pod-to-service transfers (model checkpoints, dataset shuffles, backups, log shipping).
+- Cross-AZ replication and database streaming.
+- Egress to S3 / other AWS services over VPC endpoints, and any egress to the internet.
+- Workloads on instances with 25 Gbps+ networking where a single flow is expected to fill the pipe.
+
+For workloads dominated by very short, low-volume RPCs on the same AZ, the practical difference is smaller — but BBR is generally safe to enable cluster-wide.
+
 ## Getting help
 
 For problems with deploying Cilium please post an issue to Github:

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5653,9 +5653,26 @@ spec:
                         description: DisableMasquerade disables masquerading traffic
                           to external destinations behind the node IP.
                         type: boolean
+                      enableBBR:
+                        description: |-
+                          EnableBBR enables BBR (Bottleneck Bandwidth and Round-trip propagation time)
+                          as the TCP congestion control algorithm for pod traffic. Requires
+                          EnableBandwidthManager and a Linux kernel >= 5.18 on nodes.
+                          kOps will also configure the node sysctls (net.core.default_qdisc=fq,
+                          net.ipv4.tcp_congestion_control=bbr).
+                          Default: false
+                        type: boolean
                       enableBPFMasquerade:
                         description: |-
                           EnableBPFMasquerade enables masquerading packets from endpoints leaving the host with BPF instead of iptables.
+                          Default: false
+                        type: boolean
+                      enableBandwidthManager:
+                        description: |-
+                          EnableBandwidthManager enables Cilium's eBPF-based Bandwidth Manager, which
+                          honors the kubernetes.io/egress-bandwidth Pod annotation and provides EDT-based
+                          rate-limiting on egress traffic.
+                          See https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/
                           Default: false
                         type: boolean
                       enableEncryption:

--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -170,6 +170,16 @@ func (b *SysctlBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 			"net.ipv4.conf.lxc*.rp_filter=0",
 			"net.ipv4.conf.cilium_*.rp_filter=0",
 			"")
+
+		if fi.ValueOf(b.NodeupConfig.Networking.Cilium.EnableBBR) {
+			sysctls = append(sysctls,
+				"# BBR congestion control for Cilium Bandwidth Manager.",
+				"# Requires Linux kernel >= 5.18 on the node.",
+				"# See https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/",
+				"net.core.default_qdisc=fq",
+				"net.ipv4.tcp_congestion_control=bbr",
+				"")
+		}
 	}
 
 	sysctls = append(sysctls, b.NodeupConfig.SysctlParameters...)

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -407,6 +407,19 @@ type CiliumNetworkingSpec struct {
 	// EnableHostFirewall enables the host firewall in the Cilium agent.
 	// Default: false
 	EnableHostFirewall *bool `json:"enableHostFirewall,omitempty"`
+	// EnableBandwidthManager enables Cilium's eBPF-based Bandwidth Manager, which
+	// honors the kubernetes.io/egress-bandwidth Pod annotation and provides EDT-based
+	// rate-limiting on egress traffic.
+	// See https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/
+	// Default: false
+	EnableBandwidthManager *bool `json:"enableBandwidthManager,omitempty"`
+	// EnableBBR enables BBR (Bottleneck Bandwidth and Round-trip propagation time)
+	// as the TCP congestion control algorithm for pod traffic. Requires
+	// EnableBandwidthManager and a Linux kernel >= 5.18 on nodes.
+	// kOps will also configure the node sysctls (net.core.default_qdisc=fq,
+	// net.ipv4.tcp_congestion_control=bbr).
+	// Default: false
+	EnableBBR *bool `json:"enableBBR,omitempty"`
 	// EnablePrometheusMetrics enables the Cilium "/metrics" endpoint for both the agent and the operator.
 	EnablePrometheusMetrics bool `json:"enablePrometheusMetrics,omitempty"`
 	// EnableEncryption enables Cilium Encryption.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -411,6 +411,19 @@ type CiliumNetworkingSpec struct {
 	// EnableHostFirewall enables the host firewall in the Cilium agent.
 	// Default: false
 	EnableHostFirewall *bool `json:"enableHostFirewall,omitempty"`
+	// EnableBandwidthManager enables Cilium's eBPF-based Bandwidth Manager, which
+	// honors the kubernetes.io/egress-bandwidth Pod annotation and provides EDT-based
+	// rate-limiting on egress traffic.
+	// See https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/
+	// Default: false
+	EnableBandwidthManager *bool `json:"enableBandwidthManager,omitempty"`
+	// EnableBBR enables BBR (Bottleneck Bandwidth and Round-trip propagation time)
+	// as the TCP congestion control algorithm for pod traffic. Requires
+	// EnableBandwidthManager and a Linux kernel >= 5.18 on nodes.
+	// kOps will also configure the node sysctls (net.core.default_qdisc=fq,
+	// net.ipv4.tcp_congestion_control=bbr).
+	// Default: false
+	EnableBBR *bool `json:"enableBBR,omitempty"`
 	// EnablePrometheusMetrics enables the Cilium "/metrics" endpoint for both the agent and the operator.
 	EnablePrometheusMetrics bool `json:"enablePrometheusMetrics,omitempty"`
 	// EnableEncryption enables Cilium Encryption.

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -405,6 +405,19 @@ type CiliumNetworkingSpec struct {
 	// EnableHostFirewall enables the host firewall in the Cilium agent.
 	// Default: false
 	EnableHostFirewall *bool `json:"enableHostFirewall,omitempty"`
+	// EnableBandwidthManager enables Cilium's eBPF-based Bandwidth Manager, which
+	// honors the kubernetes.io/egress-bandwidth Pod annotation and provides EDT-based
+	// rate-limiting on egress traffic.
+	// See https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/
+	// Default: false
+	EnableBandwidthManager *bool `json:"enableBandwidthManager,omitempty"`
+	// EnableBBR enables BBR (Bottleneck Bandwidth and Round-trip propagation time)
+	// as the TCP congestion control algorithm for pod traffic. Requires
+	// EnableBandwidthManager and a Linux kernel >= 5.18 on nodes.
+	// kOps will also configure the node sysctls (net.core.default_qdisc=fq,
+	// net.ipv4.tcp_congestion_control=bbr).
+	// Default: false
+	EnableBBR *bool `json:"enableBBR,omitempty"`
 	// EnableTracing is unused.
 	// +k8s:conversion-gen=false
 	EnableTracing bool `json:"enableTracing,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -412,6 +412,19 @@ type CiliumNetworkingSpec struct {
 	// EnableHostFirewall enables the host firewall in the Cilium agent.
 	// Default: false
 	EnableHostFirewall *bool `json:"enableHostFirewall,omitempty"`
+	// EnableBandwidthManager enables Cilium's eBPF-based Bandwidth Manager, which
+	// honors the kubernetes.io/egress-bandwidth Pod annotation and provides EDT-based
+	// rate-limiting on egress traffic.
+	// See https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/
+	// Default: false
+	EnableBandwidthManager *bool `json:"enableBandwidthManager,omitempty"`
+	// EnableBBR enables BBR (Bottleneck Bandwidth and Round-trip propagation time)
+	// as the TCP congestion control algorithm for pod traffic. Requires
+	// EnableBandwidthManager and a Linux kernel >= 5.18 on nodes.
+	// kOps will also configure the node sysctls (net.core.default_qdisc=fq,
+	// net.ipv4.tcp_congestion_control=bbr).
+	// Default: false
+	EnableBBR *bool `json:"enableBBR,omitempty"`
 	// EnableTracing is unused.
 	// +k8s:conversion-gen=false
 	EnableTracing bool `json:"enableTracing,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2095,6 +2095,8 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.EnableBPFMasquerade = in.EnableBPFMasquerade
 	out.EnableEndpointHealthChecking = in.EnableEndpointHealthChecking
 	out.EnableHostFirewall = in.EnableHostFirewall
+	out.EnableBandwidthManager = in.EnableBandwidthManager
+	out.EnableBBR = in.EnableBBR
 	// INFO: in.EnableTracing opted out of conversion generation
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableEncryption = in.EnableEncryption
@@ -2220,6 +2222,8 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.EnableBPFMasquerade = in.EnableBPFMasquerade
 	out.EnableEndpointHealthChecking = in.EnableEndpointHealthChecking
 	out.EnableHostFirewall = in.EnableHostFirewall
+	out.EnableBandwidthManager = in.EnableBandwidthManager
+	out.EnableBBR = in.EnableBBR
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableEncryption = in.EnableEncryption
 	out.EncryptionType = CiliumEncryptionType(in.EncryptionType)

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -654,6 +654,16 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableBandwidthManager != nil {
+		in, out := &in.EnableBandwidthManager, &out.EnableBandwidthManager
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableBBR != nil {
+		in, out := &in.EnableBBR, &out.EnableBBR
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make([]string, len(*in))

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -355,6 +355,19 @@ type CiliumNetworkingSpec struct {
 	// EnableHostFirewall enables the host firewall in the Cilium agent.
 	// Default: false
 	EnableHostFirewall *bool `json:"enableHostFirewall,omitempty"`
+	// EnableBandwidthManager enables Cilium's eBPF-based Bandwidth Manager, which
+	// honors the kubernetes.io/egress-bandwidth Pod annotation and provides EDT-based
+	// rate-limiting on egress traffic.
+	// See https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/
+	// Default: false
+	EnableBandwidthManager *bool `json:"enableBandwidthManager,omitempty"`
+	// EnableBBR enables BBR (Bottleneck Bandwidth and Round-trip propagation time)
+	// as the TCP congestion control algorithm for pod traffic. Requires
+	// EnableBandwidthManager and a Linux kernel >= 5.18 on nodes.
+	// kOps will also configure the node sysctls (net.core.default_qdisc=fq,
+	// net.ipv4.tcp_congestion_control=bbr).
+	// Default: false
+	EnableBBR *bool `json:"enableBBR,omitempty"`
 	// EnablePrometheusMetrics enables the Cilium "/metrics" endpoint for both the agent and the operator.
 	EnablePrometheusMetrics bool `json:"enablePrometheusMetrics,omitempty"`
 	// EnableEncryption enables Cilium Encryption.

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -362,6 +362,19 @@ type CiliumNetworkingSpec struct {
 	// EnableHostFirewall enables the host firewall in the Cilium agent.
 	// Default: false
 	EnableHostFirewall *bool `json:"enableHostFirewall,omitempty"`
+	// EnableBandwidthManager enables Cilium's eBPF-based Bandwidth Manager, which
+	// honors the kubernetes.io/egress-bandwidth Pod annotation and provides EDT-based
+	// rate-limiting on egress traffic.
+	// See https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/
+	// Default: false
+	EnableBandwidthManager *bool `json:"enableBandwidthManager,omitempty"`
+	// EnableBBR enables BBR (Bottleneck Bandwidth and Round-trip propagation time)
+	// as the TCP congestion control algorithm for pod traffic. Requires
+	// EnableBandwidthManager and a Linux kernel >= 5.18 on nodes.
+	// kOps will also configure the node sysctls (net.core.default_qdisc=fq,
+	// net.ipv4.tcp_congestion_control=bbr).
+	// Default: false
+	EnableBBR *bool `json:"enableBBR,omitempty"`
 	// EnablePrometheusMetrics enables the Cilium "/metrics" endpoint for both the agent and the operator.
 	EnablePrometheusMetrics bool `json:"enablePrometheusMetrics,omitempty"`
 	// EnableEncryption enables Cilium Encryption.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2279,6 +2279,8 @@ func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.EnableBPFMasquerade = in.EnableBPFMasquerade
 	out.EnableEndpointHealthChecking = in.EnableEndpointHealthChecking
 	out.EnableHostFirewall = in.EnableHostFirewall
+	out.EnableBandwidthManager = in.EnableBandwidthManager
+	out.EnableBBR = in.EnableBBR
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableEncryption = in.EnableEncryption
 	out.EncryptionType = kops.CiliumEncryptionType(in.EncryptionType)
@@ -2369,6 +2371,8 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *
 	out.EnableBPFMasquerade = in.EnableBPFMasquerade
 	out.EnableEndpointHealthChecking = in.EnableEndpointHealthChecking
 	out.EnableHostFirewall = in.EnableHostFirewall
+	out.EnableBandwidthManager = in.EnableBandwidthManager
+	out.EnableBBR = in.EnableBBR
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableEncryption = in.EnableEncryption
 	out.EncryptionType = CiliumEncryptionType(in.EncryptionType)

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -708,6 +708,16 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableBandwidthManager != nil {
+		in, out := &in.EnableBandwidthManager, &out.EnableBandwidthManager
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableBBR != nil {
+		in, out := &in.EnableBBR, &out.EnableBBR
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Masquerade != nil {
 		in, out := &in.Masquerade, &out.Masquerade
 		*out = new(bool)

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1402,6 +1402,10 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableL7Proxy"), "Cilium L7 Proxy requires installIptablesRules."))
 	}
 
+	if fi.ValueOf(v.EnableBBR) && !fi.ValueOf(v.EnableBandwidthManager) {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableBBR"), "enableBBR requires enableBandwidthManager"))
+	}
+
 	if v.IPAM != "" {
 		// "azure" not supported by kops
 		allErrs = append(allErrs, IsValidValue(fldPath.Child("ipam"), &v.IPAM, []string{"hostscope", "kubernetes", "crd", "eni"})...)

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1429,6 +1429,10 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableL7Proxy"), "Cilium L7 Proxy requires installIptablesRules."))
 	}
 
+	if fi.ValueOf(v.EnableBBR) && !fi.ValueOf(v.EnableBandwidthManager) {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableBBR"), "enableBBR requires enableBandwidthManager"))
+	}
+
 	if v.IPAM != "" {
 		// "azure" not supported by kops
 		allErrs = append(allErrs, IsValidValue(fldPath.Child("ipam"), &v.IPAM, []string{"hostscope", "kubernetes", "crd", "eni"})...)

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -1305,6 +1305,26 @@ func Test_Validate_Cilium(t *testing.T) {
 			ExpectedErrors: []string{"Forbidden::cilium.enableL7Proxy"},
 		},
 		{
+			// enableBBR together with enableBandwidthManager is valid.
+			Cilium: kops.CiliumNetworkingSpec{
+				EnableBandwidthManager: new(true),
+				EnableBBR:              new(true),
+			},
+		},
+		{
+			// enableBandwidthManager on its own is valid.
+			Cilium: kops.CiliumNetworkingSpec{
+				EnableBandwidthManager: new(true),
+			},
+		},
+		{
+			// enableBBR without enableBandwidthManager is rejected.
+			Cilium: kops.CiliumNetworkingSpec{
+				EnableBBR: new(true),
+			},
+			ExpectedErrors: []string{"Forbidden::cilium.enableBBR"},
+		},
+		{
 			Cilium: kops.CiliumNetworkingSpec{
 				IPAM: "eni",
 			},

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -1233,6 +1233,26 @@ func Test_Validate_Cilium(t *testing.T) {
 			ExpectedErrors: []string{"Forbidden::cilium.enableL7Proxy"},
 		},
 		{
+			// enableBBR together with enableBandwidthManager is valid.
+			Cilium: kops.CiliumNetworkingSpec{
+				EnableBandwidthManager: new(true),
+				EnableBBR:              new(true),
+			},
+		},
+		{
+			// enableBandwidthManager on its own is valid.
+			Cilium: kops.CiliumNetworkingSpec{
+				EnableBandwidthManager: new(true),
+			},
+		},
+		{
+			// enableBBR without enableBandwidthManager is rejected.
+			Cilium: kops.CiliumNetworkingSpec{
+				EnableBBR: new(true),
+			},
+			ExpectedErrors: []string{"Forbidden::cilium.enableBBR"},
+		},
+		{
 			Cilium: kops.CiliumNetworkingSpec{
 				IPAM: "eni",
 			},

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -789,6 +789,16 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableBandwidthManager != nil {
+		in, out := &in.EnableBandwidthManager, &out.EnableBandwidthManager
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableBBR != nil {
+		in, out := &in.EnableBBR, &out.EnableBBR
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Masquerade != nil {
 		in, out := &in.Masquerade, &out.Masquerade
 		*out = new(bool)

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -318,6 +318,13 @@ data:
   datapath-mode: "veth"
   enable-bpf-masquerade: "{{ and (WithDefaultBool .EnableBPFMasquerade false) (not IsIPv6Only) }}"
   enable-masquerade-to-route-source: "false"
+
+  {{ if WithDefaultBool .EnableBandwidthManager false }}
+  enable-bandwidth-manager: "true"
+  {{ if WithDefaultBool .EnableBBR false }}
+  enable-bbr: "true"
+  {{ end }}
+  {{ end }}
   {{ if .EnableEncryption }}
   {{ if eq .EncryptionType "ipsec" }}
   enable-ipsec: "true"


### PR DESCRIPTION
This adds support for enabling Cilium's [Bandwidth Manager](https://docs.cilium.io/en/stable/network/kubernetes/bandwidth-manager/) and BBR congestion control directly from the kOps Cilium networking spec.

Two new fields are added to `spec.networking.cilium`:

- **`enableBandwidthManager`** – enables Cilium's eBPF-based Bandwidth Manager, which honors the `kubernetes.io/egress-bandwidth` Pod annotation and provides EDT-based egress rate-limiting.
- **`enableBBR`** – enables BBR (Bottleneck Bandwidth and Round-trip propagation time) as the TCP congestion control algorithm for pod traffic. Requires `enableBandwidthManager` and a node kernel >= 5.18. kOps also configures the node sysctls (`net.core.default_qdisc=fq`, `net.ipv4.tcp_congestion_control=bbr`).

Validation rejects `enableBBR` without `enableBandwidthManager`. The fields are plumbed through all API versions (internal, v1alpha2, v1alpha3) with regenerated conversion/deepcopy code, wired into the Cilium addon template and nodeup sysctls, and documented in `docs/networking/cilium.md`.

/kind feature

```release-note
Added `spec.networking.cilium.enableBandwidthManager` and `spec.networking.cilium.enableBBR` to enable Cilium's Bandwidth Manager and BBR congestion control.
```
