### PR TITLE
aws: scope Karpenter controller IAM permissions

### DIFF
--- a/docs/operations/karpenter.md
+++ b/docs/operations/karpenter.md
@@ -109,4 +109,4 @@ Delete the generated NodePool before running `kops update cluster` after adding 
 * Generated `EC2NodeClass` objects use `spec.amiFamily: Custom`.
 * `spec.instanceStorePolicy` configuration is not supported in `EC2NodeClass`.
 * `spec.kubelet` settings that affect Karpenter scheduling (`maxPods`, `systemReserved`, `kubeReserved`) are mapped to `EC2NodeClass.spec.kubelet` so Karpenter computes node allocatable capacity correctly. Other `spec.kubelet` settings are applied via the nodeup bootstrap script but are not surfaced to `EC2NodeClass`.
-* The Karpenter controller policy only grants `iam:PassRole` for the kOps-managed node role. For InstanceGroups that use a custom `spec.iam.profile`, whoever manages that instance profile must also grant the Karpenter controller role `iam:PassRole` on the role it contains.
+* The Karpenter controller policy grants `iam:PassRole` only for the kOps-managed node role. When a Karpenter-managed InstanceGroup uses a custom `spec.iam.profile`, kOps cannot determine the role inside the custom instance profile, so the policy allows passing any role to EC2 instead.

--- a/docs/operations/karpenter.md
+++ b/docs/operations/karpenter.md
@@ -109,3 +109,4 @@ Delete the generated NodePool before running `kops update cluster` after adding 
 * Generated `EC2NodeClass` objects use `spec.amiFamily: Custom`.
 * `spec.instanceStorePolicy` configuration is not supported in `EC2NodeClass`.
 * `spec.kubelet` settings that affect Karpenter scheduling (`maxPods`, `systemReserved`, `kubeReserved`) are mapped to `EC2NodeClass.spec.kubelet` so Karpenter computes node allocatable capacity correctly. Other `spec.kubelet` settings are applied via the nodeup bootstrap script but are not surfaced to `EC2NodeClass`.
+* The Karpenter controller policy only grants `iam:PassRole` for the kOps-managed node role. For InstanceGroups that use a custom `spec.iam.profile`, whoever manages that instance profile must also grant the Karpenter controller role `iam:PassRole` on the role it contains.

