### PR TITLE
azure: allow kindnet pod CIDR to reach the kube-apiserver

### DIFF
--- a/pkg/model/azuremodel/network.go
+++ b/pkg/model/azuremodel/network.go
@@ -193,7 +193,8 @@ func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	})
 	// Kindnet preserves pod-CIDR source IPs to host services; Azure NSG ASG
 	// matching needs an explicit allow since pod IPs aren't NIC-assigned.
-	// Scoped to nodes to keep DenyAllToControlPlane and the etcd denies effective.
+	// Pods reach the nodes on all ports and the kube-apiserver on 443 only,
+	// so DenyAllToControlPlane and the etcd denies stay effective.
 	if b.Cluster.Spec.Networking.Kindnet != nil && b.Cluster.Spec.Networking.PodCIDR != "" {
 		nsgTask.SecurityRules = append(nsgTask.SecurityRules, &azuretasks.NetworkSecurityRule{
 			Name:                                     new("AllowPodCIDRToNodes"),
@@ -205,6 +206,17 @@ func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			SourcePortRange:                          new("*"),
 			DestinationApplicationSecurityGroupNames: []*string{new(b.NameForApplicationSecurityGroupNodes())},
 			DestinationPortRange:                     new("*"),
+		})
+		nsgTask.SecurityRules = append(nsgTask.SecurityRules, &azuretasks.NetworkSecurityRule{
+			Name:                                     new("AllowPodCIDRToKubernetesAPI"),
+			Priority:                                 new(int32(1007)),
+			Access:                                   network.SecurityRuleAccessAllow,
+			Direction:                                network.SecurityRuleDirectionInbound,
+			Protocol:                                 network.SecurityRuleProtocolTCP,
+			SourceAddressPrefix:                      new(b.Cluster.Spec.Networking.PodCIDR),
+			SourcePortRange:                          new("*"),
+			DestinationApplicationSecurityGroupNames: []*string{new(b.NameForApplicationSecurityGroupControlPlane())},
+			DestinationPortRange:                     new(strconv.Itoa(wellknownports.KubeAPIServer)),
 		})
 	}
 	etcdPeerMax := wellknownports.EtcdEventsPeerPort

--- a/pkg/model/azuremodel/network_test.go
+++ b/pkg/model/azuremodel/network_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package azuremodel
 
 import (
+	"slices"
+	"strconv"
 	"testing"
 
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/azuretasks"
 )
 
 func TestNetworkModelBuilder_Build(t *testing.T) {
@@ -33,4 +39,73 @@ func TestNetworkModelBuilder_Build(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error %s", err)
 	}
+}
+
+// TestNetworkModelBuilder_KindnetSecurityRules verifies the pod-CIDR NSG rules that
+// Kindnet needs. Kindnet preserves pod source IPs, which aren't NIC-assigned and so
+// don't match the ASG-based node rules. Without an explicit allow to the kube-apiserver,
+// pods such as coredns can never reach the API and never become ready.
+func TestNetworkModelBuilder_KindnetSecurityRules(t *testing.T) {
+	// Without Kindnet, pod traffic is SNAT'd to the node IP and matches the node ASG
+	// rules, so no pod-CIDR rules should be emitted.
+	nsg := buildNetworkSecurityGroup(t, newTestAzureModelContext())
+	if rule := findSecurityRule(nsg, "AllowPodCIDRToKubernetesAPI"); rule != nil {
+		t.Errorf("did not expect AllowPodCIDRToKubernetesAPI rule without Kindnet")
+	}
+
+	ctx := newTestAzureModelContext()
+	ctx.Cluster.Spec.Networking.Kindnet = &kops.KindnetNetworkingSpec{}
+	ctx.Cluster.Spec.Networking.PodCIDR = "100.96.0.0/11"
+	nsg = buildNetworkSecurityGroup(t, ctx)
+
+	rule := findSecurityRule(nsg, "AllowPodCIDRToKubernetesAPI")
+	if rule == nil {
+		t.Fatal("expected AllowPodCIDRToKubernetesAPI security rule for Kindnet")
+	}
+	if got, want := fi.ValueOf(rule.Priority), int32(1007); got != want {
+		t.Errorf("priority: got %d, want %d", got, want)
+	}
+	if got, want := rule.Protocol, network.SecurityRuleProtocolTCP; got != want {
+		t.Errorf("protocol: got %q, want %q", got, want)
+	}
+	if got, want := fi.ValueOf(rule.SourceAddressPrefix), ctx.Cluster.Spec.Networking.PodCIDR; got != want {
+		t.Errorf("source address prefix: got %q, want %q", got, want)
+	}
+	if got, want := fi.ValueOf(rule.DestinationPortRange), strconv.Itoa(wellknownports.KubeAPIServer); got != want {
+		t.Errorf("destination port range: got %q, want %q", got, want)
+	}
+	var dstASGs []string
+	for _, name := range rule.DestinationApplicationSecurityGroupNames {
+		dstASGs = append(dstASGs, fi.ValueOf(name))
+	}
+	if want := []string{ctx.NameForApplicationSecurityGroupControlPlane()}; !slices.Equal(dstASGs, want) {
+		t.Errorf("destination ASGs: got %v, want %v", dstASGs, want)
+	}
+}
+
+func buildNetworkSecurityGroup(t *testing.T, ctx *AzureModelContext) *azuretasks.NetworkSecurityGroup {
+	t.Helper()
+	b := NetworkModelBuilder{AzureModelContext: ctx}
+	c := &fi.CloudupModelBuilderContext{
+		Tasks: make(map[string]fi.CloudupTask),
+	}
+	if err := b.Build(c); err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	for _, task := range c.Tasks {
+		if nsg, ok := task.(*azuretasks.NetworkSecurityGroup); ok {
+			return nsg
+		}
+	}
+	t.Fatal("no NetworkSecurityGroup task was built")
+	return nil
+}
+
+func findSecurityRule(nsg *azuretasks.NetworkSecurityGroup, name string) *azuretasks.NetworkSecurityRule {
+	for _, rule := range nsg.SecurityRules {
+		if fi.ValueOf(rule.Name) == name {
+			return rule
+		}
+	}
+	return nil
 }

