### PR TITLE
gce: register SSH keys under the "ubuntu" user for Ubuntu images

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -198,9 +198,10 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 		}
 
 		if len(b.SSHPublicKeys) > 0 {
+			sshUser := sshUsernameForImage(ig.Spec.Image)
 			var gFmtKeys []string
 			for _, key := range b.SSHPublicKeys {
-				gFmtKeys = append(gFmtKeys, fmt.Sprintf("%s: %s", fi.SecretNameSSHPrimary, key))
+				gFmtKeys = append(gFmtKeys, fmt.Sprintf("%s: %s", sshUser, key))
 			}
 
 			t.Metadata["ssh-keys"] = fi.NewStringResource(strings.Join(gFmtKeys, "\n"))
@@ -258,6 +259,21 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 
 		return t, nil
 	}
+}
+
+// sshUsernameForImage returns the username under which SSH public keys are registered in the
+// instance's "ssh-keys" metadata; the GCE guest agent creates this user on first boot. kOps
+// historically used fi.SecretNameSSHPrimary ("admin"), but on Ubuntu images the guest agent fails
+// to create that user because those images ship with an "admin" group
+// (https://github.com/kubernetes/kops/issues/16175), so the key was never installed. For Ubuntu
+// images we use the image's built-in "ubuntu" user instead. Other images keep "admin" so that SSH
+// access to existing non-Ubuntu clusters is unchanged.
+func sshUsernameForImage(image string) string {
+	name := gce.LastComponent(image)
+	if strings.HasPrefix(strings.ToLower(name), "ubuntu") {
+		return "ubuntu"
+	}
+	return fi.SecretNameSSHPrimary
 }
 
 func (b *AutoscalingGroupModelBuilder) splitToZones(ig *kops.InstanceGroup) (map[string]int, error) {

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -198,7 +198,7 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 		}
 
 		if len(b.SSHPublicKeys) > 0 {
-			sshUser := sshUsernameForImage(ig.Spec.Image)
+			sshUser := gce.SSHUsernameForImage(ig.Spec.Image)
 			var gFmtKeys []string
 			for _, key := range b.SSHPublicKeys {
 				gFmtKeys = append(gFmtKeys, fmt.Sprintf("%s: %s", sshUser, key))
@@ -259,21 +259,6 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 
 		return t, nil
 	}
-}
-
-// sshUsernameForImage returns the username under which SSH public keys are registered in the
-// instance's "ssh-keys" metadata; the GCE guest agent creates this user on first boot. kOps
-// historically used fi.SecretNameSSHPrimary ("admin"), but on Ubuntu images the guest agent fails
-// to create that user because those images ship with an "admin" group
-// (https://github.com/kubernetes/kops/issues/16175), so the key was never installed. For Ubuntu
-// images we use the image's built-in "ubuntu" user instead. Other images keep "admin" so that SSH
-// access to existing non-Ubuntu clusters is unchanged.
-func sshUsernameForImage(image string) string {
-	name := gce.LastComponent(image)
-	if strings.HasPrefix(strings.ToLower(name), "ubuntu") {
-		return "ubuntu"
-	}
-	return fi.SecretNameSSHPrimary
 }
 
 func (b *AutoscalingGroupModelBuilder) splitToZones(ig *kops.InstanceGroup) (map[string]int, error) {

--- a/pkg/model/gcemodel/autoscalinggroup_test.go
+++ b/pkg/model/gcemodel/autoscalinggroup_test.go
@@ -25,40 +25,6 @@ import (
 	"k8s.io/kops/pkg/model"
 )
 
-func TestSSHUsernameForImage(t *testing.T) {
-	testcases := []struct {
-		image    string
-		expected string
-	}{
-		{
-			image:    "ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615",
-			expected: "ubuntu",
-		},
-		{
-			image:    "ubuntu-2404-noble-amd64-v20260615",
-			expected: "ubuntu",
-		},
-		{
-			image:    "cos-cloud/cos-stable-77-12371-114-0",
-			expected: "admin",
-		},
-		{
-			image:    "debian-cloud/debian-12-bookworm-v20260615",
-			expected: "admin",
-		},
-		{
-			image:    "my-project/my-custom-image",
-			expected: "admin",
-		},
-	}
-
-	for _, g := range testcases {
-		t.Run(g.image, func(t *testing.T) {
-			assert.Equal(t, g.expected, sshUsernameForImage(g.image))
-		})
-	}
-}
-
 func TestSplitToZones(t *testing.T) {
 	testcases := []struct {
 		name     string

--- a/pkg/model/gcemodel/autoscalinggroup_test.go
+++ b/pkg/model/gcemodel/autoscalinggroup_test.go
@@ -25,6 +25,40 @@ import (
 	"k8s.io/kops/pkg/model"
 )
 
+func TestSSHUsernameForImage(t *testing.T) {
+	testcases := []struct {
+		image    string
+		expected string
+	}{
+		{
+			image:    "ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615",
+			expected: "ubuntu",
+		},
+		{
+			image:    "ubuntu-2404-noble-amd64-v20260615",
+			expected: "ubuntu",
+		},
+		{
+			image:    "cos-cloud/cos-stable-77-12371-114-0",
+			expected: "admin",
+		},
+		{
+			image:    "debian-cloud/debian-12-bookworm-v20260615",
+			expected: "admin",
+		},
+		{
+			image:    "my-project/my-custom-image",
+			expected: "admin",
+		},
+	}
+
+	for _, g := range testcases {
+		t.Run(g.image, func(t *testing.T) {
+			assert.Equal(t, g.expected, sshUsernameForImage(g.image))
+		})
+	}
+}
+
 func TestSplitToZones(t *testing.T) {
 	testcases := []struct {
 		name     string

--- a/pkg/resources/gce/dump.go
+++ b/pkg/resources/gce/dump.go
@@ -38,6 +38,9 @@ type dumpState struct {
 
 	// instances is a cache of instances by zone
 	instances map[string]map[string]*compute.Instance
+
+	// disks is a cache of disks by zone
+	disks map[string]map[string]*compute.Disk
 }
 
 // DumpManagedInstance is responsible for dumping a resource for a ManagedInstance
@@ -107,6 +110,12 @@ func DumpManagedInstance(op *resources.DumpOperation, r *resources.Resource) err
 		i.Roles = append(i.Roles, "control-plane")
 	}
 
+	if image, err := getDumpState(op).getBootDiskImage(op.Context, u.Zone, instanceDetails); err != nil {
+		klog.Warningf("unable to determine boot disk image for instance %q: %v", u.Name, err)
+	} else if image != "" {
+		i.SSHUser = gce.SSHUsernameForImage(image)
+	}
+
 	op.Dump.Instances = append(op.Dump.Instances, i)
 
 	op.Dump.Resources = append(op.Dump.Resources, instanceDetails)
@@ -147,6 +156,52 @@ func (s *dumpState) getInstances(ctx context.Context, zone string) (map[string]*
 	}
 	s.instances[zone] = instances
 	return instances, nil
+}
+
+// getDisks retrieves the list of disks from the cloud, using a cached copy if possible
+func (s *dumpState) getDisks(ctx context.Context, zone string) (map[string]*compute.Disk, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.disks == nil {
+		s.disks = make(map[string]map[string]*compute.Disk)
+	}
+
+	if s.disks[zone] != nil {
+		return s.disks[zone], nil
+	}
+
+	l, err := s.cloud.Compute().Disks().List(ctx, s.cloud.Project(), zone)
+	if err != nil {
+		return nil, err
+	}
+	disks := make(map[string]*compute.Disk)
+	for _, d := range l {
+		disks[d.Name] = d
+	}
+	s.disks[zone] = disks
+	return disks, nil
+}
+
+// getBootDiskImage returns the source image of the instance's boot disk. The instance's attached
+// disks don't carry the source image, so we look it up on the disk resource itself. Returns "" if
+// the image cannot be determined (e.g. a disk created from a snapshot).
+func (s *dumpState) getBootDiskImage(ctx context.Context, zone string, instance *compute.Instance) (string, error) {
+	for _, d := range instance.Disks {
+		if d == nil || !d.Boot {
+			continue
+		}
+		disks, err := s.getDisks(ctx, zone)
+		if err != nil {
+			return "", err
+		}
+		disk := disks[gce.LastComponent(d.Source)]
+		if disk == nil {
+			return "", nil
+		}
+		return disk.SourceImage, nil
+	}
+	return "", nil
 }
 
 // DumpNetwork is responsible for dumping a resource for a Network

--- a/tests/integration/update_cluster/gossip-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-gce/kubernetes.tf
@@ -582,7 +582,7 @@ resource "google_compute_instance_template" "master-us-test1-a-gossip-k8s-local"
   metadata = {
     "cluster-name"                    = "gossip.k8s.local"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-gossip-k8s-local_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-gossip--7ga917-"
@@ -636,7 +636,7 @@ resource "google_compute_instance_template" "nodes-gossip-k8s-local" {
     "cluster-name"                    = "gossip.k8s.local"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-gossip-k8s-local_metadata_user-data")
   }
   name_prefix = "nodes-gossip-k8s-local-"

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -646,7 +646,7 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
   metadata = {
     "cluster-name"                    = "ha-gce.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-ha-gce--ke5ah6-"
@@ -700,7 +700,7 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
   metadata = {
     "cluster-name"                    = "ha-gce.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-b"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-b-ha-gce--c8u7qq-"
@@ -754,7 +754,7 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
   metadata = {
     "cluster-name"                    = "ha-gce.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-c"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-c-ha-gce--3unp7l-"
@@ -809,7 +809,7 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
     "cluster-name"                    = "ha-gce.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux;node_labels=kops.k8s.io/instancegroup=nodes;node_taints=a=b:c"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_user-data")
   }
   name_prefix = "nodes-ha-gce-example-com-"

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -494,7 +494,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-example-c
   metadata = {
     "cluster-name"                    = "minimal.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-minimal-e8ua4m-"
@@ -548,7 +548,7 @@ resource "google_compute_instance_template" "nodes-minimal-example-com" {
     "cluster-name"                    = "minimal.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-minimal-example-com_metadata_user-data")
   }
   name_prefix = "nodes-minimal-example-com-"

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -481,7 +481,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-examp
   metadata = {
     "cluster-name"                    = "minimal-gce.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-minimal-do16cp-"
@@ -535,7 +535,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
     "cluster-name"                    = "minimal-gce.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data")
   }
   name_prefix = "nodes-minimal-gce-example-com-"

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -560,7 +560,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-examp
   metadata = {
     "cluster-name"                    = "minimal-gce.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-minimal-do16cp-"
@@ -612,7 +612,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
     "cluster-name"                    = "minimal-gce.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data")
   }
   name_prefix = "nodes-minimal-gce-example-com-"

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -521,7 +521,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-ilb-e
   metadata = {
     "cluster-name"                    = "minimal-gce-ilb.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-minimal-k0i8ah-"
@@ -573,7 +573,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-ilb-example-com" 
     "cluster-name"                    = "minimal-gce-ilb.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-ilb-example-com_metadata_user-data")
   }
   name_prefix = "nodes-minimal-gce-ilb-exa-mk47iu-"

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/kubernetes.tf
@@ -604,7 +604,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-ilb-c
   metadata = {
     "cluster-name"                    = "minimal-gce-ilb-cilium-etcd.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-cilium-etcd-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-minimal-ukspr5-"
@@ -656,7 +656,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-ilb-cilium-etcd-e
     "cluster-name"                    = "minimal-gce-ilb-cilium-etcd.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-ilb-cilium-etcd-example-com_metadata_user-data")
   }
   name_prefix = "nodes-minimal-gce-ilb-cil-vfh7jq-"

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -521,7 +521,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-with-
   metadata = {
     "cluster-name"                    = "minimal-gce-with-a-very-very-very-very-very-long-name.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-minimal-ivl9ll-"
@@ -573,7 +573,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
     "cluster-name"                    = "minimal-gce-with-a-very-very-very-very-very-long-name.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data")
   }
   name_prefix = "nodes-minimal-gce-with-a--k0ql96-"

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -488,7 +488,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-with-
   metadata = {
     "cluster-name"                    = "minimal-gce-with-a-very-very-very-very-very-long-name.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "startup-script"                  = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script")
   }
   name_prefix = "master-us-test1-a-minimal-ivl9ll-"
