### PR TITLE
hack: parallelize GitHub release promotion and add checksum validation

### DIFF
--- a/hack/promote-to-github.sh
+++ b/hack/promote-to-github.sh
@@ -27,6 +27,13 @@ set -o pipefail
 REPO="kubernetes/kops"
 BASE_URL="https://artifacts.k8s.io/binaries/kops"
 
+# Concurrent transfers, overridable via environment. Per-connection throughput to both the
+# artifacts CDN and GitHub is throttled well below typical link speed, so parallelism is what
+# drives wall-clock time; 10 covers all large binaries in one wave, and 4 upload streams saturate
+# a ~400 Mbit/s uplink.
+DOWNLOAD_PARALLELISM="${DOWNLOAD_PARALLELISM:-10}"
+UPLOAD_PARALLELISM="${UPLOAD_PARALLELISM:-4}"
+
 # Binaries to upload: source-path -> github-name
 declare -A BINARIES=(
   ["darwin/amd64/kops"]="kops-darwin-amd64"
@@ -66,25 +73,49 @@ if ! command -v gh &>/dev/null; then
 fi
 
 WORKDIR=$(mktemp -d)
-trap 'rm -rf "${WORKDIR}"' EXIT
+# Keep the checksum manifest outside WORKDIR so it is not uploaded with the assets.
+CHECKSUMS=$(mktemp)
+trap 'rm -rf "${WORKDIR}" "${CHECKSUMS}"' EXIT
 
 echo "Downloading binaries from ${BASE_URL}/${VERSION}/ ..."
 
+curl_args=(-fsSL --retry 3 --parallel --parallel-max "${DOWNLOAD_PARALLELISM}")
 for source in "${!BINARIES[@]}"; do
   github_name="${BINARIES[$source]}"
-  dest="${WORKDIR}/${github_name}"
-  url="${BASE_URL}/${VERSION}/${source}"
-
   echo "  ${source} -> ${github_name}"
-  if ! curl -fsSL --retry 3 -o "${dest}" "${url}"; then
-    echo "Error: failed to download ${url}" >&2
-    exit 1
-  fi
+  curl_args+=(-o "${WORKDIR}/${github_name}" "${BASE_URL}/${VERSION}/${source}")
 done
+
+if ! curl "${curl_args[@]}"; then
+  echo "Error: failed to download binaries from ${BASE_URL}/${VERSION}/" >&2
+  exit 1
+fi
+
+echo "Verifying checksums ..."
+
+if command -v sha256sum &>/dev/null; then
+  SHA256SUM=(sha256sum)
+else
+  SHA256SUM=(shasum -a 256)
+fi
+
+# The downloaded .sha256 files contain a bare hash, so build a "<hash>  <file>" manifest that the
+# tool's check mode can verify in one pass. Pass it as a file argument: BSD sha256sum does not
+# read the manifest from stdin.
+for checksum_file in "${WORKDIR}"/*.sha256; do
+  read -r hash _ <"${checksum_file}"
+  echo "${hash}  $(basename "${checksum_file%.sha256}")"
+done >"${CHECKSUMS}"
+
+if ! (cd "${WORKDIR}" && "${SHA256SUM[@]}" -c "${CHECKSUMS}"); then
+  echo "Error: checksum verification failed" >&2
+  exit 1
+fi
 
 echo "Uploading binaries to GitHub release ${TAG} ..."
 
-if ! gh release upload "${TAG}" --repo "${REPO}" "${WORKDIR}"/*; then
+# Upload assets in parallel; --clobber makes reruns after a partial failure succeed.
+if ! printf '%s\0' "${WORKDIR}"/* | xargs -0 -n 1 -P "${UPLOAD_PARALLELISM}" gh release upload "${TAG}" --repo "${REPO}" --clobber; then
   echo "Error: failed to upload binaries to GitHub release ${TAG}" >&2
   exit 1
 fi

--- a/hack/promote-to-github.sh
+++ b/hack/promote-to-github.sh
@@ -24,8 +24,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO="kubernetes/kops"
-BASE_URL="https://artifacts.k8s.io/binaries/kops"
+# shellcheck source=hack/release-assets.sh
+. "$(dirname "${BASH_SOURCE[0]}")/release-assets.sh"
 
 # Concurrent transfers, overridable via environment. Per-connection throughput to both the
 # artifacts CDN and GitHub is throttled well below typical link speed, so parallelism is what
@@ -33,28 +33,6 @@ BASE_URL="https://artifacts.k8s.io/binaries/kops"
 # a ~400 Mbit/s uplink.
 DOWNLOAD_PARALLELISM="${DOWNLOAD_PARALLELISM:-10}"
 UPLOAD_PARALLELISM="${UPLOAD_PARALLELISM:-4}"
-
-# Binaries to upload: source-path -> github-name
-declare -A BINARIES=(
-  ["darwin/amd64/kops"]="kops-darwin-amd64"
-  ["darwin/amd64/kops.sha256"]="kops-darwin-amd64.sha256"
-  ["darwin/arm64/kops"]="kops-darwin-arm64"
-  ["darwin/arm64/kops.sha256"]="kops-darwin-arm64.sha256"
-  ["linux/amd64/kops"]="kops-linux-amd64"
-  ["linux/amd64/kops.sha256"]="kops-linux-amd64.sha256"
-  ["linux/arm64/kops"]="kops-linux-arm64"
-  ["linux/arm64/kops.sha256"]="kops-linux-arm64.sha256"
-  ["windows/amd64/kops.exe"]="kops-windows-amd64"
-  ["windows/amd64/kops.exe.sha256"]="kops-windows-amd64.sha256"
-  ["linux/amd64/nodeup"]="nodeup-linux-amd64"
-  ["linux/amd64/nodeup.sha256"]="nodeup-linux-amd64.sha256"
-  ["linux/arm64/nodeup"]="nodeup-linux-arm64"
-  ["linux/arm64/nodeup.sha256"]="nodeup-linux-arm64.sha256"
-  ["linux/amd64/protokube"]="protokube-linux-amd64"
-  ["linux/amd64/protokube.sha256"]="protokube-linux-amd64.sha256"
-  ["linux/arm64/protokube"]="protokube-linux-arm64"
-  ["linux/arm64/protokube.sha256"]="protokube-linux-arm64.sha256"
-)
 
 if [[ $# -ne 1 ]]; then
   echo "Usage: $0 <version>" >&2
@@ -73,9 +51,7 @@ if ! command -v gh &>/dev/null; then
 fi
 
 WORKDIR=$(mktemp -d)
-# Keep the checksum manifest outside WORKDIR so it is not uploaded with the assets.
-CHECKSUMS=$(mktemp)
-trap 'rm -rf "${WORKDIR}" "${CHECKSUMS}"' EXIT
+trap 'rm -rf "${WORKDIR}"' EXIT
 
 echo "Downloading binaries from ${BASE_URL}/${VERSION}/ ..."
 
@@ -84,6 +60,7 @@ for source in "${!BINARIES[@]}"; do
   github_name="${BINARIES[$source]}"
   echo "  ${source} -> ${github_name}"
   curl_args+=(-o "${WORKDIR}/${github_name}" "${BASE_URL}/${VERSION}/${source}")
+  curl_args+=(-o "${WORKDIR}/${github_name}.sha256" "${BASE_URL}/${VERSION}/${source}.sha256")
 done
 
 if ! curl "${curl_args[@]}"; then
@@ -93,24 +70,21 @@ fi
 
 echo "Verifying checksums ..."
 
-if command -v sha256sum &>/dev/null; then
-  SHA256SUM=(sha256sum)
-else
-  SHA256SUM=(shasum -a 256)
-fi
-
 # The downloaded .sha256 files contain a bare hash, so build a "<hash>  <file>" manifest that the
-# tool's check mode can verify in one pass. Pass it as a file argument: BSD sha256sum does not
-# read the manifest from stdin.
+# tool's check mode can verify in one pass.
 for checksum_file in "${WORKDIR}"/*.sha256; do
   read -r hash _ <"${checksum_file}"
-  echo "${hash}  $(basename "${checksum_file%.sha256}")"
-done >"${CHECKSUMS}"
+  github_name="${checksum_file##*/}"
+  echo "${hash}  ${github_name%.sha256}"
+done >"${WORKDIR}/SHA256SUMS"
 