--- a/tests/e2e/kubetest2-kops/azure/zones.go
+++ b/tests/e2e/kubetest2-kops/azure/zones.go
@@ -23,7 +23,8 @@ import (
 var allZones = []string{
 	"uksouth-1",
 	"uksouth-2",
-	"uksouth-3",
+	// uksouth-3 disabled: frequent OverconstrainedZonalAllocationRequest for Standard_D4ls_v6.
+	// "uksouth-3",
 }
 
 // RandomZones returns a random set of availability zones within a region

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -128,6 +128,15 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|should.resize.volume.when.PVC.is.edited.while.pod.is.using.it"
 		skipRegex += "|should.provision.storage.with.any.volume.data.source"
 		skipRegex += "|should.mount.multiple.PV.pointing.to.the.same.storage.on.the.same.node"
+		// Azure serializes disk attach/detach per VM in ARM, and under the suite's high
+		// parallelism a single detach can take minutes, so the attach-cycle-heavy azuredisk
+		// external-storage patterns time out on pod start or cleanup: data readback (detach +
+		// reattach mid-test), online/offline volume expansion, subPath pod restarts, and
+		// exec-after-attach. Skip only these families for the disk.csi.azure.com driver; the
+		// provisioning, topology, ephemeral, volumeMode and capacity specs still exercise
+		// attach/mount. Anchored to the driver so csi-hostpath/in-tree specs keep running.
+		// https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/storage/slow-attach-detach-operations-azure-disk
+		skipRegex += "|Driver:.disk.csi.azure.com.*(volumes.should.store.data|volume-expand|subPath|allow.exec)"
 	}
 
 	if cluster.Spec.LegacyCloudProvider == "gce" {


### PR DESCRIPTION
Bundles three fixes for the Azure e2e jobs, found while analyzing the `kops-azure` TestGrid since July 1:

**1. Fix Kindnet pod → kube-apiserver access.** #18522 scoped the `AllowNodesToKubernetesAPI` NSG rule to the NAT gateway IP. Kindnet preserves pod source IPs (no VNet masquerade), so pod → API traffic no longer matches any allow rule and hits `DenyAllToControlPlane`; coredns never reaches the API, never goes ready, and `kubetest2.Up` fails 100%. Adds `AllowPodCIDRToKubernetesAPI` (pod CIDR → control-plane ASG, TCP 443) while keeping the #18522 hardening intact.

**2. Disable `uksouth-3` in the e2e zone pool.** `Standard_D4ls_v6` there fails allocation with `OverconstrainedZonalAllocationRequest` (54/54 sampled zonal `Up` failures were uksouth-3, zero in uksouth-1/2), about 75% of all Azure `Up` failures.

**3. Skip attach-flaky azuredisk storage tests.** Azure serializes disk attach/detach per VM, so under high parallelism the attach-heavy `disk.csi.azure.com` specs (store-data, volume-expand, subPath, exec) time out. Anchored to the driver, so provisioning, topology, ephemeral, volumeMode and capacity specs keep running and non-azure drivers are unaffected.

/cc @rifelpet @ameukam 