@@ -542,7 +542,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
     "cluster-name"                    = "minimal-gce-with-a-very-very-very-very-very-long-name.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "startup-script"                  = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script")
   }
   name_prefix = "nodes-minimal-gce-with-a--k0ql96-"

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -545,7 +545,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-plb-e
   metadata = {
     "cluster-name"                    = "minimal-gce-plb.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-minimal-b9uem4-"
@@ -597,7 +597,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-plb-example-com" 
     "cluster-name"                    = "minimal-gce-plb.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-plb-example-com_metadata_user-data")
   }
   name_prefix = "nodes-minimal-gce-plb-exa-7p2hv9-"

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
@@ -570,7 +570,7 @@ resource "google_compute_instance_template" "apiserver-us-test1-a-minimal-gce-pl
   metadata = {
     "cluster-name"                    = "minimal-gce-plb-apiserver.example.com"
     "kops-k8s-io-instance-group-name" = "apiserver-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_apiserver-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data")
   }
   name_prefix = "apiserver-us-test1-a-mini-5e7snp-"
@@ -622,7 +622,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-plb-a
   metadata = {
     "cluster-name"                    = "minimal-gce-plb-apiserver.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-minimal-uuumd3-"
@@ -674,7 +674,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-plb-apiserver-exa
     "cluster-name"                    = "minimal-gce-plb-apiserver.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-plb-apiserver-example-com_metadata_user-data")
   }
   name_prefix = "nodes-minimal-gce-plb-api-2m5res-"

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -488,7 +488,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-priva
   metadata = {
     "cluster-name"                    = "minimal-gce-private.example.com"
     "kops-k8s-io-instance-group-name" = "master-us-test1-a"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_user-data")
   }
   name_prefix = "master-us-test1-a-minimal-asf34c-"
