### PR TITLE
Install CNI plugins bundle for chained Cilium

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -1002,9 +1002,14 @@ func (c *Cluster) UsesLoadBalancerForKopsController() bool {
 }
 
 func (c *Cluster) InstallCNIAssets() bool {
+	if c.Spec.Networking.Cilium != nil {
+		// Chained modes other than "none" hand hostPort/etc. handling to another
+		// CNI plugin (e.g. portmap), which must come from the standard CNI plugins bundle.
+		chainingMode := c.Spec.Networking.Cilium.ChainingMode
+		return chainingMode != "" && chainingMode != "none"
+	}
 	return c.Spec.Networking.AmazonVPC == nil &&
-		c.Spec.Networking.Calico == nil &&
-		c.Spec.Networking.Cilium == nil
+		c.Spec.Networking.Calico == nil
 }
 
 func (c *Cluster) HasImageVolumesSupport() bool {

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -1003,10 +1003,9 @@ func (c *Cluster) UsesLoadBalancerForKopsController() bool {
 
 func (c *Cluster) InstallCNIAssets() bool {
 	if c.Spec.Networking.Cilium != nil {
-		// Chained modes other than "none" hand hostPort/etc. handling to another
-		// CNI plugin (e.g. portmap), which must come from the standard CNI plugins bundle.
-		chainingMode := c.Spec.Networking.Cilium.ChainingMode
-		return chainingMode != "" && chainingMode != "none"
+		// In portmap chaining mode, Cilium delegates hostPort handling to the
+		// portmap plugin, which comes from the standard CNI plugins bundle.
+		return c.Spec.Networking.Cilium.ChainingMode == "portmap"
 	}
 	return c.Spec.Networking.AmazonVPC == nil &&
 		c.Spec.Networking.Calico == nil

--- a/pkg/apis/kops/cluster_test.go
+++ b/pkg/apis/kops/cluster_test.go
@@ -204,3 +204,50 @@ func assertResolvesValue(t *testing.T, name string, expected interface{}, warmPo
 		return assert.Equal(t, expected, value.Interface(), msg)
 	}
 }
+
+func TestCluster_InstallCNIAssets(t *testing.T) {
+	tests := []struct {
+		name       string
+		networking NetworkingSpec
+		expected   bool
+	}{
+		{
+			name:       "no networking configured",
+			networking: NetworkingSpec{},
+			expected:   true,
+		},
+		{
+			name:       "amazon vpc",
+			networking: NetworkingSpec{AmazonVPC: &AmazonVPCNetworkingSpec{}},
+			expected:   false,
+		},
+		{
+			name:       "calico",
+			networking: NetworkingSpec{Calico: &CalicoNetworkingSpec{}},
+			expected:   false,
+		},
+		{
+			name:       "cilium without chaining",
+			networking: NetworkingSpec{Cilium: &CiliumNetworkingSpec{}},
+			expected:   false,
+		},
+		{
+			name:       "cilium with chaining mode none",
+			networking: NetworkingSpec{Cilium: &CiliumNetworkingSpec{ChainingMode: "none"}},
+			expected:   false,
+		},
+		{
+			name:       "cilium with portmap chaining",
+			networking: NetworkingSpec{Cilium: &CiliumNetworkingSpec{ChainingMode: "portmap"}},
+			expected:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Cluster{Spec: ClusterSpec{Networking: tc.networking}}
+			if actual := c.InstallCNIAssets(); actual != tc.expected {
+				t.Errorf("InstallCNIAssets() = %v, want %v", actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why?

Setting `spec.networking.cilium.chainingMode: "portmap"` breaks pod sandbox creation entirely: kubelet fails with `failed to find plugin "portmap" in path [/opt/cni/bin]`. Cilium's ConfigMap correctly tells the agent to chain to the portmap plugin (for HostPort support), but nothing ever installs that binary onto the node — `Cluster.InstallCNIAssets()` treated any Cilium configuration as not needing the standard CNI plugins bundle, without checking whether chaining is actually in use.

## What?

`InstallCNIAssets()` now installs the standard CNI plugins bundle (bridge, host-local, loopback, portmap, etc.) whenever Cilium's `ChainingMode` is set to anything other than `""`/`"none"`. The default, non-chained Cilium setup is unaffected — Cilium remains self-contained there.

## How?

- `pkg/apis/kops/cluster.go`: `InstallCNIAssets()` special-cases Cilium and checks `ChainingMode` instead of just nil-checking `Cilium`.
- `pkg/apis/kops/cluster_test.go`: added `TestCluster_InstallCNIAssets` covering AmazonVPC, Calico, and Cilium with no/`none`/`portmap` chaining modes.