-if ! (cd "${WORKDIR}" && "${SHA256SUM[@]}" -c "${CHECKSUMS}"); then
+if ! (cd "${WORKDIR}" && "${SHA256SUM[@]}" -c SHA256SUMS); then
   echo "Error: checksum verification failed" >&2
   exit 1
 fi
+
+# Remove the manifest so it is not uploaded with the assets.
+rm "${WORKDIR}/SHA256SUMS"
 
 echo "Uploading binaries to GitHub release ${TAG} ..."
 

--- a/hack/release-assets.sh
+++ b/hack/release-assets.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared definitions for the release scripts that publish and validate GitHub release assets.
+# Sourced by promote-to-github.sh and validate-github-release.sh.
+# shellcheck disable=SC2034  # the variables are consumed by the sourcing scripts
+
+REPO="kubernetes/kops"
+BASE_URL="https://artifacts.k8s.io/binaries/kops"
+
+# Binaries published as GitHub release assets: source-path -> github-name.
+# Each binary is accompanied by a .sha256 asset, which the scripts derive from this table.
+# The upstream .sha256 files contain a bare hash followed by a newline.
+declare -A BINARIES=(
+  ["darwin/amd64/kops"]="kops-darwin-amd64"
+  ["darwin/arm64/kops"]="kops-darwin-arm64"
+  ["linux/amd64/kops"]="kops-linux-amd64"
+  ["linux/arm64/kops"]="kops-linux-arm64"
+  ["windows/amd64/kops.exe"]="kops-windows-amd64"
+  ["linux/amd64/nodeup"]="nodeup-linux-amd64"
+  ["linux/arm64/nodeup"]="nodeup-linux-arm64"
+  ["linux/amd64/protokube"]="protokube-linux-amd64"
+  ["linux/arm64/protokube"]="protokube-linux-arm64"
+)
+
+if command -v sha256sum &>/dev/null; then
+  SHA256SUM=(sha256sum)
+else
+  SHA256SUM=(shasum -a 256)
+fi

