### PR TITLE
aws: Add metrics port 9999 to pod-identity-webhook Service

### DIFF
--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -138,7 +138,7 @@ spec:
       k8s-addon: node-termination-handler.aws
   - id: k8s-1.16
     manifest: eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a2f5ccd4ccc38d0d212beaeaf9f98cfde7651fcf5503d0749bc474243303c48
+    manifestHash: dbab068a8b49dbba43a6f1b4167517ffa4e19a8f2372e422a6e3e408186f8d79
     name: eks-pod-identity-webhook.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
@@ -244,9 +244,14 @@ metadata:
   namespace: kube-system
 spec:
   ports:
-  - port: 443
+  - name: webhook
+    port: 443
     protocol: TCP
     targetPort: 443
+  - name: metrics
+    port: 9999
+    protocol: TCP
+    targetPort: 9999
   selector:
     app: pod-identity-webhook
 

--- a/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
@@ -189,8 +189,13 @@ metadata:
     prometheus.io/scrape: "true"
 spec:
   ports:
-  - port: 443
+  - name: webhook
+    port: 443
     targetPort: 443
+    protocol: TCP
+  - name: metrics
+    port: 9999
+    targetPort: 9999
     protocol: TCP
   selector:
     app: pod-identity-webhook


### PR DESCRIPTION
The pod-identity-webhook Service is annotated with prometheus.io/port: "9999", but that port was missing from the Service spec, so Prometheus could not scrape metrics through the Service. The webhook container serves HTTP /metrics on port 9999 by default (--metrics-port), so expose that port on the Service instead of changing the annotation. Both ports are now named, as required for multi-port Services.

Fixes #15946