--- a/pkg/model/awsmodel/iam.go
+++ b/pkg/model/awsmodel/iam.go
@@ -228,6 +228,7 @@ func (b *IAMModelBuilder) buildIAMRolePolicy(role iam.Subject, iamName string, i
 	iamPolicy := &iam.PolicyResource{
 		Builder: &iam.PolicyBuilder{
 			Cluster:                               b.Cluster,
+			AllInstanceGroups:                     b.AllInstanceGroups,
 			Role:                                  role,
 			Region:                                b.Region,
 			Partition:                             b.AWSPartition,

--- a/pkg/model/awsmodel/iam.go
+++ b/pkg/model/awsmodel/iam.go
@@ -17,13 +17,10 @@ limitations under the License.
 package awsmodel
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -404,25 +401,6 @@ func (b *IAMModelBuilder) buildPolicy(policyString string) (*iam.Policy, error) 
 	return p, nil
 }
 
-// IAMServiceEC2 returns the name of the IAM service for EC2 in the current region.
-// It is ec2.amazonaws.com in the default aws partition, but different in other isolated/custom partitions
-func IAMServiceEC2(region string) (string, error) {
-	ctx := context.TODO()
-	resolver := ec2.NewDefaultEndpointResolverV2()
-	ep, err := resolver.ResolveEndpoint(ctx, ec2.EndpointParameters{Region: aws.String(region)})
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve endpoint: %v", err)
-	}
-	if ep.URI.Host != "" {
-		// Remove the region from the hostname. Examples:
-		// ec2.us-east-1.amazonaws.com     -> ec2.amazonaws.com
-		// ec2.cn-west-1.amazonaws.com.cn  -> ec2.amazonaws.com.cn
-		// ec2.us-gov-west-1.amazonaws.com -> ec2.amazonaws.com
-		return strings.ReplaceAll(ep.URI.Host, fmt.Sprintf("%v.", region), ""), nil
-	}
-	return "ec2.amazonaws.com", nil
-}
-
 func formatAWSIAMStatement(accountId, partition, oidcProvider, namespace, name string) (*iam.Statement, error) {
 	// disallow wildcard in the service account name
 	if strings.Contains(name, "*") {
@@ -474,7 +452,7 @@ func (b *IAMModelBuilder) buildAWSIAMRolePolicy(role iam.Subject) (fi.Resource, 
 	} else {
 		// We don't generate using json.Marshal here, it would create whitespace changes in the policy for existing clusters.
 
-		ec2Service, err := IAMServiceEC2(b.Region)
+		ec2Service, err := iam.IAMServiceEC2(b.Region)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/model/awsmodel/iam_test.go
+++ b/pkg/model/awsmodel/iam_test.go
@@ -24,26 +24,6 @@ import (
 	"k8s.io/kops/pkg/util/stringorset"
 )
 
-func TestIAMServiceEC2(t *testing.T) {
-	expectations := map[string]string{
-		"us-east-1":      "ec2.amazonaws.com",
-		"randomunknown":  "ec2.amazonaws.com",
-		"us-gov-east-1":  "ec2.amazonaws.com",
-		"cn-north-1":     "ec2.amazonaws.com.cn",
-		"cn-northwest-1": "ec2.amazonaws.com.cn",
-	}
-
-	for region, expect := range expectations {
-		principal, err := IAMServiceEC2(region)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if principal != expect {
-			t.Errorf("expected %s for %s, but received %s", expect, region, principal)
-		}
-	}
-}
-
 func Test_formatAWSIAMStatement(t *testing.T) {
 	type args struct {
 		acountId     string

--- a/pkg/model/components/addonmanifests/karpenter/iam.go
+++ b/pkg/model/components/addonmanifests/karpenter/iam.go
@@ -33,7 +33,17 @@ func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, erro
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 
-	if err := iam.AddKarpenterPermissions(p); err != nil {
+	// Instance groups with custom IAM instance profiles contain roles with names that kOps
+	// cannot predict.
+	useCustomInstanceProfiles := false
+	for _, ig := range b.AllInstanceGroups {
+		if ig.IsKarpenterManaged() && ig.Spec.IAM != nil && ig.Spec.IAM.Profile != nil {
+			useCustomInstanceProfiles = true
+			break
+		}
+	}
+
+	if err := iam.AddKarpenterPermissions(p, useCustomInstanceProfiles); err != nil {
 		return nil, err
 	}
 

--- a/pkg/model/components/addonmanifests/karpenter/iam.go
+++ b/pkg/model/components/addonmanifests/karpenter/iam.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/kops/pkg/model/iam"
 )
 
-// ServiceAccount represents the service-account used by the dns-controller.
+// ServiceAccount represents the service-account used by Karpenter.
 // It implements iam.Subject to get AWS IAM permissions.
 type ServiceAccount struct{}
 
@@ -33,7 +33,9 @@ func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, erro
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition, b.Region)
 
-	addKarpenterPermissions(p)
+	if err := iam.AddKarpenterPermissions(p); err != nil {
+		return nil, err
+	}
 
 	return p, nil
 }
@@ -44,52 +46,4 @@ func (r *ServiceAccount) ServiceAccount() (types.NamespacedName, bool) {
 		Namespace: "kube-system",
 		Name:      "karpenter",
 	}, true
-}
-
-func addKarpenterPermissions(p *iam.Policy) {
-	// https://karpenter.sh/v1.6/getting-started/migrating-from-cas/#create-iam-roles
-	// Karpenter
-	p.AddUnconditionalActions(
-		"ssm:GetParameter",
-		"ec2:DescribeImages",
-		"ec2:RunInstances",
-		"ec2:DescribeSubnets",
-		"ec2:DescribeSecurityGroups",
-		"ec2:DescribeLaunchTemplates",
-		"ec2:DescribeInstances",
-		"ec2:DescribeInstanceStatus",
-		"ec2:DescribeInstanceTypes",
-		"ec2:DescribeInstanceTypeOfferings",
-		"ec2:DescribeCapacityReservations",
-		"ec2:DescribePlacementGroups",
-		"ec2:DeleteLaunchTemplate",
-		"ec2:CreateTags",
-		"ec2:CreateLaunchTemplate",
-		"ec2:CreateFleet",
-		"ec2:DescribeSpotPriceHistory",
-		"pricing:GetProducts",
-	)
-	// ConditionalEC2Termination
-	p.AddUnconditionalActions(
-		"ec2:TerminateInstances",
-	)
-	// PassNodeIAMRole
-	p.AddUnconditionalActions(
-		"iam:PassRole",
-	)
-	// AllowScopedInstanceProfileTagActions
-	p.AddUnconditionalActions(
-		"iam:TagInstanceProfile",
-	)
-	// AllowScopedInstanceProfileActions
-	p.AddUnconditionalActions(
-		"iam:AddRoleToInstanceProfile",
-		"iam:RemoveRoleFromInstanceProfile",
-		"iam:DeleteInstanceProfile",
-	)
-	// AllowInstanceProfileReadActions
-	p.AddUnconditionalActions(
-		"iam:GetInstanceProfile",
-		"iam:ListInstanceProfiles",
-	)
 }

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -27,17 +27,21 @@ package iam
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/model"
+	"k8s.io/kops/pkg/truncate"
 	"k8s.io/kops/pkg/util/stringorset"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
@@ -58,10 +62,6 @@ type Policy struct {
 	Statement                 []*Statement
 	partition                 string
 	Version                   string
-}
-
-func (p *Policy) AddUnconditionalActions(actions ...string) {
-	p.unconditionalAction.Insert(actions...)
 }
 
 func (p *Policy) AddEC2CreateAction(actions, resources []string) {
@@ -1113,6 +1113,191 @@ func AddClusterAutoscalerPermissions(p *Policy, useStaticInstanceList bool) {
 	}
 }
 
+// AddKarpenterPermissions adds the permissions needed by the Karpenter controller.
+// The mutating actions are scoped like in the upstream reference policy:
+// https://karpenter.sh/v1.6/getting-started/migrating-from-cas/#create-iam-roles
+// with the KubernetesCluster tag taking the place of the upstream cluster ownership tag, as it is
+// the tag kOps applies to the resources that Karpenter manages. The comments reference the Sids
+// of the corresponding upstream statements. Unlike upstream, no instance profile management
+// permissions are granted: kOps supplies the instance profile through the EC2NodeClass spec, so
+// Karpenter never creates or mutates instance profiles.
+func AddKarpenterPermissions(p *Policy) error {
+	ec2Service, err := IAMServiceEC2(p.region)
+	if err != nil {
+		return err
+	}
+
+	// AllowRegionalReadActions, AllowSSMReadActions, AllowPricingReadActions and
+	// AllowInstanceProfileReadActions; ssm:GetParameter is not limited to AWS-owned parameters,
+	// as kOps also supports user-owned SSM parameters as instance group images.
+	p.unconditionalAction.Insert(
+		"ec2:DescribeCapacityReservations",
+		"ec2:DescribeImages",
+		"ec2:DescribeInstanceStatus",
+		"ec2:DescribeInstanceTypeOfferings",
+		"ec2:DescribeInstanceTypes",
+		"ec2:DescribeInstances",
+		"ec2:DescribeLaunchTemplates",
+		"ec2:DescribePlacementGroups",
+		"ec2:DescribeSecurityGroups",
+		"ec2:DescribeSpotPriceHistory",
+		"ec2:DescribeSubnets",
+		"iam:GetInstanceProfile",
+		"iam:ListInstanceProfiles",
+		"pricing:GetProducts",
+		"ssm:GetParameter",
+	)
+
+	instanceARN := fmt.Sprintf("arn:%s:ec2:*:*:instance/*", p.partition)
+	launchTemplateARN := fmt.Sprintf("arn:%s:ec2:*:*:launch-template/*", p.partition)
+
+	// The EC2 resources that Karpenter creates and tags when launching instances.
+	taggableResources := []string{
+		fmt.Sprintf("arn:%s:ec2:*:*:fleet/*", p.partition),
+		instanceARN,
+		launchTemplateARN,
+		fmt.Sprintf("arn:%s:ec2:*:*:network-interface/*", p.partition),
+		fmt.Sprintf("arn:%s:ec2:*:*:spot-instances-request/*", p.partition),
+		fmt.Sprintf("arn:%s:ec2:*:*:volume/*", p.partition),
+	}
+
+	// The resources that Karpenter created for this cluster carry both the cluster tag and its
+	// own nodepool tag.
+	karpenterOwnedCondition := Condition{
+		"StringEquals": map[string]string{
+			"aws:ResourceTag/KubernetesCluster": p.clusterName,
+		},
+		"StringLike": map[string]string{
+			"aws:ResourceTag/karpenter.sh/nodepool": "*",
+		},
+	}
+
+	// Karpenter only manages worker node instance groups, which use the worker node role,
+	// named as in KopsModelContext.IAMName.
+	nodeRole := truncate.TruncateString("nodes."+p.clusterName, truncate.TruncateStringOptions{MaxLength: MaxLengthIAMRoleName, AlwaysAddHash: false})
+	passRoleResource := fmt.Sprintf("arn:%s:iam::*:role/%s", p.partition, nodeRole)
+
+	p.Statement = append(p.Statement,
+		// AllowScopedEC2InstanceAccessActions: RunInstances and CreateFleet also reference
+		// resources that do not receive tags in the request: the AMI, its snapshots and the
+		// subnets, security groups and capacity reservations to launch into.
+		&Statement{
+			Effect: StatementEffectAllow,
+			Action: stringorset.Of(
+				"ec2:CreateFleet",
+				"ec2:RunInstances",
+			),
+			Resource: stringorset.Set([]string{
+				fmt.Sprintf("arn:%s:ec2:*:*:capacity-reservation/*", p.partition),
+				fmt.Sprintf("arn:%s:ec2:*::image/*", p.partition),
+				fmt.Sprintf("arn:%s:ec2:*::snapshot/*", p.partition),
+				fmt.Sprintf("arn:%s:ec2:*:*:security-group/*", p.partition),
+				fmt.Sprintf("arn:%s:ec2:*:*:subnet/*", p.partition),
+			}),
+		},
+		// AllowScopedEC2LaunchTemplateAccessActions: launching from an existing launch template
+		// is only allowed for launch templates that Karpenter created for this cluster, as the
+		// launch template itself is not tagged by the request.
+		&Statement{
+			Effect: StatementEffectAllow,
+			Action: stringorset.Of(
+				"ec2:CreateFleet",
+				"ec2:RunInstances",
+			),
+			Resource:  stringorset.Set([]string{launchTemplateARN}),
+			Condition: karpenterOwnedCondition,
+		},
+		// AllowScopedEC2InstanceActionsWithTags: launching instances is only allowed when the
+		// request tags the created resources with the cluster tag and the karpenter.sh/nodepool
+		// tag; Karpenter tags everything it creates with the EC2NodeClass tags, which include
+		// the cluster tag, and with its own nodepool tag.
+		&Statement{
+			Effect: StatementEffectAllow,
+			Action: stringorset.Of(
+				"ec2:CreateFleet",
+				"ec2:CreateLaunchTemplate",
+				"ec2:RunInstances",
+			),
+			Resource: stringorset.Set(taggableResources),
+			Condition: Condition{
+				"StringEquals": map[string]string{
+					"aws:RequestTag/KubernetesCluster": p.clusterName,
+				},
+				"StringLike": map[string]string{
+					"aws:RequestTag/karpenter.sh/nodepool": "*",
+				},
+			},
+		},
+		// AllowScopedResourceCreationTagging: tagging the created resources as part of the
+		// create actions above.
+		&Statement{
+			Effect:   StatementEffectAllow,
+			Action:   stringorset.String("ec2:CreateTags"),
+			Resource: stringorset.Set(taggableResources),
+			Condition: Condition{
+				"StringEquals": map[string]interface{}{
+					"aws:RequestTag/KubernetesCluster": p.clusterName,
+					"ec2:CreateAction": []string{
+						"CreateFleet",
+						"CreateLaunchTemplate",
+						"RunInstances",
+					},
+				},
+				"StringLike": map[string]string{
+					"aws:RequestTag/karpenter.sh/nodepool": "*",
+				},
+			},
+		},
+		// AllowScopedResourceTagging: re-tagging the resources that Karpenter manages, without
+		// changing the cluster tag.
+		&Statement{
+			Effect: StatementEffectAllow,
+			Action: stringorset.Of(
+				"ec2:CreateTags",
+				"ec2:DeleteTags",
+			),
+			Resource: stringorset.Set(taggableResources),
+			Condition: Condition{
+				"Null": map[string]string{
+					"aws:RequestTag/KubernetesCluster": "true",
+				},
+				"StringEquals": map[string]string{
+					"aws:ResourceTag/KubernetesCluster": p.clusterName,
+				},
+				"StringLike": map[string]string{
+					"aws:ResourceTag/karpenter.sh/nodepool": "*",
+				},
+			},
+		},
+		// AllowScopedDeletion: deleting is only allowed for the instances and launch templates
+		// that Karpenter created for this cluster.
+		&Statement{
+			Effect: StatementEffectAllow,
+			Action: stringorset.Of(
+				"ec2:DeleteLaunchTemplate",
+				"ec2:TerminateInstances",
+			),
+			Resource:  stringorset.Set([]string{instanceARN, launchTemplateARN}),
+			Condition: karpenterOwnedCondition,
+		},
+		// AllowPassingInstanceRole: Karpenter may only pass the node role, and only to EC2.
+		// Instance groups with custom instance profiles contain roles that are not managed by
+		// kOps; granting iam:PassRole for those is the responsibility of whoever manages them.
+		&Statement{
+			Effect:   StatementEffectAllow,
+			Action:   stringorset.String("iam:PassRole"),
+			Resource: stringorset.String(passRoleResource),
+			Condition: Condition{
+				"StringEquals": map[string]string{
+					"iam:PassedToService": ec2Service,
+				},
+			},
+		},
+	)
+
+	return nil
+}
+
 // AddAWSEBSCSIDriverPermissions appens policy statements that the AWS EBS CSI Driver needs to operate.
 func AddAWSEBSCSIDriverPermissions(b *PolicyBuilder, p *Policy, appendSnapshotPermissions bool) {
 	// EBS CSI's data-plane KMS calls flow through EC2, so kms:ViaService applies.
@@ -1281,6 +1466,25 @@ func addKMSIAMPolicies(p *Policy, bypassViaService bool) {
 // EC2 is pinned to the cluster's region (EBS is always in-region). S3 uses a
 // region wildcard because kops supports cross-region state-store buckets; the
 // caller must therefore evaluate the values under StringLike, not StringEquals.
+// IAMServiceEC2 returns the name of the IAM service for EC2 in the current region.
+// It is ec2.amazonaws.com in the default aws partition, but different in other isolated/custom partitions
+func IAMServiceEC2(region string) (string, error) {
+	ctx := context.TODO()
+	resolver := ec2.NewDefaultEndpointResolverV2()
+	ep, err := resolver.ResolveEndpoint(ctx, ec2.EndpointParameters{Region: aws.String(region)})
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve endpoint: %v", err)
+	}
+	if ep.URI.Host != "" {
+		// Remove the region from the hostname. Examples:
+		// ec2.us-east-1.amazonaws.com     -> ec2.amazonaws.com
+		// ec2.cn-west-1.amazonaws.com.cn  -> ec2.amazonaws.com.cn
+		// ec2.us-gov-west-1.amazonaws.com -> ec2.amazonaws.com
+		return strings.ReplaceAll(ep.URI.Host, fmt.Sprintf("%v.", region), ""), nil
+	}
+	return "ec2.amazonaws.com", nil
+}
+
 func kmsViaServices(region string) []string {
 	if region == "" {
 		return nil

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -320,6 +320,7 @@ func (l *Statement) Equal(r *Statement) bool {
 // AWS IAM policy document for a given instance group role.
 type PolicyBuilder struct {
 	Cluster                               *kops.Cluster
+	AllInstanceGroups                     []*kops.InstanceGroup
 	HostedZoneID                          string
 	KMSKeys                               []string
 	Region                                string
@@ -1121,7 +1122,9 @@ func AddClusterAutoscalerPermissions(p *Policy, useStaticInstanceList bool) {
 // of the corresponding upstream statements. Unlike upstream, no instance profile management
 // permissions are granted: kOps supplies the instance profile through the EC2NodeClass spec, so
 // Karpenter never creates or mutates instance profiles.
-func AddKarpenterPermissions(p *Policy) error {
+// useCustomInstanceProfiles indicates that instance groups use custom IAM instance profiles,
+// which contain roles with names that kOps cannot predict.
+func AddKarpenterPermissions(p *Policy, useCustomInstanceProfiles bool) error {
 	ec2Service, err := IAMServiceEC2(p.region)
 	if err != nil {
 		return err
@@ -1176,6 +1179,9 @@ func AddKarpenterPermissions(p *Policy) error {
 	// named as in KopsModelContext.IAMName.
 	nodeRole := truncate.TruncateString("nodes."+p.clusterName, truncate.TruncateStringOptions{MaxLength: MaxLengthIAMRoleName, AlwaysAddHash: false})
 	passRoleResource := fmt.Sprintf("arn:%s:iam::*:role/%s", p.partition, nodeRole)
+	if useCustomInstanceProfiles {
+		passRoleResource = fmt.Sprintf("arn:%s:iam::*:role/*", p.partition)
+	}
 
 	p.Statement = append(p.Statement,
 		// AllowScopedEC2InstanceAccessActions: RunInstances and CreateFleet also reference
@@ -1281,8 +1287,8 @@ func AddKarpenterPermissions(p *Policy) error {
 			Condition: karpenterOwnedCondition,
 		},
 		// AllowPassingInstanceRole: Karpenter may only pass the node role, and only to EC2.
-		// Instance groups with custom instance profiles contain roles that are not managed by
-		// kOps; granting iam:PassRole for those is the responsibility of whoever manages them.
+		// Instance groups with custom instance profiles contain roles with names that kOps
+		// cannot predict, so any role may be passed when they are used.
 		&Statement{
 			Effect:   StatementEffectAllow,
 			Action:   stringorset.String("iam:PassRole"),

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -372,28 +372,39 @@ func TestIAMServiceEC2(t *testing.T) {
 }
 
 func TestAddKarpenterPermissions(t *testing.T) {
-	p := NewPolicy("c.example.com", "aws", "us-east-1")
-	if err := AddKarpenterPermissions(p); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		name                      string
+		useCustomInstanceProfiles bool
+		wantPassRoleResource      string
+	}{
+		{name: "managed instance profiles", useCustomInstanceProfiles: false, wantPassRoleResource: "arn:aws:iam::*:role/nodes.c.example.com"},
+		{name: "custom instance profiles", useCustomInstanceProfiles: true, wantPassRoleResource: "arn:aws:iam::*:role/*"},
 	}
-
-	var passRole *Statement
-	for _, s := range p.Statement {
-		if slices.Contains(s.Action.Value(), "iam:PassRole") {
-			if passRole != nil {
-				t.Fatalf("found multiple iam:PassRole statements")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewPolicy("c.example.com", "aws", "us-east-1")
+			if err := AddKarpenterPermissions(p, tc.useCustomInstanceProfiles); err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
-			passRole = s
-		}
-	}
-	if passRole == nil {
-		t.Fatalf("no iam:PassRole statement found")
-	}
-	wantResource := "arn:aws:iam::*:role/nodes.c.example.com"
-	if got := passRole.Resource.Value(); len(got) != 1 || got[0] != wantResource {
-		t.Errorf("iam:PassRole resource = %v, want %q", got, wantResource)
-	}
-	if _, ok := passRole.Condition["StringEquals"]; !ok {
-		t.Errorf("iam:PassRole statement missing StringEquals condition")
+
+			var passRole *Statement
+			for _, s := range p.Statement {
+				if slices.Contains(s.Action.Value(), "iam:PassRole") {
+					if passRole != nil {
+						t.Fatalf("found multiple iam:PassRole statements")
+					}
+					passRole = s
+				}
+			}
+			if passRole == nil {
+				t.Fatalf("no iam:PassRole statement found")
+			}
+			if got := passRole.Resource.Value(); len(got) != 1 || got[0] != tc.wantPassRoleResource {
+				t.Errorf("iam:PassRole resource = %v, want %q", got, tc.wantPassRoleResource)
+			}
+			if _, ok := passRole.Condition["StringEquals"]; !ok {
+				t.Errorf("iam:PassRole statement missing StringEquals condition")
+			}
+		})
 	}
 }

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -350,3 +350,50 @@ func TestKmsViaServices(t *testing.T) {
 		})
 	}
 }
+
+func TestIAMServiceEC2(t *testing.T) {
+	expectations := map[string]string{
+		"us-east-1":      "ec2.amazonaws.com",
+		"randomunknown":  "ec2.amazonaws.com",
+		"us-gov-east-1":  "ec2.amazonaws.com",
+		"cn-north-1":     "ec2.amazonaws.com.cn",
+		"cn-northwest-1": "ec2.amazonaws.com.cn",
+	}
+
+	for region, expect := range expectations {
+		principal, err := IAMServiceEC2(region)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if principal != expect {
+			t.Errorf("expected %s for %s, but received %s", expect, region, principal)
+		}
+	}
+}
+
+func TestAddKarpenterPermissions(t *testing.T) {
+	p := NewPolicy("c.example.com", "aws", "us-east-1")
+	if err := AddKarpenterPermissions(p); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var passRole *Statement
+	for _, s := range p.Statement {
+		if slices.Contains(s.Action.Value(), "iam:PassRole") {
+			if passRole != nil {
+				t.Fatalf("found multiple iam:PassRole statements")
+			}
+			passRole = s
+		}
+	}
+	if passRole == nil {
+		t.Fatalf("no iam:PassRole statement found")
+	}
+	wantResource := "arn:aws:iam::*:role/nodes.c.example.com"
+	if got := passRole.Resource.Value(); len(got) != 1 || got[0] != wantResource {
+		t.Errorf("iam:PassRole resource = %v, want %q", got, wantResource)
+	}
+	if _, ok := passRole.Condition["StringEquals"]; !ok {
+		t.Errorf("iam:PassRole statement missing StringEquals condition")
+	}
+}

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
@@ -3,9 +3,141 @@
     {
       "Action": [
         "ec2:CreateFleet",
+        "ec2:RunInstances"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:capacity-reservation/*",
+        "arn:aws-test:ec2:*:*:security-group/*",
+        "arn:aws-test:ec2:*:*:subnet/*",
+        "arn:aws-test:ec2:*::image/*",
+        "arn:aws-test:ec2:*::snapshot/*"
+      ]
+    },
+    {
+      "Action": [
+        "ec2:CreateFleet",
+        "ec2:RunInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
+        },
+        "StringLike": {
+          "aws:ResourceTag/karpenter.sh/nodepool": "*"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:launch-template/*"
+      ]
+    },
+    {
+      "Action": [
+        "ec2:CreateFleet",
         "ec2:CreateLaunchTemplate",
+        "ec2:RunInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com"
+        },
+        "StringLike": {
+          "aws:RequestTag/karpenter.sh/nodepool": "*"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:fleet/*",
+        "arn:aws-test:ec2:*:*:instance/*",
+        "arn:aws-test:ec2:*:*:launch-template/*",
+        "arn:aws-test:ec2:*:*:network-interface/*",
+        "arn:aws-test:ec2:*:*:spot-instances-request/*",
+        "arn:aws-test:ec2:*:*:volume/*"
+      ]
+    },
+    {
+      "Action": "ec2:CreateTags",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
+          "ec2:CreateAction": [
+            "CreateFleet",
+            "CreateLaunchTemplate",
+            "RunInstances"
+          ]
+        },
+        "StringLike": {
+          "aws:RequestTag/karpenter.sh/nodepool": "*"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:fleet/*",
+        "arn:aws-test:ec2:*:*:instance/*",
+        "arn:aws-test:ec2:*:*:launch-template/*",
+        "arn:aws-test:ec2:*:*:network-interface/*",
+        "arn:aws-test:ec2:*:*:spot-instances-request/*",
+        "arn:aws-test:ec2:*:*:volume/*"
+      ]
+    },
+    {
+      "Action": [
         "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
+        "StringEquals": {
+          "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
+        },
+        "StringLike": {
+          "aws:ResourceTag/karpenter.sh/nodepool": "*"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:fleet/*",
+        "arn:aws-test:ec2:*:*:instance/*",
+        "arn:aws-test:ec2:*:*:launch-template/*",
+        "arn:aws-test:ec2:*:*:network-interface/*",
+        "arn:aws-test:ec2:*:*:spot-instances-request/*",
+        "arn:aws-test:ec2:*:*:volume/*"
+      ]
+    },
+    {
+      "Action": [
         "ec2:DeleteLaunchTemplate",
+        "ec2:TerminateInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
+        },
+        "StringLike": {
+          "aws:ResourceTag/karpenter.sh/nodepool": "*"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:ec2:*:*:instance/*",
+        "arn:aws-test:ec2:*:*:launch-template/*"
+      ]
+    },
+    {
+      "Action": "iam:PassRole",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "arn:aws-test:iam::*:role/nodes.minimal.example.com"
+    },
+    {
+      "Action": [
         "ec2:DescribeCapacityReservations",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceStatus",
@@ -17,15 +149,8 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSpotPriceHistory",
         "ec2:DescribeSubnets",
-        "ec2:RunInstances",
-        "ec2:TerminateInstances",
-        "iam:AddRoleToInstanceProfile",
-        "iam:DeleteInstanceProfile",
         "iam:GetInstanceProfile",
         "iam:ListInstanceProfiles",
-        "iam:PassRole",
-        "iam:RemoveRoleFromInstanceProfile",
-        "iam:TagInstanceProfile",
         "pricing:GetProducts",
         "ssm:GetParameter"
       ],


### PR DESCRIPTION
Scope the mutating actions of the Karpenter controller policy, following the upstream reference policy:

* iam:PassRole is limited to the worker node role and to the EC2 service. When Karpenter-managed instance groups use custom IAM instance profiles, the role names are not predictable, so any role may be passed to EC2.
* ec2:RunInstances, ec2:CreateFleet and ec2:CreateLaunchTemplate require the created resources to be tagged with the cluster tag and the karpenter.sh/nodepool tag, with an unconditional resource-scoped statement for the untagged resources they reference (AMI, snapshots, subnets, security groups, capacity reservations).
* ec2:TerminateInstances, ec2:DeleteLaunchTemplate, ec2:CreateTags and ec2:DeleteTags are only allowed on resources with the cluster tag and the karpenter.sh/nodepool tag.
* The instance profile mutations are removed, as kOps supplies the instance profile through the EC2NodeClass spec, so Karpenter never creates or mutates instance profiles.

Read-only actions remain unconditional.

/cc @rifelpet @ameukam 