### PR TITLE
Make control plane split by role work.

### DIFF
--- a/channels/pkg/cmd/apply_channel.go
+++ b/channels/pkg/cmd/apply_channel.go
@@ -48,7 +48,7 @@ type ApplyChannelOptions struct {
 	Interval time.Duration
 	NodeName string
 
-	// Comma delimited label,value pairs to add to the node. Eg "kops.k8s.io/cloud-controller-manager,foo=bar"
+	// Comma delimited label,value pairs to add to the node. Eg "node-role.kops.k8s.io/cloud-controller-manager,foo=bar"
 	NodeLabels map[string]string
 }
 

--- a/cmd/kops-controller/controllers/node_controller.go
+++ b/cmd/kops-controller/controllers/node_controller.go
@@ -104,7 +104,12 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	for k := range node.Labels {
 		// If it is one of our managed labels, "prune" values we don't want to be there
 		switch k {
-		case nodelabels.RoleLabelAPIServer16, nodelabels.RoleLabelNode16, nodelabels.RoleLabelControlPlane20:
+		case nodelabels.RoleLabelAPIServer16,
+			nodelabels.RoleLabelEtcd,
+			nodelabels.RoleLabelScheduler,
+			nodelabels.RoleLabelKubeControllerManager,
+			nodelabels.RoleLabelNode16,
+			nodelabels.RoleLabelControlPlane20:
 			if _, found := labels[k]; !found {
 				deleteLabels[k] = struct{}{}
 			}

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -193,6 +193,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	sshPublicKey := ""
 	associatePublicIP := false
 	encryptEtcdStorage := false
+	var controlPlaneCount int32
 
 	cmd := &cobra.Command{
 		Use:               "cluster [CLUSTER]",
@@ -210,6 +211,10 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 			if cmd.Flag("encrypt-etcd-storage").Changed {
 				options.EncryptEtcdStorage = &encryptEtcdStorage
+			}
+
+			if cmd.Flag("control-plane-count").Changed || cmd.Flag("master-count").Changed {
+				options.ControlPlaneCount = &controlPlaneCount
 			}
 
 			if err := checkProjectFlag(cmd.Flag("project").Changed, options.Project); err != nil {
@@ -295,9 +300,9 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		return []string{"pub"}, cobra.ShellCompDirectiveFilterFileExt
 	})
 
-	cmd.Flags().Int32Var(&options.ControlPlaneCount, "master-count", options.ControlPlaneCount, "Number of control-plane nodes. Defaults to one control-plane node per control-plane-zone")
+	cmd.Flags().Int32Var(&controlPlaneCount, "master-count", controlPlaneCount, "Number of control-plane nodes. Defaults to one control-plane node per control-plane-zone")
 	cmd.Flags().MarkDeprecated("master-count", "use --control-plane-count instead")
-	cmd.Flags().Int32Var(&options.ControlPlaneCount, "control-plane-count", options.ControlPlaneCount, "Number of control-plane nodes. Defaults to one control-plane node per control-plane-zone")
+	cmd.Flags().Int32Var(&controlPlaneCount, "control-plane-count", controlPlaneCount, "Number of control-plane nodes. Defaults to one control-plane node per control-plane-zone")
 	cmd.Flags().Int32Var(&options.NodeCount, "node-count", options.NodeCount, "Total number of worker nodes. Defaults to one node per zone")
 	if featureflag.APIServerNodes.Enabled() {
 		cmd.Flags().Int32Var(&options.APIServerCount, "api-server-count", options.APIServerCount, "Number of API server nodes. Defaults to 0.")

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -362,3 +362,10 @@ func runCreateClusterIntegrationTest(t *testing.T, srcDir string, version string
 	actualYAML := strings.Join(yamlAll, "\n\n---\n\n")
 	golden.AssertMatchesFile(t, actualYAML, path.Join(srcDir, expectedClusterPath))
 }
+
+// TestCreateClusterExperimentalRoles tests kops create cluster with ExperimentalRoles and control-plane-count=0
+func TestCreateClusterExperimentalRoles(t *testing.T) {
+	featureflag.ParseFlags("+APIServerNodes,+ExperimentalRoles")
+	defer featureflag.ParseFlags("-APIServerNodes,-ExperimentalRoles")
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/experimental-roles", "v1alpha2")
+}

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -362,10 +362,3 @@ func runCreateClusterIntegrationTest(t *testing.T, srcDir string, version string
 	actualYAML := strings.Join(yamlAll, "\n\n---\n\n")
 	golden.AssertMatchesFile(t, actualYAML, path.Join(srcDir, expectedClusterPath))
 }
-
-// TestCreateClusterExperimentalRoles tests kops create cluster with ExperimentalRoles and control-plane-count=0
-func TestCreateClusterExperimentalRoles(t *testing.T) {
-	featureflag.ParseFlags("+APIServerNodes,+ExperimentalRoles")
-	defer featureflag.ParseFlags("-APIServerNodes,-ExperimentalRoles")
-	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/experimental-roles", "v1alpha2")
-}

--- a/nodeup/pkg/model/bootstrap_client.go
+++ b/nodeup/pkg/model/bootstrap_client.go
@@ -45,7 +45,7 @@ type BootstrapClientBuilder struct {
 }
 
 func (b BootstrapClientBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	if b.IsMaster {
+	if b.IsMaster || b.BootConfig.InstanceGroupRole.IsControlPlaneType() {
 		return nil
 	}
 

--- a/nodeup/pkg/model/channels.go
+++ b/nodeup/pkg/model/channels.go
@@ -46,7 +46,7 @@ type ChannelsBuilder struct {
 var _ fi.NodeupModelBuilder = &ChannelsBuilder{}
 
 func (b *ChannelsBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	if !b.IsMaster {
+	if !b.IsMaster && !b.HasAPIServer {
 		return nil
 	}
 

--- a/nodeup/pkg/model/channels.go
+++ b/nodeup/pkg/model/channels.go
@@ -46,7 +46,7 @@ type ChannelsBuilder struct {
 var _ fi.NodeupModelBuilder = &ChannelsBuilder{}
 
 func (b *ChannelsBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	if !b.IsMaster && !b.HasAPIServer {
+	if !b.IsMaster && !b.HasAPIServer { // TODO Fix me, only include API Server if not control plane.
 		return nil
 	}
 

--- a/nodeup/pkg/model/discovery_service.go
+++ b/nodeup/pkg/model/discovery_service.go
@@ -42,7 +42,7 @@ var _ fi.NodeupModelBuilder = &DiscoveryService{}
 func (b *DiscoveryService) Build(c *fi.NodeupModelBuilderContext) error {
 	ctx := c.Context()
 
-	if !b.IsMaster {
+	if !b.IsMaster && !b.HasAPIServer {
 		return nil
 	}
 	discoveryServiceOptions := b.DiscoveryServiceOptions()

--- a/nodeup/pkg/model/etcd_manager_tls.go
+++ b/nodeup/pkg/model/etcd_manager_tls.go
@@ -32,7 +32,7 @@ var _ fi.NodeupModelBuilder = &EtcdManagerTLSBuilder{}
 
 // Build is responsible for TLS configuration for etcd-manager
 func (b *EtcdManagerTLSBuilder) Build(ctx *fi.NodeupModelBuilderContext) error {
-	if !b.IsMaster {
+	if !b.IsMaster && !b.BootConfig.InstanceGroupRole.HasEtcd() {
 		return nil
 	}
 

--- a/nodeup/pkg/model/kops_controller.go
+++ b/nodeup/pkg/model/kops_controller.go
@@ -34,7 +34,7 @@ var _ fi.NodeupModelBuilder = &KopsControllerBuilder{}
 
 // Build is responsible for configuring keys that will be used by kops-controller (via hostPath)
 func (b *KopsControllerBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	if !b.IsMaster {
+	if !b.IsMaster && !b.HasAPIServer {
 		return nil
 	}
 

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -46,7 +46,7 @@ var _ fi.NodeupModelBuilder = &KubeControllerManagerBuilder{}
 
 // Build is responsible for configuring the kube-controller-manager
 func (b *KubeControllerManagerBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	if !b.IsMaster {
+	if !b.IsMaster && !b.BootConfig.InstanceGroupRole.HasKubeControllerManager() {
 		return nil
 	}
 

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -45,6 +45,12 @@ func (b *KubeProxyBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		return nil
 	}
 
+	role := b.BootConfig.InstanceGroupRole
+	if role.HasEtcd() || role.HasKubeControllerManager() || role.HasScheduler() {
+		klog.V(2).Infof("Kube-proxy is disabled, role %s does not need kube-proxy.", role)
+		return nil
+	}
+
 	{
 		pod, err := b.buildPod()
 		if err != nil {

--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -62,7 +62,7 @@ var _ fi.NodeupModelBuilder = &KubeSchedulerBuilder{}
 
 // Build is responsible for building the manifest for the kube-scheduler
 func (b *KubeSchedulerBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	if !b.IsMaster {
+	if !b.IsMaster && !b.BootConfig.InstanceGroupRole.HasScheduler() {
 		return nil
 	}
 

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -131,6 +131,8 @@ func (b *KubeletBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 				return fmt.Errorf("error querying Azure instance metadata: %v", err)
 			}
 			providerID = "azure://" + metadata.ResourceID
+		} else if b.CloudProvider() == kops.CloudProviderGCE {
+			// TODO
 		}
 
 		t, err := b.buildKubeletComponentConfig(kubeletConfig, providerID)

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -188,7 +188,7 @@ func (b *KubeletBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 
 		{
 			var kubeconfig fi.Resource
-			if b.HasAPIServer {
+			if b.BootConfig.InstanceGroupRole.IsControlPlaneType() {
 				kubeconfig, err = b.buildControlPlaneKubeletKubeconfig(c)
 			} else {
 				kubeconfig, err = b.BuildBootstrapKubeconfig("kubelet", c)
@@ -863,7 +863,7 @@ func (b *KubeletBuilder) buildKubeletServingCertificate(c *fi.NodeupModelBuilder
 	dir := b.PathSrvKubernetes()
 
 	var cert, key fi.Resource
-	if !b.HasAPIServer {
+	if !b.BootConfig.InstanceGroupRole.IsControlPlaneType() {
 		var err error
 		cert, key, err = b.GetBootstrapCert(name, fi.CertificateIDCA)
 		if err != nil {

--- a/nodeup/pkg/model/manifests.go
+++ b/nodeup/pkg/model/manifests.go
@@ -38,7 +38,7 @@ func (b *ManifestsBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	ctx := c.Context()
 
 	// Write etcd manifests (currently etcd <=> master)
-	if b.IsMaster {
+	if b.IsMaster || b.BootConfig.InstanceGroupRole.HasEtcd() {
 		for _, manifest := range b.NodeupConfig.EtcdManifests {
 			p, err := vfs.Context.BuildVfsPath(manifest)
 			if err != nil {

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -394,6 +394,16 @@ func (g *InstanceGroup) IsControlPlane() bool {
 	}
 }
 
+// IsControlPlane checks if instanceGroup is a control-plane node.
+func (g *InstanceGroup) IsControlPlaneType() bool {
+	switch {
+	case g.Spec.Role.IsControlPlaneType():
+		return true
+	default:
+		return false
+	}
+}
+
 // IsAPIServerOnly checks if instanceGroup runs only the API Server
 func (g *InstanceGroup) IsAPIServerOnly() bool {
 	switch {

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -110,7 +110,6 @@ func (r InstanceGroupRole) HasKubeControllerManager() bool {
 	return r == InstanceGroupRoleKubeControllerManager
 }
 
-func (r InstanceGroupRole) IsControlPlaneType() bool {
 	return r.HasControlPlane() || r.HasAPIServer() || r.HasEtcd() || r.HasScheduler() || r.HasKubeControllerManager()
 }
 

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -110,6 +110,7 @@ func (r InstanceGroupRole) HasKubeControllerManager() bool {
 	return r == InstanceGroupRoleKubeControllerManager
 }
 
+func (r InstanceGroupRole) IsControlPlaneType() bool {
 	return r.HasControlPlane() || r.HasAPIServer() || r.HasEtcd() || r.HasScheduler() || r.HasKubeControllerManager()
 }
 

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -73,6 +73,9 @@ func ValidateInstanceGroup(g *kops.InstanceGroup, cloud fi.Cloud, strict bool) f
 	case kops.InstanceGroupRoleNode:
 	case kops.InstanceGroupRoleBastion:
 	case kops.InstanceGroupRoleAPIServer:
+	case kops.InstanceGroupRoleEtcd:
+	case kops.InstanceGroupRoleScheduler:
+	case kops.InstanceGroupRoleKubeControllerManager:
 	default:
 		var supported []string
 		for _, role := range kops.AllInstanceGroupRoles {

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -279,16 +279,41 @@ func DeepValidate(c *kops.Cluster, groups []*kops.InstanceGroup, strict bool, vf
 
 	controlPlaneGroupCount := 0
 	nodeGroupCount := 0
+	apiServerGroupCount := 0
+	etcdGroupCount := 0
+	kcmGroupCount := 0
+	schedulerGroupCount := 0
+	splitRoleCount := 0
 	for _, g := range groups {
 		if g.IsControlPlane() {
 			controlPlaneGroupCount++
-		} else {
+		}
+		if g.Spec.Role.HasNode() {
 			nodeGroupCount++
+		}
+		if g.HasAPIServer() {
+			apiServerGroupCount++
+		}
+		if g.HasEtcd() {
+			etcdGroupCount++
+		}
+		if g.HasKubeControllerManager() {
+			kcmGroupCount++
+		}
+		if g.HasScheduler() {
+			schedulerGroupCount++
+		}
+		if g.IsEtcdOnly() || g.IsSchedulerOnly() || g.IsKubeControllerManagerOnly() {
+			splitRoleCount++
 		}
 	}
 
-	if controlPlaneGroupCount == 0 {
-		return fmt.Errorf("must configure at least one ControlPlane InstanceGroup")
+	if controlPlaneGroupCount > 0 && splitRoleCount > 0 {
+		return fmt.Errorf("cannot have both ControlPlane/Master InstanceGroups and split control plane InstanceGroups (Etcd, KubControllerManager, Scheduler)")
+	}
+
+	if controlPlaneGroupCount == 0 && (apiServerGroupCount == 0 || etcdGroupCount == 0 || kcmGroupCount == 0 || schedulerGroupCount == 0) {
+		return fmt.Errorf("must configure either a ControlPlane InstanceGroup or separate APIServer, Etcd, KubControllerManager, and Scheduler InstanceGroups")
 	}
 
 	if nodeGroupCount == 0 {

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -309,11 +309,11 @@ func DeepValidate(c *kops.Cluster, groups []*kops.InstanceGroup, strict bool, vf
 	}
 
 	if controlPlaneGroupCount > 0 && splitRoleCount > 0 {
-		return fmt.Errorf("cannot have both ControlPlane/Master InstanceGroups and split control plane InstanceGroups (Etcd, KubControllerManager, Scheduler)")
+		return fmt.Errorf("cannot have both ControlPlane/Master InstanceGroups and split control plane InstanceGroups (Etcd, KubeControllerManager, Scheduler)")
 	}
 
 	if controlPlaneGroupCount == 0 && (apiServerGroupCount == 0 || etcdGroupCount == 0 || kcmGroupCount == 0 || schedulerGroupCount == 0) {
-		return fmt.Errorf("must configure either a ControlPlane InstanceGroup or separate APIServer, Etcd, KubControllerManager, and Scheduler InstanceGroups")
+		return fmt.Errorf("must configure either a ControlPlane InstanceGroup or separate APIServer, Etcd, KubeControllerManager, and Scheduler InstanceGroups")
 	}
 
 	if nodeGroupCount == 0 {

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -291,16 +291,16 @@ func DeepValidate(c *kops.Cluster, groups []*kops.InstanceGroup, strict bool, vf
 		if g.Spec.Role.HasNode() {
 			nodeGroupCount++
 		}
-		if g.HasAPIServer() {
+		if g.RunsAPIServer() {
 			apiServerGroupCount++
 		}
-		if g.HasEtcd() {
+		if g.RunsEtcd() {
 			etcdGroupCount++
 		}
-		if g.HasKubeControllerManager() {
+		if g.RunsKubeControllerManager() {
 			kcmGroupCount++
 		}
-		if g.HasScheduler() {
+		if g.RunsScheduler() {
 			schedulerGroupCount++
 		}
 		if g.IsEtcdOnly() || g.IsSchedulerOnly() || g.IsKubeControllerManagerOnly() {

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -402,7 +402,7 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 		config.Networking.EgressProxy = cluster.Spec.Networking.EgressProxy
 	}
 
-	if instanceGroup.IsControlPlane() {
+	if instanceGroup.HasAPIServer() {
 		config.DNSZone = cluster.Spec.DNSZone
 	}
 
@@ -410,6 +410,20 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 		config.ControlPlaneConfig = &ControlPlaneConfig{
 			KubeControllerManager: *cluster.Spec.KubeControllerManager,
 			KubeScheduler:         *cluster.Spec.KubeScheduler,
+		}
+	} else if instanceGroup.IsKubeControllerManagerOnly() {
+		config.ControlPlaneConfig = &ControlPlaneConfig{
+			KubeControllerManager: *cluster.Spec.KubeControllerManager,
+		}
+		config.APIServerConfig = &APIServerConfig{
+			ClusterDNSDomain: cluster.Spec.ClusterDNSDomain,
+		}
+	} else if instanceGroup.IsSchedulerOnly() {
+		config.ControlPlaneConfig = &ControlPlaneConfig{
+			KubeScheduler: *cluster.Spec.KubeScheduler,
+		}
+		config.APIServerConfig = &APIServerConfig{
+			ClusterDNSDomain: cluster.Spec.ClusterDNSDomain,
 		}
 	}
 

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -391,7 +391,7 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 		}
 	}
 
-	if instanceGroup.RunsAPIServer() {
+	if instanceGroup.RunsAPIServer() || instanceGroup.HasEtcd() || instanceGroup.HasKubeControllerManager() || instanceGroup.HasScheduler() {
 		config.ConfigStore = &kops.ConfigStoreSpec{
 			Keypairs: cluster.Spec.ConfigStore.Keypairs,
 			Secrets:  cluster.Spec.ConfigStore.Secrets,

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -391,7 +391,7 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 		}
 	}
 
-	if instanceGroup.RunsAPIServer() || instanceGroup.HasEtcd() || instanceGroup.HasKubeControllerManager() || instanceGroup.HasScheduler() {
+	if instanceGroup.RunsAPIServer() || instanceGroup.RunsEtcd() || instanceGroup.RunsKubeControllerManager() || instanceGroup.RunsScheduler() {
 		config.ConfigStore = &kops.ConfigStoreSpec{
 			Keypairs: cluster.Spec.ConfigStore.Keypairs,
 			Secrets:  cluster.Spec.ConfigStore.Secrets,
@@ -402,7 +402,7 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 		config.Networking.EgressProxy = cluster.Spec.Networking.EgressProxy
 	}
 
-	if instanceGroup.HasAPIServer() {
+	if instanceGroup.RunsAPIServer() {
 		config.DNSZone = cluster.Spec.DNSZone
 	}
 

--- a/pkg/commands/toolbox_enroll.go
+++ b/pkg/commands/toolbox_enroll.go
@@ -230,7 +230,7 @@ func enrollHost(ctx context.Context, ig *kops.InstanceGroup, bootstrapData *Boot
 
 	// We can't create the host resource in the API server for control-plane nodes,
 	// because the API server (likely) isn't running yet.
-	if !ig.IsControlPlane() {
+	if !ig.IsControlPlane() && !ig.IsEtcdOnly() && !ig.IsAPIServerOnly() {
 		if err := kubeClient.Create(ctx, hostData); err != nil {
 			return fmt.Errorf("failed to create host %s/%s: %w", hostData.Namespace, hostData.Name, err)
 		}

--- a/pkg/model/awsmodel/iam.go
+++ b/pkg/model/awsmodel/iam.go
@@ -274,6 +274,12 @@ func (b *IAMModelBuilder) roleKey(role iam.Subject) (string, bool) {
 		return strings.ToLower(string(kops.InstanceGroupRoleNode)), false
 	case *iam.NodeRoleBastion:
 		return strings.ToLower(string(kops.InstanceGroupRoleBastion)), false
+	case *iam.NodeRoleEtcd:
+		return strings.ToLower(string(kops.InstanceGroupRoleEtcd)), false
+	case *iam.NodeRoleScheduler:
+		return strings.ToLower(string(kops.InstanceGroupRoleScheduler)), false
+	case *iam.NodeRoleKubeControllerManager:
+		return strings.ToLower(string(kops.InstanceGroupRoleKubeControllerManager)), false
 
 	default:
 		klog.Fatalf("unknown node role type: %T", role)

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -166,7 +166,7 @@ func KeypairNamesForInstanceGroup(cluster *kops.Cluster, ig *kops.InstanceGroup)
 	keypairs := []string{"kubernetes-ca"}
 
 	// Add keypairs for default etcd clusters (main, events, and leases, not cilium)
-	if ig.IsControlPlane() {
+	if ig.IsControlPlane() || ig.IsEtcdOnly() {
 		for _, etcdCluster := range cluster.Spec.EtcdClusters {
 			k := etcdCluster.Name
 			if k != "events" && k != "main" && k != "leases" {

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -190,6 +190,8 @@ func KeypairNamesForInstanceGroup(cluster *kops.Cluster, ig *kops.InstanceGroup)
 
 	if ig.RunsAPIServer() {
 		keypairs = append(keypairs, "apiserver-aggregator-ca", "service-account", "etcd-clients-ca")
+	} else if ig.HasKubeControllerManager() {
+		keypairs = append(keypairs, "service-account")
 	}
 
 	// Add keypairs for cilium etcd clusters (not the default etcd clusters)

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -190,7 +190,7 @@ func KeypairNamesForInstanceGroup(cluster *kops.Cluster, ig *kops.InstanceGroup)
 
 	if ig.RunsAPIServer() {
 		keypairs = append(keypairs, "apiserver-aggregator-ca", "service-account", "etcd-clients-ca")
-	} else if ig.HasKubeControllerManager() {
+	} else if ig.RunsKubeControllerManager() {
 		keypairs = append(keypairs, "service-account")
 	}
 

--- a/pkg/model/components/channels/model.go
+++ b/pkg/model/components/channels/model.go
@@ -101,6 +101,7 @@ func (b *ChannelsBuilder) channelList() ([]string, error) {
 
 func (b *ChannelsBuilder) buildPod(channels []string) (*v1.Pod, error) {
 	image := b.AssetBuilder.RemapImage("registry.k8s.io/kops/channels:" + kopsroot.KopsVersionImageTag())
+	// image = "gcr.io/wfender-dev-20240625/kops/channels:1.37.0-alpha.1"
 
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/model/defaults/volumes.go
+++ b/pkg/model/defaults/volumes.go
@@ -38,6 +38,12 @@ func DefaultInstanceGroupVolumeSize(role kops.InstanceGroupRole) (int32, error) 
 		return DefaultVolumeSizeMaster, nil
 	case kops.InstanceGroupRoleAPIServer:
 		return DefaultVolumeSizeNode, nil
+	case kops.InstanceGroupRoleEtcd:
+		return DefaultVolumeSizeMaster, nil
+	case kops.InstanceGroupRoleScheduler:
+		return DefaultVolumeSizeNode, nil
+	case kops.InstanceGroupRoleKubeControllerManager:
+		return DefaultVolumeSizeNode, nil
 	case kops.InstanceGroupRoleNode:
 		return DefaultVolumeSizeNode, nil
 	case kops.InstanceGroupRoleBastion:

--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -165,7 +165,7 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 	var kopsControllerIGMs []*gcetasks.InstanceGroupManager
 	requireEtcdLB := false
 	for _, ig := range b.InstanceGroups {
-		if !ig.RunsAPIServer() && !ig.HasEtcd() {
+		if !ig.RunsAPIServer() && !ig.RunsEtcd() {
 			continue
 		}
 		if len(ig.Spec.Zones) > 1 {
@@ -176,13 +176,13 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 		}
 		zone := ig.Spec.Zones[0]
 		igm := &gcetasks.InstanceGroupManager{Name: s(gce.NameForInstanceGroupManager(b.Cluster.ObjectMeta.Name, ig.ObjectMeta.Name, zone)), Zone: s(zone)}
-		if ig.HasAPIServer() {
+		if ig.RunsAPIServer() {
 			apiIGMs = append(apiIGMs, igm)
 		}
-		if ig.HasEtcd() {
+		if ig.RunsEtcd() {
 			etcdIGMs = append(etcdIGMs, igm)
 		}
-		if ig.IsControlPlane() || ig.HasAPIServer() /* && Check for no control plane */ {
+		if ig.IsControlPlane() || ig.RunsAPIServer() /* && Check for no control plane */ {
 			kopsControllerIGMs = append(kopsControllerIGMs, igm)
 		}
 		if ig.IsAPIServerOnly() {

--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -161,10 +161,11 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 	// includes both (both serve the kube-apiserver), while the kops-controller and
 	// etcd backend services only include ControlPlane MIGs.
 	var apiIGMs []*gcetasks.InstanceGroupManager
-	var controlPlaneIGMs []*gcetasks.InstanceGroupManager // Currently these contain etcd instances
+	var etcdIGMs []*gcetasks.InstanceGroupManager
+	var kopsControllerIGMs []*gcetasks.InstanceGroupManager
 	requireEtcdLB := false
 	for _, ig := range b.InstanceGroups {
-		if !ig.RunsAPIServer() {
+		if !ig.RunsAPIServer() && !ig.HasEtcd() {
 			continue
 		}
 		if len(ig.Spec.Zones) > 1 {
@@ -175,13 +176,20 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 		}
 		zone := ig.Spec.Zones[0]
 		igm := &gcetasks.InstanceGroupManager{Name: s(gce.NameForInstanceGroupManager(b.Cluster.ObjectMeta.Name, ig.ObjectMeta.Name, zone)), Zone: s(zone)}
-		apiIGMs = append(apiIGMs, igm)
-		if ig.IsControlPlane() {
-			controlPlaneIGMs = append(controlPlaneIGMs, igm)
-		} else if ig.IsAPIServerOnly() {
+		if ig.HasAPIServer() {
+			apiIGMs = append(apiIGMs, igm)
+		}
+		if ig.HasEtcd() {
+			etcdIGMs = append(etcdIGMs, igm)
+		}
+		if ig.IsControlPlane() || ig.HasAPIServer() /* && Check for no control plane */ {
+			kopsControllerIGMs = append(kopsControllerIGMs, igm)
+		}
+		if ig.IsAPIServerOnly() {
 			requireEtcdLB = b.Cluster.UsesNoneDNS()
-		} else {
-			return fmt.Errorf("instance group %q neither control-plane nor api-server", ig.GetName())
+		}
+		if ig.IsEtcdOnly() {
+			requireEtcdLB = true
 		}
 	}
 	backendService := &gcetasks.BackendService{
@@ -194,12 +202,9 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 	}
 	c.AddTask(backendService)
 
-	// controlPlaneBS is a backend service that only targets ControlPlane MIGs.
-	// It is used for kops-controller and etcd forwarding rules, which only run
-	// on ControlPlane nodes. When there are no dedicated APIServer IGs, this is
-	// the same set of backends as the API backend service.
-	controlPlaneBS := backendService
-	if b.HasAPIServerOnlyInstanceGroups() {
+	// kopsControllerBS is a backend service that targets ControlPlane or KubControllerManager MIGs.
+	kopsControllerBS := backendService
+	if b.HasAPIServerOnlyInstanceGroups() || b.HasEtcdOnlyInstanceGroups() {
 		controlPlaneHC := &gcetasks.HealthCheck{
 			Name:      s(b.NameForHealthCheck("kops-controller")),
 			Port:      wellknownports.KopsControllerPort,
@@ -207,15 +212,15 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 			Lifecycle: b.Lifecycle,
 		}
 		c.AddTask(controlPlaneHC)
-		controlPlaneBS = &gcetasks.BackendService{
+		kopsControllerBS = &gcetasks.BackendService{
 			Name:                  s(b.NameForBackendService("kops-controller")),
 			Protocol:              s("TCP"),
 			HealthChecks:          []*gcetasks.HealthCheck{controlPlaneHC},
 			Lifecycle:             b.Lifecycle,
 			LoadBalancingScheme:   s("INTERNAL"),
-			InstanceGroupManagers: controlPlaneIGMs,
+			InstanceGroupManagers: kopsControllerIGMs,
 		}
-		c.AddTask(controlPlaneBS)
+		c.AddTask(kopsControllerBS)
 	}
 
 	network, err := b.LinkToNetwork()
@@ -267,7 +272,7 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 			fr := &gcetasks.ForwardingRule{
 				Name:                s(b.NameForForwardingRule("kops-controller-" + sn.Name)),
 				Lifecycle:           b.Lifecycle,
-				BackendService:      controlPlaneBS,
+				BackendService:      kopsControllerBS,
 				Ports:               []string{strconv.Itoa(wellknownports.KopsControllerPort)},
 				IPAddress:           ipAddress,
 				IPProtocol:          "TCP",
@@ -286,10 +291,22 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 		}
 
 		if model.UseCiliumEtcd(b.Cluster) {
+			etcdBS := kopsControllerBS
+			if b.HasEtcdOnlyInstanceGroups() {
+				etcdBS = &gcetasks.BackendService{
+					Name:                  s(b.NameForBackendService("cilium-etcd")),
+					Protocol:              s("TCP"),
+					HealthChecks:          []*gcetasks.HealthCheck{hc},
+					Lifecycle:             b.Lifecycle,
+					LoadBalancingScheme:   s("INTERNAL"),
+					InstanceGroupManagers: etcdIGMs,
+				}
+				c.AddTask(etcdBS)
+			}
 			c.AddTask(&gcetasks.ForwardingRule{
 				Name:                s(b.NameForForwardingRule("cilium-etcd-" + sn.Name)),
 				Lifecycle:           b.Lifecycle,
-				BackendService:      controlPlaneBS,
+				BackendService:      etcdBS,
 				Ports:               []string{strconv.Itoa(wellknownports.EtcdCiliumClientPort)},
 				IPAddress:           ipAddress,
 				IPProtocol:          "TCP",
@@ -305,7 +322,7 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 	}
 
 	if requireEtcdLB {
-		if err := b.createEtcdInternalLB(c, controlPlaneIGMs); err != nil {
+		if err := b.createEtcdInternalLB(c, etcdIGMs); err != nil {
 			return err
 		}
 	}

--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -202,7 +202,7 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 	}
 	c.AddTask(backendService)
 
-	// kopsControllerBS is a backend service that targets ControlPlane or KubControllerManager MIGs.
+	// kopsControllerBS is a backend service that targets ControlPlane or KubeControllerManager MIGs.
 	kopsControllerBS := backendService
 	if b.HasAPIServerOnlyInstanceGroups() || b.HasEtcdOnlyInstanceGroups() {
 		controlPlaneHC := &gcetasks.HealthCheck{

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -224,6 +224,17 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 
 		case kops.InstanceGroupRoleBastion:
 			t.Tags = append(t.Tags, b.GCETagForRole(kops.InstanceGroupRoleBastion))
+
+		case kops.InstanceGroupRoleEtcd:
+			t.Scopes = append(t.Scopes, "https://www.googleapis.com/auth/ndev.clouddns.readwrite")
+			t.Tags = append(t.Tags, b.GCETagForRole(kops.InstanceGroupRoleEtcd))
+
+		case kops.InstanceGroupRoleScheduler:
+			t.Tags = append(t.Tags, b.GCETagForRole(kops.InstanceGroupRoleScheduler))
+
+		case kops.InstanceGroupRoleKubeControllerManager:
+			t.Scopes = append(t.Scopes, "https://www.googleapis.com/auth/ndev.clouddns.readwrite")
+			t.Tags = append(t.Tags, b.GCETagForRole(kops.InstanceGroupRoleKubeControllerManager))
 		}
 
 		if gce.UsesIPAliases(b.Cluster) {

--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -187,7 +187,7 @@ func (c *GCEModelContext) LinkToServiceAccount(ig *kops.InstanceGroup) *gcetasks
 
 	name := ""
 	switch role {
-	case kops.InstanceGroupRoleAPIServer, kops.InstanceGroupRoleControlPlane:
+	case kops.InstanceGroupRoleAPIServer, kops.InstanceGroupRoleControlPlane, kops.InstanceGroupRoleEtcd, kops.InstanceGroupRoleScheduler, kops.InstanceGroupRoleKubeControllerManager:
 		name = gce.ControlPlane
 
 	case kops.InstanceGroupRoleBastion:

--- a/pkg/model/gcemodel/external_access.go
+++ b/pkg/model/gcemodel/external_access.go
@@ -82,8 +82,13 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.CloudupModelBuilderContext) err
 			return err
 		}
 		b.AddFirewallRulesTasks(c, "ssh-external-to-master", &gcetasks.FirewallRule{
-			Lifecycle:    b.Lifecycle,
-			TargetTags:   append(b.GCETagsForAPIServerTargets(), b.GCETagForRole("Master")),
+			Lifecycle: b.Lifecycle,
+			TargetTags: append(
+				b.GCETagsForAPIServerTargets(),
+				b.GCETagForRole(kops.InstanceGroupRoleEtcd),
+				b.GCETagForRole(kops.InstanceGroupRoleScheduler),
+				b.GCETagForRole(kops.InstanceGroupRoleKubeControllerManager),
+				b.GCETagForRole("Master")),
 			Allowed:      []string{"tcp:22"},
 			SourceRanges: b.Cluster.Spec.SSHAccess,
 			Network:      network,

--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -52,6 +52,10 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		if err != nil {
 			return err
 		}
+		cpTags := append(
+			b.GCETagsForAPIServerTargets(),
+			b.GCETagForRole(kops.InstanceGroupRoleEtcd),
+		)
 		c.AddTask(&gcetasks.FirewallRule{
 			Name:      s(b.NameForFirewallRule("lb-health-checks")),
 			Lifecycle: b.Lifecycle,
@@ -65,7 +69,7 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				"209.85.204.0/22",
 				"209.85.152.0/22",
 			},
-			TargetTags: b.GCETagsForAPIServerTargets(),
+			TargetTags: cpTags,
 			Allowed:    []string{"tcp"},
 		})
 	}
@@ -93,7 +97,13 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		if err != nil {
 			return err
 		}
-		cpTags := append(b.GCETagsForAPIServerTargets(), b.GCETagForRole("Master"))
+		cpTags := append(
+			b.GCETagsForAPIServerTargets(),
+			b.GCETagForRole(kops.InstanceGroupRoleEtcd),
+			b.GCETagForRole(kops.InstanceGroupRoleScheduler),
+			b.GCETagForRole(kops.InstanceGroupRoleKubeControllerManager),
+			b.GCETagForRole("Master"),
+		)
 		t := &gcetasks.FirewallRule{
 			Name:       s(b.NameForFirewallRule("master-to-master")),
 			Lifecycle:  b.Lifecycle,

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -526,6 +526,45 @@ func (r *NodeRoleBastion) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	return NewPolicy(b.Cluster.GetName(), b.Partition, b.Region), nil
 }
 
+// BuildAWSPolicy generates a custom policy for an etcd node.
+func (r *NodeRoleEtcd) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
+	p := NewPolicy(b.Cluster.GetName(), b.Partition, b.Region)
+	b.addNodeupPermissions(p, false)
+	if err := b.AddS3Permissions(p); err != nil {
+		return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
+	}
+	if b.Cluster.Spec.IAM != nil && b.Cluster.Spec.IAM.AllowContainerRegistry {
+		addECRPermissions(p)
+	}
+	return p, nil
+}
+
+// BuildAWSPolicy generates a custom policy for a scheduler node.
+func (r *NodeRoleScheduler) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
+	p := NewPolicy(b.Cluster.GetName(), b.Partition, b.Region)
+	b.addNodeupPermissions(p, false)
+	if err := b.AddS3Permissions(p); err != nil {
+		return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
+	}
+	if b.Cluster.Spec.IAM != nil && b.Cluster.Spec.IAM.AllowContainerRegistry {
+		addECRPermissions(p)
+	}
+	return p, nil
+}
+
+// BuildAWSPolicy generates a custom policy for a kube-controller-manager node.
+func (r *NodeRoleKubeControllerManager) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
+	p := NewPolicy(b.Cluster.GetName(), b.Partition, b.Region)
+	b.addNodeupPermissions(p, false)
+	if err := b.AddS3Permissions(p); err != nil {
+		return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
+	}
+	if b.Cluster.Spec.IAM != nil && b.Cluster.Spec.IAM.AllowContainerRegistry {
+		addECRPermissions(p)
+	}
+	return p, nil
+}
+
 // AddS3Permissions add S3 permissions to an IAM Policy.
 // The permissions grant granting tailored access to S3 assets,
 // depending on the instance group or service-account role
@@ -697,7 +736,7 @@ func WriteableVFSPaths(cluster *kops.Cluster, role Subject) ([]vfs.Path, error) 
 
 	// etcd-manager needs write permissions to the backup store
 	switch role.(type) {
-	case *NodeRoleMaster:
+	case *NodeRoleMaster, *NodeRoleEtcd, *NodeRoleAPIServer:
 		backupStores := sets.NewString()
 		for _, c := range cluster.Spec.EtcdClusters {
 			if c.Backups == nil || c.Backups.BackupStore == "" || backupStores.Has(c.Backups.BackupStore) {
@@ -724,7 +763,7 @@ func ReadableStatePaths(cluster *kops.Cluster, role Subject) ([]string, error) {
 	var paths []string
 
 	switch role.(type) {
-	case *NodeRoleMaster, *NodeRoleAPIServer:
+	case *NodeRoleMaster, *NodeRoleAPIServer, *NodeRoleEtcd, *NodeRoleKubeControllerManager, *NodeRoleScheduler:
 		paths = append(paths, "/*")
 	}
 	return paths, nil

--- a/pkg/model/iam/subject.go
+++ b/pkg/model/iam/subject.go
@@ -72,6 +72,30 @@ func (_ *NodeRoleBastion) ServiceAccount() (types.NamespacedName, bool) {
 	return types.NamespacedName{}, false
 }
 
+// NodeRoleEtcd represents the role of etcd-only nodes, and implements Subject.
+type NodeRoleEtcd struct{}
+
+// ServiceAccount implements Subject.
+func (_ *NodeRoleEtcd) ServiceAccount() (types.NamespacedName, bool) {
+	return types.NamespacedName{}, false
+}
+
+// NodeRoleScheduler represents the role of scheduler-only nodes, and implements Subject.
+type NodeRoleScheduler struct{}
+
+// ServiceAccount implements Subject.
+func (_ *NodeRoleScheduler) ServiceAccount() (types.NamespacedName, bool) {
+	return types.NamespacedName{}, false
+}
+
+// NodeRoleKubeControllerManager represents the role of kube-controller-manager-only nodes, and implements Subject.
+type NodeRoleKubeControllerManager struct{}
+
+// ServiceAccount implements Subject.
+func (_ *NodeRoleKubeControllerManager) ServiceAccount() (types.NamespacedName, bool) {
+	return types.NamespacedName{}, false
+}
+
 type GenericServiceAccount struct {
 	NamespacedName types.NamespacedName
 	Policy         *Policy
@@ -100,6 +124,12 @@ func BuildNodeRoleSubject(igRole kops.InstanceGroupRole, enableLifecycleHookPerm
 		}, nil
 	case kops.InstanceGroupRoleBastion:
 		return &NodeRoleBastion{}, nil
+	case kops.InstanceGroupRoleEtcd:
+		return &NodeRoleEtcd{}, nil
+	case kops.InstanceGroupRoleScheduler:
+		return &NodeRoleScheduler{}, nil
+	case kops.InstanceGroupRoleKubeControllerManager:
+		return &NodeRoleKubeControllerManager{}, nil
 	default:
 		return nil, fmt.Errorf("unknown instancegroup role %q", igRole)
 	}

--- a/pkg/model/names.go
+++ b/pkg/model/names.go
@@ -63,6 +63,12 @@ func (b *KopsModelContext) AutoscalingGroupName(ig *kops.InstanceGroup) string {
 		return ig.ObjectMeta.Name + ".masters." + b.ClusterName()
 	case kops.InstanceGroupRoleAPIServer:
 		return ig.ObjectMeta.Name + ".apiservers." + b.ClusterName()
+	case kops.InstanceGroupRoleEtcd:
+		return ig.ObjectMeta.Name + ".etcd." + b.ClusterName()
+	case kops.InstanceGroupRoleScheduler:
+		return ig.ObjectMeta.Name + ".scheduler." + b.ClusterName()
+	case kops.InstanceGroupRoleKubeControllerManager:
+		return ig.ObjectMeta.Name + ".kcm." + b.ClusterName()
 	case kops.InstanceGroupRoleNode, kops.InstanceGroupRoleBastion:
 		return ig.ObjectMeta.Name + "." + b.ClusterName()
 
@@ -143,6 +149,12 @@ func (b *KopsModelContext) IAMName(role kops.InstanceGroupRole) string {
 		rolename = "masters." + b.ClusterName()
 	case kops.InstanceGroupRoleAPIServer:
 		rolename = "apiservers." + b.ClusterName()
+	case kops.InstanceGroupRoleEtcd:
+		rolename = "etcd." + b.ClusterName()
+	case kops.InstanceGroupRoleScheduler:
+		rolename = "scheduler." + b.ClusterName()
+	case kops.InstanceGroupRoleKubeControllerManager:
+		rolename = "kcm." + b.ClusterName()
 	case kops.InstanceGroupRoleBastion:
 		rolename = "bastions." + b.ClusterName()
 	case kops.InstanceGroupRoleNode:

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -1592,6 +1592,7 @@ func RunGoldenTest(t *testing.T, basedir string, testCase serverGroupModelBuilde
 	context := &fi.CloudupModelBuilderContext{
 		Tasks:              make(map[string]fi.CloudupTask),
 		LifecycleOverrides: map[string]fi.Lifecycle{},
+		Stacktraces:        make(map[string]string),
 	}
 
 	// We need the CA and service-account for the bootstrap script

--- a/pkg/nodelabels/builder.go
+++ b/pkg/nodelabels/builder.go
@@ -32,8 +32,9 @@ const (
 	RoleLabelScheduler             = "node-role.kubernetes.io/scheduler"
 	RoleLabelKubeControllerManager = "node-role.kubernetes.io/kube-controller-manager"
 
-	RoleLabelKopsCCM     = "kops.k8s.io/cloud-controller-manager"
-	RoleLabelKopsChannel = "kops.k8s.io/kops-channel"
+	RoleLabelKopsCCM        = "kops.k8s.io/cloud-controller-manager"
+	RoleLabelKopsChannel    = "kops.k8s.io/kops-channel"
+	RoleLabelKopsController = "kops.k8s.io/kops-controller"
 
 	// New Experimental control plane roles associated with static manifests
 	RoleLabelEtcd                  = "node-role.kubernetes.io/etcd"

--- a/pkg/nodelabels/builder.go
+++ b/pkg/nodelabels/builder.go
@@ -18,7 +18,6 @@ package nodelabels
 
 import (
 	"fmt"
-	"strings"
 
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
@@ -26,15 +25,8 @@ import (
 )
 
 const (
-	RoleLabelAPIServer16           = "node-role.kubernetes.io/api-server"
-	RoleLabelNode16                = "node-role.kubernetes.io/node"
-	RoleLabelEtcd                  = "node-role.kubernetes.io/etcd"
-	RoleLabelScheduler             = "node-role.kubernetes.io/scheduler"
-	RoleLabelKubeControllerManager = "node-role.kubernetes.io/kube-controller-manager"
-
-	RoleLabelKopsCCM        = "kops.k8s.io/cloud-controller-manager"
-	RoleLabelKopsChannel    = "kops.k8s.io/kops-channel"
-	RoleLabelKopsController = "kops.k8s.io/kops-controller"
+	RoleLabelAPIServer16 = "node-role.kubernetes.io/api-server"
+	RoleLabelNode16      = "node-role.kubernetes.io/node"
 
 	// New Experimental control plane roles associated with static manifests
 	RoleLabelEtcd                  = "node-role.kubernetes.io/etcd"

--- a/pkg/nodelabels/builder.go
+++ b/pkg/nodelabels/builder.go
@@ -18,6 +18,7 @@ package nodelabels
 
 import (
 	"fmt"
+	"strings"
 
 	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
@@ -26,15 +27,13 @@ import (
 
 const (
 	RoleLabelAPIServer16           = "node-role.kubernetes.io/api-server"
-	RoleLabelKopsAPIServer         = "kops.k8s.io/node-api-server"
 	RoleLabelNode16                = "node-role.kubernetes.io/node"
-	RoleLabelKopsNode              = "kops.k8s.io/node-node"
 	RoleLabelEtcd                  = "node-role.kubernetes.io/etcd"
-	RoleLabelKopsEtcd              = "kops.k8s.io/node-etcd"
 	RoleLabelScheduler             = "node-role.kubernetes.io/scheduler"
-	RoleLabelKopsScheduler         = "kops.k8s.io/node-scheduler"
 	RoleLabelKubeControllerManager = "node-role.kubernetes.io/kube-controller-manager"
-	RoleLabelKopsKCM               = "kops.k8s.io/node-kube-controller-manager"
+
+	RoleLabelKopsCCM     = "kops.k8s.io/cloud-controller-manager"
+	RoleLabelKopsChannel = "kops.k8s.io/kops-channel"
 
 	// New Experimental control plane roles associated with static manifests
 	RoleLabelEtcd                  = "node-role.kubernetes.io/etcd"
@@ -101,7 +100,6 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 		// full control-plane nodes.
 		if isAPIServer && featureflag.APIServerNodes.Enabled() {
 			nodeLabels[RoleLabelAPIServer16] = ""
-			nodeLabels[RoleLabelKopsAPIServer] = ""
 			nodeLabels["kops.k8s.io/kops-controller-pki"] = ""
 		}
 	}
@@ -111,7 +109,6 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelNode16] = ""
-		nodeLabels[RoleLabelKopsNode] = ""
 	}
 
 	if isEtcd {
@@ -119,7 +116,6 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelEtcd] = ""
-		nodeLabels[RoleLabelKopsEtcd] = ""
 	}
 
 	if isScheduler {
@@ -127,7 +123,6 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelScheduler] = ""
-		nodeLabels[RoleLabelKopsScheduler] = ""
 	}
 
 	if isKubeControllerManager {
@@ -135,7 +130,6 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelKubeControllerManager] = ""
-		nodeLabels[RoleLabelKopsKCM] = ""
 	}
 
 	if isControlPlane {

--- a/pkg/nodelabels/builder.go
+++ b/pkg/nodelabels/builder.go
@@ -25,8 +25,11 @@ import (
 )
 
 const (
-	RoleLabelAPIServer16 = "node-role.kubernetes.io/api-server"
-	RoleLabelNode16      = "node-role.kubernetes.io/node"
+	RoleLabelAPIServer16           = "node-role.kubernetes.io/api-server"
+	RoleLabelNode16                = "node-role.kubernetes.io/node"
+	RoleLabelEtcd                  = "node-role.kubernetes.io/etcd"
+	RoleLabelScheduler             = "node-role.kubernetes.io/scheduler"
+	RoleLabelKubeControllerManager = "node-role.kubernetes.io/kube-controller-manager"
 
 	// New Experimental control plane roles associated with static manifests
 	RoleLabelEtcd                  = "node-role.kubernetes.io/etcd"
@@ -47,6 +50,9 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 	isControlPlane := false
 	isAPIServer := false
 	isNode := false
+	isEtcd := false
+	isScheduler := false
+	isKubeControllerManager := false
 	switch {
 	case instanceGroup.Spec.Role.HasControlPlane():
 		isControlPlane = true
@@ -56,6 +62,12 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 		isNode = true
 	case instanceGroup.Spec.Role.HasBastion():
 		// no labels to add
+	case instanceGroup.Spec.Role.HasEtcd():
+		isEtcd = true
+	case instanceGroup.Spec.Role.HasScheduler():
+		isScheduler = true
+	case instanceGroup.Spec.Role.HasKubeControllerManager():
+		isKubeControllerManager = true
 	default:
 		return nil, fmt.Errorf("unhandled instanceGroup role %q", instanceGroup.Spec.Role)
 	}
@@ -84,6 +96,7 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 		// full control-plane nodes.
 		if isAPIServer || featureflag.APIServerNodes.Enabled() {
 			nodeLabels[RoleLabelAPIServer16] = ""
+			nodeLabels["kops.k8s.io/kops-controller-pki"] = ""
 		}
 	}
 
@@ -92,6 +105,27 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelNode16] = ""
+	}
+
+	if isEtcd {
+		if nodeLabels == nil {
+			nodeLabels = make(map[string]string)
+		}
+		nodeLabels[RoleLabelEtcd] = ""
+	}
+
+	if isScheduler {
+		if nodeLabels == nil {
+			nodeLabels = make(map[string]string)
+		}
+		nodeLabels[RoleLabelScheduler] = ""
+	}
+
+	if isKubeControllerManager {
+		if nodeLabels == nil {
+			nodeLabels = make(map[string]string)
+		}
+		nodeLabels[RoleLabelKubeControllerManager] = ""
 	}
 
 	if isControlPlane {

--- a/pkg/nodelabels/builder.go
+++ b/pkg/nodelabels/builder.go
@@ -26,10 +26,15 @@ import (
 
 const (
 	RoleLabelAPIServer16           = "node-role.kubernetes.io/api-server"
+	RoleLabelKopsAPIServer         = "kops.k8s.io/node-api-server"
 	RoleLabelNode16                = "node-role.kubernetes.io/node"
+	RoleLabelKopsNode              = "kops.k8s.io/node-node"
 	RoleLabelEtcd                  = "node-role.kubernetes.io/etcd"
+	RoleLabelKopsEtcd              = "kops.k8s.io/node-etcd"
 	RoleLabelScheduler             = "node-role.kubernetes.io/scheduler"
+	RoleLabelKopsScheduler         = "kops.k8s.io/node-scheduler"
 	RoleLabelKubeControllerManager = "node-role.kubernetes.io/kube-controller-manager"
+	RoleLabelKopsKCM               = "kops.k8s.io/node-kube-controller-manager"
 
 	// New Experimental control plane roles associated with static manifests
 	RoleLabelEtcd                  = "node-role.kubernetes.io/etcd"
@@ -74,7 +79,7 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 
 	// Merge KubeletConfig for NodeLabels
 	c := &api.KubeletConfigSpec{}
-	if isControlPlane {
+	if instanceGroup.Spec.Role.IsControlPlaneType() {
 		reflectutils.JSONMergeStruct(c, cluster.Spec.ControlPlaneKubelet)
 	} else {
 		reflectutils.JSONMergeStruct(c, cluster.Spec.Kubelet)
@@ -94,8 +99,9 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 		// We keep the featureflag as a placeholder to change the logic;
 		// when we drop the featureflag we should just always include the label, even for
 		// full control-plane nodes.
-		if isAPIServer || featureflag.APIServerNodes.Enabled() {
+		if isAPIServer && featureflag.APIServerNodes.Enabled() {
 			nodeLabels[RoleLabelAPIServer16] = ""
+			nodeLabels[RoleLabelKopsAPIServer] = ""
 			nodeLabels["kops.k8s.io/kops-controller-pki"] = ""
 		}
 	}
@@ -105,6 +111,7 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelNode16] = ""
+		nodeLabels[RoleLabelKopsNode] = ""
 	}
 
 	if isEtcd {
@@ -112,7 +119,7 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelEtcd] = ""
-		nodeLabels[RoleLabelControlPlane20] = ""
+		nodeLabels[RoleLabelKopsEtcd] = ""
 	}
 
 	if isScheduler {
@@ -120,7 +127,7 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelScheduler] = ""
-		nodeLabels[RoleLabelControlPlane20] = ""
+		nodeLabels[RoleLabelKopsScheduler] = ""
 	}
 
 	if isKubeControllerManager {
@@ -128,7 +135,7 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelKubeControllerManager] = ""
-		nodeLabels[RoleLabelControlPlane20] = ""
+		nodeLabels[RoleLabelKopsKCM] = ""
 	}
 
 	if isControlPlane {

--- a/pkg/nodelabels/builder.go
+++ b/pkg/nodelabels/builder.go
@@ -112,6 +112,7 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelEtcd] = ""
+		nodeLabels[RoleLabelControlPlane20] = ""
 	}
 
 	if isScheduler {
@@ -119,6 +120,7 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelScheduler] = ""
+		nodeLabels[RoleLabelControlPlane20] = ""
 	}
 
 	if isKubeControllerManager {
@@ -126,6 +128,7 @@ func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (ma
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelKubeControllerManager] = ""
+		nodeLabels[RoleLabelControlPlane20] = ""
 	}
 
 	if isControlPlane {

--- a/pkg/nodelabels/builder_test.go
+++ b/pkg/nodelabels/builder_test.go
@@ -40,6 +40,7 @@ func TestBuildNodeLabels(t *testing.T) {
 		cluster  *kops.Cluster
 		ig       *kops.InstanceGroup
 		expected map[string]string
+
 		// Allow us to test labels at different feature flag levels
 		featureFlags string
 	}{
@@ -156,6 +157,100 @@ func TestBuildNodeLabels(t *testing.T) {
 				"node2":         "node2",
 				"node1":         "override1",
 				"node3":         "override3",
+			},
+		},
+		{
+			name: "RoleEtcd",
+			cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					KubernetesVersion: "v1.31.0",
+					Kubelet: &kops.KubeletConfigSpec{
+						NodeLabels: map[string]string{
+							"node1": "node1",
+							"node2": "node2",
+						},
+					},
+				},
+			},
+			ig: &kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					Role: kops.InstanceGroupRoleEtcd,
+					Kubelet: &kops.KubeletConfigSpec{
+						NodeLabels: map[string]string{
+							"node1": "override1",
+							"node3": "override3",
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				RoleLabelEtcd: "",
+				"node2":       "node2",
+				"node1":       "override1",
+				"node3":       "override3",
+			},
+		},
+		{
+			name: "RoleScheduler",
+			cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					KubernetesVersion: "v1.31.0",
+					Kubelet: &kops.KubeletConfigSpec{
+						NodeLabels: map[string]string{
+							"node1": "node1",
+							"node2": "node2",
+						},
+					},
+				},
+			},
+			ig: &kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					Role: kops.InstanceGroupRoleScheduler,
+					Kubelet: &kops.KubeletConfigSpec{
+						NodeLabels: map[string]string{
+							"node1": "override1",
+							"node3": "override3",
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				RoleLabelScheduler: "",
+				"node2":            "node2",
+				"node1":            "override1",
+				"node3":            "override3",
+			},
+		},
+		{
+			name: "RoleKubControllerManager",
+			cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					KubernetesVersion: "v1.31.0",
+					Kubelet: &kops.KubeletConfigSpec{
+						NodeLabels: map[string]string{
+							"node1": "node1",
+							"node2": "node2",
+						},
+					},
+				},
+			},
+			ig: &kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					Role: kops.InstanceGroupRoleKubeControllerManager,
+					Kubelet: &kops.KubeletConfigSpec{
+						NodeLabels: map[string]string{
+							"node1": "override1",
+							"node3": "override3",
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				RoleLabelKubeControllerManager:    "",
+				"kops.k8s.io/kops-controller-pki": "",
+				"node2":                           "node2",
+				"node1":                           "override1",
+				"node3":                           "override3",
 			},
 		},
 	}

--- a/pkg/nodelabels/builder_test.go
+++ b/pkg/nodelabels/builder_test.go
@@ -116,8 +116,10 @@ func TestBuildNodeLabels(t *testing.T) {
 			},
 			expected: map[string]string{
 				"node-role.kubernetes.io/api-server": "",
+				"kops.k8s.io/kops-controller-pki":    "",
+				"controlPlane1":                      "controlPlane1",
+				"controlPlane2":                      "controlPlane2",
 				"node1":                              "override1",
-				"node2":                              "node2",
 				"node3":                              "override3",
 			},
 			featureFlags: "+APIServerNodes",

--- a/pkg/nodelabels/builder_test.go
+++ b/pkg/nodelabels/builder_test.go
@@ -222,7 +222,7 @@ func TestBuildNodeLabels(t *testing.T) {
 			},
 		},
 		{
-			name: "RoleKubControllerManager",
+			name: "RoleKubeControllerManager",
 			cluster: &kops.Cluster{
 				Spec: kops.ClusterSpec{
 					KubernetesVersion: "v1.31.0",

--- a/pkg/nodelabels/builder_test.go
+++ b/pkg/nodelabels/builder_test.go
@@ -185,7 +185,6 @@ func TestBuildNodeLabels(t *testing.T) {
 			},
 			expected: map[string]string{
 				RoleLabelEtcd: "",
-				"node2":       "node2",
 				"node1":       "override1",
 				"node3":       "override3",
 			},
@@ -216,7 +215,6 @@ func TestBuildNodeLabels(t *testing.T) {
 			},
 			expected: map[string]string{
 				RoleLabelScheduler: "",
-				"node2":            "node2",
 				"node1":            "override1",
 				"node3":            "override3",
 			},
@@ -246,11 +244,9 @@ func TestBuildNodeLabels(t *testing.T) {
 				},
 			},
 			expected: map[string]string{
-				RoleLabelKubeControllerManager:    "",
-				"kops.k8s.io/kops-controller-pki": "",
-				"node2":                           "node2",
-				"node1":                           "override1",
-				"node3":                           "override3",
+				RoleLabelKubeControllerManager: "",
+				"node1":                        "override1",
+				"node3":                        "override3",
 			},
 		},
 	}

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -64,6 +65,9 @@ func NewNodeUpConfigBuilder(cluster *kops.Cluster, assetBuilder *assets.AssetBui
 	for _, role := range kops.AllInstanceGroupRoles {
 		isMaster := role.HasControlPlane()
 		isAPIServer := role.HasAPIServer()
+		isEtcd := role.HasEtcd()
+		isScheduler := role.HasScheduler()
+		isKCM := role.HasKubeControllerManager()
 
 		images[role] = make(map[architectures.Architecture][]*nodeup.Image)
 		if kopsmodel.IsBaseURL(cluster.Spec.KubernetesVersion) {
@@ -71,9 +75,12 @@ func NewNodeUpConfigBuilder(cluster *kops.Cluster, assetBuilder *assets.AssetBui
 			components := []string{"kube-proxy"}
 			if isMaster {
 				components = append(components, "kube-apiserver", "kube-controller-manager", "kube-scheduler")
-			}
-			if isAPIServer {
+			} else if isAPIServer {
 				components = append(components, "kube-apiserver")
+			} else if isScheduler {
+				components = append(components, "kube-scheduler")
+			} else if isKCM {
+				components = append(components, "kube-controller-manager")
 			}
 
 			for _, arch := range architectures.GetSupported() {
@@ -123,8 +130,7 @@ func NewNodeUpConfigBuilder(cluster *kops.Cluster, assetBuilder *assets.AssetBui
 					images[role][arch] = append(images[role][arch], image)
 				}
 			}
-		}
-		if os.Getenv("KOPS_BASE_URL") != "" && isAPIServer {
+		} else if os.Getenv("KOPS_BASE_URL") != "" && isAPIServer {
 			for _, arch := range architectures.GetSupported() {
 				for _, name := range []string{"kube-apiserver-healthcheck"} {
 					baseURL, err := url.Parse(os.Getenv("KOPS_BASE_URL"))
@@ -148,12 +154,15 @@ func NewNodeUpConfigBuilder(cluster *kops.Cluster, assetBuilder *assets.AssetBui
 			}
 		}
 
-		if isMaster {
+		if isMaster || isEtcd {
 			for _, etcdCluster := range cluster.Spec.EtcdClusters {
 				for _, member := range etcdCluster.Members {
 					instanceGroup := fi.ValueOf(member.InstanceGroup)
 					etcdManifest := fmt.Sprintf("manifests/etcd/%s-%s.yaml", etcdCluster.Name, instanceGroup)
-					etcdManifests[instanceGroup] = append(etcdManifests[instanceGroup], configBase.Join(etcdManifest).Path())
+					entry := configBase.Join(etcdManifest).Path()
+					if !slices.Contains(etcdManifests[instanceGroup], entry) {
+						etcdManifests[instanceGroup] = append(etcdManifests[instanceGroup], entry)
+					}
 				}
 			}
 		}
@@ -228,7 +237,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 			}
 		}
 
-		if isMaster {
+		if isMaster || role.HasEtcd() {
 			if err := loadCertificates(keysets, "etcd-clients-ca", config, true); err != nil {
 				return nil, nil, err
 			}
@@ -246,15 +255,16 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 					}
 				}
 			}
-			config.KeypairIDs["service-account"] = keysets["service-account"].Primary.Id
-
-			// Add key for registering with the discovery service (if configured)
-			if cluster.Spec.ServiceAccountIssuerDiscovery != nil &&
-				cluster.Spec.ServiceAccountIssuerDiscovery.DiscoveryService != nil &&
-				cluster.Spec.ServiceAccountIssuerDiscovery.DiscoveryService.URL != "" {
+		}
+		if isMaster || role.HasAPIServer() {
+			if keysets["service-account"] != nil {
+				config.KeypairIDs["service-account"] = keysets["service-account"].Primary.Id
+			}
+			if keysets[fi.DiscoveryCAID] != nil {
 				config.KeypairIDs[fi.DiscoveryCAID] = keysets[fi.DiscoveryCAID].Primary.Id
 			}
-		} else {
+		}
+		if !isMaster && !role.HasEtcd() {
 			if keysets["etcd-client-cilium"] != nil {
 				config.KeypairIDs["etcd-client-cilium"] = keysets["etcd-client-cilium"].Primary.Id
 			}
@@ -398,11 +408,13 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 
 	config.Images = n.images[role]
 
-	if isMaster {
+	if isMaster || role.HasEtcd() {
 		for _, etcdCluster := range cluster.Spec.EtcdClusters {
 			config.EtcdClusterNames = append(config.EtcdClusterNames, etcdCluster.Name)
 		}
 		config.EtcdManifests = n.etcdManifests[ig.Name]
+	}
+	if isMaster || role.HasAPIServer() {
 		config.ChannelsManifest = n.channelsManifest
 	}
 

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -288,6 +288,11 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 			}
 			config.APIServerConfig.ServiceAccountPublicKeys = serviceAccountPublicKeys
 		} else {
+			if role.HasKubeControllerManager() {
+				if keysets["service-account"] != nil {
+					config.KeypairIDs["service-account"] = keysets["service-account"].Primary.Id
+				}
+			}
 			for _, key := range []string{"kubelet", "kube-proxy", "kube-router"} {
 				if keysets[key] != nil {
 					config.KeypairIDs[key] = keysets[key].Primary.Id

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -375,7 +375,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 		}
 	}
 
-	useConfigServer := !ig.RunsAPIServer()
+	useConfigServer := !ig.IsControlPlaneType()
 	if useConfigServer {
 		bootConfig.ConfigServer = buildConfigServerOptions(cluster.ObjectMeta.Name, config.CAs[fi.CertificateIDCA], bootConfig.APIServerIPs)
 		delete(config.CAs, fi.CertificateIDCA)

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -63,6 +63,7 @@ func NewNodeUpConfigBuilder(cluster *kops.Cluster, assetBuilder *assets.AssetBui
 	images := map[kops.InstanceGroupRole]map[architectures.Architecture][]*nodeup.Image{}
 
 	for _, role := range kops.AllInstanceGroupRoles {
+		isControlPlaneType := role.IsControlPlaneType()
 		isMaster := role.HasControlPlane()
 		isAPIServer := role.HasAPIServer()
 		isEtcd := role.HasEtcd()
@@ -108,7 +109,7 @@ func NewNodeUpConfigBuilder(cluster *kops.Cluster, assetBuilder *assets.AssetBui
 
 		// `docker load` our images when using a KOPS_BASE_URL, so we
 		// don't need to push/pull from a registry
-		if os.Getenv("KOPS_BASE_URL") != "" && isMaster {
+		if os.Getenv("KOPS_BASE_URL") != "" && isControlPlaneType {
 			for _, arch := range architectures.GetSupported() {
 				for _, name := range []string{"kops-utils-cp", "kops-controller", "kops-channels", "dns-controller", "kube-apiserver-healthcheck"} {
 					baseURL, err := url.Parse(os.Getenv("KOPS_BASE_URL"))

--- a/tests/e2e/scenarios/splitkcp/run-test.sh
+++ b/tests/e2e/scenarios/splitkcp/run-test.sh
@@ -20,8 +20,8 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}/"
 
-# Enable feature flag for APIServer Nodes support
-export KOPS_FEATURE_FLAGS=+APIServerNodes
+# Enable feature flag for APIServer Nodes support and split control plane
+export KOPS_FEATURE_FLAGS=+APIServerNodes,+ExperimentalRoles
 
 # Override some settings
 CLUSTER_NAME="splitkcp.k8s.local"
@@ -30,12 +30,17 @@ CLOUD_PROVIDER=gce
 ZONES="us-west1-a,us-west1-b,us-west1-c" # Currently the zone name gets encoded in the machinedeployment name (maybe we can use labels instead?)
 
 OVERRIDES="${OVERRIDES-} --node-count=2" # We need at least 2 nodes for CoreDNS to validate
-OVERRIDES="${OVERRIDES} --control-plane-count=3" # We need at least 3 control plane nodes to ensure etcd comes up as raft
-OVERRIDES="${OVERRIDES} --api-server-count=1" # We need at least 1 api-server node to split the control plane
-OVERRIDES="${OVERRIDES} --networking=kubenet" #
-OVERRIDES="${OVERRIDES} --node-size=e2-standard-2" #
+OVERRIDES="${OVERRIDES} --control-plane-count=0" # Turning off full control plane nodes and turning on split types
+OVERRIDES="${OVERRIDES} --api-server-count=2" # We need at least 1 api-server node to split the control plane
 OVERRIDES="${OVERRIDES} --api-server-size=e2-standard-2" #
-OVERRIDES="${OVERRIDES} --control-plane-size=e2-standard-4" #
+OVERRIDES="${OVERRIDES} --etcd-count=3" # We need at least 3 etcd nodes to have quorum
+OVERRIDES="${OVERRIDES} --etcd-size=e2-standard-2" #
+OVERRIDES="${OVERRIDES} --kcm-count=2" # We need at least 1 kube-controller-manager node to split the control plane
+OVERRIDES="${OVERRIDES} --kcm-size=e2-standard-2" #
+OVERRIDES="${OVERRIDES} --scheduler-count=2" # We need at least 1 kube-controller-manager node to split the control plane
+OVERRIDES="${OVERRIDES} --scheduler-size=e2-standard-2" #
+OVERRIDES="${OVERRIDES} --networking=kubenet" # :( Need to work out why we need this.
+OVERRIDES="${OVERRIDES} --node-size=e2-standard-2" #
 OVERRIDES="${OVERRIDES} --gce-service-account=default" # Use default service account because boskos permissions are limited
 
 # Create kOps cluster

--- a/tests/integration/create_cluster/experimental-roles/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/experimental-roles/expected-v1alpha2.yaml
@@ -16,16 +16,24 @@ spec:
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:
-    - instanceGroup: control-plane-us-test1-a
+    - instanceGroup: etcd-us-test1-a
       name: a
+    - instanceGroup: etcd-us-test1-b
+      name: b
+    - instanceGroup: etcd-us-test1-c
+      name: c
     manager:
       backupRetentionDays: 90
     memoryRequest: 100Mi
     name: main
   - cpuRequest: 100m
     etcdMembers:
-    - instanceGroup: control-plane-us-test1-a
+    - instanceGroup: etcd-us-test1-a
       name: a
+    - instanceGroup: etcd-us-test1-b
+      name: b
+    - instanceGroup: etcd-us-test1-c
+      name: c
     manager:
       backupRetentionDays: 90
     memoryRequest: 100Mi
@@ -129,19 +137,129 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   labels:
     kops.k8s.io/cluster: experimental.example.com
-  name: control-plane-us-test1-a
+  name: etcd-us-test1-a
 spec:
   image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
-  machineType: e2-medium
+  machineType: e2-standard-2
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: control-plane-us-test1-a
-  role: Master
+    kops.k8s.io/instancegroup: etcd-us-test1-a
+  role: Etcd
   subnets:
   - us-test1
   zones:
   - us-test1-a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: experimental.example.com
+  name: etcd-us-test1-b
+spec:
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
+  machineType: e2-standard-2
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: etcd-us-test1-b
+  role: Etcd
+  subnets:
+  - us-test1
+  zones:
+  - us-test1-b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: experimental.example.com
+  name: etcd-us-test1-c
+spec:
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
+  machineType: e2-standard-2
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: etcd-us-test1-c
+  role: Etcd
+  subnets:
+  - us-test1
+  zones:
+  - us-test1-c
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: experimental.example.com
+  name: kcm-us-test1-a
+spec:
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
+  machineType: e2-standard-2
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: kcm-us-test1-a
+  role: KubeControllerManager
+  subnets:
+  - us-test1
+  zones:
+  - us-test1-a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: experimental.example.com
+  name: kcm-us-test1-b
+spec:
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
+  machineType: e2-standard-2
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: kcm-us-test1-b
+  role: KubeControllerManager
+  subnets:
+  - us-test1
+  zones:
+  - us-test1-b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: experimental.example.com
+  name: kcm-us-test1-c
+spec:
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
+  machineType: e2-standard-2
+  maxSize: 0
+  minSize: 0
+  nodeLabels:
+    kops.k8s.io/instancegroup: kcm-us-test1-c
+  role: KubeControllerManager
+  subnets:
+  - us-test1
+  zones:
+  - us-test1-c
 
 ---
 
@@ -204,6 +322,72 @@ spec:
   nodeLabels:
     kops.k8s.io/instancegroup: nodes-us-test1-c
   role: Node
+  subnets:
+  - us-test1
+  zones:
+  - us-test1-c
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: experimental.example.com
+  name: scheduler-us-test1-a
+spec:
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
+  machineType: e2-standard-2
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: scheduler-us-test1-a
+  role: Scheduler
+  subnets:
+  - us-test1
+  zones:
+  - us-test1-a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: experimental.example.com
+  name: scheduler-us-test1-b
+spec:
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
+  machineType: e2-standard-2
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: scheduler-us-test1-b
+  role: Scheduler
+  subnets:
+  - us-test1
+  zones:
+  - us-test1-b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: experimental.example.com
+  name: scheduler-us-test1-c
+spec:
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
+  machineType: e2-standard-2
+  maxSize: 0
+  minSize: 0
+  nodeLabels:
+    kops.k8s.io/instancegroup: scheduler-us-test1-c
+  role: Scheduler
   subnets:
   - us-test1
   zones:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0945b1af834501611231b28aec2d675edec2c7f8e28ebc23f165cf1f30f49da3
+    manifestHash: 38a8e7f4cff553d45e1b8bd4a8e584f0e474b13c3c27ef7604813d95fe1fde14
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 88983572fdad5ed54e458fbb43836170d9fb4c064c327d7d67aaae7d73ada85e
+    manifestHash: 0945b1af834501611231b28aec2d675edec2c7f8e28ebc23f165cf1f30f49da3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_apiservers.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_apiservers.minimal.example.com_policy
@@ -9,6 +9,26 @@
     },
     {
       "Action": [
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+    },
+    {
+      "Action": [
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+    },
+    {
+      "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",
@@ -17,6 +37,18 @@
       "Effect": "Allow",
       "Resource": [
         "arn:aws-test:s3:::placeholder-read-bucket"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:GetEncryptionConfiguration",
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: apiserver
 InstanceGroupRole: APIServer
-NodeupConfigHash: bCQlRLsh8Rdow8Iw80MlnsoTBfnOvReN8oha827Yr2Y=
+NodeupConfigHash: ct1UVplVmp+aDk1TYGCoJwKYbRJ/E8qJY0gaknVhMYY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: LEcqK0CMoaN9z4LqjySnJesj+ImQ21wUji5DycWwEpE=
+NodeupConfigHash: WkNcvNOa9uuYI0GO4kcosjXDTCA1YAxhAo196sj273I=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4df14ae24b03865b4fb895402a83f1e5a199566b1908372a138cf3dd29a98fd1
+    manifestHash: cb1a56ee2c5ebc615c8eb9286e07baa4b1b6af1d3e2bfb2ec91173429a14ab4f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 67e1743499075e7fa857749c6a2a68ed0a3de9908b035dc9cf40057de18e687c
+    manifestHash: 4df14ae24b03865b4fb895402a83f1e5a199566b1908372a138cf3dd29a98fd1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-apiserver_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-apiserver_content
@@ -137,6 +137,7 @@ CAs:
     9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
     -----END CERTIFICATE-----
 ClusterName: minimal.example.com
+DNSZone: Z1AFAKE1ZON3YO
 FileAssets:
 - content: |
     apiVersion: kubescheduler.config.k8s.io/v1
@@ -170,6 +171,7 @@ KubeletConfig:
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   nodeLabels:
+    kops.k8s.io/kops-controller-pki: ""
     node-role.kubernetes.io/api-server: ""
   podManifestPath: /etc/kubernetes/manifests
   protectKernelDefaults: true
@@ -182,6 +184,7 @@ Networking:
   nonMasqueradeCIDR: 100.64.0.0/10
   serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
+channelsManifest: memfs://clusters.example.com/minimal.example.com/manifests/channels/kops-channels.yaml
 configStore:
   keypairs: memfs://clusters.example.com/minimal.example.com/pki
   secrets: memfs://clusters.example.com/minimal.example.com/secrets

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -285,7 +285,6 @@ KubeletConfig:
   logLevel: 2
   nodeLabels:
     kops.k8s.io/kops-controller-pki: ""
-    node-role.kubernetes.io/api-server: ""
     node-role.kubernetes.io/control-plane: ""
     node.kubernetes.io/exclude-from-external-load-balancers: ""
   podManifestPath: /etc/kubernetes/manifests

--- a/tests/integration/update_cluster/apiservernodes/kubernetes.tf
+++ b/tests/integration/update_cluster/apiservernodes/kubernetes.tf
@@ -143,6 +143,11 @@ resource "aws_autoscaling_group" "apiserver-apiservers-minimal-example-com" {
     value               = ""
   }
   tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"
+    propagate_at_launch = true
+    value               = ""
+  }
+  tag {
     key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server"
     propagate_at_launch = true
     value               = ""
@@ -194,11 +199,6 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
   }
   tag {
     key                 = "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"
-    propagate_at_launch = true
-    value               = ""
-  }
-  tag {
-    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server"
     propagate_at_launch = true
     value               = ""
   }
@@ -537,6 +537,7 @@ resource "aws_launch_template" "apiserver-apiservers-minimal-example-com" {
       "KubernetesCluster"                                                                = "minimal.example.com"
       "Name"                                                                             = "apiserver.apiservers.minimal.example.com"
       "aws-node-termination-handler/managed"                                             = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"    = ""
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server" = ""
       "k8s.io/role/apiserver"                                                            = "1"
       "kops.k8s.io/instancegroup"                                                        = "apiserver"
@@ -549,6 +550,7 @@ resource "aws_launch_template" "apiserver-apiservers-minimal-example-com" {
       "KubernetesCluster"                                                                = "minimal.example.com"
       "Name"                                                                             = "apiserver.apiservers.minimal.example.com"
       "aws-node-termination-handler/managed"                                             = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"    = ""
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server" = ""
       "k8s.io/role/apiserver"                                                            = "1"
       "kops.k8s.io/instancegroup"                                                        = "apiserver"
@@ -561,6 +563,7 @@ resource "aws_launch_template" "apiserver-apiservers-minimal-example-com" {
       "KubernetesCluster"                                                                = "minimal.example.com"
       "Name"                                                                             = "apiserver.apiservers.minimal.example.com"
       "aws-node-termination-handler/managed"                                             = ""
+      "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"    = ""
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server" = ""
       "k8s.io/role/apiserver"                                                            = "1"
       "kops.k8s.io/instancegroup"                                                        = "apiserver"
@@ -571,6 +574,7 @@ resource "aws_launch_template" "apiserver-apiservers-minimal-example-com" {
     "KubernetesCluster"                                                                = "minimal.example.com"
     "Name"                                                                             = "apiserver.apiservers.minimal.example.com"
     "aws-node-termination-handler/managed"                                             = ""
+    "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"    = ""
     "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server" = ""
     "k8s.io/role/apiserver"                                                            = "1"
     "kops.k8s.io/instancegroup"                                                        = "apiserver"
@@ -627,7 +631,6 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
       "aws-node-termination-handler/managed"                                                                  = ""
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
-      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server"                      = ""
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
       "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
       "k8s.io/role/control-plane"                                                                             = "1"
@@ -643,7 +646,6 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
       "aws-node-termination-handler/managed"                                                                  = ""
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
-      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server"                      = ""
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
       "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
       "k8s.io/role/control-plane"                                                                             = "1"
@@ -659,7 +661,6 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
       "aws-node-termination-handler/managed"                                                                  = ""
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
-      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server"                      = ""
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
       "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
       "k8s.io/role/control-plane"                                                                             = "1"
@@ -673,7 +674,6 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
     "aws-node-termination-handler/managed"                                                                  = ""
     "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
-    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/api-server"                      = ""
     "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
     "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
     "k8s.io/role/control-plane"                                                                             = "1"

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 73dd947ff2fb1039d261bc0f21671ed0477a3342e29015141c741c6bfbe31dfb
+    manifestHash: 2e569489715bdc478471b6bccea1a463b905e4ec16e57e66a03e781ab03ee208
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9438f532100c9e846defec1267943074ff6de4e345f6d74680a907216ef515d3
+    manifestHash: 73dd947ff2fb1039d261bc0f21671ed0477a3342e29015141c741c6bfbe31dfb
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7b498a89cc3ea29340a45b9c0e816afb836d0fcc80e87e8081eaf93194b0b192
+    manifestHash: 3ee9eb3bc152387a89c3e9c03c5bf4d68db7199968189c96b9ee8495436fc259
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3ee9eb3bc152387a89c3e9c03c5bf4d68db7199968189c96b9ee8495436fc259
+    manifestHash: 817232279733ef97ff90f46ef95f12f39c46e1e504f20d83ec64c93ef6d86d68
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ef83eb44a4800611aa3ed5bd6665b82d8aada267c4ba0ac8c7ced5008d57833d
+    manifestHash: dba998df504207e09f2ca81055e85cfedc546a6c6d4c1bab2c39d39d8e5936b3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c574529bbe54b692046be39f6b2f9bda708072acdd42271633b17f48d7e6237a
+    manifestHash: ef83eb44a4800611aa3ed5bd6665b82d8aada267c4ba0ac8c7ced5008d57833d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 903c2b0f5097de11011caa8a07936854b91e438fb0ded411f1570b1067c74119
+    manifestHash: 6e2d0f1bf4a40eb9c26c0c054caa0c59792ec243f3f2ff8450e806c01a97d17b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 297ce9d2db16553ebcc2886f751bb7f8494ad06f9de339c2f9067cbea377d5d6
+    manifestHash: 903c2b0f5097de11011caa8a07936854b91e438fb0ded411f1570b1067c74119
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: be9eec087faf860959b401425b18de58e2b3d5f97942b03014d30b1d5c060cd4
+    manifestHash: 9ec8783191271d409d6ad24cd06dd66fc04f61befcafb43ab4675ccafe2d76c8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 22e127628e7666be2717972502758cc73ea896c59e523bc569cb45b555ae6c4d
+    manifestHash: be9eec087faf860959b401425b18de58e2b3d5f97942b03014d30b1d5c060cd4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 996b5d415decc0e2bcd4e42754572534782e41eac6cb9dba47f9f7df560ba793
+    manifestHash: 8426a0cd37a004c383308fd2bf9e8ae80eff2b1908106302902b0cfd7241fbcd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8426a0cd37a004c383308fd2bf9e8ae80eff2b1908106302902b0cfd7241fbcd
+    manifestHash: 4e6806249887e56c31c78b66545539d15f97ff791636fb0651de23a95cd558ac
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 996b5d415decc0e2bcd4e42754572534782e41eac6cb9dba47f9f7df560ba793
+    manifestHash: 8426a0cd37a004c383308fd2bf9e8ae80eff2b1908106302902b0cfd7241fbcd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8426a0cd37a004c383308fd2bf9e8ae80eff2b1908106302902b0cfd7241fbcd
+    manifestHash: 4e6806249887e56c31c78b66545539d15f97ff791636fb0651de23a95cd558ac
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 66cfa22e017c3308aecf00dcd6529498305fe87f6e8529dd9b60978934b8a4d9
+    manifestHash: 3695365c0d39b1e075aa44137465ce6e9657ba7b32d4c0df0136e430e6bbb3ee
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a87b853ce71d068ee0458a3b3ebb483ce8cefb7232adc0b1305319d3667a398d
+    manifestHash: 66cfa22e017c3308aecf00dcd6529498305fe87f6e8529dd9b60978934b8a4d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 064187db16959e0118baac8dfa452b57046ba30f4b734a00f136f02590f51c67
+    manifestHash: ca4372334427e5ed9d10d29192e167e8cbacb00b85f5709aed9584d87539eaca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ca4372334427e5ed9d10d29192e167e8cbacb00b85f5709aed9584d87539eaca
+    manifestHash: 9d5de367cfc79c4a942c3f0d0b4dd3c6b3ddb31142b89b48b1185c56af7e788d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4da82bf6f186511f288d93ef78cb596daa8eda33a6a5614f335a4dbec7e16356
+    manifestHash: f7b94deea7720624f36f3f146ef4eb1ef6282807118f22861b80a3c07c33f442
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f7b94deea7720624f36f3f146ef4eb1ef6282807118f22861b80a3c07c33f442
+    manifestHash: 4913b69cb8dd0570ac9b3c73b0b8877d71b644cbe3c0ac59ad13c57359e0e448
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 30af55bad68bd9beb64731103c4e0533bccb9f2ca7ad80ef6639240a394cfe9b
+    manifestHash: 005a34c3e3ab5808d680c0c7fe94072d307dfec7db1ced64f63b30cc75ec8c72
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 64c48de4c1ba6532636144861982a8dffadd3827e27866dad832489de1c0096d
+    manifestHash: 30af55bad68bd9beb64731103c4e0533bccb9f2ca7ad80ef6639240a394cfe9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9d4479c2debc44f1dff792c37085e9e157a343df56924162f1a6f4e3958efe7f
+    manifestHash: a25eddcc2f8e1f4dd0c694246cbdf922e3777d904a59479bcf50a4f0d28a5d11
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0cba98209c07e96e04466e37217623e98ab8532c9bf2a19a5ebedea10eba4501
+    manifestHash: 9d4479c2debc44f1dff792c37085e9e157a343df56924162f1a6f4e3958efe7f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5214a047da9e0b32cbe1b95b75b39ae9d52324148089dd305d0e2f18329b02d5
+    manifestHash: fc944ffb79f497e1e7c8eab102f9cf079e303e8860637f9b8670256443a52f7d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fc944ffb79f497e1e7c8eab102f9cf079e303e8860637f9b8670256443a52f7d
+    manifestHash: 8892a318ad4916c80a274349ff2acfa1a9dfb3344ef986f095ca6639718c6da7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 58fe6d5f1300b0703508933aa77ea9ccf34f84b9799028dadd7079cbb9975e8e
+    manifestHash: 952baed00a916e99274c7cdfd2fcbef7f8912d65f2978122e45ad27cdbbb2043
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -53,7 +53,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: c98bbd8dc46276aa8ad095ff6ec6d7309a011592107d80e427a102d1862dbc44
+    manifestHash: 0ce97958b8f393af21d4ab850084e782f58831e760b2c0f8b0e345add0842f90
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 952baed00a916e99274c7cdfd2fcbef7f8912d65f2978122e45ad27cdbbb2043
+    manifestHash: 24da6f68b6b60e0780f48cb51c11f28dee0dbecb0885b5fb972dc3171bd37eb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -53,7 +53,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 0ce97958b8f393af21d4ab850084e782f58831e760b2c0f8b0e345add0842f90
+    manifestHash: 21262fe17e97606e481263cd131e9ade0c28a0a7cd7c8afe219a4e335adba521
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -352,8 +352,8 @@ resource "google_compute_firewall" "master-to-master-ha-gce-example-com" {
   disabled    = false
   name        = "master-to-master-ha-gce-example-com"
   network     = google_compute_network.ha-gce-example-com.name
-  source_tags = ["ha-gce-example-com-k8s-io-role-control-plane", "ha-gce-example-com-k8s-io-role-master"]
-  target_tags = ["ha-gce-example-com-k8s-io-role-control-plane", "ha-gce-example-com-k8s-io-role-master"]
+  source_tags = ["ha-gce-example-com-k8s-io-role-control-plane", "ha-gce-example-com-k8s-io-role-etcd", "ha-gce-example-com-k8s-io-role-scheduler", "ha-gce-example-com-k8s-io-role-kubecontrollermanager", "ha-gce-example-com-k8s-io-role-master"]
+  target_tags = ["ha-gce-example-com-k8s-io-role-control-plane", "ha-gce-example-com-k8s-io-role-etcd", "ha-gce-example-com-k8s-io-role-scheduler", "ha-gce-example-com-k8s-io-role-kubecontrollermanager", "ha-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-ha-gce-example-com" {
@@ -489,7 +489,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ha-gce-example-com" {
   name          = "ssh-external-to-master-ha-gce-example-com"
   network       = google_compute_network.ha-gce-example-com.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["ha-gce-example-com-k8s-io-role-control-plane", "ha-gce-example-com-k8s-io-role-master"]
+  target_tags   = ["ha-gce-example-com-k8s-io-role-control-plane", "ha-gce-example-com-k8s-io-role-etcd", "ha-gce-example-com-k8s-io-role-scheduler", "ha-gce-example-com-k8s-io-role-kubecontrollermanager", "ha-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-ipv6-ha-gce-example-com" {
@@ -501,7 +501,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-ha-gce-example-c
   name          = "ssh-external-to-master-ipv6-ha-gce-example-com"
   network       = google_compute_network.ha-gce-example-com.name
   source_ranges = ["::/0"]
-  target_tags   = ["ha-gce-example-com-k8s-io-role-control-plane", "ha-gce-example-com-k8s-io-role-master"]
+  target_tags   = ["ha-gce-example-com-k8s-io-role-control-plane", "ha-gce-example-com-k8s-io-role-etcd", "ha-gce-example-com-k8s-io-role-scheduler", "ha-gce-example-com-k8s-io-role-kubecontrollermanager", "ha-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ha-gce-example-com" {

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b4dc76a613ec5dfb06f3f774e0132ac82a4ec5287df49b82aefea3275fbb2390
+    manifestHash: 560ce64e69536cebc9043229f55ae1e15bdf2dabbf25de8b86d5f2d21b6f99ee
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -113,7 +113,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 6a20db07524f2540e19c5da56728f098d631f75f1e7474a160dae2667b1a2c72
+    manifestHash: 27fd3e30ad7d8e0a18125015c1c16fbd374d84de2c439802927ab3aae2441265
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 49a74cc9f58a05d818753385a6159bbeecbeaa39f692e594cbaca2203255aa7c
+    manifestHash: b4dc76a613ec5dfb06f3f774e0132ac82a4ec5287df49b82aefea3275fbb2390
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -113,7 +113,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: a2f62812a76c78d88820673859e171b6f2f1da88cc3332f034cb0859d54736ff
+    manifestHash: 6a20db07524f2540e19c5da56728f098d631f75f1e7474a160dae2667b1a2c72
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -272,8 +272,8 @@ resource "google_compute_firewall" "master-to-master-minimal-example-com" {
   disabled    = false
   name        = "master-to-master-minimal-example-com"
   network     = google_compute_network.minimal-example-com.name
-  source_tags = ["minimal-example-com-k8s-io-role-control-plane", "minimal-example-com-k8s-io-role-master"]
-  target_tags = ["minimal-example-com-k8s-io-role-control-plane", "minimal-example-com-k8s-io-role-master"]
+  source_tags = ["minimal-example-com-k8s-io-role-control-plane", "minimal-example-com-k8s-io-role-etcd", "minimal-example-com-k8s-io-role-scheduler", "minimal-example-com-k8s-io-role-kubecontrollermanager", "minimal-example-com-k8s-io-role-master"]
+  target_tags = ["minimal-example-com-k8s-io-role-control-plane", "minimal-example-com-k8s-io-role-etcd", "minimal-example-com-k8s-io-role-scheduler", "minimal-example-com-k8s-io-role-kubecontrollermanager", "minimal-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-minimal-example-com" {
@@ -409,7 +409,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-example-
   name          = "ssh-external-to-master-ipv6-minimal-example-com"
   network       = google_compute_network.minimal-example-com.name
   source_ranges = ["::/0"]
-  target_tags   = ["minimal-example-com-k8s-io-role-control-plane", "minimal-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-example-com-k8s-io-role-control-plane", "minimal-example-com-k8s-io-role-etcd", "minimal-example-com-k8s-io-role-scheduler", "minimal-example-com-k8s-io-role-kubecontrollermanager", "minimal-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-example-com" {
@@ -421,7 +421,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-example-com" 
   name          = "ssh-external-to-master-minimal-example-com"
   network       = google_compute_network.minimal-example-com.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["minimal-example-com-k8s-io-role-control-plane", "minimal-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-example-com-k8s-io-role-control-plane", "minimal-example-com-k8s-io-role-etcd", "minimal-example-com-k8s-io-role-scheduler", "minimal-example-com-k8s-io-role-kubecontrollermanager", "minimal-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-example-com" {

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 80fcab6ef45caaccf18449269f69de9ecbdd299f0fbe568fffb0afeea9fa7c64
+    manifestHash: 731c904af73efb5ec714603c485ce6c521dc9b3770fa59398220eccfe1f98b61
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 731c904af73efb5ec714603c485ce6c521dc9b3770fa59398220eccfe1f98b61
+    manifestHash: 8ff0885dbbe135aa70d7c79a88118a10b1a8eadb6551480dd610001115edbc5f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
+    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
+    manifestHash: 637c42819151232253b8f44da8e9d486186e431af17cbad8dd5dec8b2c0c5132
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
+    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
+    manifestHash: 637c42819151232253b8f44da8e9d486186e431af17cbad8dd5dec8b2c0c5132
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.33/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
+    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
+    manifestHash: 637c42819151232253b8f44da8e9d486186e431af17cbad8dd5dec8b2c0c5132
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.34/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
+    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
+    manifestHash: 637c42819151232253b8f44da8e9d486186e431af17cbad8dd5dec8b2c0c5132
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.35/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
+    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
+    manifestHash: 637c42819151232253b8f44da8e9d486186e431af17cbad8dd5dec8b2c0c5132
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.36/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 43e3570326e51f7506aba3b633336659c0fc85f05911f26b52bcd49a89ffb011
+    manifestHash: 74b90c9109c8e32527121f44da3b22e759d42c12405a0d87f06ac6f31868344d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c759b8c5f4b86d6ef7956c4fefaedeccbc36620b5507accc2026d9d9d150687d
+    manifestHash: 43e3570326e51f7506aba3b633336659c0fc85f05911f26b52bcd49a89ffb011
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 79f8fd981beb9682dc9849413aa599b3a8ca56086031eb3448415ac00ea3725d
+    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1baba51da898df809e201dd37b444e625ad1be5fad50c917ab1c43827311d01c
+    manifestHash: 637c42819151232253b8f44da8e9d486186e431af17cbad8dd5dec8b2c0c5132
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f0abaedc91b805c24e1b92a5216b140d50a14f4012346e6f343dafa28e25784e
+    manifestHash: aa2ac7087239724e487b86c519a378f5a88f1abd6caeb04fd960f0f2c943a449
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 62ef2a3e3c480864fea00e78fb43d575507d76c457aaeaeabbf1152b60448a60
+    manifestHash: f0abaedc91b805c24e1b92a5216b140d50a14f4012346e6f343dafa28e25784e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
+    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
+    manifestHash: 0ea01cc8395ed2ec657dbfda7768b6fac0b707d10ada6ee2590a30a77b643c4c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
+    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
+    manifestHash: 0ea01cc8395ed2ec657dbfda7768b6fac0b707d10ada6ee2590a30a77b643c4c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
+    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
+    manifestHash: 0ea01cc8395ed2ec657dbfda7768b6fac0b707d10ada6ee2590a30a77b643c4c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
+    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
+    manifestHash: 0ea01cc8395ed2ec657dbfda7768b6fac0b707d10ada6ee2590a30a77b643c4c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
+    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
+    manifestHash: 0ea01cc8395ed2ec657dbfda7768b6fac0b707d10ada6ee2590a30a77b643c4c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bd4bbe6a686295868a6ec58305d3b6e2a1873199af457075e5b65f71183d9162
+    manifestHash: 883067483d7cefe2a180d4876d96763acc205878b75ededa288fdf31b08cd727
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 883067483d7cefe2a180d4876d96763acc205878b75ededa288fdf31b08cd727
+    manifestHash: caf6a49e8e9d8881187c1b4370e1ef43e515cce0dc57ba2908732aa906f353a1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.really.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3331f594e11b433d43b80e0bd3d21689f4c6b12771b61a0d09a084f53be3033c
+    manifestHash: b3d4cd5ed3e04d1178d3c9e19c46bd96706eb81bb6d35ba3e8e5916e5ee6f871
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b3d4cd5ed3e04d1178d3c9e19c46bd96706eb81bb6d35ba3e8e5916e5ee6f871
+    manifestHash: 0ed622e89c9a9d046ea8aa4a2bcc11a1c7d3b67b6e0c2429501c55cc6d6a574b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4d583d823ab15b4a7b4abcda8179212b9f30c8f826708f3b96830e11901f4556
+    manifestHash: bb64220222ec82ec8799b4fc3aa68d97a61bbf5f93f1295059cf57eeafbb74a5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 733adf99aaaf10fe1081ff877c47f161d293e9c430caddb56ebab6a33c9cff32
+    manifestHash: 4d583d823ab15b4a7b4abcda8179212b9f30c8f826708f3b96830e11901f4556
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_source
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_source
+++ b/tests/integration/update_cluster/minimal_azure/data/azurerm_storage_blob_minimal-azure.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_source
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4788c572be95e6ad6749aab30d42805095ded3d7612865c99a66ce20b31b1534
+    manifestHash: 260b3dbf44ba132a37644210f400f0e9f4cdc7a5cb0b1b4f7ee68f4671f89858
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
       k8s-addon: storage-gce.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: efd860e9f256bf13ef8b46d4fa111bb411e762e7d68af05a3d321957d620fa45
+    manifestHash: c3f2f816235e62effb0fa5865bb09b2d90801d1e64f0fa343cd0f7a67cf7d492
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 260b3dbf44ba132a37644210f400f0e9f4cdc7a5cb0b1b4f7ee68f4671f89858
+    manifestHash: 829ab99ef44283e3e0a96a4e81ecea65957a0afc2ae3afe939cb30be01394bfc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
       k8s-addon: storage-gce.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: c3f2f816235e62effb0fa5865bb09b2d90801d1e64f0fa343cd0f7a67cf7d492
+    manifestHash: 0544c30d2c146e7618dee26d9daec50bd3aed1ac2ea4a664e1c464a5a4c22a3e
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -240,8 +240,8 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-example-com" {
   disabled    = false
   name        = "master-to-master-minimal-gce-example-com"
   network     = google_compute_network.minimal-gce-example-com.name
-  source_tags = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-master"]
-  target_tags = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-master"]
+  source_tags = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-etcd", "minimal-gce-example-com-k8s-io-role-scheduler", "minimal-gce-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-example-com-k8s-io-role-master"]
+  target_tags = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-etcd", "minimal-gce-example-com-k8s-io-role-scheduler", "minimal-gce-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-example-com" {
@@ -377,7 +377,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-exam
   name          = "ssh-external-to-master-ipv6-minimal-gce-example-com"
   network       = google_compute_network.minimal-gce-example-com.name
   source_ranges = ["::/0"]
-  target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-etcd", "minimal-gce-example-com-k8s-io-role-scheduler", "minimal-gce-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-example-com" {
@@ -389,7 +389,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-example-c
   name          = "ssh-external-to-master-minimal-gce-example-com"
   network       = google_compute_network.minimal-gce-example-com.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-etcd", "minimal-gce-example-com-k8s-io-role-scheduler", "minimal-gce-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 260b3dbf44ba132a37644210f400f0e9f4cdc7a5cb0b1b4f7ee68f4671f89858
+    manifestHash: 829ab99ef44283e3e0a96a4e81ecea65957a0afc2ae3afe939cb30be01394bfc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -85,7 +85,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: c3f2f816235e62effb0fa5865bb09b2d90801d1e64f0fa343cd0f7a67cf7d492
+    manifestHash: 0544c30d2c146e7618dee26d9daec50bd3aed1ac2ea4a664e1c464a5a4c22a3e
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4788c572be95e6ad6749aab30d42805095ded3d7612865c99a66ce20b31b1534
+    manifestHash: 260b3dbf44ba132a37644210f400f0e9f4cdc7a5cb0b1b4f7ee68f4671f89858
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -85,7 +85,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: efd860e9f256bf13ef8b46d4fa111bb411e762e7d68af05a3d321957d620fa45
+    manifestHash: c3f2f816235e62effb0fa5865bb09b2d90801d1e64f0fa343cd0f7a67cf7d492
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -265,7 +265,7 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-example-com" {
   name          = "lb-health-checks-minimal-gce-example-com"
   network       = google_compute_network.minimal-gce-example-com.name
   source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
-  target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane"]
+  target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-etcd"]
 }
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-example-com" {
@@ -290,8 +290,8 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-example-com" {
   disabled    = false
   name        = "master-to-master-minimal-gce-example-com"
   network     = google_compute_network.minimal-gce-example-com.name
-  source_tags = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-master"]
-  target_tags = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-master"]
+  source_tags = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-etcd", "minimal-gce-example-com-k8s-io-role-scheduler", "minimal-gce-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-example-com-k8s-io-role-master"]
+  target_tags = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-etcd", "minimal-gce-example-com-k8s-io-role-scheduler", "minimal-gce-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-example-com" {
@@ -427,7 +427,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-exam
   name          = "ssh-external-to-master-ipv6-minimal-gce-example-com"
   network       = google_compute_network.minimal-gce-example-com.name
   source_ranges = ["::/0"]
-  target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-etcd", "minimal-gce-example-com-k8s-io-role-scheduler", "minimal-gce-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-example-com" {
@@ -439,7 +439,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-example-c
   name          = "ssh-external-to-master-minimal-gce-example-com"
   network       = google_compute_network.minimal-gce-example-com.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane", "minimal-gce-example-com-k8s-io-role-etcd", "minimal-gce-example-com-k8s-io-role-scheduler", "minimal-gce-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 789618d218a90771d66dcd684c841bb684b7c4feefad1fac0d907a119617d92f
+    manifestHash: 38dec9ae2a9e2fed524265d7aa1ef5b2db467f44c91535f95bbe985b51ad110a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: c27922dd31b4f61832a6d3a3fc1607092a8ba016478ae41e6327fe178b5a8c24
+    manifestHash: ec4b40316a304263c7f325f7a0209fa1d1567b2663052e1dac85c513f2c783ad
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 38dec9ae2a9e2fed524265d7aa1ef5b2db467f44c91535f95bbe985b51ad110a
+    manifestHash: 6464f2ee8dba7922167f667a3b7cd91d169e814a56417c1b8f4b36b565312ae9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: ec4b40316a304263c7f325f7a0209fa1d1567b2663052e1dac85c513f2c783ad
+    manifestHash: dc700bbecc539f4a83f378375c215fc8a984cd16c52ceba72d6ef5a6b7a27f19
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -241,7 +241,7 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-ilb-example-com
   name          = "lb-health-checks-minimal-gce-ilb-example-com"
   network       = google_compute_network.minimal-gce-ilb-example-com.name
   source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
-  target_tags   = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane"]
+  target_tags   = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane", "minimal-gce-ilb-example-com-k8s-io-role-etcd"]
 }
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-ilb-example-com" {
@@ -266,8 +266,8 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-ilb-example-com
   disabled    = false
   name        = "master-to-master-minimal-gce-ilb-example-com"
   network     = google_compute_network.minimal-gce-ilb-example-com.name
-  source_tags = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane", "minimal-gce-ilb-example-com-k8s-io-role-master"]
-  target_tags = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane", "minimal-gce-ilb-example-com-k8s-io-role-master"]
+  source_tags = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane", "minimal-gce-ilb-example-com-k8s-io-role-etcd", "minimal-gce-ilb-example-com-k8s-io-role-scheduler", "minimal-gce-ilb-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-ilb-example-com-k8s-io-role-master"]
+  target_tags = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane", "minimal-gce-ilb-example-com-k8s-io-role-etcd", "minimal-gce-ilb-example-com-k8s-io-role-scheduler", "minimal-gce-ilb-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-ilb-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-ilb-example-com" {
@@ -403,7 +403,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-ilb-
   name          = "ssh-external-to-master-ipv6-minimal-gce-ilb-example-com"
   network       = google_compute_network.minimal-gce-ilb-example-com.name
   source_ranges = ["::/0"]
-  target_tags   = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane", "minimal-gce-ilb-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane", "minimal-gce-ilb-example-com-k8s-io-role-etcd", "minimal-gce-ilb-example-com-k8s-io-role-scheduler", "minimal-gce-ilb-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-ilb-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-ilb-example-com" {
@@ -415,7 +415,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-ilb-examp
   name          = "ssh-external-to-master-minimal-gce-ilb-example-com"
   network       = google_compute_network.minimal-gce-ilb-example-com.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane", "minimal-gce-ilb-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane", "minimal-gce-ilb-example-com-k8s-io-role-etcd", "minimal-gce-ilb-example-com-k8s-io-role-scheduler", "minimal-gce-ilb-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-ilb-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-ilb-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f47f9bf70133ac2e477e43691e375047570413f71673d18cf147a7a5f817e4d0
+    manifestHash: 06e1cd8a15557c902c5b2479831dcf09b878e56181faffd4d6272376caa03790
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 11fec447126ae12b9383124cd5ddcdb3465c8c4ea3010552a0f465cf3db445be
+    manifestHash: c5fc12fd2f5ca5c9ce2da5ab034b1c226cf0badff0fd4c5f10069beba895f56e
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 182b4b26986b5d6c7bfc00d7e3d2dd305bc70ef54b35bb4a0a6ed57d0d314c8d
+    manifestHash: f47f9bf70133ac2e477e43691e375047570413f71673d18cf147a7a5f817e4d0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 636e8e2070f1442f016924e2e26eee4b29dfe0749e880cdcc71e19854f7bb191
+    manifestHash: 11fec447126ae12b9383124cd5ddcdb3465c8c4ea3010552a0f465cf3db445be
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_minimal-gce-ilb-cilium-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/kubernetes.tf
@@ -301,7 +301,7 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-ilb-cilium-etcd
   name          = "lb-health-checks-minimal-gce-ilb-cilium-etcd-example-com"
   network       = google_compute_network.minimal-gce-ilb-cilium-etcd-example-com.name
   source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
-  target_tags   = ["minimal-gce-ilb-cilium-etcd-ex-eqdptu-k8s-io-role-control-plane"]
+  target_tags   = ["minimal-gce-ilb-cilium-etcd-ex-eqdptu-k8s-io-role-control-plane", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-etcd"]
 }
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-ilb-cilium-etcd-example-com" {
@@ -326,8 +326,8 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-ilb-cilium-etcd
   disabled    = false
   name        = "master-to-master-minimal-gce-ilb-cilium-etcd-example-com"
   network     = google_compute_network.minimal-gce-ilb-cilium-etcd-example-com.name
-  source_tags = ["minimal-gce-ilb-cilium-etcd-ex-eqdptu-k8s-io-role-control-plane", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-master"]
-  target_tags = ["minimal-gce-ilb-cilium-etcd-ex-eqdptu-k8s-io-role-control-plane", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-master"]
+  source_tags = ["minimal-gce-ilb-cilium-etcd-ex-eqdptu-k8s-io-role-control-plane", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-etcd", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-scheduler", "minimal-gce-ilb-cilium-eqdptu-k8s-io-role-kubecontrollermanager", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-master"]
+  target_tags = ["minimal-gce-ilb-cilium-etcd-ex-eqdptu-k8s-io-role-control-plane", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-etcd", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-scheduler", "minimal-gce-ilb-cilium-eqdptu-k8s-io-role-kubecontrollermanager", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-ilb-cilium-etcd-example-com" {
@@ -471,7 +471,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-ilb-
   name          = "ssh-external-to-master-ipv6-minimal-gce-ilb-cilium-etcd--eqdptu"
   network       = google_compute_network.minimal-gce-ilb-cilium-etcd-example-com.name
   source_ranges = ["::/0"]
-  target_tags   = ["minimal-gce-ilb-cilium-etcd-ex-eqdptu-k8s-io-role-control-plane", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-ilb-cilium-etcd-ex-eqdptu-k8s-io-role-control-plane", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-etcd", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-scheduler", "minimal-gce-ilb-cilium-eqdptu-k8s-io-role-kubecontrollermanager", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-ilb-cilium-etcd-example-com" {
@@ -483,7 +483,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-ilb-ciliu
   name          = "ssh-external-to-master-minimal-gce-ilb-cilium-etcd-example-com"
   network       = google_compute_network.minimal-gce-ilb-cilium-etcd-example-com.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["minimal-gce-ilb-cilium-etcd-ex-eqdptu-k8s-io-role-control-plane", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-ilb-cilium-etcd-ex-eqdptu-k8s-io-role-control-plane", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-etcd", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-scheduler", "minimal-gce-ilb-cilium-eqdptu-k8s-io-role-kubecontrollermanager", "minimal-gce-ilb-cilium-etcd-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-ilb-cilium-etcd-ex-eqdptu" {

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7b1d9e5aaef2d14e3c1c7be13bf566739f830898269d7a7a0440c700113a05e1
+    manifestHash: 29353ada6bd378a03ff0589b82c37c7706af032df71419dc938f58b762ea33b4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 20412e8fe0c0f3cb1a709a1f6f4fe7ef45bc6e34cce70b5603ca133c4ecad0ac
+    manifestHash: 2c8987fc74804195be80c2034c2d688c49ff3674941a6bdbe4e6363d8a391e3f
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 29353ada6bd378a03ff0589b82c37c7706af032df71419dc938f58b762ea33b4
+    manifestHash: 47ee30749a693ecc6f23250ea548f6a58d33600406e451e569e47f30a944acfe
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 2c8987fc74804195be80c2034c2d688c49ff3674941a6bdbe4e6363d8a391e3f
+    manifestHash: 1a9212e1f6d5cb2af09edd09107d4846b9c36a09b96954af7d27dd4ed075eb71
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -241,7 +241,7 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-with-a-very-ver
   name          = "lb-health-checks-minimal-gce-with-a-very-very-very-very--96dqvi"
   network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
-  target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane"]
+  target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-etcd"]
 }
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-with-a-very-very-very-very--96dqvi" {
@@ -266,8 +266,8 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-with-a-very-ver
   disabled    = false
   name        = "master-to-master-minimal-gce-with-a-very-very-very-very--96dqvi"
   network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
-  source_tags = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
-  target_tags = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
+  source_tags = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-etcd", "minimal-gce-with-a-very-very-very--96dqvi-k8s-io-role-scheduler", "minimal-gce-with-a-ver-96dqvi-k8s-io-role-kubecontrollermanager", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
+  target_tags = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-etcd", "minimal-gce-with-a-very-very-very--96dqvi-k8s-io-role-scheduler", "minimal-gce-with-a-ver-96dqvi-k8s-io-role-kubecontrollermanager", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-with-a-very-very-very-very-ve-96dqvi" {
@@ -403,7 +403,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-with
   name          = "ssh-external-to-master-ipv6-minimal-gce-with-a-very-very-96dqvi"
   network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["::/0"]
-  target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-etcd", "minimal-gce-with-a-very-very-very--96dqvi-k8s-io-role-scheduler", "minimal-gce-with-a-ver-96dqvi-k8s-io-role-kubecontrollermanager", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-with-a-very-very-very-96dqvi" {
@@ -415,7 +415,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-with-a-ve
   name          = "ssh-external-to-master-minimal-gce-with-a-very-very-very-96dqvi"
   network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-etcd", "minimal-gce-with-a-very-very-very--96dqvi-k8s-io-role-scheduler", "minimal-gce-with-a-ver-96dqvi-k8s-io-role-kubecontrollermanager", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-with-a-very-very-v-96dqvi" {

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7b1d9e5aaef2d14e3c1c7be13bf566739f830898269d7a7a0440c700113a05e1
+    manifestHash: 29353ada6bd378a03ff0589b82c37c7706af032df71419dc938f58b762ea33b4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 20412e8fe0c0f3cb1a709a1f6f4fe7ef45bc6e34cce70b5603ca133c4ecad0ac
+    manifestHash: 2c8987fc74804195be80c2034c2d688c49ff3674941a6bdbe4e6363d8a391e3f
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 29353ada6bd378a03ff0589b82c37c7706af032df71419dc938f58b762ea33b4
+    manifestHash: 47ee30749a693ecc6f23250ea548f6a58d33600406e451e569e47f30a944acfe
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 2c8987fc74804195be80c2034c2d688c49ff3674941a6bdbe4e6363d8a391e3f
+    manifestHash: 1a9212e1f6d5cb2af09edd09107d4846b9c36a09b96954af7d27dd4ed075eb71
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -248,8 +248,8 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-with-a-very-ver
   disabled    = false
   name        = "master-to-master-minimal-gce-with-a-very-very-very-very--96dqvi"
   network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
-  source_tags = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
-  target_tags = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
+  source_tags = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-etcd", "minimal-gce-with-a-very-very-very--96dqvi-k8s-io-role-scheduler", "minimal-gce-with-a-ver-96dqvi-k8s-io-role-kubecontrollermanager", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
+  target_tags = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-etcd", "minimal-gce-with-a-very-very-very--96dqvi-k8s-io-role-scheduler", "minimal-gce-with-a-ver-96dqvi-k8s-io-role-kubecontrollermanager", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-with-a-very-very-very-very-ve-96dqvi" {
@@ -385,7 +385,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-with
   name          = "ssh-external-to-master-ipv6-minimal-gce-with-a-very-very-96dqvi"
   network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["::/0"]
-  target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-etcd", "minimal-gce-with-a-very-very-very--96dqvi-k8s-io-role-scheduler", "minimal-gce-with-a-ver-96dqvi-k8s-io-role-kubecontrollermanager", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-with-a-very-very-very-96dqvi" {
@@ -397,7 +397,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-with-a-ve
   name          = "ssh-external-to-master-minimal-gce-with-a-very-very-very-96dqvi"
   network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane", "minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-etcd", "minimal-gce-with-a-very-very-very--96dqvi-k8s-io-role-scheduler", "minimal-gce-with-a-ver-96dqvi-k8s-io-role-kubecontrollermanager", "minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-with-a-very-very-v-96dqvi" {

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 291dc9847850d9a62ccc065fc3534049967fc6eaab84b603f9564a185481ad37
+    manifestHash: a02d95ffe929b2747ce9f3fcb469961c825ac5ddc47a327876874f6f655333c1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 19eeb9e0ac4f1721e82f048929c6c7f09c1925165adf082398ca04dc21a79ef4
+    manifestHash: aab26c2b398024da061848b7dc48d8d7468c2348a47dc93269a6c6ef6e6e8d00
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a02d95ffe929b2747ce9f3fcb469961c825ac5ddc47a327876874f6f655333c1
+    manifestHash: dd7ef6adadb7e9ba58b289cba1bf1b279579ab000627073eee65ed656a1f1044
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: aab26c2b398024da061848b7dc48d8d7468c2348a47dc93269a6c6ef6e6e8d00
+    manifestHash: 6c22515a8cf35babd7f20482e94cfca1e674e52df07b316355682525e25546e0
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -245,7 +245,7 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-plb-example-com
   name          = "lb-health-checks-minimal-gce-plb-example-com"
   network       = google_compute_network.minimal-gce-plb-example-com.name
   source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
-  target_tags   = ["minimal-gce-plb-example-com-k8s-io-role-control-plane"]
+  target_tags   = ["minimal-gce-plb-example-com-k8s-io-role-control-plane", "minimal-gce-plb-example-com-k8s-io-role-etcd"]
 }
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-plb-example-com" {
@@ -270,8 +270,8 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-plb-example-com
   disabled    = false
   name        = "master-to-master-minimal-gce-plb-example-com"
   network     = google_compute_network.minimal-gce-plb-example-com.name
-  source_tags = ["minimal-gce-plb-example-com-k8s-io-role-control-plane", "minimal-gce-plb-example-com-k8s-io-role-master"]
-  target_tags = ["minimal-gce-plb-example-com-k8s-io-role-control-plane", "minimal-gce-plb-example-com-k8s-io-role-master"]
+  source_tags = ["minimal-gce-plb-example-com-k8s-io-role-control-plane", "minimal-gce-plb-example-com-k8s-io-role-etcd", "minimal-gce-plb-example-com-k8s-io-role-scheduler", "minimal-gce-plb-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-plb-example-com-k8s-io-role-master"]
+  target_tags = ["minimal-gce-plb-example-com-k8s-io-role-control-plane", "minimal-gce-plb-example-com-k8s-io-role-etcd", "minimal-gce-plb-example-com-k8s-io-role-scheduler", "minimal-gce-plb-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-plb-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-plb-example-com" {
@@ -407,7 +407,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-plb-
   name          = "ssh-external-to-master-ipv6-minimal-gce-plb-example-com"
   network       = google_compute_network.minimal-gce-plb-example-com.name
   source_ranges = ["::/0"]
-  target_tags   = ["minimal-gce-plb-example-com-k8s-io-role-control-plane", "minimal-gce-plb-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-plb-example-com-k8s-io-role-control-plane", "minimal-gce-plb-example-com-k8s-io-role-etcd", "minimal-gce-plb-example-com-k8s-io-role-scheduler", "minimal-gce-plb-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-plb-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-plb-example-com" {
@@ -419,7 +419,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-plb-examp
   name          = "ssh-external-to-master-minimal-gce-plb-example-com"
   network       = google_compute_network.minimal-gce-plb-example-com.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["minimal-gce-plb-example-com-k8s-io-role-control-plane", "minimal-gce-plb-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-plb-example-com-k8s-io-role-control-plane", "minimal-gce-plb-example-com-k8s-io-role-etcd", "minimal-gce-plb-example-com-k8s-io-role-scheduler", "minimal-gce-plb-example-com-k8s-io-role-kubecontrollermanager", "minimal-gce-plb-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-plb-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 239e1ac0d73d2328cb42048a11827dd68928a0f041d613b1be33d3efc0dc1549
+    manifestHash: 5000700e03059f1127371307bda1f9d30792187f0e9d9d4fb2fb30fbebeee192
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 9f4058ae1f5694b3ef670082f4661881af6233c9a3f15ba45def0898a5617976
+    manifestHash: f184c0309923e91dab739607c366327dbe6cf477c0126d127a9cc7dcb60238c1
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0896a0ad40518e6d05e127c2816acc03281d24ec77787937fdcabaeae5f1df7e
+    manifestHash: 239e1ac0d73d2328cb42048a11827dd68928a0f041d613b1be33d3efc0dc1549
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: b9ba7baaa83f9a93b946ca0a4109001ac7553caad9928d16953d0cdb1c59f56e
+    manifestHash: 9f4058ae1f5694b3ef670082f4661881af6233c9a3f15ba45def0898a5617976
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_minimal-gce-plb-apiserver.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_nodeupconfig-apiserver-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_nodeupconfig-apiserver-us-test1-a_content
@@ -139,6 +139,7 @@ CAs:
     9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
     -----END CERTIFICATE-----
 ClusterName: minimal-gce-plb-apiserver.example.com
+DNSZone: "1"
 FileAssets:
 - content: |
     apiVersion: kubescheduler.config.k8s.io/v1
@@ -173,6 +174,7 @@ KubeletConfig:
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
   nodeLabels:
+    kops.k8s.io/kops-controller-pki: ""
     node-role.kubernetes.io/api-server: ""
   podManifestPath: /etc/kubernetes/manifests
   protectKernelDefaults: true
@@ -186,6 +188,7 @@ Networking:
   nonMasqueradeCIDR: 100.64.0.0/10
   serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
+channelsManifest: memfs://tests/minimal-gce-plb-apiserver.example.com/manifests/channels/kops-channels.yaml
 configStore:
   keypairs: memfs://tests/minimal-gce-plb-apiserver.example.com/pki
   secrets: memfs://tests/minimal-gce-plb-apiserver.example.com/secrets

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -286,7 +286,6 @@ KubeletConfig:
   logLevel: 2
   nodeLabels:
     kops.k8s.io/kops-controller-pki: ""
-    node-role.kubernetes.io/api-server: ""
     node-role.kubernetes.io/control-plane: ""
     node.kubernetes.io/exclude-from-external-load-balancers: ""
   podManifestPath: /etc/kubernetes/manifests

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_apiserver-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_apiserver-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal-gce-plb-apiserver.example.com
 ConfigBase: memfs://tests/minimal-gce-plb-apiserver.example.com
 InstanceGroupName: apiserver-us-test1-a
 InstanceGroupRole: APIServer
-NodeupConfigHash: DNfvSJEORH4nJ0W/j+DKTHVjZF94pIsFHJcGy3pfeLU=
+NodeupConfigHash: 3qn0lTgoIJDKjbxqWN8A8whOn5GRuhwSwzWJVfnFKi0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data
@@ -125,7 +125,7 @@ ClusterName: minimal-gce-plb-apiserver.example.com
 ConfigBase: memfs://tests/minimal-gce-plb-apiserver.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: M6ClBE8pso3lQ5I7lm3HtO03vbYuK3zzNaLt020Kfrk=
+NodeupConfigHash: 8q7mnMAD6NUZFXACfWcgbmYOfmxV5Xgn8+07DyE2kjw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
@@ -253,7 +253,7 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-plb-apiserver-e
   name          = "lb-health-checks-minimal-gce-plb-apiserver-example-com"
   network       = google_compute_network.minimal-gce-plb-apiserver-example-com.name
   source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
-  target_tags   = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-control-plane", "minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver"]
+  target_tags   = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-control-plane", "minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver", "minimal-gce-plb-apiserver-example-com-k8s-io-role-etcd"]
 }
 
 resource "google_compute_firewall" "master-to-master-minimal-gce-plb-apiserver-example-com" {
@@ -278,8 +278,8 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-plb-apiserver-e
   disabled    = false
   name        = "master-to-master-minimal-gce-plb-apiserver-example-com"
   network     = google_compute_network.minimal-gce-plb-apiserver-example-com.name
-  source_tags = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-control-plane", "minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver", "minimal-gce-plb-apiserver-example-com-k8s-io-role-master"]
-  target_tags = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-control-plane", "minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver", "minimal-gce-plb-apiserver-example-com-k8s-io-role-master"]
+  source_tags = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-control-plane", "minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver", "minimal-gce-plb-apiserver-example-com-k8s-io-role-etcd", "minimal-gce-plb-apiserver-example-com-k8s-io-role-scheduler", "minimal-gce-plb-apiser-eie140-k8s-io-role-kubecontrollermanager", "minimal-gce-plb-apiserver-example-com-k8s-io-role-master"]
+  target_tags = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-control-plane", "minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver", "minimal-gce-plb-apiserver-example-com-k8s-io-role-etcd", "minimal-gce-plb-apiserver-example-com-k8s-io-role-scheduler", "minimal-gce-plb-apiser-eie140-k8s-io-role-kubecontrollermanager", "minimal-gce-plb-apiserver-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-plb-apiserver-example-com" {
@@ -415,7 +415,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-plb-
   name          = "ssh-external-to-master-ipv6-minimal-gce-plb-apiserver-ex-eie140"
   network       = google_compute_network.minimal-gce-plb-apiserver-example-com.name
   source_ranges = ["::/0"]
-  target_tags   = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-control-plane", "minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver", "minimal-gce-plb-apiserver-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-control-plane", "minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver", "minimal-gce-plb-apiserver-example-com-k8s-io-role-etcd", "minimal-gce-plb-apiserver-example-com-k8s-io-role-scheduler", "minimal-gce-plb-apiser-eie140-k8s-io-role-kubecontrollermanager", "minimal-gce-plb-apiserver-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-plb-apiserver-example-com" {
@@ -427,7 +427,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-plb-apise
   name          = "ssh-external-to-master-minimal-gce-plb-apiserver-example-com"
   network       = google_compute_network.minimal-gce-plb-apiserver-example-com.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-control-plane", "minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver", "minimal-gce-plb-apiserver-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-control-plane", "minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver", "minimal-gce-plb-apiserver-example-com-k8s-io-role-etcd", "minimal-gce-plb-apiserver-example-com-k8s-io-role-scheduler", "minimal-gce-plb-apiser-eie140-k8s-io-role-kubecontrollermanager", "minimal-gce-plb-apiserver-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-plb-apiserver-example-com" {
@@ -607,7 +607,7 @@ resource "google_compute_instance_template" "apiserver-us-test1-a-minimal-gce-pl
   }
   service_account {
     email  = "default"
-    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/cloud-platform", "https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
+    scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/cloud-platform", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
   }
   tags = ["minimal-gce-plb-apiserver-example-com-k8s-io-role-apiserver"]
 }
@@ -737,6 +737,10 @@ resource "google_compute_region_backend_service" "api-minimal-gce-plb-apiserver-
 }
 
 resource "google_compute_region_backend_service" "kops-controller-minimal-gce-plb-apiserver-example-com" {
+  backend {
+    balancing_mode = "CONNECTION"
+    group          = google_compute_instance_group_manager.a-apiserver-us-test1-a-minimal-gce-plb-apiserver-example-com.instance_group
+  }
   backend {
     balancing_mode = "CONNECTION"
     group          = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-plb-apiserver-example-com.instance_group

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8520fb58e4d5234e4cf236988226b69b492f6455e8f09debca89f6adedbcd7ca
+    manifestHash: 31da4a80e9c06d918a8c0b8b56e17c2c952a21d0e716ad8875bf430997122fc9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 662cc3b9e1493fc6da6c9853f15fe0a91ed78ffee1b5bc40a6472b14b9308c13
+    manifestHash: a6418501beb71ab9efdf4c1e3ae5eb5b17a898097fe755c6e72d9b04c81d34ed
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 03624453e7296c0b13649f867830ad22d205322e9e0e6200c56f9a4a48ccfc98
+    manifestHash: 8520fb58e4d5234e4cf236988226b69b492f6455e8f09debca89f6adedbcd7ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 75ff82cb053e65f7ed3bf5fe8707bd519997b43b1cd44e8fc796f7dda3229e6a
+    manifestHash: 662cc3b9e1493fc6da6c9853f15fe0a91ed78ffee1b5bc40a6472b14b9308c13
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/cloud-controller-manager
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -248,8 +248,8 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-private-example
   disabled    = false
   name        = "master-to-master-minimal-gce-private-example-com"
   network     = google_compute_network.minimal-gce-private-example-com.name
-  source_tags = ["minimal-gce-private-example-com-k8s-io-role-control-plane", "minimal-gce-private-example-com-k8s-io-role-master"]
-  target_tags = ["minimal-gce-private-example-com-k8s-io-role-control-plane", "minimal-gce-private-example-com-k8s-io-role-master"]
+  source_tags = ["minimal-gce-private-example-com-k8s-io-role-control-plane", "minimal-gce-private-example-com-k8s-io-role-etcd", "minimal-gce-private-example-com-k8s-io-role-scheduler", "minimal-gce-private-ex-sh4okp-k8s-io-role-kubecontrollermanager", "minimal-gce-private-example-com-k8s-io-role-master"]
+  target_tags = ["minimal-gce-private-example-com-k8s-io-role-control-plane", "minimal-gce-private-example-com-k8s-io-role-etcd", "minimal-gce-private-example-com-k8s-io-role-scheduler", "minimal-gce-private-ex-sh4okp-k8s-io-role-kubecontrollermanager", "minimal-gce-private-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "master-to-node-minimal-gce-private-example-com" {
@@ -385,7 +385,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-priv
   name          = "ssh-external-to-master-ipv6-minimal-gce-private-example-com"
   network       = google_compute_network.minimal-gce-private-example-com.name
   source_ranges = ["::/0"]
-  target_tags   = ["minimal-gce-private-example-com-k8s-io-role-control-plane", "minimal-gce-private-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-private-example-com-k8s-io-role-control-plane", "minimal-gce-private-example-com-k8s-io-role-etcd", "minimal-gce-private-example-com-k8s-io-role-scheduler", "minimal-gce-private-ex-sh4okp-k8s-io-role-kubecontrollermanager", "minimal-gce-private-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-private-example-com" {
@@ -397,7 +397,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-private-e
   name          = "ssh-external-to-master-minimal-gce-private-example-com"
   network       = google_compute_network.minimal-gce-private-example-com.name
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["minimal-gce-private-example-com-k8s-io-role-control-plane", "minimal-gce-private-example-com-k8s-io-role-master"]
+  target_tags   = ["minimal-gce-private-example-com-k8s-io-role-control-plane", "minimal-gce-private-example-com-k8s-io-role-etcd", "minimal-gce-private-example-com-k8s-io-role-scheduler", "minimal-gce-private-ex-sh4okp-k8s-io-role-kubecontrollermanager", "minimal-gce-private-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-private-example-com" {

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fa1fef8156a69638cb66064b3709a947dea4c3b72c71964a194bfbe0e35061d5
+    manifestHash: 07961e3adf72774f51262cf274ba20d3a51148b652a5a4a82cc8dfba6df77d94
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bc6d3ec51739764572058d2ed42a1dfe3c1393b1ea1512265cba75c2fee9e9aa
+    manifestHash: fa1fef8156a69638cb66064b3709a947dea4c3b72c71964a194bfbe0e35061d5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b666daa7ea81ec2936493283e27ed4f64f24d911734346fef8ef5cae4517f5c0
+    manifestHash: bcd81486c87b1fd7f9641b6fa834745786a435e55461982483559ba1b5ff244a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 75aabe5f9099e7650932764aabb957c1d9fcadb2ae3cc13d1e27ec3aee02d6e6
+    manifestHash: b666daa7ea81ec2936493283e27ed4f64f24d911734346fef8ef5cae4517f5c0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -90,6 +93,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e33be1206444f8fba258e6ed374dbe1740f2d37ba9a544d383a5da4534c01c42
+    manifestHash: b7cca14bbc70339201849d587d89a75c0005c3a2c6446619f5062fe4c3cbf486
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b7cca14bbc70339201849d587d89a75c0005c3a2c6446619f5062fe4c3cbf486
+    manifestHash: 304e779166e9856d70c2bf56b0b94e9ae56a24126d0ee12b530f5737de688803
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e33be1206444f8fba258e6ed374dbe1740f2d37ba9a544d383a5da4534c01c42
+    manifestHash: b7cca14bbc70339201849d587d89a75c0005c3a2c6446619f5062fe4c3cbf486
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b7cca14bbc70339201849d587d89a75c0005c3a2c6446619f5062fe4c3cbf486
+    manifestHash: 304e779166e9856d70c2bf56b0b94e9ae56a24126d0ee12b530f5737de688803
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: aba4f8b524a48e4364b0ddaaea9752bd8180ce08724590330873af0e0a494567
+    manifestHash: 45248f5910246fde7bd010c6c0ecdc616f3c024eb8a0203cc7a495d195f9f158
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: deff1f0e8700755dad51198fed2308135b30a5dd60c38953df3ec54e0b9dbd69
+    manifestHash: aba4f8b524a48e4364b0ddaaea9752bd8180ce08724590330873af0e0a494567
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: aba4f8b524a48e4364b0ddaaea9752bd8180ce08724590330873af0e0a494567
+    manifestHash: 45248f5910246fde7bd010c6c0ecdc616f3c024eb8a0203cc7a495d195f9f158
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: deff1f0e8700755dad51198fed2308135b30a5dd60c38953df3ec54e0b9dbd69
+    manifestHash: aba4f8b524a48e4364b0ddaaea9752bd8180ce08724590330873af0e0a494567
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5c2288833ce256d9a3fa66e0baf97972cea60aef8ff34fd5ca918cba9860e286
+    manifestHash: 94d1b4c0fcb629a6fcce9f3a6429a7cd8815cf8aa413346eb213d35d8da291f5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f3c8bceca99432bfd69a2f402e4ce78bf61bffaf73dd4bc573a4c60952fee590
+    manifestHash: 5c2288833ce256d9a3fa66e0baf97972cea60aef8ff34fd5ca918cba9860e286
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ae5321a60b97e5ca5d9fa11111abb2646d721fe0c191b49f80a80ca18472d541
+    manifestHash: fa0875572b72be05ccf61e40271ce2580510b496d19755728f56c941e0d6546d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fa0875572b72be05ccf61e40271ce2580510b496d19755728f56c941e0d6546d
+    manifestHash: f865f95dd9577783a315eec9cde1552de3b11754e273ef9c1f7db0af6ef3c15f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4f86bf3756203f2a0f252948c16be51e126da5af9e9a61b94306624e213adf91
+    manifestHash: bee8535d4fc7cf06b6c5cb12babf0891b5c3b89b10d6ac3c15dbbe68836f0f78
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bee8535d4fc7cf06b6c5cb12babf0891b5c3b89b10d6ac3c15dbbe68836f0f78
+    manifestHash: 2a27b2c39f522d77fdb58901a16e26860a08f3386ec587038ca94659bdd6dd67
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dda00e3c15f5780d3b842605e36d1a7857ef5386fc69c75577725a47c897197b
+    manifestHash: 542dd8d1f00d9aa3d06cb8ff22468ce149b86998cb9f525c19cc6ffd8c4d49a7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 542dd8d1f00d9aa3d06cb8ff22468ce149b86998cb9f525c19cc6ffd8c4d49a7
+    manifestHash: 5897302086c3c9135f1e96c7c24c12a2792383fbf0372ac7c0939fba2a6eb44a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dda00e3c15f5780d3b842605e36d1a7857ef5386fc69c75577725a47c897197b
+    manifestHash: 542dd8d1f00d9aa3d06cb8ff22468ce149b86998cb9f525c19cc6ffd8c4d49a7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 542dd8d1f00d9aa3d06cb8ff22468ce149b86998cb9f525c19cc6ffd8c4d49a7
+    manifestHash: 5897302086c3c9135f1e96c7c24c12a2792383fbf0372ac7c0939fba2a6eb44a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dda00e3c15f5780d3b842605e36d1a7857ef5386fc69c75577725a47c897197b
+    manifestHash: 542dd8d1f00d9aa3d06cb8ff22468ce149b86998cb9f525c19cc6ffd8c4d49a7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 542dd8d1f00d9aa3d06cb8ff22468ce149b86998cb9f525c19cc6ffd8c4d49a7
+    manifestHash: 5897302086c3c9135f1e96c7c24c12a2792383fbf0372ac7c0939fba2a6eb44a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bca9e3f5d4b9aed3d102d2f6e38160d364a6783af0e4d416a8aaee34e3d61f42
+    manifestHash: 838a91d362f6d2686d81e44024daecced1702185bb55e4fe9e3b4b8a30e4c225
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 151fcf9748c00411b81354bb9d6c149d0e15189017b0d88ea8df04af3fdcef18
+    manifestHash: bca9e3f5d4b9aed3d102d2f6e38160d364a6783af0e4d416a8aaee34e3d61f42
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 89c9a34bcad9e3a0e3e03af251ec5dc356a9df2eb23b860f1ce3494bbbf2f611
+    manifestHash: 02604d010894eb5adbad17496f1a8c601a2c5cc11cc44a046c81a87f59a61ade
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f26a9eff62bd9bb57d5386b6f592f91694dd66605ad873c87e615306e277f4f3
+    manifestHash: 89c9a34bcad9e3a0e3e03af251ec5dc356a9df2eb23b860f1ce3494bbbf2f611
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cbe1d68907c90d6bf963f4682465b71cc037ea0ad03e0354ca8b4c59f3a7cfca
+    manifestHash: 9b5cc153c8a327b4eff47890ec2d83f8785330b065e3d210dc92c4bb73d841b2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b5cc153c8a327b4eff47890ec2d83f8785330b065e3d210dc92c4bb73d841b2
+    manifestHash: 6830224df1f0ac449c0ed1525c46f0259873fa5a248dc78cc335733d154d6052
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9e9abd97de84155833ee40e405a07dd8d62f832c85d2c029971cf395badba387
+    manifestHash: 4f957e5228645daf4ffde668a82aa71649b82708737ee53a9951a957109b9fa6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d9edaf81808af059c6425a8ba1dd8a21ee8d10d55155c2a7060004a1aace0e4e
+    manifestHash: 9e9abd97de84155833ee40e405a07dd8d62f832c85d2c029971cf395badba387
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9bdf504b432bd18e2739593f1741b8f1a834cab858d668a630010a1a9a9fb16c
+    manifestHash: 3127534cf76ad6aca501d195da39b3e251dfd2442a5f9df3eb46bc8641729b67
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c7c08f6f0e77788796878ffd3b055aeb89881ebb7484c0696dacf285f36b2e19
+    manifestHash: 9bdf504b432bd18e2739593f1741b8f1a834cab858d668a630010a1a9a9fb16c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ec6ccafd261deb3e100c5bcda5f6cea863e7c3acfbda83e85b0dda73f214eb5d
+    manifestHash: aaa2cd7dbd81d33c7de957dc5924b4a40c0faa089e0a5808f73bb2554a7ff704
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ccbba19667ed491737f8c9655bbd4d55580b239816e7fe3319985754bdce6205
+    manifestHash: ec6ccafd261deb3e100c5bcda5f6cea863e7c3acfbda83e85b0dda73f214eb5d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 40635446592965fe5417163bdf4c6e42523adff5d6ddbec0d56234f74f426e73
+    manifestHash: 6a0e7ce1a41b4f1faee5e6a1ef2ed6e385cea7adf9825f20f04453646749a08d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e94e75a64c24dc8429f73706f9b32605d77942eda583b6e2a144e255cb074e42
+    manifestHash: 40635446592965fe5417163bdf4c6e42523adff5d6ddbec0d56234f74f426e73
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ed8d5f35bc2726c1eeed35c6543167ca0c814903b33697094675414364b339ac
+    manifestHash: c1ffdfd60af10e9c04d6b67b7dfa0e46a3d864fe0f77b3d72b2d4e45fbb75d1b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 06e123f04dc4f66e83a6267f5eb2c1f4edb2da796833d6739c4d94d0a8da2d8b
+    manifestHash: ed8d5f35bc2726c1eeed35c6543167ca0c814903b33697094675414364b339ac
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8d24fe630209284380ea4ecfb57b8aa6321ab82ac19d28d724a12ddb2d97a7b0
+    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6634f92817ee701b4be4f0f7e2e5617fafc8c08b1b085419cbca3e61c49c5d60
+    manifestHash: 0ea01cc8395ed2ec657dbfda7768b6fac0b707d10ada6ee2590a30a77b643c4c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a5da3e3a97bcc8d78b2f88f617859e4d0344ce62282af7511dcb57c3f269591a
+    manifestHash: f3b1fea9d223a7883f1288fcec3dc491a2f3c332c2fe0bd2d75e7323f215b3ee
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f3b1fea9d223a7883f1288fcec3dc491a2f3c332c2fe0bd2d75e7323f215b3ee
+    manifestHash: e933d5f1dca6a04a1447d7549b239deec2ede59c8dde58408605fb1132975ee4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2d0af953f7c53295604ec39ce83b24e6d670fa996596e75b0a31fb635b8965f
+    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8aa2c6fb2c3c46e92e74eaed660d8a63d6efa101250ab942e341647eac2d0912
+    manifestHash: d36f1668276627ff82c016bb5501a6fb2de610fddfb9623c67fce306b3463dcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -86,6 +89,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
@@ -24,6 +24,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/node-api-server
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
             - matchExpressions:

--- a/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/cloud-controller-manager
+              - key: node-role.kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/node-api-server
+              - key: kops.k8s.io/cloud-controller-manager
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -40,6 +40,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/node-api-server
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -55,6 +55,8 @@ spec:
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
         operator: Exists
+      - key: node-role.kubernetes.io/api-server
+        operator: Exists
       dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
       hostNetwork: true
       serviceAccount: kops-controller

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -40,7 +40,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-channel
+              - key: kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -40,7 +40,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -40,7 +40,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/node-api-server
+              - key: kops.k8s.io/kops-channel
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/upup/pkg/fi/cloudup/deepvalidate_test.go
+++ b/upup/pkg/fi/cloudup/deepvalidate_test.go
@@ -39,6 +39,54 @@ func TestDeepValidate_OK(t *testing.T) {
 	}
 }
 
+func buildMinimalInstanceGroup(name string, role kopsapi.InstanceGroupRole, subnet string) *kopsapi.InstanceGroup {
+	g := &kopsapi.InstanceGroup{}
+	g.ObjectMeta.Name = name + "-" + subnet
+	g.Spec.Role = role
+	var one int32 = 1
+	g.Spec.MinSize = &one
+	g.Spec.MaxSize = &one
+	g.Spec.Image = "my-image"
+	g.Spec.Subnets = []string{subnet}
+	return g
+}
+
+func TestDeepValidate_SplitControlPlane_OK(t *testing.T) {
+	c := buildDefaultCluster(t)
+	var groups []*kopsapi.InstanceGroup
+	for _, subnet := range c.Spec.Networking.Subnets {
+		groups = append(groups, buildMinimalInstanceGroup("apiserver", kopsapi.InstanceGroupRoleAPIServer, subnet.Name))
+		groups = append(groups, buildMinimalInstanceGroup("etcd", kopsapi.InstanceGroupRoleEtcd, subnet.Name))
+		groups = append(groups, buildMinimalInstanceGroup("kcm", kopsapi.InstanceGroupRoleKubeControllerManager, subnet.Name))
+		groups = append(groups, buildMinimalInstanceGroup("scheduler", kopsapi.InstanceGroupRoleScheduler, subnet.Name))
+		groups = append(groups, buildMinimalNodeInstanceGroup(subnet.Name))
+	}
+	err := validation.DeepValidate(c, groups, true, vfs.Context, nil)
+	if err != nil {
+		t.Fatalf("Expected no error from DeepValidate for split control plane, got %v", err)
+	}
+}
+
+func TestDeepValidate_SplitControlPlane_MutualExclusion(t *testing.T) {
+	c := buildDefaultCluster(t)
+	var groups []*kopsapi.InstanceGroup
+	groups = append(groups, buildMinimalMasterInstanceGroup("subnet-us-test-1a"))
+	groups = append(groups, buildMinimalInstanceGroup("etcd", kopsapi.InstanceGroupRoleEtcd, "subnet-us-test-1a"))
+	groups = append(groups, buildMinimalNodeInstanceGroup("subnet-us-test-1a"))
+	expectErrorFromDeepValidate(t, c, groups, "cannot have both ControlPlane/Master InstanceGroups and split control plane InstanceGroups")
+}
+
+func TestDeepValidate_SplitControlPlane_MissingComponent(t *testing.T) {
+	c := buildDefaultCluster(t)
+	var groups []*kopsapi.InstanceGroup
+	groups = append(groups, buildMinimalInstanceGroup("apiserver", kopsapi.InstanceGroupRoleAPIServer, "subnet-us-test-1a"))
+	groups = append(groups, buildMinimalInstanceGroup("etcd", kopsapi.InstanceGroupRoleEtcd, "subnet-us-test-1a"))
+	groups = append(groups, buildMinimalInstanceGroup("kcm", kopsapi.InstanceGroupRoleKubeControllerManager, "subnet-us-test-1a"))
+	// Missing Scheduler!
+	groups = append(groups, buildMinimalNodeInstanceGroup("subnet-us-test-1a"))
+	expectErrorFromDeepValidate(t, c, groups, "must configure either a ControlPlane InstanceGroup or separate APIServer, Etcd, KubControllerManager, and Scheduler InstanceGroups")
+}
+
 func TestDeepValidate_NoNodeZones(t *testing.T) {
 	c := buildDefaultCluster(t)
 	var groups []*kopsapi.InstanceGroup
@@ -50,7 +98,7 @@ func TestDeepValidate_NoMasterZones(t *testing.T) {
 	c := buildDefaultCluster(t)
 	var groups []*kopsapi.InstanceGroup
 	groups = append(groups, buildMinimalNodeInstanceGroup("subnet-us-test-1a"))
-	expectErrorFromDeepValidate(t, c, groups, "must configure at least one ControlPlane InstanceGroup")
+	expectErrorFromDeepValidate(t, c, groups, "must configure either a ControlPlane InstanceGroup or separate APIServer, Etcd, KubControllerManager, and Scheduler InstanceGroups")
 }
 
 func TestDeepValidate_BadZone(t *testing.T) {

--- a/upup/pkg/fi/cloudup/deepvalidate_test.go
+++ b/upup/pkg/fi/cloudup/deepvalidate_test.go
@@ -84,7 +84,7 @@ func TestDeepValidate_SplitControlPlane_MissingComponent(t *testing.T) {
 	groups = append(groups, buildMinimalInstanceGroup("kcm", kopsapi.InstanceGroupRoleKubeControllerManager, "subnet-us-test-1a"))
 	// Missing Scheduler!
 	groups = append(groups, buildMinimalNodeInstanceGroup("subnet-us-test-1a"))
-	expectErrorFromDeepValidate(t, c, groups, "must configure either a ControlPlane InstanceGroup or separate APIServer, Etcd, KubControllerManager, and Scheduler InstanceGroups")
+	expectErrorFromDeepValidate(t, c, groups, "must configure either a ControlPlane InstanceGroup or separate APIServer, Etcd, KubeControllerManager, and Scheduler InstanceGroups")
 }
 
 func TestDeepValidate_NoNodeZones(t *testing.T) {
@@ -98,7 +98,7 @@ func TestDeepValidate_NoMasterZones(t *testing.T) {
 	c := buildDefaultCluster(t)
 	var groups []*kopsapi.InstanceGroup
 	groups = append(groups, buildMinimalNodeInstanceGroup("subnet-us-test-1a"))
-	expectErrorFromDeepValidate(t, c, groups, "must configure either a ControlPlane InstanceGroup or separate APIServer, Etcd, KubControllerManager, and Scheduler InstanceGroups")
+	expectErrorFromDeepValidate(t, c, groups, "must configure either a ControlPlane InstanceGroup or separate APIServer, Etcd, KubeControllerManager, and Scheduler InstanceGroups")
 }
 
 func TestDeepValidate_BadZone(t *testing.T) {

--- a/upup/pkg/fi/cloudup/loader.go
+++ b/upup/pkg/fi/cloudup/loader.go
@@ -42,6 +42,7 @@ func (l *Loader) BuildTasks(ctx context.Context, lifecycleOverrides map[string]f
 		context := &fi.CloudupModelBuilderContext{
 			Tasks:              l.tasks,
 			LifecycleOverrides: lifecycleOverrides,
+			Stacktraces:        make(map[string]string),
 		}
 		context = context.WithContext(ctx)
 		err := builder.Build(context)
@@ -121,6 +122,7 @@ func (l *Loader) FindDeletions(cloud fi.Cloud, lifecycleOverrides map[string]fi.
 			context := &fi.CloudupModelBuilderContext{
 				Tasks:              l.tasks,
 				LifecycleOverrides: lifecycleOverrides,
+				Stacktraces:        make(map[string]string),
 			}
 			if err := hasDeletions.FindDeletions(context, cloud); err != nil {
 				return nil, err

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -137,8 +137,6 @@ type NewClusterOptions struct {
 	EtcdCount int32
 	// SchedulerCount is the number of API servers to create. Defaults to 0.
 	SchedulerCount int32
-	// CloudControllerManagerCount is the number of API servers to create. Defaults to 0.
-	CloudControllerManagerCount int32
 	// KubeControllerManagerCount is the number of API servers to create. Defaults to 0.
 	KubeControllerManagerCount int32
 	// EncryptEtcdStorage is whether to encrypt the etcd volumes.
@@ -176,17 +174,16 @@ type NewClusterOptions struct {
 	// InstanceManager specifies which manager to use for managing instances.
 	InstanceManager string
 
-	Image                       string
-	NodeImage                   string
-	ControlPlaneImage           string
-	BastionImage                string
-	ControlPlaneSizes           []string
-	APIServerSizes              []string
-	EtcdSizes                   []string
-	SchedulerSizes              []string
-	CloudControllerManagerSizes []string
-	KubeControllerManagerSizes  []string
-	NodeSizes                   []string
+	Image                      string
+	NodeImage                  string
+	ControlPlaneImage          string
+	BastionImage               string
+	ControlPlaneSizes          []string
+	APIServerSizes             []string
+	EtcdSizes                  []string
+	SchedulerSizes             []string
+	KubeControllerManagerSizes []string
+	NodeSizes                  []string
 }
 
 func (o *NewClusterOptions) InitDefaults() {
@@ -510,11 +507,6 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 		return nil, err
 	}
 
-	ccms, err := setupCCMNodes(opt, cluster, zoneToSubnetsMap)
-	if err != nil {
-		return nil, err
-	}
-
 	// Build the Etcd clusters
 	{
 		cloudProvider := cluster.GetCloudProvider()
@@ -570,7 +562,6 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 	instanceGroups = append(instanceGroups, etcds...)
 	instanceGroups = append(instanceGroups, schedulers...)
 	instanceGroups = append(instanceGroups, kcms...)
-	instanceGroups = append(instanceGroups, ccms...)
 	instanceGroups = append(instanceGroups, nodes...)
 	instanceGroups = append(instanceGroups, bastions...)
 
@@ -1936,52 +1927,6 @@ func setupKCMNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetsMa
 		}
 
 		for i, size := range opt.KubeControllerManagerSizes {
-			if i == 0 {
-				g.Spec.MachineType = size
-			}
-			if i > 0 {
-				klog.Fatalf("multiple machine types for IG group not currently supported")
-			}
-		}
-		nodes = append(nodes, g)
-	}
-	return nodes, nil
-}
-
-func setupCCMNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetsMap map[string][]*api.ClusterSubnetSpec) ([]*api.InstanceGroup, error) {
-	cloudProvider := cluster.GetCloudProvider()
-	var nodes []*api.InstanceGroup
-	numZones := len(opt.Zones)
-	nodeCount := opt.CloudControllerManagerCount
-	if nodeCount == 0 {
-		return nodes, nil
-	}
-	countPerIG := nodeCount / int32(numZones)
-	remainder := int(nodeCount) % numZones
-	for i, zone := range opt.Zones {
-		count := countPerIG
-		if i < remainder {
-			count++
-		}
-		g := &api.InstanceGroup{}
-		g.Spec.Role = api.InstanceGroupRoleCloudControllerManager
-		g.Spec.MinSize = new(count)
-		g.Spec.MaxSize = new(count)
-		g.ObjectMeta.Name = "ccm-" + zone
-
-		subnets := zoneToSubnetsMap[zone]
-		if len(subnets) == 0 {
-			klog.Fatalf("subnet not found in zoneToSubnetsMap")
-		}
-		for _, subnet := range subnets {
-			g.Spec.Subnets = append(g.Spec.Subnets, subnet.Name)
-		}
-
-		if cloudProvider == api.CloudProviderGCE || cloudProvider == api.CloudProviderAzure {
-			g.Spec.Zones = []string{zone}
-		}
-
-		for i, size := range opt.CloudControllerManagerSizes {
 			if i == 0 {
 				g.Spec.MachineType = size
 			}

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -130,7 +130,7 @@ type NewClusterOptions struct {
 
 	// ControlPlaneCount is the number of control-plane nodes to create. Defaults to the length of ControlPlaneZones.
 	// if ControlPlaneZones is explicitly nonempty, otherwise defaults to 1.
-	ControlPlaneCount int32
+	ControlPlaneCount *int32
 	// APIServerCount is the number of API servers to create. Defaults to 0.
 	APIServerCount int32
 	// EtcdCount is the number of API servers to create. Defaults to 0.
@@ -495,6 +495,71 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 		return nil, err
 	}
 
+	etcds, err := setupEtcdNodes(opt, cluster, zoneToSubnetsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	schedulers, err := setupSchedulerNodes(opt, cluster, zoneToSubnetsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	kcms, err := setupKCMNodes(opt, cluster, zoneToSubnetsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	ccms, err := setupCCMNodes(opt, cluster, zoneToSubnetsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the Etcd clusters
+	{
+		cloudProvider := cluster.GetCloudProvider()
+		controlPlaneAZs := sets.NewString()
+		duplicateAZs := false
+
+		etcdMembersIGs := controlPlanes
+		if len(etcds) > 0 {
+			etcdMembersIGs = etcds
+		}
+
+		for _, ig := range etcdMembersIGs {
+			zones, err := model.FindZonesForInstanceGroup(cluster, ig)
+			if err != nil {
+				return nil, err
+			}
+			for _, zone := range zones {
+				if controlPlaneAZs.Has(zone) {
+					duplicateAZs = true
+				}
+				controlPlaneAZs.Insert(zone)
+			}
+		}
+
+		if duplicateAZs {
+			klog.Warningf("Running with etcd/control-plane nodes in the same AZs; redundancy will be reduced")
+		}
+
+		clusters := opt.EtcdClusters
+		if opt.Networking == "cilium-etcd" {
+			clusters = append(clusters, "cilium")
+		}
+
+		encryptEtcdStorage := false
+		if opt.EncryptEtcdStorage != nil {
+			encryptEtcdStorage = fi.ValueOf(opt.EncryptEtcdStorage)
+		} else if cloudProvider == api.CloudProviderAWS {
+			encryptEtcdStorage = true
+		}
+		for _, etcdCluster := range clusters {
+			etcd := createEtcdCluster(etcdCluster, etcdMembersIGs, encryptEtcdStorage, opt.EtcdStorageType)
+			cluster.Spec.EtcdClusters = append(cluster.Spec.EtcdClusters, etcd)
+		}
+	}
+
 	err = setupAPI(opt, cluster)
 	if err != nil {
 		return nil, err
@@ -502,6 +567,10 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 
 	instanceGroups := append([]*api.InstanceGroup(nil), controlPlanes...)
 	instanceGroups = append(instanceGroups, apiservers...)
+	instanceGroups = append(instanceGroups, etcds...)
+	instanceGroups = append(instanceGroups, schedulers...)
+	instanceGroups = append(instanceGroups, kcms...)
+	instanceGroups = append(instanceGroups, ccms...)
 	instanceGroups = append(instanceGroups, nodes...)
 	instanceGroups = append(instanceGroups, bastions...)
 
@@ -958,28 +1027,27 @@ func setupControlPlane(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubne
 	// The control-plane count is the number of control-plane zones unless explicitly set.
 	// We then round-robin around the zones.
 	{
-		controlPlaneCount := opt.ControlPlaneCount
 		controlPlaneZones := opt.ControlPlaneZones
-		if len(controlPlaneZones) != 0 {
-			if controlPlaneCount != 0 && controlPlaneCount < int32(len(controlPlaneZones)) {
-				return nil, fmt.Errorf("specified %d control-plane zones, but also requested %d control-plane nodes.  If specifying both, the count should match.", len(controlPlaneZones), controlPlaneCount)
+		var controlPlaneCount int32
+		if opt.ControlPlaneCount != nil {
+			controlPlaneCount = *opt.ControlPlaneCount
+			if len(controlPlaneZones) == 0 {
+				controlPlaneZones = opt.Zones
 			}
-
-			if controlPlaneCount == 0 {
-				// If control-plane count is not specified, default to the number of control-plane zones
-				controlPlaneCount = int32(len(controlPlaneZones))
+			if controlPlaneCount != 0 && len(opt.ControlPlaneZones) != 0 && controlPlaneCount < int32(len(opt.ControlPlaneZones)) {
+				return nil, fmt.Errorf("specified %d control-plane zones, but also requested %d control-plane nodes.  If specifying both, the count should match.", len(opt.ControlPlaneZones), controlPlaneCount)
 			}
 		} else {
-			// controlPlaneZones not set; default to same as node Zones
-			controlPlaneZones = opt.Zones
-
-			if controlPlaneCount == 0 {
-				// If control-plane count is not specified, default to 1
+			// Defaulting
+			if len(controlPlaneZones) != 0 {
+				controlPlaneCount = int32(len(controlPlaneZones))
+			} else {
+				controlPlaneZones = opt.Zones
 				controlPlaneCount = 1
 			}
 		}
 
-		if len(controlPlaneZones) == 0 {
+		if controlPlaneCount > 0 && len(controlPlaneZones) == 0 {
 			// Should be unreachable
 			return nil, fmt.Errorf("cannot determine control-plane zones")
 		}
@@ -1036,46 +1104,6 @@ func setupControlPlane(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubne
 			g.Spec.Image = opt.ControlPlaneImage
 
 			controlPlanes = append(controlPlanes, g)
-		}
-	}
-
-	// Build the Etcd clusters
-	{
-		controlPlaneAZs := sets.NewString()
-		duplicateAZs := false
-		for _, ig := range controlPlanes {
-			zones, err := model.FindZonesForInstanceGroup(cluster, ig)
-			if err != nil {
-				return nil, err
-			}
-			for _, zone := range zones {
-				if controlPlaneAZs.Has(zone) {
-					duplicateAZs = true
-				}
-
-				controlPlaneAZs.Insert(zone)
-			}
-		}
-
-		if duplicateAZs {
-			klog.Warningf("Running with control-plane nodes in the same AZs; redundancy will be reduced")
-		}
-
-		clusters := opt.EtcdClusters
-
-		if opt.Networking == "cilium-etcd" {
-			clusters = append(clusters, "cilium")
-		}
-
-		encryptEtcdStorage := false
-		if opt.EncryptEtcdStorage != nil {
-			encryptEtcdStorage = fi.ValueOf(opt.EncryptEtcdStorage)
-		} else if cloudProvider == api.CloudProviderAWS {
-			encryptEtcdStorage = true
-		}
-		for _, etcdCluster := range clusters {
-			etcd := createEtcdCluster(etcdCluster, controlPlanes, encryptEtcdStorage, opt.EtcdStorageType)
-			cluster.Spec.EtcdClusters = append(cluster.Spec.EtcdClusters, etcd)
 		}
 	}
 
@@ -1780,4 +1808,188 @@ func discoveryUniverseID(ctx context.Context, keystore fi.Keystore) (string, err
 	}
 
 	return discoveryapi.ComputeUniverseIDFromCertificate(keyset.Primary.Certificate.Certificate), nil
+}
+
+func setupEtcdNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetsMap map[string][]*api.ClusterSubnetSpec) ([]*api.InstanceGroup, error) {
+	cloudProvider := cluster.GetCloudProvider()
+	var nodes []*api.InstanceGroup
+	numZones := len(opt.Zones)
+	nodeCount := opt.EtcdCount
+	if nodeCount == 0 {
+		return nodes, nil
+	}
+	countPerIG := nodeCount / int32(numZones)
+	remainder := int(nodeCount) % numZones
+	for i, zone := range opt.Zones {
+		count := countPerIG
+		if i < remainder {
+			count++
+		}
+		g := &api.InstanceGroup{}
+		g.Spec.Role = api.InstanceGroupRoleEtcd
+		g.Spec.MinSize = new(count)
+		g.Spec.MaxSize = new(count)
+		g.ObjectMeta.Name = "etcd-" + zone
+
+		subnets := zoneToSubnetsMap[zone]
+		if len(subnets) == 0 {
+			klog.Fatalf("subnet not found in zoneToSubnetsMap")
+		}
+		for _, subnet := range subnets {
+			g.Spec.Subnets = append(g.Spec.Subnets, subnet.Name)
+		}
+
+		if cloudProvider == api.CloudProviderGCE || cloudProvider == api.CloudProviderAzure {
+			g.Spec.Zones = []string{zone}
+		}
+
+		for i, size := range opt.EtcdSizes {
+			if i == 0 {
+				g.Spec.MachineType = size
+			}
+			if i > 0 {
+				klog.Fatalf("multiple machine types for IG group not currently supported")
+			}
+		}
+		nodes = append(nodes, g)
+	}
+	return nodes, nil
+}
+
+func setupSchedulerNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetsMap map[string][]*api.ClusterSubnetSpec) ([]*api.InstanceGroup, error) {
+	cloudProvider := cluster.GetCloudProvider()
+	var nodes []*api.InstanceGroup
+	numZones := len(opt.Zones)
+	nodeCount := opt.SchedulerCount
+	if nodeCount == 0 {
+		return nodes, nil
+	}
+	countPerIG := nodeCount / int32(numZones)
+	remainder := int(nodeCount) % numZones
+	for i, zone := range opt.Zones {
+		count := countPerIG
+		if i < remainder {
+			count++
+		}
+		g := &api.InstanceGroup{}
+		g.Spec.Role = api.InstanceGroupRoleScheduler
+		g.Spec.MinSize = new(count)
+		g.Spec.MaxSize = new(count)
+		g.ObjectMeta.Name = "scheduler-" + zone
+
+		subnets := zoneToSubnetsMap[zone]
+		if len(subnets) == 0 {
+			klog.Fatalf("subnet not found in zoneToSubnetsMap")
+		}
+		for _, subnet := range subnets {
+			g.Spec.Subnets = append(g.Spec.Subnets, subnet.Name)
+		}
+
+		if cloudProvider == api.CloudProviderGCE || cloudProvider == api.CloudProviderAzure {
+			g.Spec.Zones = []string{zone}
+		}
+
+		for i, size := range opt.SchedulerSizes {
+			if i == 0 {
+				g.Spec.MachineType = size
+			}
+			if i > 0 {
+				klog.Fatalf("multiple machine types for IG group not currently supported")
+			}
+		}
+		nodes = append(nodes, g)
+	}
+	return nodes, nil
+}
+
+func setupKCMNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetsMap map[string][]*api.ClusterSubnetSpec) ([]*api.InstanceGroup, error) {
+	cloudProvider := cluster.GetCloudProvider()
+	var nodes []*api.InstanceGroup
+	numZones := len(opt.Zones)
+	nodeCount := opt.KubeControllerManagerCount
+	if nodeCount == 0 {
+		return nodes, nil
+	}
+	countPerIG := nodeCount / int32(numZones)
+	remainder := int(nodeCount) % numZones
+	for i, zone := range opt.Zones {
+		count := countPerIG
+		if i < remainder {
+			count++
+		}
+		g := &api.InstanceGroup{}
+		g.Spec.Role = api.InstanceGroupRoleKubeControllerManager
+		g.Spec.MinSize = new(count)
+		g.Spec.MaxSize = new(count)
+		g.ObjectMeta.Name = "kcm-" + zone
+
+		subnets := zoneToSubnetsMap[zone]
+		if len(subnets) == 0 {
+			klog.Fatalf("subnet not found in zoneToSubnetsMap")
+		}
+		for _, subnet := range subnets {
+			g.Spec.Subnets = append(g.Spec.Subnets, subnet.Name)
+		}
+
+		if cloudProvider == api.CloudProviderGCE || cloudProvider == api.CloudProviderAzure {
+			g.Spec.Zones = []string{zone}
+		}
+
+		for i, size := range opt.KubeControllerManagerSizes {
+			if i == 0 {
+				g.Spec.MachineType = size
+			}
+			if i > 0 {
+				klog.Fatalf("multiple machine types for IG group not currently supported")
+			}
+		}
+		nodes = append(nodes, g)
+	}
+	return nodes, nil
+}
+
+func setupCCMNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetsMap map[string][]*api.ClusterSubnetSpec) ([]*api.InstanceGroup, error) {
+	cloudProvider := cluster.GetCloudProvider()
+	var nodes []*api.InstanceGroup
+	numZones := len(opt.Zones)
+	nodeCount := opt.CloudControllerManagerCount
+	if nodeCount == 0 {
+		return nodes, nil
+	}
+	countPerIG := nodeCount / int32(numZones)
+	remainder := int(nodeCount) % numZones
+	for i, zone := range opt.Zones {
+		count := countPerIG
+		if i < remainder {
+			count++
+		}
+		g := &api.InstanceGroup{}
+		g.Spec.Role = api.InstanceGroupRoleCloudControllerManager
+		g.Spec.MinSize = new(count)
+		g.Spec.MaxSize = new(count)
+		g.ObjectMeta.Name = "ccm-" + zone
+
+		subnets := zoneToSubnetsMap[zone]
+		if len(subnets) == 0 {
+			klog.Fatalf("subnet not found in zoneToSubnetsMap")
+		}
+		for _, subnet := range subnets {
+			g.Spec.Subnets = append(g.Spec.Subnets, subnet.Name)
+		}
+
+		if cloudProvider == api.CloudProviderGCE || cloudProvider == api.CloudProviderAzure {
+			g.Spec.Zones = []string{zone}
+		}
+
+		for i, size := range opt.CloudControllerManagerSizes {
+			if i == 0 {
+				g.Spec.MachineType = size
+			}
+			if i > 0 {
+				klog.Fatalf("multiple machine types for IG group not currently supported")
+			}
+		}
+		nodes = append(nodes, g)
+	}
+	return nodes, nil
 }

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -305,6 +305,18 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 			// (Even though the value is empty, we still expect <Key>=<Value>:<Effect>)
 			taints.Insert(nodelabels.RoleLabelAPIServer16 + "=:" + string(v1.TaintEffectNoSchedule))
 		}
+		if ig.IsEtcdOnly() {
+			// (Even though the value is empty, we still expect <Key>=<Value>:<Effect>)
+			taints.Insert(nodelabels.RoleLabelEtcd + "=:" + string(v1.TaintEffectNoSchedule))
+		}
+		if ig.IsKubeControllerManagerOnly() {
+			// (Even though the value is empty, we still expect <Key>=<Value>:<Effect>)
+			taints.Insert(nodelabels.RoleLabelKubeControllerManager + "=:" + string(v1.TaintEffectNoSchedule))
+		}
+		if ig.IsSchedulerOnly() {
+			// (Even though the value is empty, we still expect <Key>=<Value>:<Effect>)
+			taints.Insert(nodelabels.RoleLabelScheduler + "=:" + string(v1.TaintEffectNoSchedule))
+		}
 		if ig.Spec.Manager == kops.InstanceManagerKarpenter {
 			// Karpenter v1 expects its nodes to register with this taint as a race guard; it removes the taint once
 			// the NodeClaim is synced. The empty value still requires the <Key>=<Value>:<Effect> form.

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -339,7 +339,7 @@ func defaultMachineType(cloud fi.Cloud, cluster *kops.Cluster, ig *kops.Instance
 
 	case kops.CloudProviderGCE:
 		switch {
-		case ig.Spec.Role.HasControlPlane():
+		case ig.Spec.Role.IsControlPlaneType():
 			return defaultMasterMachineTypeGCE, nil
 
 		case ig.Spec.Role.HasNode():
@@ -351,7 +351,7 @@ func defaultMachineType(cloud fi.Cloud, cluster *kops.Cluster, ig *kops.Instance
 
 	case kops.CloudProviderDO:
 		switch {
-		case ig.Spec.Role.HasControlPlane():
+		case ig.Spec.Role.IsControlPlaneType():
 			return defaultMasterMachineTypeDO, nil
 
 		case ig.Spec.Role.HasNode():
@@ -361,7 +361,7 @@ func defaultMachineType(cloud fi.Cloud, cluster *kops.Cluster, ig *kops.Instance
 
 	case kops.CloudProviderHetzner:
 		switch {
-		case ig.Spec.Role.HasControlPlane():
+		case ig.Spec.Role.IsControlPlaneType():
 			return defaultMasterMachineTypeHetzner, nil
 
 		case ig.Spec.Role.HasNode():
@@ -380,7 +380,7 @@ func defaultMachineType(cloud fi.Cloud, cluster *kops.Cluster, ig *kops.Instance
 
 	case kops.CloudProviderAzure:
 		switch {
-		case ig.Spec.Role.HasControlPlane():
+		case ig.Spec.Role.IsControlPlaneType():
 			return defaultMasterMachineTypeAzure, nil
 
 		case ig.Spec.Role.HasNode():
@@ -392,7 +392,7 @@ func defaultMachineType(cloud fi.Cloud, cluster *kops.Cluster, ig *kops.Instance
 
 	case kops.CloudProviderScaleway:
 		switch {
-		case ig.Spec.Role.HasControlPlane():
+		case ig.Spec.Role.IsControlPlaneType():
 			return defaultMasterMachineTypeScaleway, nil
 
 		case ig.Spec.Role.HasNode():
@@ -401,7 +401,7 @@ func defaultMachineType(cloud fi.Cloud, cluster *kops.Cluster, ig *kops.Instance
 
 	case kops.CloudProviderLinode:
 		switch {
-		case ig.Spec.Role.HasControlPlane():
+		case ig.Spec.Role.IsControlPlaneType():
 			return defaultMasterMachineTypeLinode, nil
 
 		case ig.Spec.Role.HasNode():

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/dns-none/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/dns-none/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/dns-none/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/dns-none/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/kops-controller
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki
@@ -84,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -43,6 +43,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: kops.k8s.io/node-api-server
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
               - key: kops.k8s.io/kops-controller-pki

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/node-api-server
+              - key: kops.k8s.io/kops-channel
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-channel
+              - key: kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
@@ -87,6 +87,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/api-server
         operator: Exists
       volumes:
       - configMap:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -43,7 +43,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kops.k8s.io/kops-controller
+              - key: node-role.kops.k8s.io/kops-controller
                 operator: Exists
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
+    manifestHash: dbd6f3414341bcea75fd1a796720de9d165b618d5b376f9774d1fa517504327a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -5,7 +5,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61493f9c382002b36101714b460a9cc47df58037112e95619dfe0d89197a9423
+    manifestHash: 42756d8d6ede1e2238c41d12e9bdb4e5d17fc2e04cd5e12a757dee39ea1495c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/executor.go
+++ b/upup/pkg/fi/executor.go
@@ -221,6 +221,7 @@ func (e *executor[T]) forkJoin(ctx context.Context, tasks []*taskState[T]) []err
 			}
 
 			result := ts.task.Run(e.context)
+			klog.V(2).Infof("Ran task %q: %v: Result %v\n", ts.key, ts.task, result)
 
 			resultsMutex.Lock()
 			results[index] = result

--- a/upup/pkg/fi/nodeup/nodetasks/service.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service.go
@@ -98,6 +98,9 @@ func (s *Service) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTas
 		case *File:
 			if len(v.BeforeServices) > 0 {
 				for _, b := range v.BeforeServices {
+					if v.Path == "/var/lib/kube-proxy/kubeconfig" {
+						continue
+					}
 					if s.Name == b {
 						deps = append(deps, v)
 					}

--- a/upup/pkg/fi/task.go
+++ b/upup/pkg/fi/task.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"runtime/debug"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -104,6 +105,7 @@ type ModelBuilderContext[T SubContext] struct {
 
 	Tasks              map[string]Task[T]
 	LifecycleOverrides map[string]Lifecycle
+	Stacktraces        map[string]string
 }
 
 func (c *ModelBuilderContext[T]) WithContext(ctx context.Context) *ModelBuilderContext[T] {
@@ -129,9 +131,15 @@ func (c *ModelBuilderContext[T]) AddTask(task Task[T]) {
 	key := buildTaskKey(task)
 
 	existing, found := c.Tasks[key]
+	stack := string(debug.Stack())
 	if found {
-		klog.Fatalf("found duplicate tasks with name %q: %v and %v", key, task, existing)
+		klog.Fatalf("found duplicate tasks with name %q: %v and %v: stack %s and stack %s",
+			key, task, existing, stack, c.Stacktraces[key])
 	}
+	if c.Stacktraces == nil {
+		c.Stacktraces = make(map[string]string)
+	}
+	c.Stacktraces[key] = stack
 	c.Tasks[key] = task
 }
 


### PR DESCRIPTION
Create Etcd, Scheduler and Kube-Controller-Manager only IGs.
Able to create a cluser where the control plane is the composition of 4 IGs.
Enables separate APIServer, Etcd, Scheduler and KCM IGs.
CCM and Kops-Controller are then run on the APIServer.