--- a/hack/validate-github-release.sh
+++ b/hack/validate-github-release.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validates that the assets attached to a GitHub release match the canonical .sha256 checksums
+# published on artifacts.k8s.io, using the SHA-256 digests that the GitHub API reports for each
+# asset (no binaries are downloaded).
+#
+# Usage: validate-github-release.sh <version>
+#   e.g. validate-github-release.sh 1.30.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO="kubernetes/kops"
+BASE_URL="https://artifacts.k8s.io/binaries/kops"
+
+# Binaries to validate: source-path -> github-name.
+# Each binary is checked together with its .sha256 companion asset.
+declare -A BINARIES=(
+  ["darwin/amd64/kops"]="kops-darwin-amd64"
+  ["darwin/arm64/kops"]="kops-darwin-arm64"
+  ["linux/amd64/kops"]="kops-linux-amd64"
+  ["linux/arm64/kops"]="kops-linux-arm64"
+  ["windows/amd64/kops.exe"]="kops-windows-amd64"
+  ["linux/amd64/nodeup"]="nodeup-linux-amd64"
+  ["linux/arm64/nodeup"]="nodeup-linux-arm64"
+  ["linux/amd64/protokube"]="protokube-linux-amd64"
+  ["linux/arm64/protokube"]="protokube-linux-arm64"
+)
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>" >&2
+  echo "  e.g. $0 1.30.0" >&2
+  exit 1
+fi
+
+VERSION="$1"
+# Strip leading 'v' if provided
+VERSION="${VERSION#v}"
+TAG="v${VERSION}"
+
+if ! command -v gh &>/dev/null; then
+  echo "Error: gh (GitHub CLI) is required but not found in PATH" >&2
+  exit 1
+fi
+
+if command -v sha256sum &>/dev/null; then
+  SHA256SUM=(sha256sum)
+else
+  SHA256SUM=(shasum -a 256)
+fi
+
+echo "Fetching asset digests for GitHub release ${TAG} ..."
+
+# The by-tag endpoint does not serve draft releases, so search the release list instead.
+assets=$(gh api --paginate "repos/${REPO}/releases?per_page=100" \
+  --jq ".[] | select(.tag_name == \"${TAG}\") | .assets[] | \"\(.name) \(.digest)\"")
+
+if [[ -z "${assets}" ]]; then
+  echo "Error: GitHub release ${TAG} not found or has no assets" >&2
+  exit 1
+fi
+
+failed=0
+
+# check <asset-name> <expected-sha256>: compare against the digest GitHub reports for the asset
+check() {
+  local actual
+  actual=$(awk -v name="$1" '$1 == name {print $2}' <<<"${assets}")
+  if [[ -z "${actual}" ]]; then
+    echo "$1: MISSING from GitHub release"
+    failed=1
+  elif [[ "${actual}" != "sha256:$2" ]]; then
+    echo "$1: FAILED (expected sha256:$2, got ${actual})"
+    failed=1
+  else
+    echo "$1: OK"
+  fi
+}
+
+for source in $(printf '%s\n' "${!BINARIES[@]}" | sort); do
+  url="${BASE_URL}/${VERSION}/${source}.sha256"
+  check "${BINARIES[$source]}" "$(curl -fsSL --retry 3 "${url}")"
+  # The .sha256 asset itself must be byte-identical to the artifacts.k8s.io file.
+  check "${BINARIES[$source]}.sha256" "$(curl -fsSL --retry 3 "${url}" | "${SHA256SUM[@]}" | cut -d' ' -f1)"
+done
+
+# Anything else attached to the release was not published by promote-to-github.sh.
+expected=$(for name in "${BINARIES[@]}"; do printf '%s\n%s.sha256\n' "${name}" "${name}"; done | sort)
+while read -r name; do
+  echo "${name}: UNEXPECTED asset on GitHub release"
+  failed=1
+done < <(comm -23 <(awk '{print $1}' <<<"${assets}" | sort) <(echo "${expected}"))
+
+if [[ "${failed}" -ne 0 ]]; then
+  echo "Error: GitHub release ${TAG} does not match artifacts.k8s.io" >&2
+  exit 1
+fi
+
+echo "GitHub release ${TAG} matches artifacts.k8s.io"