@@ -540,7 +540,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-private-example-c
     "cluster-name"                    = "minimal-gce-private.example.com"
     "kops-k8s-io-instance-group-name" = "nodes"
     "kube-env"                        = "AUTOSCALER_ENV_VARS: os_distribution=ubuntu;arch=amd64;os=linux"
-    "ssh-keys"                        = "admin: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
+    "ssh-keys"                        = "ubuntu: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCtWu40XQo8dczLsCq0OWV+hxm9uV3WxeH9Kgh4sMzQxNtoU1pvW0XdjpkBesRKGoolfWeCLXWxpyQb1IaiMkKoz7MdhQ/6UKjMjP66aFWWp3pwD0uj0HuJ7tq4gKHKRYGTaZIRWpzUiANBrjugVgA+Sd7E/mYwc/DMXkIyRZbvhQ=="
     "user-data"                       = file("${path.module}/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_user-data")
   }
   name_prefix = "nodes-minimal-gce-private-4aopo5-"

--- a/upup/pkg/fi/cloudup/gce/utils.go
+++ b/upup/pkg/fi/cloudup/gce/utils.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/api/googleapi"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/truncate"
+	"k8s.io/kops/upup/pkg/fi"
 )
 
 func IsNotFound(err error) bool {
@@ -146,6 +147,21 @@ func LastComponent(s string) string {
 		s = s[lastSlash+1:]
 	}
 	return s
+}
+
+// SSHUsernameForImage returns the username under which SSH public keys are registered in the
+// instance's "ssh-keys" metadata; the GCE guest agent creates this user on first boot. kOps
+// historically used fi.SecretNameSSHPrimary ("admin"), but on Ubuntu images the guest agent fails
+// to create that user because those images ship with an "admin" group
+// (https://github.com/kubernetes/kops/issues/16175), so the key was never installed. For Ubuntu
+// images we use the image's built-in "ubuntu" user instead. Other images keep "admin" so that SSH
+// access to existing non-Ubuntu clusters is unchanged.
+func SSHUsernameForImage(image string) string {
+	name := LastComponent(image)
+	if strings.HasPrefix(strings.ToLower(name), "ubuntu") {
+		return "ubuntu"
+	}
+	return fi.SecretNameSSHPrimary
 }
 
 // ZoneToRegion maps a GCE zone name to a GCE region name, returning an error if it cannot be mapped

