### PR TITLE
aws: Require https scheme for pre-signed STS URLs in V2 tokens

### DIFF
--- a/pkg/bootstrap/awsbootstrap/verifier.go
+++ b/pkg/bootstrap/awsbootstrap/verifier.go
@@ -354,6 +354,11 @@ type stsRequestValidator struct {
 
 // IsValid performs some basic pre-validation of the request URL.
 func (s *stsRequestValidator) isValidV2(u *url.URL) bool {
+	// The URL comes from the (untrusted) token; without this check a crafted http:// URL would
+	// make us send the request in plaintext.
+	if u.Scheme != "https" {
+		return false
+	}
 	if u.Host != s.Host {
 		return false
 	}

--- a/pkg/bootstrap/awsbootstrap/verifier_test.go
+++ b/pkg/bootstrap/awsbootstrap/verifier_test.go
@@ -80,6 +80,14 @@ func TestGetSTSRequestInfo(t *testing.T) {
 			URL:     "https://sts.us-east-1.amazonaws.com/?Action=GetCallerIdentity&Action=GetCallerIdentity",
 			IsValid: false,
 		},
+		{
+			URL:     "http://sts.us-east-1.amazonaws.com/?Action=GetCallerIdentity",
+			IsValid: false,
+		},
+		{
+			URL:     "//sts.us-east-1.amazonaws.com/?Action=GetCallerIdentity",
+			IsValid: false,
+		},
 	}
 
 	for _, g := range grid {


### PR DESCRIPTION
isValidV2 validated the token-supplied pre-signed URL's host, path, and Action, but not its scheme, and getCallerIdentityV2 issued the request with the decoded URL verbatim. A crafted token with an http:// URL would cause the verifier to send the pre-signed request in plaintext, losing the server authentication that TLS provides on this path. The V1 path already hardcodes https://.

/cc @rifelpet @ameukam