### PR TITLE
gce: verify MIG membership in the TPM verifier

### DIFF
--- a/pkg/nodeidentity/clusterapi/capimanager/manager.go
+++ b/pkg/nodeidentity/clusterapi/capimanager/manager.go
@@ -39,7 +39,9 @@ func NewManager(kubeClient client.Client) *Manager {
 	}
 }
 
-func (m *Manager) FindMachineByProviderID(ctx context.Context, providerID string) (*clusterapi.Machine, error) {
+// FindMachineByProviderID returns the Machine with the given spec.providerID, or nil if not found.
+// Machines belonging to CAPI clusters other than clusterName are ignored.
+func (m *Manager) FindMachineByProviderID(ctx context.Context, providerID string, clusterName string) (*clusterapi.Machine, error) {
 	// TODO: Can we build an index
 	// selector := client.MatchingFieldsSelector{
 	// 	Selector: fields.OneTermEqualSelector("spec.providerID", providerID),
@@ -58,6 +60,10 @@ func (m *Manager) FindMachineByProviderID(ctx context.Context, providerID string
 		machine := &machines.Items[i]
 		machineSpecProviderID, _, _ := unstructured.NestedString(machine.Object, "spec", "providerID")
 		if machineSpecProviderID != providerID {
+			continue
+		}
+		machineClusterName, _, _ := unstructured.NestedString(machine.Object, "spec", "clusterName")
+		if machineClusterName != clusterName {
 			continue
 		}
 		matches = append(matches, machine)

--- a/pkg/nodeidentity/clusterapi/capimanager/manager.go
+++ b/pkg/nodeidentity/clusterapi/capimanager/manager.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kops/pkg/nodeidentity/clusterapi"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -40,10 +41,10 @@ func NewManager(kubeClient client.Client) *Manager {
 }
 
 // FindMachineByProviderID returns the Machine with the given spec.providerID, or nil if not found.
-// Machines belonging to CAPI clusters other than capiClusterName are ignored; note that
-// capiClusterName is the Machine's spec.clusterName (for CAPG, the kOps cluster name escaped with
+// Machines belonging to CAPI clusters other than capiCluster are ignored; note that
+// capiCluster.Name is the Machine's spec.clusterName (for CAPG, the kOps cluster name escaped with
 // gce.SafeClusterName), not the kOps cluster name.
-func (m *Manager) FindMachineByProviderID(ctx context.Context, providerID string, capiClusterName string) (*clusterapi.Machine, error) {
+func (m *Manager) FindMachineByProviderID(ctx context.Context, providerID string, capiCluster types.NamespacedName) (*clusterapi.Machine, error) {
 	// TODO: Can we build an index
 	// selector := client.MatchingFieldsSelector{
 	// 	Selector: fields.OneTermEqualSelector("spec.providerID", providerID),
@@ -54,7 +55,7 @@ func (m *Manager) FindMachineByProviderID(ctx context.Context, providerID string
 		Kind:    "Machine",
 		Version: "v1beta1",
 	})
-	if err := m.kubeClient.List(ctx, &machines); err != nil {
+	if err := m.kubeClient.List(ctx, &machines, client.InNamespace(capiCluster.Namespace)); err != nil {
 		return nil, fmt.Errorf("error listing machines: %w", err)
 	}
 	var matches []*unstructured.Unstructured
@@ -65,7 +66,7 @@ func (m *Manager) FindMachineByProviderID(ctx context.Context, providerID string
 			continue
 		}
 		machineClusterName, _, _ := unstructured.NestedString(machine.Object, "spec", "clusterName")
-		if machineClusterName != capiClusterName {
+		if machineClusterName != capiCluster.Name {
 			continue
 		}
 		matches = append(matches, machine)

--- a/pkg/nodeidentity/clusterapi/capimanager/manager.go
+++ b/pkg/nodeidentity/clusterapi/capimanager/manager.go
@@ -40,8 +40,10 @@ func NewManager(kubeClient client.Client) *Manager {
 }
 
 // FindMachineByProviderID returns the Machine with the given spec.providerID, or nil if not found.
-// Machines belonging to CAPI clusters other than clusterName are ignored.
-func (m *Manager) FindMachineByProviderID(ctx context.Context, providerID string, clusterName string) (*clusterapi.Machine, error) {
+// Machines belonging to CAPI clusters other than capiClusterName are ignored; note that
+// capiClusterName is the Machine's spec.clusterName (for CAPG, the kOps cluster name escaped with
+// gce.SafeClusterName), not the kOps cluster name.
+func (m *Manager) FindMachineByProviderID(ctx context.Context, providerID string, capiClusterName string) (*clusterapi.Machine, error) {
 	// TODO: Can we build an index
 	// selector := client.MatchingFieldsSelector{
 	// 	Selector: fields.OneTermEqualSelector("spec.providerID", providerID),
@@ -63,7 +65,7 @@ func (m *Manager) FindMachineByProviderID(ctx context.Context, providerID string
 			continue
 		}
 		machineClusterName, _, _ := unstructured.NestedString(machine.Object, "spec", "clusterName")
-		if machineClusterName != clusterName {
+		if machineClusterName != capiClusterName {
 			continue
 		}
 		matches = append(matches, machine)

--- a/pkg/nodeidentity/gce/identify.go
+++ b/pkg/nodeidentity/gce/identify.go
@@ -204,15 +204,10 @@ func GetInstanceTemplateForMIGMember(ctx context.Context, computeService *comput
 		return nil, fmt.Errorf("cannot find owner for instance %s", instance.Name)
 	}
 
-	// We need to double-check the MIG configuration, in case created-by was changed
+	// We need to double-check the MIG membership, in case created-by was changed
 	migName := lastComponent(createdBy)
 
-	mig, err := computeService.InstanceGroupManagers.Get(project, lastComponent(instance.Zone), migName).Context(ctx).Do()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching GCE managed instance group %q: %v", migName, err)
-	}
-
-	migMember, err := getManagedInstance(ctx, computeService, project, mig, instance.Id)
+	migMember, err := getManagedInstance(ctx, computeService, project, lastComponent(instance.Zone), migName, instance.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -231,12 +226,11 @@ func GetInstanceTemplateForMIGMember(ctx context.Context, computeService *comput
 }
 
 // getManagedInstance queries GCE for the instance from the MIG
-func getManagedInstance(ctx context.Context, computeService *compute.Service, project string, mig *compute.InstanceGroupManager, instanceID uint64) (*compute.ManagedInstance, error) {
+func getManagedInstance(ctx context.Context, computeService *compute.Service, project string, zone string, migName string, instanceID uint64) (*compute.ManagedInstance, error) {
 	var matches []*compute.ManagedInstance
 
 	filter := "id=" + strconv.FormatUint(instanceID, 10)
-	zone := lastComponent(mig.Zone)
-	if err := computeService.InstanceGroupManagers.ListManagedInstances(project, zone, mig.Name).Filter(filter).Pages(ctx, func(page *compute.InstanceGroupManagersListManagedInstancesResponse) error {
+	if err := computeService.InstanceGroupManagers.ListManagedInstances(project, zone, migName).Filter(filter).Pages(ctx, func(page *compute.InstanceGroupManagersListManagedInstancesResponse) error {
 		// Post-filter... filters aren't implemented (b/27605549)
 		for _, instance := range page.ManagedInstances {
 			if instance.Id != instanceID {
@@ -246,15 +240,15 @@ func getManagedInstance(ctx context.Context, computeService *compute.Service, pr
 		}
 		return nil
 	}); err != nil {
-		return nil, fmt.Errorf("error fetching GCE managed instance group members for %q: %v", mig.Name, err)
+		return nil, fmt.Errorf("error fetching GCE managed instance group members for %q: %v", migName, err)
 	}
 
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("instance %v not managed by mig %s", instanceID, mig.Name)
+		return nil, fmt.Errorf("instance %v not managed by mig %s", instanceID, migName)
 	}
 	if len(matches) > 1 {
 		// Should be impossible - shows that filters / post-filters are not working
-		return nil, fmt.Errorf("found multiple instances with id %v managed by mig %s", instanceID, mig.Name)
+		return nil, fmt.Errorf("found multiple instances with id %v managed by mig %s", instanceID, migName)
 	}
 
 	return matches[0], nil

--- a/pkg/nodeidentity/gce/identify.go
+++ b/pkg/nodeidentity/gce/identify.go
@@ -141,38 +141,12 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 
 	var igName string
 	if capiMachine == nil {
-		// The metadata itself is potentially mutable from the instance
-		// We instead look at the MIG configuration
-		createdBy := getMetadataValue(instance.Metadata, "created-by")
-		if createdBy == "" {
-			return nil, fmt.Errorf("cannot find owner for instance %s", instance.Name)
-		}
-
-		// We need to double-check the MIG configuration, in case created-by was changed
-		migName := lastComponent(createdBy)
-
-		mig, err := i.getMIG(zone, migName)
+		instanceTemplate, err := GetInstanceTemplateForMIGMember(ctx, i.computeService, i.project, instance)
 		if err != nil {
 			return nil, err
 		}
 
-		// We now double check that the instance is indeed managed by the MIG
-		// this can't be spoofed without GCE API access
-		migMember, err := i.getManagedInstance(ctx, mig, instance.Id)
-		if err != nil {
-			return nil, err
-		}
-
-		if migMember.Version == nil {
-			return nil, fmt.Errorf("instance %s did not have Version set", instance.Name)
-		}
-
-		instanceTemplate, err := i.getInstanceTemplate(lastComponent(migMember.Version.InstanceTemplate))
-		if err != nil {
-			return nil, err
-		}
-
-		igName = getMetadataValue(instanceTemplate.Properties.Metadata, MetadataKeyInstanceGroupName)
+		igName = GetMetadataValue(instanceTemplate.Properties.Metadata, MetadataKeyInstanceGroupName)
 		if igName == "" {
 			return nil, fmt.Errorf("ig name not set on instance template %s", instanceTemplate.Name)
 		}
@@ -220,33 +194,49 @@ func (i *nodeIdentifier) getInstance(zone string, instanceName string) (*compute
 	return instance, nil
 }
 
-// getInstanceTemplate queries GCE for the IG Template with the specified name, returning an error if not found
-func (i *nodeIdentifier) getInstanceTemplate(name string) (*compute.InstanceTemplate, error) {
-	t, err := i.computeService.InstanceTemplates.Get(i.project, name).Do()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching GCE instance group template %q: %v", name, err)
+// GetInstanceTemplateForMIGMember returns the instance template of the MIG that manages the given
+// instance. The instance metadata is potentially mutable by whoever created the instance, so we
+// instead resolve the MIG from the created-by metadata and verify that the instance is indeed
+// managed by it; MIG membership can't be spoofed without GCE API access.
+func GetInstanceTemplateForMIGMember(ctx context.Context, computeService *compute.Service, project string, instance *compute.Instance) (*compute.InstanceTemplate, error) {
+	createdBy := GetMetadataValue(instance.Metadata, "created-by")
+	if createdBy == "" {
+		return nil, fmt.Errorf("cannot find owner for instance %s", instance.Name)
 	}
 
-	return t, nil
-}
+	// We need to double-check the MIG configuration, in case created-by was changed
+	migName := lastComponent(createdBy)
 
-// getMIG queries GCE for the MIG with the specified name, returning an error if not found
-func (i *nodeIdentifier) getMIG(zone string, migName string) (*compute.InstanceGroupManager, error) {
-	mig, err := i.computeService.InstanceGroupManagers.Get(i.project, zone, migName).Do()
+	mig, err := computeService.InstanceGroupManagers.Get(project, lastComponent(instance.Zone), migName).Context(ctx).Do()
 	if err != nil {
 		return nil, fmt.Errorf("error fetching GCE managed instance group %q: %v", migName, err)
 	}
 
-	return mig, nil
+	migMember, err := getManagedInstance(ctx, computeService, project, mig, instance.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	if migMember.Version == nil {
+		return nil, fmt.Errorf("instance %s did not have Version set", instance.Name)
+	}
+
+	templateName := lastComponent(migMember.Version.InstanceTemplate)
+	instanceTemplate, err := computeService.InstanceTemplates.Get(project, templateName).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching GCE instance group template %q: %v", templateName, err)
+	}
+
+	return instanceTemplate, nil
 }
 
 // getManagedInstance queries GCE for the instance from the MIG
-func (i *nodeIdentifier) getManagedInstance(ctx context.Context, mig *compute.InstanceGroupManager, instanceID uint64) (*compute.ManagedInstance, error) {
+func getManagedInstance(ctx context.Context, computeService *compute.Service, project string, mig *compute.InstanceGroupManager, instanceID uint64) (*compute.ManagedInstance, error) {
 	var matches []*compute.ManagedInstance
 
 	filter := "id=" + strconv.FormatUint(instanceID, 10)
 	zone := lastComponent(mig.Zone)
-	if err := i.computeService.InstanceGroupManagers.ListManagedInstances(i.project, zone, mig.Name).Filter(filter).Pages(ctx, func(page *compute.InstanceGroupManagersListManagedInstancesResponse) error {
+	if err := computeService.InstanceGroupManagers.ListManagedInstances(project, zone, mig.Name).Filter(filter).Pages(ctx, func(page *compute.InstanceGroupManagersListManagedInstancesResponse) error {
 		// Post-filter... filters aren't implemented (b/27605549)
 		for _, instance := range page.ManagedInstances {
 			if instance.Id != instanceID {
@@ -280,7 +270,8 @@ func lastComponent(s string) string {
 	return s
 }
 
-func getMetadataValue(metadata *compute.Metadata, key string) string {
+// GetMetadataValue returns the value for the given key in the metadata, or "" if not present.
+func GetMetadataValue(metadata *compute.Metadata, key string) string {
 	value := ""
 	if metadata != nil {
 		for _, item := range metadata.Items {

--- a/pkg/nodeidentity/gce/identify.go
+++ b/pkg/nodeidentity/gce/identify.go
@@ -132,7 +132,7 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 	if i.capiManager != nil && capgRole != "" {
 		providerID := "gce://" + project + "/" + zone + "/" + instanceName
 
-		m, err := i.capiManager.FindMachineByProviderID(ctx, providerID)
+		m, err := i.capiManager.FindMachineByProviderID(ctx, providerID, gce.SafeClusterName(i.clusterName))
 		if err != nil {
 			return nil, fmt.Errorf("error finding Machine with providerID %q: %w", providerID, err)
 		}

--- a/pkg/nodeidentity/gce/identify.go
+++ b/pkg/nodeidentity/gce/identify.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
@@ -141,12 +140,12 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 
 	var igName string
 	if capiMachine == nil {
-		instanceTemplate, err := GetInstanceTemplateForMIGMember(ctx, i.computeService, i.project, instance)
+		instanceTemplate, err := gce.GetInstanceTemplateForMIGMember(ctx, i.computeService, i.project, instance)
 		if err != nil {
 			return nil, err
 		}
 
-		igName = GetMetadataValue(instanceTemplate.Properties.Metadata, MetadataKeyInstanceGroupName)
+		igName = gce.GetMetadataValue(instanceTemplate.Properties.Metadata, MetadataKeyInstanceGroupName)
 		if igName == "" {
 			return nil, fmt.Errorf("ig name not set on instance template %s", instanceTemplate.Name)
 		}
@@ -192,87 +191,4 @@ func (i *nodeIdentifier) getInstance(zone string, instanceName string) (*compute
 	}
 
 	return instance, nil
-}
-
-// GetInstanceTemplateForMIGMember returns the instance template of the MIG that manages the given
-// instance. The instance metadata is potentially mutable by whoever created the instance, so we
-// instead resolve the MIG from the created-by metadata and verify that the instance is indeed
-// managed by it; MIG membership can't be spoofed without GCE API access.
-func GetInstanceTemplateForMIGMember(ctx context.Context, computeService *compute.Service, project string, instance *compute.Instance) (*compute.InstanceTemplate, error) {
-	createdBy := GetMetadataValue(instance.Metadata, "created-by")
-	if createdBy == "" {
-		return nil, fmt.Errorf("cannot find owner for instance %s", instance.Name)
-	}
-
-	// We need to double-check the MIG membership, in case created-by was changed
-	migName := lastComponent(createdBy)
-
-	migMember, err := getManagedInstance(ctx, computeService, project, lastComponent(instance.Zone), migName, instance.Id)
-	if err != nil {
-		return nil, err
-	}
-
-	if migMember.Version == nil {
-		return nil, fmt.Errorf("instance %s did not have Version set", instance.Name)
-	}
-
-	templateName := lastComponent(migMember.Version.InstanceTemplate)
-	instanceTemplate, err := computeService.InstanceTemplates.Get(project, templateName).Context(ctx).Do()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching GCE instance group template %q: %v", templateName, err)
-	}
-
-	return instanceTemplate, nil
-}
-
-// getManagedInstance queries GCE for the instance from the MIG
-func getManagedInstance(ctx context.Context, computeService *compute.Service, project string, zone string, migName string, instanceID uint64) (*compute.ManagedInstance, error) {
-	var matches []*compute.ManagedInstance
-
-	filter := "id=" + strconv.FormatUint(instanceID, 10)
-	if err := computeService.InstanceGroupManagers.ListManagedInstances(project, zone, migName).Filter(filter).Pages(ctx, func(page *compute.InstanceGroupManagersListManagedInstancesResponse) error {
-		// Post-filter... filters aren't implemented (b/27605549)
-		for _, instance := range page.ManagedInstances {
-			if instance.Id != instanceID {
-				continue
-			}
-			matches = append(matches, instance)
-		}
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("error fetching GCE managed instance group members for %q: %v", migName, err)
-	}
-
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("instance %v not managed by mig %s", instanceID, migName)
-	}
-	if len(matches) > 1 {
-		// Should be impossible - shows that filters / post-filters are not working
-		return nil, fmt.Errorf("found multiple instances with id %v managed by mig %s", instanceID, migName)
-	}
-
-	return matches[0], nil
-}
-
-// lastComponent returns the last component of a URL, i.e. anything after the last slash
-// If there is no slash, returns the whole string
-func lastComponent(s string) string {
-	lastSlash := strings.LastIndex(s, "/")
-	if lastSlash != -1 {
-		s = s[lastSlash+1:]
-	}
-	return s
-}
-
-// GetMetadataValue returns the value for the given key in the metadata, or "" if not present.
-func GetMetadataValue(metadata *compute.Metadata, key string) string {
-	value := ""
-	if metadata != nil {
-		for _, item := range metadata.Items {
-			if item.Key == key && item.Value != nil {
-				value = *item.Value
-			}
-		}
-	}
-	return value
 }

--- a/pkg/nodeidentity/gce/identify.go
+++ b/pkg/nodeidentity/gce/identify.go
@@ -25,6 +25,8 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	compute "google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/nodeidentity"
@@ -131,7 +133,11 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 	if i.capiManager != nil && capgRole != "" {
 		providerID := "gce://" + project + "/" + zone + "/" + instanceName
 
-		m, err := i.capiManager.FindMachineByProviderID(ctx, providerID, gce.SafeClusterName(i.clusterName))
+		capiCluster := types.NamespacedName{
+			Namespace: metav1.NamespaceSystem,
+			Name:      gce.SafeClusterName(i.clusterName),
+		}
+		m, err := i.capiManager.FindMachineByProviderID(ctx, providerID, capiCluster)
 		if err != nil {
 			return nil, fmt.Errorf("error finding Machine with providerID %q: %w", providerID, err)
 		}

--- a/upup/pkg/fi/cloudup/gce/miginstance.go
+++ b/upup/pkg/fi/cloudup/gce/miginstance.go
@@ -57,32 +57,29 @@ func GetInstanceTemplateForMIGMember(ctx context.Context, computeService *comput
 
 // getManagedInstance queries GCE for the instance from the MIG
 func getManagedInstance(ctx context.Context, computeService *compute.Service, project string, migName string, instance *compute.Instance) (*compute.ManagedInstance, error) {
-	var matches []*compute.ManagedInstance
-
 	zone := LastComponent(instance.Zone)
 	filter := "id=" + strconv.FormatUint(instance.Id, 10)
-	if err := computeService.InstanceGroupManagers.ListManagedInstances(project, zone, migName).Filter(filter).Pages(ctx, func(page *compute.InstanceGroupManagersListManagedInstancesResponse) error {
+	call := computeService.InstanceGroupManagers.ListManagedInstances(project, zone, migName).Filter(filter).Context(ctx)
+	for {
+		page, err := call.Do()
+		if err != nil {
+			return nil, fmt.Errorf("error fetching GCE managed instance group members for %q: %v", migName, err)
+		}
+
 		// Post-filter... filters aren't implemented (b/27605549)
 		for _, member := range page.ManagedInstances {
-			if member.Id != instance.Id {
-				continue
+			if member.Id == instance.Id {
+				return member, nil
 			}
-			matches = append(matches, member)
 		}
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("error fetching GCE managed instance group members for %q: %v", migName, err)
+
+		if page.NextPageToken == "" {
+			break
+		}
+		call.PageToken(page.NextPageToken)
 	}
 
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("instance %v not managed by mig %s", instance.Id, migName)
-	}
-	if len(matches) > 1 {
-		// Should be impossible - shows that filters / post-filters are not working
-		return nil, fmt.Errorf("found multiple instances with id %v managed by mig %s", instance.Id, migName)
-	}
-
-	return matches[0], nil
+	return nil, fmt.Errorf("instance %v not managed by mig %s", instance.Id, migName)
 }
 
 // GetMetadataValue returns the value for the given key in the metadata, or "" if not present.

--- a/upup/pkg/fi/cloudup/gce/miginstance.go
+++ b/upup/pkg/fi/cloudup/gce/miginstance.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	compute "google.golang.org/api/compute/v1"
+)
+
+// GetInstanceTemplateForMIGMember returns the instance template of the MIG that manages the given
+// instance. The instance metadata is potentially mutable by whoever created the instance, so we
+// instead resolve the MIG from the created-by metadata and verify that the instance is indeed
+// managed by it; MIG membership can't be spoofed without GCE API access.
+func GetInstanceTemplateForMIGMember(ctx context.Context, computeService *compute.Service, project string, instance *compute.Instance) (*compute.InstanceTemplate, error) {
+	createdBy := GetMetadataValue(instance.Metadata, "created-by")
+	if createdBy == "" {
+		return nil, fmt.Errorf("cannot find owner for instance %s", instance.Name)
+	}
+
+	// We need to double-check the MIG membership, in case created-by was changed
+	migName := LastComponent(createdBy)
+
+	migMember, err := getManagedInstance(ctx, computeService, project, migName, instance)
+	if err != nil {
+		return nil, err
+	}
+
+	if migMember.Version == nil {
+		return nil, fmt.Errorf("instance %s did not have Version set", instance.Name)
+	}
+
+	templateName := LastComponent(migMember.Version.InstanceTemplate)
+	instanceTemplate, err := computeService.InstanceTemplates.Get(project, templateName).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching GCE instance group template %q: %v", templateName, err)
+	}
+
+	return instanceTemplate, nil
+}
+
+// getManagedInstance queries GCE for the instance from the MIG
+func getManagedInstance(ctx context.Context, computeService *compute.Service, project string, migName string, instance *compute.Instance) (*compute.ManagedInstance, error) {
+	var matches []*compute.ManagedInstance
+
+	zone := LastComponent(instance.Zone)
+	filter := "id=" + strconv.FormatUint(instance.Id, 10)
+	if err := computeService.InstanceGroupManagers.ListManagedInstances(project, zone, migName).Filter(filter).Pages(ctx, func(page *compute.InstanceGroupManagersListManagedInstancesResponse) error {
+		// Post-filter... filters aren't implemented (b/27605549)
+		for _, member := range page.ManagedInstances {
+			if member.Id != instance.Id {
+				continue
+			}
+			matches = append(matches, member)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("error fetching GCE managed instance group members for %q: %v", migName, err)
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("instance %v not managed by mig %s", instance.Id, migName)
+	}
+	if len(matches) > 1 {
+		// Should be impossible - shows that filters / post-filters are not working
+		return nil, fmt.Errorf("found multiple instances with id %v managed by mig %s", instance.Id, migName)
+	}
+
+	return matches[0], nil
+}
+
+// GetMetadataValue returns the value for the given key in the metadata, or "" if not present.
+func GetMetadataValue(metadata *compute.Metadata, key string) string {
+	value := ""
+	if metadata != nil {
+		for _, item := range metadata.Items {
+			if item.Key == key && item.Value != nil {
+				value = *item.Value
+			}
+		}
+	}
+	return value
+}

--- a/upup/pkg/fi/cloudup/gce/miginstance_test.go
+++ b/upup/pkg/fi/cloudup/gce/miginstance_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+)
+
+func TestGetManagedInstanceStopsPaginationAfterMatch(t *testing.T) {
+	const (
+		project    = "test-project"
+		zone       = "test-zone"
+		mig        = "test-mig"
+		instanceID = uint64(1234567890)
+	)
+
+	var pageTokens []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pageToken := r.URL.Query().Get("pageToken")
+		pageTokens = append(pageTokens, pageToken)
+
+		var response *compute.InstanceGroupManagersListManagedInstancesResponse
+		switch pageToken {
+		case "":
+			response = &compute.InstanceGroupManagersListManagedInstancesResponse{
+				ManagedInstances: []*compute.ManagedInstance{{Id: 1}},
+				NextPageToken:    "second",
+			}
+		case "second":
+			response = &compute.InstanceGroupManagersListManagedInstancesResponse{
+				ManagedInstances: []*compute.ManagedInstance{{Id: instanceID}},
+				NextPageToken:    "third",
+			}
+		default:
+			http.Error(w, "unexpected page token "+pageToken, http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	computeService, err := compute.NewService(context.Background(), option.WithEndpoint(server.URL+"/"), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("building compute client: %v", err)
+	}
+
+	instance := &compute.Instance{
+		Id:   instanceID,
+		Zone: "https://www.googleapis.com/compute/v1/projects/" + project + "/zones/" + zone,
+	}
+	member, err := getManagedInstance(context.Background(), computeService, project, mig, instance)
+	if err != nil {
+		t.Fatalf("getting managed instance: %v", err)
+	}
+	if member.Id != instanceID {
+		t.Errorf("expected instance ID %d, got %d", instanceID, member.Id)
+	}
+
+	if len(pageTokens) != 2 || pageTokens[0] != "" || pageTokens[1] != "second" {
+		t.Errorf("expected requests for the first two pages, got page tokens %q", pageTokens)
+	}
+}

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/kops/pkg/nodeidentity/clusterapi/capimanager"
 	nodeidentitygce "k8s.io/kops/pkg/nodeidentity/gce"
 	"k8s.io/kops/pkg/wellknownports"
-	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce/gcemetadata"
 	gcetpm "k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm"
@@ -152,26 +151,7 @@ func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request,
 		return nil, fmt.Errorf("instance was in zone %q, expected region %q", instance.Zone, v.opt.Region)
 	}
 
-	clusterName := ""
-	instanceGroupName := ""
-	for _, item := range instance.Metadata.Items {
-		switch item.Key {
-		case nodeidentitygce.MetadataKeyInstanceGroupName:
-			instanceGroupName = fi.ValueOf(item.Value)
-		case gcemetadata.MetadataKeyClusterName:
-			clusterName = fi.ValueOf(item.Value)
-		}
-	}
-
 	capgRole := instance.Labels[nodeidentitygce.LabelKeyCAPIRoleName]
-
-	if clusterName == "" {
-		return nil, fmt.Errorf("could not determine cluster for instance %s", instance.SelfLink)
-	}
-
-	if clusterName != v.opt.ClusterName {
-		return nil, fmt.Errorf("clusterName does not match expected: got %q, want %q", clusterName, v.opt.ClusterName)
-	}
 
 	var capiMachine *clusterapi.Machine
 
@@ -186,9 +166,29 @@ func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request,
 		capiMachine = m
 	}
 
-	// Check if this is a CAPG managed instance
-	if instanceGroupName == "" && capiMachine == nil {
-		return nil, fmt.Errorf("could not determine ownership for instance %s", instance.SelfLink)
+	instanceGroupName := ""
+	if capiMachine == nil {
+		// The instance metadata is set by whoever created the instance, so we can't trust it for
+		// authorization decisions. Instead we verify that the instance is actually a member of a
+		// MIG, and read the cluster name and instance group name from the MIG's instance template,
+		// which requires GCE API access to change.
+		instanceTemplate, err := nodeidentitygce.GetInstanceTemplateForMIGMember(ctx, v.computeClient, v.opt.ProjectID, instance)
+		if err != nil {
+			return nil, err
+		}
+
+		clusterName := nodeidentitygce.GetMetadataValue(instanceTemplate.Properties.Metadata, gcemetadata.MetadataKeyClusterName)
+		if clusterName == "" {
+			return nil, fmt.Errorf("could not determine cluster for instance %s", instance.SelfLink)
+		}
+		if clusterName != v.opt.ClusterName {
+			return nil, fmt.Errorf("clusterName does not match expected: got %q, want %q", clusterName, v.opt.ClusterName)
+		}
+
+		instanceGroupName = nodeidentitygce.GetMetadataValue(instanceTemplate.Properties.Metadata, nodeidentitygce.MetadataKeyInstanceGroupName)
+		if instanceGroupName == "" {
+			return nil, fmt.Errorf("ig name not set on instance template %s", instanceTemplate.Name)
+		}
 	}
 
 	sans, err := GetInstanceCertificateAlternateNames(instance)

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
@@ -38,9 +38,10 @@ import (
 	"k8s.io/kops/pkg/bootstrap"
 	"k8s.io/kops/pkg/nodeidentity/clusterapi"
 	"k8s.io/kops/pkg/nodeidentity/clusterapi/capimanager"
-	"k8s.io/kops/pkg/nodeidentity/gce"
+	nodeidentitygce "k8s.io/kops/pkg/nodeidentity/gce"
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce/gcemetadata"
 	gcetpm "k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm"
 )
@@ -142,14 +143,14 @@ func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request,
 	instanceGroupName := ""
 	for _, item := range instance.Metadata.Items {
 		switch item.Key {
-		case gce.MetadataKeyInstanceGroupName:
+		case nodeidentitygce.MetadataKeyInstanceGroupName:
 			instanceGroupName = fi.ValueOf(item.Value)
 		case gcemetadata.MetadataKeyClusterName:
 			clusterName = fi.ValueOf(item.Value)
 		}
 	}
 
-	capgRole := instance.Labels[gce.LabelKeyCAPIRoleName]
+	capgRole := instance.Labels[nodeidentitygce.LabelKeyCAPIRoleName]
 
 	if clusterName == "" {
 		return nil, fmt.Errorf("could not determine cluster for instance %s", instance.SelfLink)
@@ -164,7 +165,8 @@ func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request,
 	if v.capiManager != nil && capgRole != "" {
 		providerID := "gce://" + tokenData.GCPProjectID + "/" + tokenData.Zone + "/" + tokenData.Instance
 
-		m, err := v.capiManager.FindMachineByProviderID(ctx, providerID)
+		// The CAPI cluster name is the kOps cluster name escaped for GCE
+		m, err := v.capiManager.FindMachineByProviderID(ctx, providerID, gce.SafeClusterName(v.opt.ClusterName))
 		if err != nil {
 			return nil, fmt.Errorf("error finding Machine with providerID %q: %w", providerID, err)
 		}

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
@@ -127,6 +127,19 @@ func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request,
 		return nil, fmt.Errorf("projectID does not match expected: got %q, want %q", tokenData.GCPProjectID, v.opt.ProjectID)
 	}
 
+	// Verify the token has a valid GCE TPM signature before making any other API calls.
+	{
+		// Note - we might be able to avoid this call by including the attestation certificate (signed by GCE) in the claim.
+		tpmSigningKey, err := v.getTPMSigningKey(ctx, &tokenData)
+		if err != nil {
+			return nil, err
+		}
+
+		if !verifySignature(tpmSigningKey, token.Data, token.Signature) {
+			return nil, fmt.Errorf("failed to verify claim signature for node")
+		}
+	}
+
 	instance, err := v.computeClient.Instances.Get(tokenData.GCPProjectID, tokenData.Zone, tokenData.Instance).Context(ctx).Do()
 	if err != nil {
 		if isNotFound(err) {
@@ -176,19 +189,6 @@ func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request,
 	// Check if this is a CAPG managed instance
 	if instanceGroupName == "" && capiMachine == nil {
 		return nil, fmt.Errorf("could not determine ownership for instance %s", instance.SelfLink)
-	}
-
-	// Verify the token has a valid GCE TPM signature.
-	{
-		// Note - we might be able to avoid this call by including the attestation certificate (signed by GCE) in the claim.
-		tpmSigningKey, err := v.getTPMSigningKey(ctx, &tokenData)
-		if err != nil {
-			return nil, err
-		}
-
-		if !verifySignature(tpmSigningKey, token.Data, token.Signature) {
-			return nil, fmt.Errorf("failed to verify claim signature for node: %w", err)
-		}
 	}
 
 	sans, err := GetInstanceCertificateAlternateNames(instance)

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
@@ -35,6 +35,8 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kops/pkg/bootstrap"
 	"k8s.io/kops/pkg/nodeidentity/clusterapi"
 	"k8s.io/kops/pkg/nodeidentity/clusterapi/capimanager"
@@ -159,7 +161,11 @@ func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request,
 		providerID := "gce://" + tokenData.GCPProjectID + "/" + tokenData.Zone + "/" + tokenData.Instance
 
 		// The CAPI cluster name is the kOps cluster name escaped for GCE
-		m, err := v.capiManager.FindMachineByProviderID(ctx, providerID, gce.SafeClusterName(v.opt.ClusterName))
+		capiCluster := types.NamespacedName{
+			Namespace: metav1.NamespaceSystem,
+			Name:      gce.SafeClusterName(v.opt.ClusterName),
+		}
+		m, err := v.capiManager.FindMachineByProviderID(ctx, providerID, capiCluster)
 		if err != nil {
 			return nil, fmt.Errorf("error finding Machine with providerID %q: %w", providerID, err)
 		}

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
@@ -147,7 +147,7 @@ func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request,
 		return nil, fmt.Errorf("error fetching instance from compute API: %w", err)
 	}
 
-	if !strings.HasPrefix(lastComponent(instance.Zone), v.opt.Region+"-") {
+	if !strings.HasPrefix(gce.LastComponent(instance.Zone), v.opt.Region+"-") {
 		return nil, fmt.Errorf("instance was in zone %q, expected region %q", instance.Zone, v.opt.Region)
 	}
 
@@ -168,16 +168,14 @@ func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request,
 
 	instanceGroupName := ""
 	if capiMachine == nil {
-		// The instance metadata is set by whoever created the instance, so we can't trust it for
-		// authorization decisions. Instead we verify that the instance is actually a member of a
-		// MIG, and read the cluster name and instance group name from the MIG's instance template,
-		// which requires GCE API access to change.
-		instanceTemplate, err := nodeidentitygce.GetInstanceTemplateForMIGMember(ctx, v.computeClient, v.opt.ProjectID, instance)
+		// Read the cluster name and instance group name from the MIG's instance template, which
+		// requires GCE API access to change, rather than from the untrusted instance metadata.
+		instanceTemplate, err := gce.GetInstanceTemplateForMIGMember(ctx, v.computeClient, v.opt.ProjectID, instance)
 		if err != nil {
 			return nil, err
 		}
 
-		clusterName := nodeidentitygce.GetMetadataValue(instanceTemplate.Properties.Metadata, gcemetadata.MetadataKeyClusterName)
+		clusterName := gce.GetMetadataValue(instanceTemplate.Properties.Metadata, gcemetadata.MetadataKeyClusterName)
 		if clusterName == "" {
 			return nil, fmt.Errorf("could not determine cluster for instance %s", instance.SelfLink)
 		}
@@ -185,7 +183,7 @@ func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request,
 			return nil, fmt.Errorf("clusterName does not match expected: got %q, want %q", clusterName, v.opt.ClusterName)
 		}
 
-		instanceGroupName = nodeidentitygce.GetMetadataValue(instanceTemplate.Properties.Metadata, nodeidentitygce.MetadataKeyInstanceGroupName)
+		instanceGroupName = gce.GetMetadataValue(instanceTemplate.Properties.Metadata, nodeidentitygce.MetadataKeyInstanceGroupName)
 		if instanceGroupName == "" {
 			return nil, fmt.Errorf("ig name not set on instance template %s", instanceTemplate.Name)
 		}
@@ -258,16 +256,6 @@ func GetInstanceCertificateAlternateNames(instance *compute.Instance) ([]string,
 func isNotFound(err error) bool {
 	gerr, ok := err.(*googleapi.Error)
 	return ok && gerr.Code == http.StatusNotFound
-}
-
-// lastComponent returns the last component of a URL, i.e. anything after the last slash
-// If there is no slash, returns the whole string
-func lastComponent(s string) string {
-	lastSlash := strings.LastIndex(s, "/")
-	if lastSlash != -1 {
-		s = s[lastSlash+1:]
-	}
-	return s
 }
 
 func verifySignature(signingKey *rsa.PublicKey, payload []byte, signature []byte) bool {

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier_test.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier_test.go
@@ -1,0 +1,433 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcetpmverifier
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/kops/pkg/nodeidentity/clusterapi/capimanager"
+	gcetpm "k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	testProject     = "testproject"
+	testZone        = "us-test1-a"
+	testRegion      = "us-test1"
+	testClusterName = "cluster.example.com"
+	testInstance    = "node1"
+	testInstanceID  = uint64(1234567890)
+	testMIG         = "nodes-us-test1-a"
+	testTemplate    = "nodes-us-test1-a-template"
+)
+
+// fakeComputeAPI serves the subset of the GCE compute API used by the TPM verifier.
+type fakeComputeAPI struct {
+	instance         *compute.Instance
+	signingKey       *rsa.PrivateKey
+	migExists        bool
+	managedInstances []*compute.ManagedInstance
+	instanceTemplate *compute.InstanceTemplate
+
+	// requests records the paths of all requests served
+	requests []string
+}
+
+func (f *fakeComputeAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.requests = append(f.requests, r.URL.Path)
+
+	var response any
+
+	switch r.URL.Path {
+	case "/projects/" + testProject + "/zones/" + testZone + "/instances/" + testInstance:
+		response = f.instance
+	case "/projects/" + testProject + "/zones/" + testZone + "/instances/" + testInstance + "/getShieldedInstanceIdentity":
+		der, err := x509.MarshalPKIXPublicKey(&f.signingKey.PublicKey)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		ekPub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+		response = &compute.ShieldedInstanceIdentity{
+			SigningKey: &compute.ShieldedInstanceIdentityEntry{
+				EkPub: string(ekPub),
+			},
+		}
+	case "/projects/" + testProject + "/zones/" + testZone + "/instanceGroupManagers/" + testMIG + "/listManagedInstances":
+		if !f.migExists {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		response = &compute.InstanceGroupManagersListManagedInstancesResponse{
+			ManagedInstances: f.managedInstances,
+		}
+	case "/projects/" + testProject + "/global/instanceTemplates/" + testTemplate:
+		response = f.instanceTemplate
+	default:
+		http.Error(w, "unexpected request "+r.URL.Path, http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// defaultFakeComputeAPI returns a fake where the instance is a genuine member of a kOps-managed
+// MIG whose instance template carries the expected metadata.
+func defaultFakeComputeAPI(t *testing.T) *fakeComputeAPI {
+	t.Helper()
+
+	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+
+	return &fakeComputeAPI{
+		signingKey: signingKey,
+		instance: &compute.Instance{
+			Name:     testInstance,
+			Id:       testInstanceID,
+			SelfLink: "https://www.googleapis.com/compute/v1/projects/" + testProject + "/zones/" + testZone + "/instances/" + testInstance,
+			Zone:     "https://www.googleapis.com/compute/v1/projects/" + testProject + "/zones/" + testZone,
+			Metadata: &compute.Metadata{
+				Items: []*compute.MetadataItems{
+					{Key: "created-by", Value: ptr.To("https://www.googleapis.com/compute/v1/projects/" + testProject + "/zones/" + testZone + "/instanceGroupManagers/" + testMIG)},
+					// Live instance metadata is settable by whoever created the instance; the
+					// verifier must not trust these values.
+					{Key: "cluster-name", Value: ptr.To("spoofed.example.com")},
+					{Key: "kops-k8s-io-instance-group-name", Value: ptr.To("spoofed-ig")},
+				},
+			},
+			NetworkInterfaces: []*compute.NetworkInterface{
+				{NetworkIP: "10.0.0.1"},
+			},
+		},
+		migExists: true,
+		managedInstances: []*compute.ManagedInstance{
+			{
+				Id: testInstanceID,
+				Version: &compute.ManagedInstanceVersion{
+					InstanceTemplate: "https://www.googleapis.com/compute/v1/projects/" + testProject + "/global/instanceTemplates/" + testTemplate,
+				},
+			},
+		},
+		instanceTemplate: &compute.InstanceTemplate{
+			Name: testTemplate,
+			Properties: &compute.InstanceProperties{
+				Metadata: &compute.Metadata{
+					Items: []*compute.MetadataItems{
+						{Key: "cluster-name", Value: ptr.To(testClusterName)},
+						{Key: "kops-k8s-io-instance-group-name", Value: ptr.To("nodes")},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAuthToken(t *testing.T, signingKey *rsa.PrivateKey, body []byte) string {
+	t.Helper()
+
+	requestHash := sha256.Sum256(body)
+	tokenData := gcetpm.AuthTokenData{
+		GCPProjectID: testProject,
+		Zone:         testZone,
+		Instance:     testInstance,
+		RequestHash:  requestHash[:],
+		Timestamp:    time.Now().Unix(),
+		Audience:     gcetpm.AudienceNodeAuthentication,
+	}
+	data, err := json.Marshal(&tokenData)
+	if err != nil {
+		t.Fatalf("marshalling token data: %v", err)
+	}
+
+	dataHash := sha256.Sum256(data)
+	signature, err := rsa.SignPKCS1v15(rand.Reader, signingKey, crypto.SHA256, dataHash[:])
+	if err != nil {
+		t.Fatalf("signing token data: %v", err)
+	}
+
+	token, err := json.Marshal(&gcetpm.AuthToken{
+		Signature: signature,
+		Data:      data,
+	})
+	if err != nil {
+		t.Fatalf("marshalling token: %v", err)
+	}
+
+	return gcetpm.GCETPMAuthenticationTokenPrefix + base64.StdEncoding.EncodeToString(token)
+}
+
+func newTestVerifier(t *testing.T, fake *fakeComputeAPI) *tpmVerifier {
+	t.Helper()
+
+	server := httptest.NewServer(fake)
+	t.Cleanup(server.Close)
+
+	computeClient, err := compute.NewService(context.Background(), option.WithEndpoint(server.URL+"/"), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("building compute client: %v", err)
+	}
+
+	return &tpmVerifier{
+		opt: gcetpm.TPMVerifierOptions{
+			ProjectID:   testProject,
+			Region:      testRegion,
+			ClusterName: testClusterName,
+			MaxTimeSkew: 300,
+		},
+		computeClient: computeClient,
+	}
+}
+
+func TestVerifyToken(t *testing.T) {
+	body := []byte("test-request-body")
+
+	tests := []struct {
+		name              string
+		setup             func(fake *fakeComputeAPI)
+		expectedError     string
+		expectedNodeName  string
+		expectedGroupName string
+	}{
+		{
+			name:              "valid MIG member",
+			setup:             func(fake *fakeComputeAPI) {},
+			expectedNodeName:  testInstance,
+			expectedGroupName: "nodes",
+		},
+		{
+			name: "instance not a member of the MIG",
+			setup: func(fake *fakeComputeAPI) {
+				// The instance spoofs created-by (and cluster-name) in its metadata, but the MIG
+				// does not actually manage it.
+				fake.managedInstances = nil
+			},
+			expectedError: "not managed by mig",
+		},
+		{
+			name: "instance without created-by metadata",
+			setup: func(fake *fakeComputeAPI) {
+				fake.instance.Metadata.Items = fake.instance.Metadata.Items[1:]
+			},
+			expectedError: "cannot find owner",
+		},
+		{
+			name: "created-by references MIG that does not exist",
+			setup: func(fake *fakeComputeAPI) {
+				fake.migExists = false
+			},
+			expectedError: "error fetching GCE managed instance group",
+		},
+		{
+			name: "instance template belongs to another cluster",
+			setup: func(fake *fakeComputeAPI) {
+				fake.instanceTemplate.Properties.Metadata.Items[0].Value = ptr.To("other.example.com")
+			},
+			expectedError: "clusterName does not match expected",
+		},
+		{
+			name: "instance template without cluster name",
+			setup: func(fake *fakeComputeAPI) {
+				fake.instanceTemplate.Properties.Metadata.Items = fake.instanceTemplate.Properties.Metadata.Items[1:]
+			},
+			expectedError: "could not determine cluster",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			fake := defaultFakeComputeAPI(t)
+			tc.setup(fake)
+			verifier := newTestVerifier(t, fake)
+
+			authToken := buildAuthToken(t, fake.signingKey, body)
+			request := httptest.NewRequest(http.MethodPost, "/bootstrap", nil)
+
+			result, err := verifier.VerifyToken(ctx, request, authToken, body)
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got result %+v", tc.expectedError, result)
+				}
+				if !strings.Contains(err.Error(), tc.expectedError) {
+					t.Fatalf("expected error containing %q, got %q", tc.expectedError, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.NodeName != tc.expectedNodeName {
+				t.Errorf("expected NodeName %q, got %q", tc.expectedNodeName, result.NodeName)
+			}
+			if result.InstanceGroupName != tc.expectedGroupName {
+				t.Errorf("expected InstanceGroupName %q, got %q", tc.expectedGroupName, result.InstanceGroupName)
+			}
+		})
+	}
+}
+
+func TestVerifyTokenRejectsBadSignature(t *testing.T) {
+	ctx := context.Background()
+	body := []byte("test-request-body")
+
+	fake := defaultFakeComputeAPI(t)
+	verifier := newTestVerifier(t, fake)
+
+	// Sign with a key that does not match the instance's TPM endorsement key.
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+	authToken := buildAuthToken(t, otherKey, body)
+	request := httptest.NewRequest(http.MethodPost, "/bootstrap", nil)
+
+	result, err := verifier.VerifyToken(ctx, request, authToken, body)
+	if err == nil {
+		t.Fatalf("expected signature verification error, got result %+v", result)
+	}
+	if !strings.Contains(err.Error(), "failed to verify claim signature") {
+		t.Fatalf("expected signature verification error, got %q", err.Error())
+	}
+
+	// Requests that fail signature verification must not trigger authorization lookups.
+	for _, path := range fake.requests {
+		if strings.Contains(path, "instanceGroupManagers") || strings.Contains(path, "instanceTemplates") {
+			t.Errorf("request with invalid signature reached authorization endpoint %s", path)
+		}
+	}
+}
+
+// fakeKubeClient implements the parts of client.Client used by capimanager.
+type fakeKubeClient struct {
+	client.Client
+	machines []unstructured.Unstructured
+}
+
+func (f *fakeKubeClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	ul, ok := list.(*unstructured.UnstructuredList)
+	if !ok {
+		return fmt.Errorf("unexpected list type %T", list)
+	}
+	ul.Items = f.machines
+	return nil
+}
+
+func capiMachineObject(providerID, clusterName string) unstructured.Unstructured {
+	return unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "cluster.x-k8s.io/v1beta1",
+		"kind":       "Machine",
+		"metadata": map[string]any{
+			"name":      "machine-1",
+			"namespace": "default",
+		},
+		"spec": map[string]any{
+			"providerID":  providerID,
+			"clusterName": clusterName,
+		},
+	}}
+}
+
+func TestVerifyTokenCAPI(t *testing.T) {
+	body := []byte("test-request-body")
+	providerID := "gce://" + testProject + "/" + testZone + "/" + testInstance
+
+	tests := []struct {
+		name               string
+		machineClusterName string
+		expectedError      string
+	}{
+		{
+			name: "machine in this cluster",
+			// The CAPI cluster name is the kOps cluster name escaped for GCE
+			machineClusterName: "cluster-example-com",
+		},
+		{
+			// A Machine from another cluster must not match; without a Machine the instance
+			// falls back to the MIG check, which fails as CAPI instances are not MIG members.
+			name:               "machine in another cluster",
+			machineClusterName: "other-example-com",
+			expectedError:      "cannot find owner",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			fake := defaultFakeComputeAPI(t)
+			fake.instance.Labels = map[string]string{"capg-role": "node"}
+			// CAPI instances are not members of a kOps MIG and have no created-by metadata.
+			fake.instance.Metadata.Items = nil
+			fake.migExists = false
+			fake.managedInstances = nil
+
+			verifier := newTestVerifier(t, fake)
+			verifier.capiManager = capimanager.NewManager(&fakeKubeClient{
+				machines: []unstructured.Unstructured{capiMachineObject(providerID, tc.machineClusterName)},
+			})
+
+			authToken := buildAuthToken(t, fake.signingKey, body)
+			request := httptest.NewRequest(http.MethodPost, "/bootstrap", nil)
+
+			result, err := verifier.VerifyToken(ctx, request, authToken, body)
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got result %+v", tc.expectedError, result)
+				}
+				if !strings.Contains(err.Error(), tc.expectedError) {
+					t.Fatalf("expected error containing %q, got %q", tc.expectedError, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.CAPIMachine == nil {
+				t.Error("expected CAPIMachine to be set")
+			}
+			if result.InstanceGroupName != "" {
+				t.Errorf("expected empty InstanceGroupName, got %q", result.InstanceGroupName)
+			}
+		})
+	}
+}

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier_test.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier_test.go
@@ -36,7 +36,10 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/kops/pkg/bootstrap"
 	"k8s.io/kops/pkg/nodeidentity/clusterapi/capimanager"
+	nodeidentitygce "k8s.io/kops/pkg/nodeidentity/gce"
+	"k8s.io/kops/upup/pkg/fi/cloudup/gce/gcemetadata"
 	gcetpm "k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -128,8 +131,8 @@ func defaultFakeComputeAPI(t *testing.T) *fakeComputeAPI {
 					{Key: "created-by", Value: ptr.To("https://www.googleapis.com/compute/v1/projects/" + testProject + "/zones/" + testZone + "/instanceGroupManagers/" + testMIG)},
 					// Live instance metadata is settable by whoever created the instance; the
 					// verifier must not trust these values.
-					{Key: "cluster-name", Value: ptr.To("spoofed.example.com")},
-					{Key: "kops-k8s-io-instance-group-name", Value: ptr.To("spoofed-ig")},
+					{Key: gcemetadata.MetadataKeyClusterName, Value: ptr.To("spoofed.example.com")},
+					{Key: nodeidentitygce.MetadataKeyInstanceGroupName, Value: ptr.To("spoofed-ig")},
 				},
 			},
 			NetworkInterfaces: []*compute.NetworkInterface{
@@ -150,8 +153,8 @@ func defaultFakeComputeAPI(t *testing.T) *fakeComputeAPI {
 			Properties: &compute.InstanceProperties{
 				Metadata: &compute.Metadata{
 					Items: []*compute.MetadataItems{
-						{Key: "cluster-name", Value: ptr.To(testClusterName)},
-						{Key: "kops-k8s-io-instance-group-name", Value: ptr.To("nodes")},
+						{Key: gcemetadata.MetadataKeyClusterName, Value: ptr.To(testClusterName)},
+						{Key: nodeidentitygce.MetadataKeyInstanceGroupName, Value: ptr.To("nodes")},
 					},
 				},
 			},
@@ -215,9 +218,33 @@ func newTestVerifier(t *testing.T, fake *fakeComputeAPI) *tpmVerifier {
 	}
 }
 
-func TestVerifyToken(t *testing.T) {
-	body := []byte("test-request-body")
+// runVerify builds a token signed with signingKey, calls VerifyToken, and checks the outcome
+// against expectedError. It returns the result on success, or nil when an error was expected.
+func runVerify(t *testing.T, verifier *tpmVerifier, signingKey *rsa.PrivateKey, expectedError string) *bootstrap.VerifyResult {
+	t.Helper()
 
+	body := []byte("test-request-body")
+	authToken := buildAuthToken(t, signingKey, body)
+	request := httptest.NewRequest(http.MethodPost, "/bootstrap", nil)
+
+	result, err := verifier.VerifyToken(context.Background(), request, authToken, body)
+	if expectedError != "" {
+		if err == nil {
+			t.Fatalf("expected error containing %q, got result %+v", expectedError, result)
+		}
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("expected error containing %q, got %q", expectedError, err.Error())
+		}
+		return nil
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return result
+}
+
+func TestVerifyToken(t *testing.T) {
 	tests := []struct {
 		name              string
 		setup             func(fake *fakeComputeAPI)
@@ -272,29 +299,15 @@ func TestVerifyToken(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-
 			fake := defaultFakeComputeAPI(t)
 			tc.setup(fake)
 			verifier := newTestVerifier(t, fake)
 
-			authToken := buildAuthToken(t, fake.signingKey, body)
-			request := httptest.NewRequest(http.MethodPost, "/bootstrap", nil)
-
-			result, err := verifier.VerifyToken(ctx, request, authToken, body)
-			if tc.expectedError != "" {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got result %+v", tc.expectedError, result)
-				}
-				if !strings.Contains(err.Error(), tc.expectedError) {
-					t.Fatalf("expected error containing %q, got %q", tc.expectedError, err.Error())
-				}
+			result := runVerify(t, verifier, fake.signingKey, tc.expectedError)
+			if result == nil {
 				return
 			}
 
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
 			if result.NodeName != tc.expectedNodeName {
 				t.Errorf("expected NodeName %q, got %q", tc.expectedNodeName, result.NodeName)
 			}
@@ -306,9 +319,6 @@ func TestVerifyToken(t *testing.T) {
 }
 
 func TestVerifyTokenRejectsBadSignature(t *testing.T) {
-	ctx := context.Background()
-	body := []byte("test-request-body")
-
 	fake := defaultFakeComputeAPI(t)
 	verifier := newTestVerifier(t, fake)
 
@@ -317,16 +327,8 @@ func TestVerifyTokenRejectsBadSignature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generating RSA key: %v", err)
 	}
-	authToken := buildAuthToken(t, otherKey, body)
-	request := httptest.NewRequest(http.MethodPost, "/bootstrap", nil)
 
-	result, err := verifier.VerifyToken(ctx, request, authToken, body)
-	if err == nil {
-		t.Fatalf("expected signature verification error, got result %+v", result)
-	}
-	if !strings.Contains(err.Error(), "failed to verify claim signature") {
-		t.Fatalf("expected signature verification error, got %q", err.Error())
-	}
+	runVerify(t, verifier, otherKey, "failed to verify claim signature")
 
 	// Requests that fail signature verification must not trigger authorization lookups.
 	for _, path := range fake.requests {
@@ -367,7 +369,6 @@ func capiMachineObject(providerID, clusterName string) unstructured.Unstructured
 }
 
 func TestVerifyTokenCAPI(t *testing.T) {
-	body := []byte("test-request-body")
 	providerID := "gce://" + testProject + "/" + testZone + "/" + testInstance
 
 	tests := []struct {
@@ -391,37 +392,21 @@ func TestVerifyTokenCAPI(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-
 			fake := defaultFakeComputeAPI(t)
-			fake.instance.Labels = map[string]string{"capg-role": "node"}
+			fake.instance.Labels = map[string]string{nodeidentitygce.LabelKeyCAPIRoleName: "node"}
 			// CAPI instances are not members of a kOps MIG and have no created-by metadata.
 			fake.instance.Metadata.Items = nil
-			fake.migExists = false
-			fake.managedInstances = nil
 
 			verifier := newTestVerifier(t, fake)
 			verifier.capiManager = capimanager.NewManager(&fakeKubeClient{
 				machines: []unstructured.Unstructured{capiMachineObject(providerID, tc.machineClusterName)},
 			})
 
-			authToken := buildAuthToken(t, fake.signingKey, body)
-			request := httptest.NewRequest(http.MethodPost, "/bootstrap", nil)
-
-			result, err := verifier.VerifyToken(ctx, request, authToken, body)
-			if tc.expectedError != "" {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got result %+v", tc.expectedError, result)
-				}
-				if !strings.Contains(err.Error(), tc.expectedError) {
-					t.Fatalf("expected error containing %q, got %q", tc.expectedError, err.Error())
-				}
+			result := runVerify(t, verifier, fake.signingKey, tc.expectedError)
+			if result == nil {
 				return
 			}
 
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
 			if result.CAPIMachine == nil {
 				t.Error("expected CAPIMachine to be set")
 			}

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier_test.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier_test.go
@@ -35,6 +35,7 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/kops/pkg/bootstrap"
 	"k8s.io/kops/pkg/nodeidentity/clusterapi/capimanager"
@@ -349,17 +350,22 @@ func (f *fakeKubeClient) List(ctx context.Context, list client.ObjectList, opts 
 	if !ok {
 		return fmt.Errorf("unexpected list type %T", list)
 	}
-	ul.Items = f.machines
+	listOptions := (&client.ListOptions{}).ApplyOptions(opts)
+	for _, machine := range f.machines {
+		if listOptions.Namespace == "" || machine.GetNamespace() == listOptions.Namespace {
+			ul.Items = append(ul.Items, machine)
+		}
+	}
 	return nil
 }
 
-func capiMachineObject(providerID, clusterName string) unstructured.Unstructured {
+func capiMachineObject(providerID, clusterName, namespace string) unstructured.Unstructured {
 	return unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "cluster.x-k8s.io/v1beta1",
 		"kind":       "Machine",
 		"metadata": map[string]any{
 			"name":      "machine-1",
-			"namespace": "default",
+			"namespace": namespace,
 		},
 		"spec": map[string]any{
 			"providerID":  providerID,
@@ -372,21 +378,39 @@ func TestVerifyTokenCAPI(t *testing.T) {
 	providerID := "gce://" + testProject + "/" + testZone + "/" + testInstance
 
 	tests := []struct {
-		name               string
-		machineClusterName string
-		expectedError      string
+		name          string
+		machines      []unstructured.Unstructured
+		expectedError string
 	}{
 		{
 			name: "machine in this cluster",
 			// The CAPI cluster name is the kOps cluster name escaped for GCE
-			machineClusterName: "cluster-example-com",
+			machines: []unstructured.Unstructured{
+				capiMachineObject(providerID, "cluster-example-com", metav1.NamespaceSystem),
+			},
 		},
 		{
 			// A Machine from another cluster must not match; without a Machine the instance
 			// falls back to the MIG check, which fails as CAPI instances are not MIG members.
-			name:               "machine in another cluster",
-			machineClusterName: "other-example-com",
-			expectedError:      "cannot find owner",
+			name: "machine in another cluster",
+			machines: []unstructured.Unstructured{
+				capiMachineObject(providerID, "other-example-com", metav1.NamespaceSystem),
+			},
+			expectedError: "cannot find owner",
+		},
+		{
+			name: "machine in another namespace",
+			machines: []unstructured.Unstructured{
+				capiMachineObject(providerID, "cluster-example-com", "other"),
+			},
+			expectedError: "cannot find owner",
+		},
+		{
+			name: "duplicate machine in another namespace",
+			machines: []unstructured.Unstructured{
+				capiMachineObject(providerID, "cluster-example-com", metav1.NamespaceSystem),
+				capiMachineObject(providerID, "cluster-example-com", "other"),
+			},
 		},
 	}
 
@@ -399,7 +423,7 @@ func TestVerifyTokenCAPI(t *testing.T) {
 
 			verifier := newTestVerifier(t, fake)
 			verifier.capiManager = capimanager.NewManager(&fakeKubeClient{
-				machines: []unstructured.Unstructured{capiMachineObject(providerID, tc.machineClusterName)},
+				machines: tc.machines,
 			})
 
 			result := runVerify(t, verifier, fake.signingKey, tc.expectedError)


### PR DESCRIPTION
The GCE TPM verifier read `cluster-name` and `kops-k8s-io-instance-group-name` from live instance metadata, which is set by whoever creates the VM. The TPM signature only proves control of some Shielded VM in the project, so anyone with `compute.instances.create` could bootstrap a rogue node into the cluster.

Do what the node identifier in `pkg/nodeidentity/gce` already does: confirm the instance is actually managed by the MIG named in its `created-by` metadata and read the cluster name and instance group name from the MIG's instance template, which cannot be changed without GCE API access. The logic is extracted into a shared helper used by both.

Also: CAPI Machines are now matched only from the given cluster, the TPM signature is checked before any other API calls, and a redundant `InstanceGroupManagers.Get` call is dropped. No new IAM permissions; kops-controller already makes these calls when identifying nodes.

/cc @rifelpet @justinsb 