--- a/upup/pkg/fi/cloudup/gce/utils_test.go
+++ b/upup/pkg/fi/cloudup/gce/utils_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSHUsernameForImage(t *testing.T) {
+	testcases := []struct {
+		image    string
+		expected string
+	}{
+		{
+			image:    "ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615",
+			expected: "ubuntu",
+		},
+		{
+			image:    "ubuntu-2404-noble-amd64-v20260615",
+			expected: "ubuntu",
+		},
+		{
+			image:    "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2404-noble-amd64-v20260615",
+			expected: "ubuntu",
+		},
+		{
+			image:    "cos-cloud/cos-stable-77-12371-114-0",
+			expected: "admin",
+		},
+		{
+			image:    "debian-cloud/debian-12-bookworm-v20260615",
+			expected: "admin",
+		},
+		{
+			image:    "my-project/my-custom-image",
+			expected: "admin",
+		},
+	}
+
+	for _, g := range testcases {
+		t.Run(g.image, func(t *testing.T) {
+			assert.Equal(t, g.expected, SSHUsernameForImage(g.image))
+		})
+	}
+}


### PR DESCRIPTION
kOps registers SSH public keys in GCE instance metadata under the "admin" username, but on Ubuntu images the GCE guest agent fails to create that user because the images ship with an "admin" group, so the key is never installed and SSH to instances does not work.

Derive the username from the instance group image instead: Ubuntu images register the key under the built-in "ubuntu" user, while other images keep "admin" so SSH access to existing non-Ubuntu clusters is unchanged.

Refs #16642
