### PR TITLE
tests/e2e: disable uksouth-3 in Azure e2e zone pool

### DIFF
--- a/tests/e2e/kubetest2-kops/azure/zones.go
+++ b/tests/e2e/kubetest2-kops/azure/zones.go
@@ -23,7 +23,8 @@ import (
 var allZones = []string{
 	"uksouth-1",
 	"uksouth-2",
-	"uksouth-3",
+	// uksouth-3 disabled: frequent OverconstrainedZonalAllocationRequest for Standard_D4ls_v6.
+	// "uksouth-3",
 }
 
 // RandomZones returns a random set of availability zones within a region


### PR DESCRIPTION
Standard_D4ls_v6 there fails often with OverconstrainedZonalAllocationRequest, breaking kubetest2.Up.

/cc @rifelpet @ameukam 