### PR TITLE
nodeup: don't mutate the cluster spec when clearing authenticator config

### DIFF
--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -375,11 +375,13 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 			},
 		}
 		if cluster.Spec.Authentication != nil {
-			config.APIServerConfig.Authentication = cluster.Spec.Authentication
-			if cluster.Spec.Authentication.AWS != nil {
+			// Copy before clearing fields, so that we don't mutate the shared cluster spec.
+			authentication := *cluster.Spec.Authentication
+			if authentication.AWS != nil {
 				// The values go into the manifest and aren't needed by nodeup.
-				config.APIServerConfig.Authentication.AWS = &kops.AWSAuthenticationSpec{}
+				authentication.AWS = &kops.AWSAuthenticationSpec{}
 			}
+			config.APIServerConfig.Authentication = &authentication
 		}
 		if cluster.Spec.API.DNS != nil {
 			config.APIServerConfig.API.DNS = &kops.DNSAccessSpec{}

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -23,7 +23,14 @@ spec:
         name: us-test-1a
       type: Public
   authentication:
-    aws: {}
+    aws:
+      backendMode: CRD
+      clusterID: complex.example.com
+      identityMappings:
+      - arn: arn:aws-test:iam::000000000000:role/AWSReservedSSO_Developer_7de86b085b6056ae
+        groups:
+        - he:dev
+        username: dev:{{SessionNameRaw}}
   authorization:
     rbac: {}
   channel: stable

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
@@ -155,9 +155,10 @@ spec:
       containers:
       - args:
         - server
-        - --config=/etc/aws-iam-authenticator/config.yaml
+        - --cluster-id=complex.example.com
         - --state-dir=/var/aws-iam-authenticator
         - --kubeconfig-pregenerated=true
+        - --backend-mode=CRD
         image: public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.6.20-eks-1-30-7
         livenessProbe:
           httpGet:
@@ -180,8 +181,6 @@ spec:
           runAsGroup: 10000
           runAsUser: 10000
         volumeMounts:
-        - mountPath: /etc/aws-iam-authenticator/
-          name: config
         - mountPath: /var/aws-iam-authenticator/
           name: state
         - mountPath: /etc/kubernetes/aws-iam-authenticator/
@@ -203,9 +202,6 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       volumes:
-      - configMap:
-          name: aws-iam-authenticator
-        name: config
       - hostPath:
           path: /srv/kubernetes/aws-iam-authenticator/
         name: output
@@ -214,3 +210,20 @@ spec:
         name: state
   updateStrategy:
     type: RollingUpdate
+
+---
+
+apiVersion: iamauthenticator.k8s.aws/v1alpha1
+kind: IAMIdentityMapping
+metadata:
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    k8s-app: aws-iam-authenticator
+    role.kubernetes.io/authentication: "1"
+  name: iam-identity-mapping-0
+spec:
+  arn: arn:aws-test:iam::000000000000:role/AWSReservedSSO_Developer_7de86b085b6056ae
+  groups:
+  - he:dev
+  username: dev:{{SessionNameRaw}}

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 7233a06582f37d422ad0fd908ff5c23965edff21d81e5888549c9ea9089a8309
+    manifestHash: 22e33f833fccae05f3e7060ea11f4eca26c2a480d8beff874ffda473b6dd0140
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -20,7 +20,14 @@ spec:
       accessLog:
         bucket: access-log-example
   authentication:
-    aws: {}
+    aws:
+      backendMode: CRD
+      clusterID: complex.example.com
+      identityMappings:
+      - arn: arn:aws-test:iam::000000000000:role/AWSReservedSSO_Developer_7de86b085b6056ae
+        groups:
+        - he:dev
+        username: dev:{{SessionNameRaw}}
   kubernetesApiAccess:
   - 1.1.1.0/24
   - pl-44444444

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -20,7 +20,14 @@ spec:
       accessLog:
         bucket: access-log-example
   authentication:
-    aws: {}
+    aws:
+      backendMode: CRD
+      clusterID: complex.example.com
+      identityMappings:
+      - arn: arn:aws-test:iam::000000000000:role/AWSReservedSSO_Developer_7de86b085b6056ae
+        groups:
+        - he:dev
+        username: dev:{{SessionNameRaw}}
   kubernetesApiAccess:
   - 1.1.1.0/24
   - pl-44444444


### PR DESCRIPTION
BuildNodeUpConfig assigned the shared Authentication pointer into the nodeup config and then replaced its AWS field with an empty struct, wiping spec.authentication.aws on the live cluster object. Since #18215 moved addon rendering to task run time, the aws-iam-authenticator manifest rendered after this mutation, losing backendMode, clusterID and identityMappings.

Copy the struct before clearing the field, and extend the complex integration test to cover backendMode: CRD with identity mappings.