--- a/hack/validate-github-release.sh
+++ b/hack/validate-github-release.sh
@@ -25,22 +25,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO="kubernetes/kops"
-BASE_URL="https://artifacts.k8s.io/binaries/kops"
-
-# Binaries to validate: source-path -> github-name.
-# Each binary is checked together with its .sha256 companion asset.
-declare -A BINARIES=(
-  ["darwin/amd64/kops"]="kops-darwin-amd64"
-  ["darwin/arm64/kops"]="kops-darwin-arm64"
-  ["linux/amd64/kops"]="kops-linux-amd64"
-  ["linux/arm64/kops"]="kops-linux-arm64"
-  ["windows/amd64/kops.exe"]="kops-windows-amd64"
-  ["linux/amd64/nodeup"]="nodeup-linux-amd64"
-  ["linux/arm64/nodeup"]="nodeup-linux-arm64"
-  ["linux/amd64/protokube"]="protokube-linux-amd64"
-  ["linux/arm64/protokube"]="protokube-linux-arm64"
-)
+# shellcheck source=hack/release-assets.sh
+. "$(dirname "${BASH_SOURCE[0]}")/release-assets.sh"
 
 if [[ $# -ne 1 ]]; then
   echo "Usage: $0 <version>" >&2
@@ -58,12 +44,6 @@ if ! command -v gh &>/dev/null; then
   exit 1
 fi
 
-if command -v sha256sum &>/dev/null; then
-  SHA256SUM=(sha256sum)
-else
-  SHA256SUM=(shasum -a 256)
-fi
-
 echo "Fetching asset digests for GitHub release ${TAG} ..."
 
 # The by-tag endpoint does not serve draft releases, so search the release list instead.
@@ -75,12 +55,16 @@ if [[ -z "${assets}" ]]; then
   exit 1
 fi
 
+declare -A DIGESTS=()
+while read -r name digest; do
+  DIGESTS[$name]="${digest}"
+done <<<"${assets}"
+
 failed=0
 
 # check <asset-name> <expected-sha256>: compare against the digest GitHub reports for the asset
 check() {
-  local actual
-  actual=$(awk -v name="$1" '$1 == name {print $2}' <<<"${assets}")
+  local actual="${DIGESTS[$1]:-}"
   if [[ -z "${actual}" ]]; then
     echo "$1: MISSING from GitHub release"
     failed=1
@@ -93,18 +77,26 @@ check() {
 }
 
 for source in $(printf '%s\n' "${!BINARIES[@]}" | sort); do
-  url="${BASE_URL}/${VERSION}/${source}.sha256"
-  check "${BINARIES[$source]}" "$(curl -fsSL --retry 3 "${url}")"
-  # The .sha256 asset itself must be byte-identical to the artifacts.k8s.io file.
-  check "${BINARIES[$source]}.sha256" "$(curl -fsSL --retry 3 "${url}" | "${SHA256SUM[@]}" | cut -d' ' -f1)"
+  hash=$(curl -fsSL --retry 3 "${BASE_URL}/${VERSION}/${source}.sha256")
+  check "${BINARIES[$source]}" "${hash}"
+  # The .sha256 asset must be byte-identical to the artifacts.k8s.io file, which is the bare hash
+  # followed by a newline; reconstruct those bytes to compute its expected digest.
+  check "${BINARIES[$source]}.sha256" "$(printf '%s\n' "${hash}" | "${SHA256SUM[@]}" | cut -d' ' -f1)"
 done
 
 # Anything else attached to the release was not published by promote-to-github.sh.
-expected=$(for name in "${BINARIES[@]}"; do printf '%s\n%s.sha256\n' "${name}" "${name}"; done | sort)
-while read -r name; do
-  echo "${name}: UNEXPECTED asset on GitHub release"
-  failed=1
-done < <(comm -23 <(awk '{print $1}' <<<"${assets}" | sort) <(echo "${expected}"))
+declare -A EXPECTED=()
+for github_name in "${BINARIES[@]}"; do
+  EXPECTED[$github_name]=1
+  EXPECTED[$github_name.sha256]=1
+done
+
+for name in $(printf '%s\n' "${!DIGESTS[@]}" | sort); do
+  if [[ -z "${EXPECTED[$name]:-}" ]]; then
+    echo "${name}: UNEXPECTED asset on GitHub release"
+    failed=1
+  fi
+done
 
 if [[ "${failed}" -ne 0 ]]; then
   echo "Error: GitHub release ${TAG} does not match artifacts.k8s.io" >&2


### PR DESCRIPTION
Speeds up the release promotion to GitHub and adds a script that validates published releases.

**hack/promote-to-github.sh**
- Download all artifacts with a single parallel curl invocation instead of one file at a time.
- Verify each binary against its .sha256 file before uploading.
- Upload assets in parallel, one `gh release upload --clobber` per file, so reruns after a partial failure are idempotent.
- Parallelism defaults were tuned on real releases and can be overridden via `DOWNLOAD_PARALLELISM` / `UPLOAD_PARALLELISM`. Promoting a release now takes about 90 seconds end to end on a 400 Mbit/s link, previously bounded by serial transfers.

**hack/validate-github-release.sh** (new)
- Validates that the assets attached to a GitHub release match the canonical .sha256 checksums on artifacts.k8s.io, using the SHA-256 digests the GitHub API reports for each asset, so no binaries are downloaded. A full release validates in a few seconds.
- Flags mismatched, missing and unexpected assets, and works on draft releases.

**hack/release-assets.sh** (new)
- Shared definitions sourced by both scripts: the published asset table and the sha256 tool selection. Adding a platform is a one line change in one file.

Used for the 1.35.2, 1.36.0 and 1.37.0-alpha.1 releases; all three validate clean.

/cc @rifelpet @ameukam