### PR TITLE
Add support for `oci://` URLs in `assets.fileRepository`

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -1500,6 +1500,28 @@ spec:
     containerProxy: proxy.example.com
 ```
 
+### fileRepository with an OCI registry
+
+`fileRepository` may be an `oci://` URL pointing at an OCI registry. File assets
+(including nodeup) are then stored in the registry as OCI artifacts. Nodes download
+the assets with anonymous pulls, so the registry must allow anonymous (public) pulls
+of the assets; this works on any cloud provider. Registries with authenticated pull
+access are not supported.
+
+```yaml
+spec:
+  assets:
+    fileRepository: oci://registry.example.com/assets
+```
+
+Run `kops get assets --copy` to push the file assets to the registry before bringing
+up the cluster or applying an update that changes the assets. Pushing authenticates
+with the local docker credentials (`~/.docker/config.json`, including configured
+credential helpers), so log in to the registry first with the usual command for your
+registry, for example `docker login`. The registry must already exist; for registries
+that do not create repositories on push, the repository for each asset path must
+also be created beforehand.
+
 ## sysctlParameters
 {{ kops_feature_table(kops_added_default='1.17') }}
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -781,6 +781,11 @@ func validateFileAssetSpec(v *kops.FileAssetSpec, fieldPath *field.Path) field.E
 	return allErrs
 }
 
+// ociRepositoryComponent matches one path component of an OCI repository name, which the path of an
+// oci:// fileRepository becomes part of: lowercase alphanumerics separated by '.', one or two '_',
+// or runs of '-', per the OCI distribution spec's repository-name grammar.
+var ociRepositoryComponent = regexp.MustCompile(`^[a-z0-9]+(?:(?:\.|_{1,2}|-+)[a-z0-9]+)*$`)
+
 func validateFileRepository(s string, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -789,8 +794,26 @@ func validateFileRepository(s string, fieldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("cannot parse fileRepository URL: %v", err)))
 		return allErrs
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must be an http:// or https:// URL"))
+	switch u.Scheme {
+	case "http", "https":
+	case "oci":
+		// The registry must allow anonymous pulls of the assets; nodes do not authenticate, so this works
+		// on any cloud provider.
+		if !strings.ContainsAny(u.Host, ".:") {
+			allErrs = append(allErrs, field.Invalid(fieldPath, s, "an oci:// fileRepository registry host must be a fully qualified domain name or include a port"))
+		}
+		if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+			allErrs = append(allErrs, field.Invalid(fieldPath, s, "an oci:// fileRepository cannot include credentials, a query or a fragment"))
+		}
+		if repository := strings.Trim(u.Path, "/"); repository != "" {
+			for _, component := range strings.Split(repository, "/") {
+				if !ociRepositoryComponent.MatchString(component) {
+					allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("%q is not a valid OCI repository-name component: lowercase alphanumerics separated by '.', '_' or '-'", component)))
+				}
+			}
+		}
+	default:
+		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must be an http://, https:// or oci:// URL"))
 	}
 	if u.Host == "" {
 		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must include a host"))

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -2239,6 +2239,36 @@ func TestValidateFileRepository(t *testing.T) {
 			Input:          "https://",
 			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
 		},
+		{
+			Input: "oci://registry.example.com/assets",
+		},
+		{
+			Input: "oci://myregistry.azurecr.io/assets",
+		},
+		{
+			// The path becomes part of an OCI repository name, which has a restricted character set.
+			Input:          "oci://registry.example.com/Assets",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
+			// A registry host without a dot or port would be normalized to a Docker Hub repository when
+			// pushing.
+			Input:          "oci://registry/assets",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
+			// Repository-name components may contain inner separators.
+			Input: "oci://registry.example.com/a__b/c--d/e.f",
+		},
+		{
+			// Repository-name components must start with an alphanumeric.
+			Input:          "oci://registry.example.com/-assets",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
+			Input:          "oci://registry.example.com/assets?x=1",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
 	}
 	for _, g := range grid {
 		errs := validateFileRepository(g.Input, field.NewPath("spec", "assets", "fileRepository"))

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -2251,8 +2251,8 @@ func TestValidateFileRepository(t *testing.T) {
 			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
 		},
 		{
-			// A registry host without a dot or port would be normalized to a Docker Hub repository when
-			// pushing.
+			// A registry host without a dot or port would be normalized to a repository on the
+			// default registry when pushing.
 			Input:          "oci://registry/assets",
 			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
 		},

--- a/pkg/assets/assetcopy/copy.go
+++ b/pkg/assets/assetcopy/copy.go
@@ -57,6 +57,32 @@ func Copy(imageAssets []*assets.ImageAsset, fileAssets []*assets.FileAsset, vfsC
 
 	for _, fileAsset := range fileAssets {
 		if fileAsset.DownloadURL.String() != fileAsset.CanonicalURL.String() {
+			if fileAsset.DownloadURL.Scheme == "oci" {
+				copyFileTask := &CopyFileToOCI{
+					Name:       fileAsset.CanonicalURL.String(),
+					TargetRef:  fileAsset.DownloadURL.String(),
+					SourceFile: fileAsset.CanonicalURL.String(),
+					SHA:        fileAsset.SHAValue.Hex(),
+					VFSContext: vfsContext,
+				}
+
+				if existing, ok := tasks[copyFileTask.Name]; ok {
+					e, ok := existing.(*CopyFileToOCI)
+					if !ok {
+						return fmt.Errorf("different types for copy target %s", copyFileTask.Name)
+					}
+					if e.TargetRef != copyFileTask.TargetRef {
+						return fmt.Errorf("different targets for same file %s: %s vs %s", copyFileTask.Name, copyFileTask.TargetRef, e.TargetRef)
+					}
+					if e.SHA != copyFileTask.SHA {
+						return fmt.Errorf("different sha for same file %s: %s vs %s", copyFileTask.Name, copyFileTask.SHA, e.SHA)
+					}
+				}
+
+				tasks[copyFileTask.Name] = copyFileTask
+				continue
+			}
+
 			copyFileTask := &CopyFile{
 				Name:       fileAsset.CanonicalURL.String(),
 				TargetFile: fileAsset.DownloadURL.String(),

--- a/pkg/assets/assetcopy/copyoci.go
+++ b/pkg/assets/assetcopy/copyoci.go
@@ -59,8 +59,9 @@ func (e *CopyFileToOCI) Run() error {
 	}
 
 	// name.NewTag applies Docker-style normalization: a registry host without a dot or port is treated
-	// as a Docker Hub repository, and docker.io aliases gain a library/ prefix. Nodes pull from the
-	// URL literally, so refuse any reference that does not round-trip exactly.
+	// as part of a repository on the default registry, and single-component repositories gain a
+	// library/ prefix. Nodes pull from the URL literally, so refuse any reference that does not
+	// round-trip exactly.
 	if ref.Context().Name() != repository {
 		return fmt.Errorf("target %q parses as %q, which is not the location nodes download from; the registry host must be a fully qualified domain name", e.TargetRef, ref.Context().Name())
 	}

--- a/pkg/assets/assetcopy/copyoci.go
+++ b/pkg/assets/assetcopy/copyoci.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assetcopy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"k8s.io/klog/v2"
+	"k8s.io/kops/util/pkg/vfs"
+)
+
+// CopyFileToOCI copies a file from a source file repository to an OCI registry, pushing it as an
+// image with a single layer (a Docker schema 2 image manifest, which OCI registries accept). The
+// layer blob digest is the sha256 hash of the file, so clients can download the blob directly by
+// the file's hash without reading the manifest. Pushing authenticates with the local docker
+// credentials.
+type CopyFileToOCI struct {
+	Name       string
+	SourceFile string
+	// TargetRef is the target location, in the form oci://<registry>/<repository>.
+	TargetRef  string
+	SHA        string
+	VFSContext *vfs.VFSContext
+}
+
+func (e *CopyFileToOCI) Run() error {
+	repository := strings.TrimPrefix(e.TargetRef, "oci://")
+
+	// Tag the artifact with the file's hash; this makes the check for an already-pushed artifact a
+	// single manifest fetch.
+	ref, err := name.NewTag(repository + ":" + e.SHA)
+	if err != nil {
+		return fmt.Errorf("parsing reference for %q: %w", e.TargetRef, err)
+	}
+
+	// name.NewTag applies Docker-style normalization: a registry host without a dot or port is treated
+	// as a Docker Hub repository, and docker.io aliases gain a library/ prefix. Nodes pull from the
+	// URL literally, so refuse any reference that does not round-trip exactly.
+	if ref.Context().Name() != repository {
+		return fmt.Errorf("target %q parses as %q, which is not the location nodes download from; the registry host must be a fully qualified domain name", e.TargetRef, ref.Context().Name())
+	}
+
+	options := []remote.Option{remote.WithAuthFromKeychain(authn.DefaultKeychain)}
+
+	if e.alreadyPushed(ref, options) {
+		klog.Infof("no need to copy file from %v to %v", e.SourceFile, e.TargetRef)
+		return nil
+	}
+
+	data, err := e.VFSContext.ReadFile(e.SourceFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("file not found %q: %w", e.SourceFile, err)
+		}
+		return fmt.Errorf("error downloading file %q: %w", e.SourceFile, err)
+	}
+
+	digest := sha256.Sum256(data)
+	actualSHA := hex.EncodeToString(digest[:])
+	if actualSHA != e.SHA {
+		return fmt.Errorf("hash mismatch for %q: expected %q, got %q", e.SourceFile, e.SHA, actualSHA)
+	}
+
+	layer := static.NewLayer(data, types.MediaType("application/octet-stream"))
+	image, err := mutate.AppendLayers(empty.Image, layer)
+	if err != nil {
+		return fmt.Errorf("building artifact for %q: %w", e.TargetRef, err)
+	}
+
+	klog.V(2).Infof("copying bits from %q to %q", e.SourceFile, e.TargetRef)
+
+	if err := remote.Write(ref, image, options...); err != nil {
+		return fmt.Errorf("unable to transfer %q to %q: %w", e.SourceFile, e.TargetRef, err)
+	}
+
+	return nil
+}
+
+// alreadyPushed reports whether the tag exists and its manifest references the expected layer blob.
+// The tag alone is not proof: nodes download the blob directly by digest, so a stale or foreign
+// manifest under this tag must be overwritten, not skipped.
+func (e *CopyFileToOCI) alreadyPushed(ref name.Tag, options []remote.Option) bool {
+	desc, err := remote.Get(ref, options...)
+	if err != nil {
+		return false
+	}
+	image, err := desc.Image()
+	if err != nil {
+		return false
+	}
+	manifest, err := image.Manifest()
+	if err != nil {
+		return false
+	}
+	for _, layer := range manifest.Layers {
+		if layer.Digest.Hex == e.SHA {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/assets/assetcopy/copyoci_test.go
+++ b/pkg/assets/assetcopy/copyoci_test.go
@@ -88,10 +88,10 @@ func TestCopyFileToOCI_RoundTrip(t *testing.T) {
 }
 
 func TestCopyFileToOCI_RejectsNormalizingReference(t *testing.T) {
-	// A registry host without a dot or port would be normalized to a Docker Hub repository on push,
-	// while nodes would pull from that literal host.
+	// A registry host without a dot or port would be normalized to a repository on the default
+	// registry on push, while nodes would pull from that literal host.
 	task := &CopyFileToOCI{
-		TargetRef: "oci://docker.io/assets",
+		TargetRef: "oci://registry/assets",
 		SHA:       strings.Repeat("0", 64),
 	}
 	err := task.Run()

--- a/pkg/assets/assetcopy/copyoci_test.go
+++ b/pkg/assets/assetcopy/copyoci_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assetcopy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"k8s.io/kops/util/pkg/vfs"
+)
+
+func TestCopyFileToOCI_RoundTrip(t *testing.T) {
+	server := httptest.NewServer(registry.New(registry.Logger(log.New(io.Discard, "", 0))))
+	defer server.Close()
+	host := strings.TrimPrefix(server.URL, "http://")
+
+	content := []byte("test file asset content")
+	digest := sha256.Sum256(content)
+	sha := hex.EncodeToString(digest[:])
+
+	sourceFile := filepath.Join(t.TempDir(), "nodeup")
+	if err := os.WriteFile(sourceFile, content, 0o600); err != nil {
+		t.Fatalf("writing source file: %v", err)
+	}
+
+	task := &CopyFileToOCI{
+		Name:       sourceFile,
+		SourceFile: sourceFile,
+		TargetRef:  "oci://" + host + "/assets/binaries/nodeup",
+		SHA:        sha,
+		VFSContext: vfs.Context,
+	}
+	if err := task.Run(); err != nil {
+		t.Fatalf("pushing file to the registry: %v", err)
+	}
+
+	// Nodes download the layer blob directly, addressed by the file's hash.
+	response, err := http.Get(server.URL + "/v2/assets/binaries/nodeup/blobs/sha256:" + sha)
+	if err != nil {
+		t.Fatalf("downloading blob: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected response downloading blob: HTTP %s", response.Status)
+	}
+	downloaded, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("reading blob: %v", err)
+	}
+	if !bytes.Equal(downloaded, content) {
+		t.Errorf("downloaded blob does not match the source file")
+	}
+
+	// A second run finds the already-pushed artifact and is a no-op.
+	if err := task.Run(); err != nil {
+		t.Fatalf("re-pushing file to the registry: %v", err)
+	}
+}
+
+func TestCopyFileToOCI_RejectsNormalizingReference(t *testing.T) {
+	// A registry host without a dot or port would be normalized to a Docker Hub repository on push,
+	// while nodes would pull from that literal host.
+	task := &CopyFileToOCI{
+		TargetRef: "oci://docker.io/assets",
+		SHA:       strings.Repeat("0", 64),
+	}
+	err := task.Run()
+	if err == nil || !strings.Contains(err.Error(), "is not the location nodes download from") {
+		t.Fatalf("expected a reference mismatch error, got: %v", err)
+	}
+}
+
+func TestCopyFileToOCI_OverwritesStaleTag(t *testing.T) {
+	server := httptest.NewServer(registry.New(registry.Logger(log.New(io.Discard, "", 0))))
+	defer server.Close()
+	host := strings.TrimPrefix(server.URL, "http://")
+
+	content := []byte("test file asset content")
+	digest := sha256.Sum256(content)
+	sha := hex.EncodeToString(digest[:])
+
+	sourceFile := filepath.Join(t.TempDir(), "nodeup")
+	if err := os.WriteFile(sourceFile, content, 0o600); err != nil {
+		t.Fatalf("writing source file: %v", err)
+	}
+
+	// Pre-push different content under the tag the copy task uses.
+	staleRef, err := name.NewTag(host + "/assets/binaries/nodeup:" + sha)
+	if err != nil {
+		t.Fatalf("parsing stale reference: %v", err)
+	}
+	staleLayer := static.NewLayer([]byte("stale content"), types.MediaType("application/octet-stream"))
+	staleImage, err := mutate.AppendLayers(empty.Image, staleLayer)
+	if err != nil {
+		t.Fatalf("building stale artifact: %v", err)
+	}
+	if err := remote.Write(staleRef, staleImage); err != nil {
+		t.Fatalf("pushing stale artifact: %v", err)
+	}
+
+	task := &CopyFileToOCI{
+		Name:       sourceFile,
+		SourceFile: sourceFile,
+		TargetRef:  "oci://" + host + "/assets/binaries/nodeup",
+		SHA:        sha,
+		VFSContext: vfs.Context,
+	}
+	if err := task.Run(); err != nil {
+		t.Fatalf("pushing file to the registry: %v", err)
+	}
+
+	// The stale tag must not have been trusted; the expected blob must now exist.
+	response, err := http.Get(server.URL + "/v2/assets/binaries/nodeup/blobs/sha256:" + sha)
+	if err != nil {
+		t.Fatalf("downloading blob: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected response downloading blob: HTTP %s", response.Status)
+	}
+}

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -328,7 +328,9 @@ func (a *AssetBuilder) RemapFile(canonicalURL *url.URL, knownHash *hashing.Hash)
 			return nil, err
 		}
 
-		if canonicalURL.Host != normalizedFile.Host {
+		// Skip the remap only when the canonical URL already points at the file repository; the scheme
+		// matters for an oci:// repository that shares its host with an asset's https source.
+		if canonicalURL.Host != normalizedFile.Host || canonicalURL.Scheme != normalizedFile.Scheme {
 			fileAsset.DownloadURL = normalizedFile
 			klog.V(4).Infof("adding remapped file: %q", fileAsset.DownloadURL.String())
 		}
@@ -340,6 +342,12 @@ func (a *AssetBuilder) RemapFile(canonicalURL *url.URL, knownHash *hashing.Hash)
 			return nil, err
 		}
 		knownHash = h
+	}
+
+	// OCI blobs are addressed by their sha256 digest; fail here rather than when nodes try to download
+	// the asset.
+	if fileAsset.DownloadURL.Scheme == "oci" && knownHash.Algorithm != hashing.HashAlgorithmSHA256 {
+		return nil, fmt.Errorf("asset %q must have a sha256 hash to be stored in the oci:// assets.fileRepository, got %q", canonicalURL, knownHash.Algorithm)
 	}
 
 	fileAsset.SHAValue = knownHash
@@ -366,6 +374,12 @@ func (a *AssetBuilder) findHash(file *FileAsset) (*hashing.Hash, error) {
 	// before it exists.
 	u := file.DownloadURL
 	if a.getAssets {
+		u = file.CanonicalURL
+	}
+
+	if u != nil && u.Scheme == "oci" {
+		// OCI artifacts are addressed by digest (the sha256 of the content), so the hash must come from
+		// the canonical source; the registry has no sidecar hash files.
 		u = file.CanonicalURL
 	}
 
@@ -441,9 +455,43 @@ func (a *AssetBuilder) remapURL(canonicalURL *url.URL) (*url.URL, error) {
 		return nil, fmt.Errorf("unable to parse assetsLocation.fileRepository %q: %v", f, err)
 	}
 
-	fileRepo.Path = path.Join(fileRepo.Path, canonicalURL.Path)
+	assetPath := canonicalURL.Path
+	if fileRepo.Scheme == "oci" {
+		// The path becomes an OCI repository name (one repository per asset), which has a restricted
+		// character set. The asset path must be preserved in the repository name rather than collapsed
+		// into a single repository: nodeup keys assets by the last component of their URL, so every asset
+		// needs a distinct URL.
+		assetPath = sanitizeOCIRepository(assetPath)
+	}
+	fileRepo.Path = path.Join(fileRepo.Path, assetPath)
 
 	return fileRepo, nil
+}
+
+// ociRepositoryIllegalCharacters matches the characters that are not allowed in OCI repository
+// names, which can only contain lowercase alphanumerics, `.`, `_`, `-` and `/`.
+var ociRepositoryIllegalCharacters = regexp.MustCompile(`[^a-z0-9._/-]`)
+
+// ociRepositorySeparatorRuns matches consecutive separator characters, which are not allowed inside
+// a repository path component.
+var ociRepositorySeparatorRuns = regexp.MustCompile(`[._-]{2,}`)
+
+// sanitizeOCIRepository maps an asset path to a valid OCI repository name; for example, CI builds
+// are staged under paths containing `+`. Illegal characters become `_`; path components must also
+// start and end with an alphanumeric. Separator runs, which the replacement can produce and which
+// the repository-name grammar only partially allows, are conservatively collapsed to a single `_`.
+func sanitizeOCIRepository(assetPath string) string {
+	sanitized := ociRepositoryIllegalCharacters.ReplaceAllString(strings.ToLower(assetPath), "_")
+
+	var components []string
+	for _, component := range strings.Split(sanitized, "/") {
+		component = ociRepositorySeparatorRuns.ReplaceAllString(component, "_")
+		component = strings.Trim(component, "._-")
+		if component != "" {
+			components = append(components, component)
+		}
+	}
+	return strings.Join(components, "/")
 }
 
 func NormalizeImage(a *AssetBuilder, image string) string {

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -441,6 +441,14 @@ func (a *AssetBuilder) findHash(file *FileAsset) (*hashing.Hash, error) {
 	return nil, fmt.Errorf("cannot determine hash for %q (have you specified a valid file location?)", u)
 }
 
+// FileRepository returns the configured assets.fileRepository, or "" if not set.
+func (a *AssetBuilder) FileRepository() string {
+	if a.assetsLocation != nil && a.assetsLocation.FileRepository != nil {
+		return *a.assetsLocation.FileRepository
+	}
+	return ""
+}
+
 func (a *AssetBuilder) remapURL(canonicalURL *url.URL) (*url.URL, error) {
 	f := ""
 	if a.assetsLocation != nil {

--- a/pkg/assets/builder_test.go
+++ b/pkg/assets/builder_test.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -258,5 +259,108 @@ func TestAssetBuilderConcurrentCollection(t *testing.T) {
 		if prev.Path > curr.Path {
 			t.Fatalf("static files not sorted: %q > %q", prev.Path, curr.Path)
 		}
+	}
+}
+
+func TestRemapFile_OCIRepository(t *testing.T) {
+	builder := buildAssetBuilder(t)
+
+	fileRepository := "oci://registry.example.com/assets"
+	builder.assetsLocation.FileRepository = &fileRepository
+
+	// CI builds are staged under paths with characters that are not allowed in OCI repository names,
+	// such as `+`.
+	canonicalURL, err := url.Parse("https://example.com/kops/1.37.0-alpha.2+v1.37.0-alpha.1/linux/amd64/nodeup")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hash, err := hashing.FromString("833723369ad345a88dd85d61b1e77336d56e61b864557ded71b92b6e34158e6a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	asset, err := builder.RemapFile(canonicalURL, hash)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "oci://registry.example.com/assets/kops/1.37.0-alpha.2_v1.37.0-alpha.1/linux/amd64/nodeup"
+	if a := asset.DownloadURL.String(); a != expected {
+		t.Errorf("unexpected remapped file (expecting: %s, got %s)", expected, a)
+	}
+}
+
+func TestSanitizeOCIRepository(t *testing.T) {
+	grid := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "/binaries/kops/1.35.0/linux/amd64/nodeup",
+			expected: "binaries/kops/1.35.0/linux/amd64/nodeup",
+		},
+		{
+			input:    "/kops/1.37.0-alpha.2+v1.37.0-alpha.1/linux/amd64/nodeup",
+			expected: "kops/1.37.0-alpha.2_v1.37.0-alpha.1/linux/amd64/nodeup",
+		},
+		{
+			// Repository path components cannot start with a separator or contain separator runs, and are
+			// lowercased.
+			input:    "/kops/+build/Upper/a++b/nodeup",
+			expected: "kops/build/upper/a_b/nodeup",
+		},
+	}
+
+	for _, g := range grid {
+		if actual := sanitizeOCIRepository(g.input); actual != g.expected {
+			t.Errorf("sanitizeOCIRepository(%q): expected %q, got %q", g.input, g.expected, actual)
+		}
+	}
+}
+
+func TestRemapFile_OCIRequiresSHA256(t *testing.T) {
+	builder := buildAssetBuilder(t)
+
+	fileRepository := "oci://registry.example.com/assets"
+	builder.assetsLocation.FileRepository = &fileRepository
+
+	canonicalURL, err := url.Parse("https://example.com/kops/nodeup")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sha1Hash, err := hashing.FromString("da39a3ee5e6b4b0d3255bfef95601890afd80709")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = builder.RemapFile(canonicalURL, sha1Hash)
+	if err == nil || !strings.Contains(err.Error(), "must have a sha256 hash") {
+		t.Fatalf("expected a sha256 requirement error, got: %v", err)
+	}
+}
+
+func TestRemapFile_OCISharedHost(t *testing.T) {
+	builder := buildAssetBuilder(t)
+
+	// The registry shares a host with the asset's https source; the differing scheme must still
+	// trigger the remap.
+	fileRepository := "oci://example.com/assets"
+	builder.assetsLocation.FileRepository = &fileRepository
+
+	canonicalURL, err := url.Parse("https://example.com/kops/nodeup")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hash, err := hashing.FromString("833723369ad345a88dd85d61b1e77336d56e61b864557ded71b92b6e34158e6a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	asset, err := builder.RemapFile(canonicalURL, hash)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "oci://example.com/assets/kops/nodeup"
+	if a := asset.DownloadURL.String(); a != expected {
+		t.Errorf("unexpected remapped file (expecting: %s, got %s)", expected, a)
 	}
 }

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -107,6 +107,8 @@ validate-hash() {
   fi
 }
 
+{{- OCIDownloadFunctions }}
+
 function download-release() {
   case "$(uname -m)" in
   x86_64*|i?86_64*|amd64*)
@@ -167,6 +169,19 @@ type NodeUpScript struct {
 	CloudProvider        string
 	ProxyEnv             func() (string, error)
 	EnvironmentVariables func() (string, error)
+}
+
+// usesOCIAssetRegistry is true when nodeup is downloaded from an OCI registry (an oci://
+// assets.fileRepository), with anonymous pulls.
+func (b *NodeUpScript) usesOCIAssetRegistry() bool {
+	for _, asset := range b.NodeUpAssets {
+		for _, location := range asset.Locations {
+			if strings.HasPrefix(location, "oci://") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func funcEmptyString() (string, error) {
@@ -233,13 +248,83 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 		"ProxyEnv":             b.ProxyEnv,
 		"EnvironmentVariables": b.EnvironmentVariables,
 		"CopyCheckUrlBlock":    b.copyCheckUrlBlock,
+		"OCIDownloadFunctions": b.ociDownloadFunctions,
 	}
 
 	return newTemplateResource("nodeup", nodeUpTemplate, functions, nil)
 }
 
+// ociDownloadFunctions returns a shell function that downloads a blob from an OCI registry with an
+// anonymous pull. Assets stored in OCI registries are addressed by digest, which is the sha256 hash
+// of their content. The direct pull is tried first; registries such as Docker Hub or ghcr.io
+// require a pull token even for anonymous pulls, obtained anonymously from the endpoint advertised
+// in the WWW-Authenticate challenge (curl --get merges the parameters into any query the realm
+// already carries). The token is returned as "token" (Docker registry auth) or "access_token"
+// (OAuth2). Comments in the emitted script are kept brief: it is part of the instance user data,
+// which has a limited size.
+func (b *NodeUpScript) ociDownloadFunctions() (string, error) {
+	if !b.usesOCIAssetRegistry() {
+		return "", nil
+	}
+
+	return `
+# Download an OCI blob by digest. args: file, hash, url
+download-oci() {
+  local -r file="$1"
+  local -r hash="$2"
+  local -r url="$3"
+
+  local -r stripped="${url#oci://}"
+  local -r registry="${stripped%%/*}"
+  local -r repository="${stripped#*/}"
+  local -r blob_url="https://${registry}/v2/${repository}/blobs/sha256:${hash}"
+
+  # Try a tokenless pull first
+  if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${blob_url}"; then
+    return 0
+  fi
+
+  # Get an anonymous pull token per the WWW-Authenticate challenge
+  local challenge realm service response token
+  challenge=$(curl -sSI "${blob_url}" | tr -d '\r' | sed -n 's/^[Ww][Ww][Ww]-[Aa]uthenticate: [Bb]earer //p')
+  realm=$(echo "${challenge}" | sed -n 's/.*realm="\([^"]*\)".*/\1/p')
+  service=$(echo "${challenge}" | sed -n 's/.*service="\([^"]*\)".*/\1/p')
+  if [[ -z "${realm}" ]]; then
+    echo "== Failed to get a pull token challenge from ${registry} =="
+    return 1
+  fi
+  if ! response=$(curl -fsS --get --data-urlencode "service=${service}" --data-urlencode "scope=repository:${repository}:pull" "${realm}"); then
+    echo "== Failed to get an anonymous pull token from ${realm} =="
+    return 1
+  fi
+  # The token field is "token" or "access_token"
+  token=$(echo "${response}" | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  if [[ -z "${token}" ]]; then
+    token=$(echo "${response}" | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  fi
+  if [[ -z "${token}" ]]; then
+    echo "== Failed to parse the anonymous pull token from ${realm} =="
+    return 1
+  fi
+  curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 -H "Authorization: Bearer ${token}" "${blob_url}"
+}`, nil
+}
+
 func (b *NodeUpScript) copyCheckUrlBlock() (string, error) {
-	if b.CloudProvider == string(kops.CloudProviderGCE) {
+	if b.usesOCIAssetRegistry() {
+		// All file assets are remapped to the OCI registry, so all urls are oci:// URLs.
+		return `if ! download-oci "${file}" "${hash}" "${url}"; then
+        echo "== Failed to download ${url} =="
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Failed to validate hash for ${url} =="
+        rm -f "${file}"
+        continue
+      fi
+      echo "== Downloaded ${url} with hash ${hash} =="
+      return 0`, nil
+	} else if b.CloudProvider == string(kops.CloudProviderGCE) {
 		return `commands=(
         "gcloud storage cp ${url} ${file}"
         "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -256,9 +256,9 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 
 // ociDownloadFunctions returns a shell function that downloads a blob from an OCI registry with an
 // anonymous pull. Assets stored in OCI registries are addressed by digest, which is the sha256 hash
-// of their content. The direct pull is tried first; registries such as Docker Hub or ghcr.io
-// require a pull token even for anonymous pulls, obtained anonymously from the endpoint advertised
-// in the WWW-Authenticate challenge (curl --get merges the parameters into any query the realm
+// of their content. The direct pull is tried first; some registries require a pull token even for
+// anonymous pulls, obtained anonymously from the endpoint advertised in the WWW-Authenticate
+// challenge (curl --get merges the parameters into any query the realm
 // already carries). The token is returned as "token" (Docker registry auth) or "access_token"
 // (OAuth2). Comments in the emitted script are kept brief: it is part of the instance user data,
 // which has a limited size.

--- a/pkg/model/resources/nodeup_test.go
+++ b/pkg/model/resources/nodeup_test.go
@@ -19,6 +19,12 @@ package resources
 import (
 	"strings"
 	"testing"
+
+	"k8s.io/kops/pkg/apis/nodeup"
+	"k8s.io/kops/pkg/assets"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/util/pkg/architectures"
+	"k8s.io/kops/util/pkg/hashing"
 )
 
 func Test_NodeUpTabs(t *testing.T) {
@@ -26,5 +32,70 @@ func Test_NodeUpTabs(t *testing.T) {
 		if strings.Contains(line, "\t") {
 			t.Errorf("NodeUpTemplate contains unexpected character %q on line %d: %q", "\t", i, line)
 		}
+	}
+}
+
+func Test_NodeUpScriptOCIAssetRegistry(t *testing.T) {
+	renderScript := func(cloudProvider, baseURL string) string {
+		script := &NodeUpScript{
+			NodeUpAssets: map[architectures.Architecture]*assets.MirroredAsset{
+				architectures.ArchitectureAmd64: {
+					Locations: []string{baseURL + "/binaries/kops/1.35.0/linux/amd64/nodeup"},
+					Hash:      hashing.MustFromString("833723369ad345a88dd85d61b1e77336d56e61b864557ded71b92b6e34158e6a"),
+				},
+				architectures.ArchitectureArm64: {
+					Locations: []string{baseURL + "/binaries/kops/1.35.0/linux/arm64/nodeup"},
+					Hash:      hashing.MustFromString("e525c28a65ff0ce4f95f9e730195b4e67fdcb15ceb1f36b5ad6921a8a4490c71"),
+				},
+			},
+			BootConfig:    &nodeup.BootConfig{},
+			CloudProvider: cloudProvider,
+		}
+		resource, err := script.Build()
+		if err != nil {
+			t.Fatalf("building nodeup script: %v", err)
+		}
+		rendered, err := fi.ResourceAsString(resource)
+		if err != nil {
+			t.Fatalf("rendering nodeup script: %v", err)
+		}
+		return rendered
+	}
+
+	rendered := renderScript("hetzner", "oci://registry.example.com/assets")
+	for _, expected := range []string{
+		"download-oci()",
+		`if ! download-oci "${file}" "${hash}" "${url}"; then`,
+		`"https://${registry}/v2/${repository}/blobs/sha256:${hash}"`,
+		// Anonymous pulls may need a token from the challenge endpoint.
+		`realm=$(`,
+		// curl merges the token parameters into any query the realm already carries.
+		`--get --data-urlencode "service=${service}"`,
+	} {
+		if !strings.Contains(rendered, expected) {
+			t.Errorf("expected the nodeup script to contain %q", expected)
+		}
+	}
+	// All file assets are remapped to the OCI registry; the generic download commands are not needed.
+	if strings.Contains(rendered, "commands=(") {
+		t.Errorf("expected the nodeup script to not contain the generic download commands")
+	}
+
+	// The OCI download also replaces the GCE download commands.
+	rendered = renderScript("gce", "oci://registry.example.com/assets")
+	if !strings.Contains(rendered, "download-oci()") {
+		t.Errorf("expected the nodeup script to contain the OCI download function")
+	}
+	if strings.Contains(rendered, "gcloud storage cp") {
+		t.Errorf("expected the nodeup script to not contain the GCE download commands")
+	}
+
+	// Without an oci:// fileRepository, the OCI download function is not emitted.
+	rendered = renderScript("gce", "https://artifacts.k8s.io")
+	if strings.Contains(rendered, "download-oci") {
+		t.Errorf("expected the nodeup script to not contain the OCI download function")
+	}
+	if !strings.Contains(rendered, "gcloud storage cp") {
+		t.Errorf("expected the nodeup script to contain the GCE download commands")
 	}
 }

--- a/pkg/nodemodel/wellknownassets/kopsassets.go
+++ b/pkg/nodemodel/wellknownassets/kopsassets.go
@@ -34,11 +34,19 @@ const (
 
 var kopsBaseURL *url.URL
 
+// kopsAssetKey identifies a cached kops binary location. The location is remapped per the cluster's
+// assets.fileRepository, which must therefore be part of the key: one process can build several
+// clusters (notably in tests).
+type kopsAssetKey struct {
+	arch           architectures.Architecture
+	fileRepository string
+}
+
 // nodeUpAsset caches the nodeup binary download url/hash
-var nodeUpAsset map[architectures.Architecture]*assets.MirroredAsset
+var nodeUpAsset map[kopsAssetKey]*assets.MirroredAsset
 
 // protokubeAsset caches the protokube binary download url/hash
-var protokubeAsset map[architectures.Architecture]*assets.MirroredAsset
+var protokubeAsset map[kopsAssetKey]*assets.MirroredAsset
 
 // BaseURL returns the base url for the distribution of kops - in particular for nodeup & docker images
 func BaseURL() (*url.URL, error) {
@@ -88,42 +96,44 @@ func copyBaseURL(base *url.URL) (*url.URL, error) {
 // NodeUpAsset returns the asset for where nodeup should be downloaded
 func NodeUpAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Architecture) (*assets.MirroredAsset, error) {
 	if nodeUpAsset == nil {
-		nodeUpAsset = make(map[architectures.Architecture]*assets.MirroredAsset)
+		nodeUpAsset = make(map[kopsAssetKey]*assets.MirroredAsset)
 	}
-	if nodeUpAsset[arch] != nil {
+	key := kopsAssetKey{arch: arch, fileRepository: assetsBuilder.FileRepository()}
+	if nodeUpAsset[key] != nil {
 		// Avoid repeated logging
-		klog.V(8).Infof("Using cached nodeup location for %s: %v", arch, nodeUpAsset[arch].Locations)
-		return nodeUpAsset[arch], nil
+		klog.V(8).Infof("Using cached nodeup location for %s: %v", arch, nodeUpAsset[key].Locations)
+		return nodeUpAsset[key], nil
 	}
 
 	asset, err := KopsFileURL(fmt.Sprintf("linux/%s/nodeup", arch), assetsBuilder)
 	if err != nil {
 		return nil, err
 	}
-	nodeUpAsset[arch] = assets.BuildMirroredAsset(asset)
+	nodeUpAsset[key] = assets.BuildMirroredAsset(asset)
 	klog.V(8).Infof("Using default nodeup location for %s: %q", arch, asset.DownloadURL.String())
 
-	return nodeUpAsset[arch], nil
+	return nodeUpAsset[key], nil
 }
 
 // ProtokubeAsset returns the url and hash of the protokube binary
 func ProtokubeAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Architecture) (*assets.MirroredAsset, error) {
 	if protokubeAsset == nil {
-		protokubeAsset = make(map[architectures.Architecture]*assets.MirroredAsset)
+		protokubeAsset = make(map[kopsAssetKey]*assets.MirroredAsset)
 	}
-	if protokubeAsset[arch] != nil {
-		klog.V(8).Infof("Using cached protokube binary location for %s: %v", arch, protokubeAsset[arch].Locations)
-		return protokubeAsset[arch], nil
+	key := kopsAssetKey{arch: arch, fileRepository: assetsBuilder.FileRepository()}
+	if protokubeAsset[key] != nil {
+		klog.V(8).Infof("Using cached protokube binary location for %s: %v", arch, protokubeAsset[key].Locations)
+		return protokubeAsset[key], nil
 	}
 
 	asset, err := KopsFileURL(fmt.Sprintf("linux/%s/protokube", arch), assetsBuilder)
 	if err != nil {
 		return nil, err
 	}
-	protokubeAsset[arch] = assets.BuildMirroredAsset(asset)
+	protokubeAsset[key] = assets.BuildMirroredAsset(asset)
 	klog.V(8).Infof("Using default protokube location for %s: %q", arch, asset.DownloadURL.String())
 
-	return protokubeAsset[arch], nil
+	return protokubeAsset[key], nil
 }
 
 // KopsFileURL returns the base url for the distribution of kops - in particular for nodeup & docker images

--- a/pkg/nodemodel/wellknownassets/kopsassets_test.go
+++ b/pkg/nodemodel/wellknownassets/kopsassets_test.go
@@ -20,10 +20,13 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"k8s.io/kops"
+	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/assets"
+	"k8s.io/kops/util/pkg/architectures"
 	"k8s.io/kops/util/pkg/hashing"
 )
 
@@ -128,5 +131,28 @@ func Test_BuildMirroredAsset(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+func TestNodeUpAssetNotSharedAcrossFileRepositories(t *testing.T) {
+	// One process can build several clusters (notably in tests); the cached location must not leak
+	// one cluster's fileRepository into another.
+	plainBuilder := assets.NewAssetBuilder(nil, &kopsapi.AssetsSpec{}, false)
+	plain, err := NodeUpAsset(plainBuilder, architectures.ArchitectureAmd64)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.HasPrefix(plain.Locations[0], "oci://") {
+		t.Fatalf("unexpected oci location without a fileRepository: %v", plain.Locations)
+	}
+
+	fileRepository := "oci://registry.example.com/kops"
+	remappedBuilder := assets.NewAssetBuilder(nil, &kopsapi.AssetsSpec{FileRepository: &fileRepository}, false)
+	remapped, err := NodeUpAsset(remappedBuilder, architectures.ArchitectureAmd64)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(remapped.Locations[0], "oci://registry.example.com/kops/") {
+		t.Fatalf("expected a location remapped to the fileRepository, got: %v", remapped.Locations)
 	}
 }

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -12,9 +12,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/nodeup-linux-amd64
+NODEUP_URL_AMD64=oci://registry.example.com/kops/binaries/kops/1.34.0-beta.1/linux/amd64/nodeup
 NODEUP_HASH_AMD64=c86e072f622b91546b7b3f3cb1a0f8a131e48b966ad018a0ac1520ceedf37725
-NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/nodeup-linux-arm64
+NODEUP_URL_ARM64=oci://registry.example.com/kops/binaries/kops/1.34.0-beta.1/linux/arm64/nodeup
 NODEUP_HASH_ARM64=64a9a9510538a449e85d05e13e3cd98b80377d68a673447c26821d40f00f0075
 
 export AWS_REGION=us-test-1
@@ -57,26 +57,17 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd} "${url}"); then
-          echo "== Failed to download ${url} using ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Failed to validate hash for ${url} =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} with hash ${hash} =="
-          return 0
-        fi
-      done
+      if ! download-oci "${file}" "${hash}" "${url}"; then
+        echo "== Failed to download ${url} =="
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Failed to validate hash for ${url} =="
+        rm -f "${file}"
+        continue
+      fi
+      echo "== Downloaded ${url} with hash ${hash} =="
+      return 0
     done
 
     echo "== All downloads failed; sleeping before retrying =="
@@ -94,6 +85,46 @@ validate-hash() {
     echo "== File ${file} is corrupted; hash ${actual} doesn't match expected ${expected} =="
     return 1
   fi
+}
+# Download an OCI blob by digest. args: file, hash, url
+download-oci() {
+  local -r file="$1"
+  local -r hash="$2"
+  local -r url="$3"
+
+  local -r stripped="${url#oci://}"
+  local -r registry="${stripped%%/*}"
+  local -r repository="${stripped#*/}"
+  local -r blob_url="https://${registry}/v2/${repository}/blobs/sha256:${hash}"
+
+  # Try a tokenless pull first
+  if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${blob_url}"; then
+    return 0
+  fi
+
+  # Get an anonymous pull token per the WWW-Authenticate challenge
+  local challenge realm service response token
+  challenge=$(curl -sSI "${blob_url}" | tr -d '\r' | sed -n 's/^[Ww][Ww][Ww]-[Aa]uthenticate: [Bb]earer //p')
+  realm=$(echo "${challenge}" | sed -n 's/.*realm="\([^"]*\)".*/\1/p')
+  service=$(echo "${challenge}" | sed -n 's/.*service="\([^"]*\)".*/\1/p')
+  if [[ -z "${realm}" ]]; then
+    echo "== Failed to get a pull token challenge from ${registry} =="
+    return 1
+  fi
+  if ! response=$(curl -fsS --get --data-urlencode "service=${service}" --data-urlencode "scope=repository:${repository}:pull" "${realm}"); then
+    echo "== Failed to get an anonymous pull token from ${realm} =="
+    return 1
+  fi
+  # The token field is "token" or "access_token"
+  token=$(echo "${response}" | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  if [[ -z "${token}" ]]; then
+    token=$(echo "${response}" | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  fi
+  if [[ -z "${token}" ]]; then
+    echo "== Failed to parse the anonymous pull token from ${realm} =="
+    return 1
+  fi
+  curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 -H "Authorization: Bearer ${token}" "${blob_url}"
 }
 
 function download-release() {
@@ -135,7 +166,7 @@ ClusterName: complex.example.com
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: z/EmOrmnme+vGiKvJOslpEZWgLRQZGVzsYYgyy9v640=
+NodeupConfigHash: CZA5tt6I6yquM7na2oqBGJFg9GRBYlNZwPT3IrUhVB4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
@@ -12,9 +12,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/nodeup-linux-amd64
+NODEUP_URL_AMD64=oci://registry.example.com/kops/binaries/kops/1.34.0-beta.1/linux/amd64/nodeup
 NODEUP_HASH_AMD64=c86e072f622b91546b7b3f3cb1a0f8a131e48b966ad018a0ac1520ceedf37725
-NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/nodeup-linux-arm64
+NODEUP_URL_ARM64=oci://registry.example.com/kops/binaries/kops/1.34.0-beta.1/linux/arm64/nodeup
 NODEUP_HASH_ARM64=64a9a9510538a449e85d05e13e3cd98b80377d68a673447c26821d40f00f0075
 
 export AWS_REGION=us-test-1
@@ -57,26 +57,17 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd} "${url}"); then
-          echo "== Failed to download ${url} using ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Failed to validate hash for ${url} =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} with hash ${hash} =="
-          return 0
-        fi
-      done
+      if ! download-oci "${file}" "${hash}" "${url}"; then
+        echo "== Failed to download ${url} =="
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Failed to validate hash for ${url} =="
+        rm -f "${file}"
+        continue
+      fi
+      echo "== Downloaded ${url} with hash ${hash} =="
+      return 0
     done
 
     echo "== All downloads failed; sleeping before retrying =="
@@ -94,6 +85,46 @@ validate-hash() {
     echo "== File ${file} is corrupted; hash ${actual} doesn't match expected ${expected} =="
     return 1
   fi
+}
+# Download an OCI blob by digest. args: file, hash, url
+download-oci() {
+  local -r file="$1"
+  local -r hash="$2"
+  local -r url="$3"
+
+  local -r stripped="${url#oci://}"
+  local -r registry="${stripped%%/*}"
+  local -r repository="${stripped#*/}"
+  local -r blob_url="https://${registry}/v2/${repository}/blobs/sha256:${hash}"
+
+  # Try a tokenless pull first
+  if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${blob_url}"; then
+    return 0
+  fi
+
+  # Get an anonymous pull token per the WWW-Authenticate challenge
+  local challenge realm service response token
+  challenge=$(curl -sSI "${blob_url}" | tr -d '\r' | sed -n 's/^[Ww][Ww][Ww]-[Aa]uthenticate: [Bb]earer //p')
+  realm=$(echo "${challenge}" | sed -n 's/.*realm="\([^"]*\)".*/\1/p')
+  service=$(echo "${challenge}" | sed -n 's/.*service="\([^"]*\)".*/\1/p')
+  if [[ -z "${realm}" ]]; then
+    echo "== Failed to get a pull token challenge from ${registry} =="
+    return 1
+  fi
+  if ! response=$(curl -fsS --get --data-urlencode "service=${service}" --data-urlencode "scope=repository:${repository}:pull" "${realm}"); then
+    echo "== Failed to get an anonymous pull token from ${realm} =="
+    return 1
+  fi
+  # The token field is "token" or "access_token"
+  token=$(echo "${response}" | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  if [[ -z "${token}" ]]; then
+    token=$(echo "${response}" | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  fi
+  if [[ -z "${token}" ]]; then
+    echo "== Failed to parse the anonymous pull token from ${realm} =="
+    return 1
+  fi
+  curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 -H "Authorization: Bearer ${token}" "${blob_url}"
 }
 
 function download-release() {
@@ -158,7 +189,7 @@ ConfigServer:
   - https://kops-controller.internal.complex.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: a8sS9KyTeFxroHIgKXwF+NW5cr0D2tnK13XW9tLy6QM=
+NodeupConfigHash: 8hCwhf496RpNb040/BLxebmo7HHUcHgl2kLdtvLyBq0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -22,6 +22,8 @@ spec:
       - allocationId: eipalloc-012345a678b9cdefa
         name: us-test-1a
       type: Public
+  assets:
+    fileRepository: oci://registry.example.com/kops
   authentication:
     aws:
       backendMode: CRD

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -65,21 +65,21 @@ APIServerConfig:
     -----END RSA PUBLIC KEY-----
 Assets:
   amd64:
-  - 5ad4965598773d56a37a8e8429c3dc3d86b4c5c26d8417ab333ae345c053dae2@https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubelet
-  - 646d58f6d98ee670a71d9cdffbf6625aeea2849d567f214bc43a35f8ccb7bf70@https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl
-  - 7644623e4ec9ad443ab352a8a5800a5180ee28741288be805286ba72bb8e7164@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/amd64/ecr-credential-provider-linux-amd64
-  - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
-  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
-  - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-amd64
+  - 5ad4965598773d56a37a8e8429c3dc3d86b4c5c26d8417ab333ae345c053dae2@oci://registry.example.com/kops/release/v1.32.0/bin/linux/amd64/kubelet
+  - 646d58f6d98ee670a71d9cdffbf6625aeea2849d567f214bc43a35f8ccb7bf70@oci://registry.example.com/kops/release/v1.32.0/bin/linux/amd64/kubectl
+  - 7644623e4ec9ad443ab352a8a5800a5180ee28741288be805286ba72bb8e7164@oci://registry.example.com/kops/binaries/cloud-provider-aws/v1.31.7/linux/amd64/ecr-credential-provider-linux-amd64
+  - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@oci://registry.example.com/kops/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@oci://registry.example.com/kops/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@oci://registry.example.com/kops/opencontainers/runc/releases/download/v1.3.5/runc.amd64
+  - 86189e1e8de9692eb02daf2f06db8495f687ce2c4ba09a6b64f135990dfb315d@oci://registry.example.com/kops/binaries/kops/1.34.0-beta.1/linux/amd64/protokube
   arm64:
-  - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
-  - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
-  - 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
-  - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
-  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
-  - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.34.0-beta.1/protokube-linux-arm64
+  - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@oci://registry.example.com/kops/release/v1.32.0/bin/linux/arm64/kubelet
+  - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@oci://registry.example.com/kops/release/v1.32.0/bin/linux/arm64/kubectl
+  - 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849@oci://registry.example.com/kops/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
+  - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@oci://registry.example.com/kops/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@oci://registry.example.com/kops/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@oci://registry.example.com/kops/opencontainers/runc/releases/download/v1.3.5/runc.arm64
+  - 25b57b0555fad42e5762246334681bf1c943794fcecdb680a79e482be5c08815@oci://registry.example.com/kops/binaries/kops/1.34.0-beta.1/linux/arm64/protokube
 CAs:
   apiserver-aggregator-ca: |
     -----BEGIN CERTIFICATE-----

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
@@ -1,18 +1,18 @@
 Assets:
   amd64:
-  - 5ad4965598773d56a37a8e8429c3dc3d86b4c5c26d8417ab333ae345c053dae2@https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubelet
-  - 646d58f6d98ee670a71d9cdffbf6625aeea2849d567f214bc43a35f8ccb7bf70@https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl
-  - 7644623e4ec9ad443ab352a8a5800a5180ee28741288be805286ba72bb8e7164@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/amd64/ecr-credential-provider-linux-amd64
-  - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
-  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
-  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.amd64
+  - 5ad4965598773d56a37a8e8429c3dc3d86b4c5c26d8417ab333ae345c053dae2@oci://registry.example.com/kops/release/v1.32.0/bin/linux/amd64/kubelet
+  - 646d58f6d98ee670a71d9cdffbf6625aeea2849d567f214bc43a35f8ccb7bf70@oci://registry.example.com/kops/release/v1.32.0/bin/linux/amd64/kubectl
+  - 7644623e4ec9ad443ab352a8a5800a5180ee28741288be805286ba72bb8e7164@oci://registry.example.com/kops/binaries/cloud-provider-aws/v1.31.7/linux/amd64/ecr-credential-provider-linux-amd64
+  - b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090@oci://registry.example.com/kops/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz
+  - 62e77f6294e432dca5b56ad7e7d6085b5bbb526ebba0a51d832714f9b04cfdfd@oci://registry.example.com/kops/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-amd64.tar.gz
+  - 66fa8390be8fb3b23dfbb60c767368bb5b51f1acfa88692bbff1a82953d4d9e9@oci://registry.example.com/kops/opencontainers/runc/releases/download/v1.3.5/runc.amd64
   arm64:
-  - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubelet
-  - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl
-  - 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
-  - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
-  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@https://github.com/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
-  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@https://github.com/opencontainers/runc/releases/download/v1.3.5/runc.arm64
+  - bda9b2324c96693b38c41ecea051bab4c7c434be5683050b5e19025b50dbc0bf@oci://registry.example.com/kops/release/v1.32.0/bin/linux/arm64/kubelet
+  - ba4004f98f3d3a7b7d2954ff0a424caa2c2b06b78c17b1dccf2acc76a311a896@oci://registry.example.com/kops/release/v1.32.0/bin/linux/arm64/kubectl
+  - 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849@oci://registry.example.com/kops/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
+  - 01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4@oci://registry.example.com/kops/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-arm64-v1.6.2.tgz
+  - d0897c8e27c96a7b7d4c73e9b278ea9f559dda619d497d88b323a528bd1412c3@oci://registry.example.com/kops/containerd/containerd/releases/download/v2.2.4/containerd-2.2.4-linux-arm64.tar.gz
+  - bd843d75a788e612c9df286b1fa519a44fcbb7a7b8d01e2268431433cc7c718c@oci://registry.example.com/kops/opencontainers/runc/releases/download/v1.3.5/runc.arm64
 CAs: {}
 ClusterName: complex.example.com
 Hooks:

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -19,6 +19,8 @@ spec:
           allocationId: eipalloc-012345a678b9cdefa
       accessLog:
         bucket: access-log-example
+  assets:
+    fileRepository: oci://registry.example.com/kops
   authentication:
     aws:
       backendMode: CRD

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -19,6 +19,8 @@ spec:
           allocationId: eipalloc-012345a678b9cdefa
       accessLog:
         bucket: access-log-example
+  assets:
+    fileRepository: oci://registry.example.com/kops
   authentication:
     aws:
       backendMode: CRD

--- a/upup/pkg/fi/assetstore.go
+++ b/upup/pkg/fi/assetstore.go
@@ -211,6 +211,9 @@ func (a *AssetStore) Add(ctx context.Context, id string) error {
 	if i == -1 {
 		i = strings.Index(id, "@gs://")
 	}
+	if i == -1 {
+		i = strings.Index(id, "@oci://")
+	}
 	if i != -1 {
 		urls := strings.Split(id[i+1:], ",")
 		hash, err := hashing.FromString(id[:i])

--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -88,13 +88,8 @@ func downloadURLToWriter(ctx context.Context, desturl string, dest io.Writer, ha
 	if err != nil {
 		return nil, fmt.Errorf("Invalud URL for file %q: %v", desturl, err)
 	}
-	if u.Scheme != "gs" {
-		reader, err = OpenURL(desturl)
-		if err != nil {
-			return nil, err
-		}
-		defer reader.Close()
-	} else {
+	switch u.Scheme {
+	case "gs":
 		bucketName := u.Host
 		objectName := strings.TrimPrefix(u.Path, "/")
 
@@ -108,8 +103,18 @@ func downloadURLToWriter(ctx context.Context, desturl string, dest io.Writer, ha
 		if err != nil {
 			return nil, fmt.Errorf("Failed to open reader on object %q: %v", desturl, err)
 		}
-		defer reader.Close()
+	case "oci":
+		reader, err = openOCIBlob(ctx, u, hash)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		reader, err = OpenURL(desturl)
+		if err != nil {
+			return nil, err
+		}
 	}
+	defer reader.Close()
 	start := time.Now()
 	defer func() {
 		klog.V(2).Infof("Downloading %q took %q", desturl, time.Since(start))

--- a/upup/pkg/fi/oci.go
+++ b/upup/pkg/fi/oci.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"k8s.io/kops/util/pkg/hashing"
+)
+
+// openOCIBlob opens a stream for an OCI registry blob addressed by digest. The URL has the form
+// oci://<registry>/<repository>; the digest is the sha256 hash of the asset. The registry must
+// allow anonymous pulls of the asset.
+func openOCIBlob(ctx context.Context, u *url.URL, hash *hashing.Hash) (io.ReadCloser, error) {
+	if hash == nil {
+		return nil, fmt.Errorf("OCI asset %q requires a known hash", u)
+	}
+	if hash.Algorithm != hashing.HashAlgorithmSHA256 {
+		return nil, fmt.Errorf("OCI asset %q requires a sha256 hash, got %q", u, hash.Algorithm)
+	}
+
+	registry := u.Host
+	repository := strings.Trim(u.Path, "/")
+	if registry == "" || repository == "" {
+		return nil, fmt.Errorf("cannot parse OCI asset URL %q; expected oci://<registry>/<repository>", u)
+	}
+
+	blobURL := fmt.Sprintf("https://%s/v2/%s/blobs/sha256:%s", registry, repository, hash.Hex())
+	httpClient := newDownloadHTTPClient()
+
+	response, err := getOCIBlob(ctx, httpClient, blobURL, "")
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode == http.StatusUnauthorized {
+		// Anonymous pulls may still need a token, obtained anonymously from the endpoint advertised in
+		// the unauthorized response's challenge.
+		challenge := response.Header.Get("WWW-Authenticate")
+		response.Body.Close()
+		token, err := anonymousPullToken(ctx, httpClient, challenge, repository)
+		if err != nil {
+			return nil, fmt.Errorf("getting anonymous pull token for registry %q: %w", registry, err)
+		}
+		response, err = getOCIBlob(ctx, httpClient, blobURL, "Bearer "+token)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		response.Body.Close()
+		return nil, fmt.Errorf("unexpected response from %q: HTTP %s", blobURL, response.Status)
+	}
+	return response.Body, nil
+}
+
+func getOCIBlob(ctx context.Context, httpClient *http.Client, blobURL, auth string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, blobURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create request: %w", err)
+	}
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	response, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error doing HTTP fetch of %q: %w", blobURL, err)
+	}
+	return response, nil
+}
+
+// anonymousPullToken obtains a pull token for an anonymous client from the token endpoint
+// advertised in a registry's WWW-Authenticate challenge.
+func anonymousPullToken(ctx context.Context, httpClient *http.Client, challenge, repository string) (string, error) {
+	realm, service, err := parseBearerChallenge(challenge)
+	if err != nil {
+		return "", err
+	}
+
+	// Merge the service and scope parameters into any query the realm already carries.
+	realmURL, err := url.Parse(realm)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse realm %q: %w", realm, err)
+	}
+	query := realmURL.Query()
+	query.Set("service", service)
+	query.Set("scope", "repository:"+repository+":pull")
+	realmURL.RawQuery = query.Encode()
+
+	tokenURL := realmURL.String()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("cannot create request: %w", err)
+	}
+
+	response, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error querying %q: %w", tokenURL, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		return "", fmt.Errorf("unexpected response from %q: HTTP %s", tokenURL, response.Status)
+	}
+
+	// Registries return the token as "token" (Docker registry auth) or "access_token" (OAuth2).
+	return tokenFromJSON(response.Body, "token", "access_token")
+}
+
+// parseBearerChallenge extracts the realm and service from a Bearer WWW-Authenticate challenge,
+// such as `Bearer realm="https://auth.example.com/token",service="example.com"`.
+func parseBearerChallenge(challenge string) (string, string, error) {
+	// The authentication scheme is case-insensitive (RFC 9110).
+	const prefix = "Bearer "
+	if len(challenge) < len(prefix) || !strings.EqualFold(challenge[:len(prefix)], prefix) {
+		return "", "", fmt.Errorf("unsupported WWW-Authenticate challenge %q", challenge)
+	}
+	params := challenge[len(prefix):]
+
+	var realm, service string
+	for _, param := range strings.Split(params, ",") {
+		key, value, found := strings.Cut(strings.TrimSpace(param), "=")
+		if !found {
+			continue
+		}
+		switch key {
+		case "realm":
+			realm = strings.Trim(value, `"`)
+		case "service":
+			service = strings.Trim(value, `"`)
+		}
+	}
+	if realm == "" {
+		return "", "", fmt.Errorf("WWW-Authenticate challenge %q does not contain a realm", challenge)
+	}
+	return realm, service, nil
+}
+
+func tokenFromJSON(r io.Reader, fields ...string) (string, error) {
+	var body map[string]any
+	if err := json.NewDecoder(r).Decode(&body); err != nil {
+		return "", fmt.Errorf("cannot decode response: %w", err)
+	}
+	for _, field := range fields {
+		if token, _ := body[field].(string); token != "" {
+			return token, nil
+		}
+	}
+	return "", fmt.Errorf("response did not contain %s", strings.Join(fields, " or "))
+}

--- a/upup/pkg/fi/oci_test.go
+++ b/upup/pkg/fi/oci_test.go
@@ -32,14 +32,14 @@ func TestParseBearerChallenge(t *testing.T) {
 		expectError     bool
 	}{
 		{
-			challenge:       `Bearer realm="https://auth.docker.io/token",service="registry.docker.io"`,
-			expectedRealm:   "https://auth.docker.io/token",
-			expectedService: "registry.docker.io",
+			challenge:       `Bearer realm="https://auth.example.com/token",service="registry.example.com"`,
+			expectedRealm:   "https://auth.example.com/token",
+			expectedService: "registry.example.com",
 		},
 		{
-			challenge:       `Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:owner/repo:pull"`,
-			expectedRealm:   "https://ghcr.io/token",
-			expectedService: "ghcr.io",
+			challenge:       `Bearer realm="https://registry.example.com/token",service="registry.example.com",scope="repository:owner/repo:pull"`,
+			expectedRealm:   "https://registry.example.com/token",
+			expectedService: "registry.example.com",
 		},
 		{
 			challenge:     `Bearer realm="https://example.com/token"`,

--- a/upup/pkg/fi/oci_test.go
+++ b/upup/pkg/fi/oci_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseBearerChallenge(t *testing.T) {
+	grid := []struct {
+		challenge       string
+		expectedRealm   string
+		expectedService string
+		expectError     bool
+	}{
+		{
+			challenge:       `Bearer realm="https://auth.docker.io/token",service="registry.docker.io"`,
+			expectedRealm:   "https://auth.docker.io/token",
+			expectedService: "registry.docker.io",
+		},
+		{
+			challenge:       `Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:owner/repo:pull"`,
+			expectedRealm:   "https://ghcr.io/token",
+			expectedService: "ghcr.io",
+		},
+		{
+			challenge:     `Bearer realm="https://example.com/token"`,
+			expectedRealm: "https://example.com/token",
+		},
+		{
+			// The authentication scheme is case-insensitive.
+			challenge:       `bearer realm="https://example.com/token",service="example.com"`,
+			expectedRealm:   "https://example.com/token",
+			expectedService: "example.com",
+		},
+		{
+			challenge:   `Basic realm="registry"`,
+			expectError: true,
+		},
+		{
+			challenge:   `Bearer service="example.com"`,
+			expectError: true,
+		},
+		{
+			challenge:   "",
+			expectError: true,
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.challenge, func(t *testing.T) {
+			realm, service, err := parseBearerChallenge(g.challenge)
+			if g.expectError {
+				if err == nil {
+					t.Fatalf("expected an error, got realm %q, service %q", realm, service)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if realm != g.expectedRealm {
+				t.Errorf("unexpected realm: expected %q, but got %q", g.expectedRealm, realm)
+			}
+			if service != g.expectedService {
+				t.Errorf("unexpected service: expected %q, but got %q", g.expectedService, service)
+			}
+		})
+	}
+}
+
+func TestAnonymousPullToken(t *testing.T) {
+	// Registries return the token as "token" (Docker registry auth) or "access_token" (OAuth2).
+	for _, field := range []string{"token", "access_token"} {
+		t.Run(field, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.URL.Query().Get("service"); got != "registry.example.com" {
+					t.Errorf("unexpected service in token request: %q", got)
+				}
+				if got := r.URL.Query().Get("scope"); got != "repository:assets/nodeup:pull" {
+					t.Errorf("unexpected scope in token request: %q", got)
+				}
+				// A query already present in the realm must be preserved.
+				if got := r.URL.Query().Get("issuer"); got != "test" {
+					t.Errorf("unexpected issuer in token request: %q", got)
+				}
+				fmt.Fprintf(w, `{"%s":"secret","expires_in":300}`, field)
+			}))
+			defer server.Close()
+
+			challenge := fmt.Sprintf(`Bearer realm="%s/token?issuer=test",service="registry.example.com"`, server.URL)
+			token, err := anonymousPullToken(context.Background(), server.Client(), challenge, "assets/nodeup")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if token != "secret" {
+				t.Errorf("unexpected token: %q", token)
+			}
+		})
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/internal/httptest/httptest.go
+++ b/vendor/github.com/google/go-containerregistry/internal/httptest/httptest.go
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httptest provides a method for testing a TLS server a la net/http/httptest.
+package httptest
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// NewTLSServer returns an httptest server, with an http client that has been configured to
+// send all requests to the returned server. The TLS certs are generated for the given domain.
+// If you need a transport, Client().Transport is correctly configured.
+func NewTLSServer(domain string, handler http.Handler) (*httptest.Server, error) {
+	s := httptest.NewUnstartedServer(handler)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses: []net.IP{
+			net.IPv4(127, 0, 0, 1),
+			net.IPv6loopback,
+		},
+		DNSNames: []string{domain},
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := &bytes.Buffer{}
+	if err := pem.Encode(pc, &pem.Block{Type: "CERTIFICATE", Bytes: b}); err != nil {
+		return nil, err
+	}
+
+	ek, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	pk := &bytes.Buffer{}
+	if err := pem.Encode(pk, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ek}); err != nil {
+		return nil, err
+	}
+
+	c, err := tls.X509KeyPair(pc.Bytes(), pk.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	s.TLS = &tls.Config{
+		Certificates: []tls.Certificate{c},
+	}
+	s.StartTLS()
+
+	certpool := x509.NewCertPool()
+	certpool.AddCert(s.Certificate())
+
+	t := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: certpool,
+		},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return net.Dial(s.Listener.Addr().Network(), s.Listener.Addr().String())
+		},
+	}
+	s.Client().Transport = t
+
+	return s, nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/README.md
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/README.md
@@ -1,0 +1,14 @@
+# `pkg/registry`
+
+This package implements a Docker v2 registry and the OCI distribution specification.
+
+It is designed to be used anywhere a low dependency container registry is needed, with an initial focus on tests.
+
+Its goal is to be standards compliant and its strictness will increase over time.
+
+This is currently a low flightmiles system. It's likely quite safe to use in tests; If you're using it in production, please let us know how and send us PRs for integration tests.
+
+Before sending a PR, understand that the expectation of this package is that it remain free of extraneous dependencies.
+This means that we expect `pkg/registry` to only have dependencies on Go's standard library, and other packages in `go-containerregistry`.
+
+You may be asked to change your code to reduce dependencies, and your PR might be rejected if this is deemed impossible.

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/blobs.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/blobs.go
@@ -1,0 +1,538 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/google/go-containerregistry/internal/verify"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// Returns whether this url should be handled by the blob handler
+// This is complicated because blob is indicated by the trailing path, not the leading path.
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pulling-a-layer
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pushing-a-layer
+func isBlob(req *http.Request) bool {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	if elem[len(elem)-1] == "" {
+		elem = elem[:len(elem)-1]
+	}
+	if len(elem) < 3 {
+		return false
+	}
+	return elem[len(elem)-2] == "blobs" || (elem[len(elem)-3] == "blobs" &&
+		elem[len(elem)-2] == "uploads")
+}
+
+// BlobHandler represents a minimal blob storage backend, capable of serving
+// blob contents.
+type BlobHandler interface {
+	// Get gets the blob contents, or errNotFound if the blob wasn't found.
+	Get(ctx context.Context, repo string, h v1.Hash) (io.ReadCloser, error)
+}
+
+// BlobStatHandler is an extension interface representing a blob storage
+// backend that can serve metadata about blobs.
+type BlobStatHandler interface {
+	// Stat returns the size of the blob, or errNotFound if the blob wasn't
+	// found, or redirectError if the blob can be found elsewhere.
+	Stat(ctx context.Context, repo string, h v1.Hash) (int64, error)
+}
+
+// BlobPutHandler is an extension interface representing a blob storage backend
+// that can write blob contents.
+type BlobPutHandler interface {
+	// Put puts the blob contents.
+	//
+	// The contents will be verified against the expected size and digest
+	// as the contents are read, and an error will be returned if these
+	// don't match. Implementations should return that error, or a wrapper
+	// around that error, to return the correct error when these don't match.
+	Put(ctx context.Context, repo string, h v1.Hash, rc io.ReadCloser) error
+}
+
+// BlobDeleteHandler is an extension interface representing a blob storage
+// backend that can delete blob contents.
+type BlobDeleteHandler interface {
+	// Delete the blob contents.
+	Delete(ctx context.Context, repo string, h v1.Hash) error
+}
+
+// redirectError represents a signal that the blob handler doesn't have the blob
+// contents, but that those contents are at another location which registry
+// clients should redirect to.
+type redirectError struct {
+	// Location is the location to find the contents.
+	Location string
+
+	// Code is the HTTP redirect status code to return to clients.
+	Code int
+}
+
+type bytesCloser struct {
+	*bytes.Reader
+}
+
+func (r *bytesCloser) Close() error {
+	return nil
+}
+
+func (e redirectError) Error() string { return fmt.Sprintf("redirecting (%d): %s", e.Code, e.Location) }
+
+// errNotFound represents an error locating the blob.
+var errNotFound = errors.New("not found")
+
+type memHandler struct {
+	m    map[string][]byte
+	lock sync.Mutex
+}
+
+func NewInMemoryBlobHandler() BlobHandler { return &memHandler{m: map[string][]byte{}} }
+
+func (m *memHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	b, found := m.m[h.String()]
+	if !found {
+		return 0, errNotFound
+	}
+	return int64(len(b)), nil
+}
+
+func (m *memHandler) Get(_ context.Context, _ string, h v1.Hash) (io.ReadCloser, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	b, found := m.m[h.String()]
+	if !found {
+		return nil, errNotFound
+	}
+	return &bytesCloser{bytes.NewReader(b)}, nil
+}
+
+func (m *memHandler) Put(_ context.Context, _ string, h v1.Hash, rc io.ReadCloser) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	defer rc.Close()
+	all, err := io.ReadAll(rc)
+	if err != nil {
+		return err
+	}
+	m.m[h.String()] = all
+	return nil
+}
+
+func (m *memHandler) Delete(_ context.Context, _ string, h v1.Hash) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if _, found := m.m[h.String()]; !found {
+		return errNotFound
+	}
+
+	delete(m.m, h.String())
+	return nil
+}
+
+// blobs
+type blobs struct {
+	blobHandler BlobHandler
+
+	// Each upload gets a unique id that writes occur to until finalized.
+	uploads map[string][]byte
+	lock    sync.Mutex
+	log     *log.Logger
+}
+
+func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	if elem[len(elem)-1] == "" {
+		elem = elem[:len(elem)-1]
+	}
+	// Must have a path of form /v2/{name}/blobs/{upload,sha256:}
+	if len(elem) < 4 {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "NAME_INVALID",
+			Message: "blobs must be attached to a repo",
+		}
+	}
+	target := elem[len(elem)-1]
+	service := elem[len(elem)-2]
+	digest := req.URL.Query().Get("digest")
+	contentRange := req.Header.Get("Content-Range")
+	rangeHeader := req.Header.Get("Range")
+
+	repo := req.URL.Host + path.Join(elem[1:len(elem)-2]...)
+
+	switch req.Method {
+	case http.MethodHead:
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		var size int64
+		if bsh, ok := b.blobHandler.(BlobStatHandler); ok {
+			size, err = bsh.Stat(req.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr redirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+		} else {
+			rc, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr redirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+			defer rc.Close()
+			size, err = io.Copy(io.Discard, rc)
+			if err != nil {
+				return regErrInternal(err)
+			}
+		}
+
+		resp.Header().Set("Content-Length", fmt.Sprint(size))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.WriteHeader(http.StatusOK)
+		return nil
+
+	case http.MethodGet:
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		var size int64
+		var r io.Reader
+		if bsh, ok := b.blobHandler.(BlobStatHandler); ok {
+			size, err = bsh.Stat(req.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr redirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+
+			rc, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr redirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+
+				return regErrInternal(err)
+			}
+
+			defer rc.Close()
+			r = rc
+
+		} else {
+			tmp, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr redirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+
+				return regErrInternal(err)
+			}
+			defer tmp.Close()
+			var buf bytes.Buffer
+			io.Copy(&buf, tmp)
+			size = int64(buf.Len())
+			r = &buf
+		}
+
+		if rangeHeader != "" {
+			start, end := int64(0), int64(0)
+			if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UNKNOWN",
+					Message: "We don't understand your Range",
+				}
+			}
+
+			n := (end + 1) - start
+			if ra, ok := r.(io.ReaderAt); ok {
+				if end+1 > size {
+					return &regError{
+						Status:  http.StatusRequestedRangeNotSatisfiable,
+						Code:    "BLOB_UNKNOWN",
+						Message: fmt.Sprintf("range end %d > %d size", end+1, size),
+					}
+				}
+				r = io.NewSectionReader(ra, start, n)
+			} else {
+				if _, err := io.CopyN(io.Discard, r, start); err != nil {
+					return &regError{
+						Status:  http.StatusRequestedRangeNotSatisfiable,
+						Code:    "BLOB_UNKNOWN",
+						Message: fmt.Sprintf("Failed to discard %d bytes", start),
+					}
+				}
+
+				r = io.LimitReader(r, n)
+			}
+
+			resp.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, size))
+			resp.Header().Set("Content-Length", fmt.Sprint(n))
+			resp.Header().Set("Docker-Content-Digest", h.String())
+			resp.WriteHeader(http.StatusPartialContent)
+		} else {
+			resp.Header().Set("Content-Length", fmt.Sprint(size))
+			resp.Header().Set("Docker-Content-Digest", h.String())
+			resp.WriteHeader(http.StatusOK)
+		}
+
+		io.Copy(resp, r)
+		return nil
+
+	case http.MethodPost:
+		bph, ok := b.blobHandler.(BlobPutHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		// It is weird that this is "target" instead of "service", but
+		// that's how the index math works out above.
+		if target != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("POST to /blobs must be followed by /uploads, got %s", target),
+			}
+		}
+
+		if digest != "" {
+			h, err := v1.NewHash(digest)
+			if err != nil {
+				return regErrDigestInvalid
+			}
+
+			vrc, err := verify.ReadCloser(req.Body, req.ContentLength, h)
+			if err != nil {
+				return regErrInternal(err)
+			}
+			defer vrc.Close()
+
+			if err = bph.Put(req.Context(), repo, h, vrc); err != nil {
+				if errors.As(err, &verify.Error{}) {
+					log.Printf("Digest mismatch: %v", err)
+					return regErrDigestMismatch
+				}
+				return regErrInternal(err)
+			}
+			resp.Header().Set("Docker-Content-Digest", h.String())
+			resp.WriteHeader(http.StatusCreated)
+			return nil
+		}
+
+		id := fmt.Sprint(rand.Int63())
+		resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-2]...), "blobs/uploads", id))
+		resp.Header().Set("Range", "0-0")
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	case http.MethodPatch:
+		if service != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("PATCH to /blobs must be followed by /uploads, got %s", service),
+			}
+		}
+
+		if contentRange != "" {
+			start, end := 0, 0
+			if _, err := fmt.Sscanf(contentRange, "%d-%d", &start, &end); err != nil {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UPLOAD_UNKNOWN",
+					Message: "We don't understand your Content-Range",
+				}
+			}
+			b.lock.Lock()
+			defer b.lock.Unlock()
+			if start != len(b.uploads[target]) {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UPLOAD_UNKNOWN",
+					Message: "Your content range doesn't match what we have",
+				}
+			}
+			l := bytes.NewBuffer(b.uploads[target])
+			io.Copy(l, req.Body)
+			b.uploads[target] = l.Bytes()
+			resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-3]...), "blobs/uploads", target))
+			resp.Header().Set("Range", fmt.Sprintf("0-%d", len(l.Bytes())-1))
+			resp.WriteHeader(http.StatusNoContent)
+			return nil
+		}
+
+		b.lock.Lock()
+		defer b.lock.Unlock()
+		if _, ok := b.uploads[target]; ok {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "BLOB_UPLOAD_INVALID",
+				Message: "Stream uploads after first write are not allowed",
+			}
+		}
+
+		l := &bytes.Buffer{}
+		io.Copy(l, req.Body)
+
+		b.uploads[target] = l.Bytes()
+		resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-3]...), "blobs/uploads", target))
+		resp.Header().Set("Range", fmt.Sprintf("0-%d", len(l.Bytes())-1))
+		resp.WriteHeader(http.StatusNoContent)
+		return nil
+
+	case http.MethodPut:
+		bph, ok := b.blobHandler.(BlobPutHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		if service != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("PUT to /blobs must be followed by /uploads, got %s", service),
+			}
+		}
+
+		if digest == "" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "DIGEST_INVALID",
+				Message: "digest not specified",
+			}
+		}
+
+		b.lock.Lock()
+		defer b.lock.Unlock()
+
+		h, err := v1.NewHash(digest)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		defer req.Body.Close()
+		in := io.NopCloser(io.MultiReader(bytes.NewBuffer(b.uploads[target]), req.Body))
+
+		size := int64(verify.SizeUnknown)
+		if req.ContentLength > 0 {
+			size = int64(len(b.uploads[target])) + req.ContentLength
+		}
+
+		vrc, err := verify.ReadCloser(in, size, h)
+		if err != nil {
+			return regErrInternal(err)
+		}
+		defer vrc.Close()
+
+		if err := bph.Put(req.Context(), repo, h, vrc); err != nil {
+			if errors.As(err, &verify.Error{}) {
+				log.Printf("Digest mismatch: %v", err)
+				return regErrDigestMismatch
+			}
+			return regErrInternal(err)
+		}
+
+		delete(b.uploads, target)
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.WriteHeader(http.StatusCreated)
+		return nil
+
+	case http.MethodDelete:
+		bdh, ok := b.blobHandler.(BlobDeleteHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+		if err := bdh.Delete(req.Context(), repo, h); err != nil {
+			return regErrInternal(err)
+		}
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	default:
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/blobs_disk.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/blobs_disk.go
@@ -1,0 +1,71 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+type diskHandler struct {
+	dir string
+}
+
+func NewDiskBlobHandler(dir string) BlobHandler { return &diskHandler{dir: dir} }
+
+func (m *diskHandler) blobHashPath(h v1.Hash) string {
+	return filepath.Join(m.dir, h.Algorithm, h.Hex)
+}
+
+func (m *diskHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error) {
+	fi, err := os.Stat(m.blobHashPath(h))
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, errNotFound
+	} else if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}
+func (m *diskHandler) Get(_ context.Context, _ string, h v1.Hash) (io.ReadCloser, error) {
+	return os.Open(m.blobHashPath(h))
+}
+func (m *diskHandler) Put(_ context.Context, _ string, h v1.Hash, rc io.ReadCloser) error {
+	// Put the temp file in the same directory to avoid cross-device problems
+	// during the os.Rename.  The filenames cannot conflict.
+	f, err := os.CreateTemp(m.dir, "upload-*")
+	if err != nil {
+		return err
+	}
+
+	if err := func() error {
+		defer f.Close()
+		_, err := io.Copy(f, rc)
+		return err
+	}(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(m.dir, h.Algorithm), os.ModePerm); err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), m.blobHashPath(h))
+}
+func (m *diskHandler) Delete(_ context.Context, _ string, h v1.Hash) error {
+	return os.Remove(m.blobHashPath(h))
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/error.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/error.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type regError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (r *regError) Write(resp http.ResponseWriter) error {
+	resp.WriteHeader(r.Status)
+
+	type err struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	type wrap struct {
+		Errors []err `json:"errors"`
+	}
+	return json.NewEncoder(resp).Encode(wrap{
+		Errors: []err{
+			{
+				Code:    r.Code,
+				Message: r.Message,
+			},
+		},
+	})
+}
+
+// regErrInternal returns an internal server error.
+func regErrInternal(err error) *regError {
+	return &regError{
+		Status:  http.StatusInternalServerError,
+		Code:    "INTERNAL_SERVER_ERROR",
+		Message: err.Error(),
+	}
+}
+
+var regErrBlobUnknown = &regError{
+	Status:  http.StatusNotFound,
+	Code:    "BLOB_UNKNOWN",
+	Message: "Unknown blob",
+}
+
+var regErrUnsupported = &regError{
+	Status:  http.StatusMethodNotAllowed,
+	Code:    "UNSUPPORTED",
+	Message: "Unsupported operation",
+}
+
+var regErrDigestMismatch = &regError{
+	Status:  http.StatusBadRequest,
+	Code:    "DIGEST_INVALID",
+	Message: "digest does not match contents",
+}
+
+var regErrDigestInvalid = &regError{
+	Status:  http.StatusBadRequest,
+	Code:    "NAME_INVALID",
+	Message: "invalid digest",
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/manifest.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/manifest.go
@@ -1,0 +1,444 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type catalog struct {
+	Repos []string `json:"repositories"`
+}
+
+type listTags struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+type manifest struct {
+	contentType string
+	blob        []byte
+}
+
+type manifests struct {
+	// maps repo -> manifest tag/digest -> manifest
+	manifests map[string]map[string]manifest
+	lock      sync.RWMutex
+	log       *log.Logger
+}
+
+func isManifest(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "manifests"
+}
+
+func isTags(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "tags"
+}
+
+func isCatalog(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 2 {
+		return false
+	}
+
+	return elems[len(elems)-1] == "_catalog"
+}
+
+// Returns whether this url should be handled by the referrers handler
+func isReferrers(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "referrers"
+}
+
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pulling-an-image-manifest
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pushing-an-image
+func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	target := elem[len(elem)-1]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	switch req.Method {
+	case http.MethodGet:
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		c, ok := m.manifests[repo]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+		m, ok := c[target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		h, _, _ := v1.SHA256(bytes.NewReader(m.blob))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.Header().Set("Content-Type", m.contentType)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(m.blob)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader(m.blob))
+		return nil
+
+	case http.MethodHead:
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		if _, ok := m.manifests[repo]; !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+		m, ok := m.manifests[repo][target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		h, _, _ := v1.SHA256(bytes.NewReader(m.blob))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.Header().Set("Content-Type", m.contentType)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(m.blob)))
+		resp.WriteHeader(http.StatusOK)
+		return nil
+
+	case http.MethodPut:
+		b := &bytes.Buffer{}
+		io.Copy(b, req.Body)
+		h, _, _ := v1.SHA256(bytes.NewReader(b.Bytes()))
+		digest := h.String()
+		mf := manifest{
+			blob:        b.Bytes(),
+			contentType: req.Header.Get("Content-Type"),
+		}
+
+		// If the manifest is a manifest list, check that the manifest
+		// list's constituent manifests are already uploaded.
+		// This isn't strictly required by the registry API, but some
+		// registries require this.
+		if types.MediaType(mf.contentType).IsIndex() {
+			if err := func() *regError {
+				m.lock.RLock()
+				defer m.lock.RUnlock()
+
+				im, err := v1.ParseIndexManifest(b)
+				if err != nil {
+					return &regError{
+						Status:  http.StatusBadRequest,
+						Code:    "MANIFEST_INVALID",
+						Message: err.Error(),
+					}
+				}
+				for _, desc := range im.Manifests {
+					if !desc.MediaType.IsDistributable() {
+						continue
+					}
+					if desc.MediaType.IsIndex() || desc.MediaType.IsImage() {
+						if _, found := m.manifests[repo][desc.Digest.String()]; !found {
+							return &regError{
+								Status:  http.StatusNotFound,
+								Code:    "MANIFEST_UNKNOWN",
+								Message: fmt.Sprintf("Sub-manifest %q not found", desc.Digest),
+							}
+						}
+					} else {
+						// TODO: Probably want to do an existence check for blobs.
+						m.log.Printf("TODO: Check blobs for %q", desc.Digest)
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+
+		m.lock.Lock()
+		defer m.lock.Unlock()
+
+		if _, ok := m.manifests[repo]; !ok {
+			m.manifests[repo] = make(map[string]manifest, 2)
+		}
+
+		// Allow future references by target (tag) and immutable digest.
+		// See https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier.
+		m.manifests[repo][digest] = mf
+		m.manifests[repo][target] = mf
+		resp.Header().Set("Docker-Content-Digest", digest)
+		resp.WriteHeader(http.StatusCreated)
+		return nil
+
+	case http.MethodDelete:
+		m.lock.Lock()
+		defer m.lock.Unlock()
+		if _, ok := m.manifests[repo]; !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+
+		_, ok := m.manifests[repo][target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		delete(m.manifests[repo], target)
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	default:
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+}
+
+func (m *manifests) handleTags(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	if req.Method == "GET" {
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		c, ok := m.manifests[repo]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+
+		var tags []string
+		for tag := range c {
+			if !strings.Contains(tag, "sha256:") {
+				tags = append(tags, tag)
+			}
+		}
+		sort.Strings(tags)
+
+		// https://github.com/opencontainers/distribution-spec/blob/b505e9cc53ec499edbd9c1be32298388921bb705/detail.md#tags-paginated
+		// Offset using last query parameter.
+		if last := req.URL.Query().Get("last"); last != "" {
+			for i, t := range tags {
+				if t > last {
+					tags = tags[i:]
+					break
+				}
+			}
+		}
+
+		// Limit using n query parameter.
+		if ns := req.URL.Query().Get("n"); ns != "" {
+			if n, err := strconv.Atoi(ns); err != nil {
+				return &regError{
+					Status:  http.StatusBadRequest,
+					Code:    "BAD_REQUEST",
+					Message: fmt.Sprintf("parsing n: %v", err),
+				}
+			} else if n < len(tags) {
+				tags = tags[:n]
+			}
+		}
+
+		tagsToList := listTags{
+			Name: repo,
+			Tags: tags,
+		}
+
+		msg, _ := json.Marshal(tagsToList)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader([]byte(msg)))
+		return nil
+	}
+
+	return &regError{
+		Status:  http.StatusBadRequest,
+		Code:    "METHOD_UNKNOWN",
+		Message: "We don't understand your method + url",
+	}
+}
+
+func (m *manifests) handleCatalog(resp http.ResponseWriter, req *http.Request) *regError {
+	query := req.URL.Query()
+	nStr := query.Get("n")
+	n := 10000
+	if nStr != "" {
+		n, _ = strconv.Atoi(nStr)
+	}
+
+	if req.Method == "GET" {
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		var repos []string
+		countRepos := 0
+		// TODO: implement pagination
+		for key := range m.manifests {
+			if countRepos >= n {
+				break
+			}
+			countRepos++
+
+			repos = append(repos, key)
+		}
+
+		repositoriesToList := catalog{
+			Repos: repos,
+		}
+
+		msg, _ := json.Marshal(repositoriesToList)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader([]byte(msg)))
+		return nil
+	}
+
+	return &regError{
+		Status:  http.StatusBadRequest,
+		Code:    "METHOD_UNKNOWN",
+		Message: "We don't understand your method + url",
+	}
+}
+
+// TODO: implement handling of artifactType querystring
+func (m *manifests) handleReferrers(resp http.ResponseWriter, req *http.Request) *regError {
+	// Ensure this is a GET request
+	if req.Method != "GET" {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	target := elem[len(elem)-1]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	// Validate that incoming target is a valid digest
+	if _, err := v1.NewHash(target); err != nil {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "UNSUPPORTED",
+			Message: "Target must be a valid digest",
+		}
+	}
+
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	digestToManifestMap, repoExists := m.manifests[repo]
+	if !repoExists {
+		return &regError{
+			Status:  http.StatusNotFound,
+			Code:    "NAME_UNKNOWN",
+			Message: "Unknown name",
+		}
+	}
+
+	im := v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIImageIndex,
+		Manifests:     []v1.Descriptor{},
+	}
+	for digest, manifest := range digestToManifestMap {
+		h, err := v1.NewHash(digest)
+		if err != nil {
+			continue
+		}
+		var refPointer struct {
+			Subject *v1.Descriptor `json:"subject"`
+		}
+		json.Unmarshal(manifest.blob, &refPointer)
+		if refPointer.Subject == nil {
+			continue
+		}
+		referenceDigest := refPointer.Subject.Digest
+		if referenceDigest.String() != target {
+			continue
+		}
+		// At this point, we know the current digest references the target
+		var imageAsArtifact struct {
+			Config struct {
+				MediaType string `json:"mediaType"`
+			} `json:"config"`
+		}
+		json.Unmarshal(manifest.blob, &imageAsArtifact)
+		im.Manifests = append(im.Manifests, v1.Descriptor{
+			MediaType:    types.MediaType(manifest.contentType),
+			Size:         int64(len(manifest.blob)),
+			Digest:       h,
+			ArtifactType: imageAsArtifact.Config.MediaType,
+		})
+	}
+	msg, _ := json.Marshal(&im)
+	resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+	resp.Header().Set("Content-Type", string(types.OCIImageIndex))
+	resp.WriteHeader(http.StatusOK)
+	io.Copy(resp, bytes.NewReader([]byte(msg)))
+	return nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/registry.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/registry.go
@@ -1,0 +1,144 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registry implements a docker V2 registry and the OCI distribution specification.
+//
+// It is designed to be used anywhere a low dependency container registry is needed, with an
+// initial focus on tests.
+//
+// Its goal is to be standards compliant and its strictness will increase over time.
+//
+// This is currently a low flightmiles system. It's likely quite safe to use in tests; If you're using it
+// in production, please let us know how and send us CL's for integration tests.
+package registry
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+)
+
+type registry struct {
+	log              *log.Logger
+	blobs            blobs
+	manifests        manifests
+	referrersEnabled bool
+	warnings         map[float64]string
+}
+
+// https://docs.docker.com/registry/spec/api/#api-version-check
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#api-version-check
+func (r *registry) v2(resp http.ResponseWriter, req *http.Request) *regError {
+	if r.warnings != nil {
+		rnd := rand.Float64()
+		for prob, msg := range r.warnings {
+			if prob > rnd {
+				resp.Header().Add("Warning", fmt.Sprintf(`299 - "%s"`, msg))
+			}
+		}
+	}
+
+	if isBlob(req) {
+		return r.blobs.handle(resp, req)
+	}
+	if isManifest(req) {
+		return r.manifests.handle(resp, req)
+	}
+	if isTags(req) {
+		return r.manifests.handleTags(resp, req)
+	}
+	if isCatalog(req) {
+		return r.manifests.handleCatalog(resp, req)
+	}
+	if r.referrersEnabled && isReferrers(req) {
+		return r.manifests.handleReferrers(resp, req)
+	}
+	resp.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+	if req.URL.Path != "/v2/" && req.URL.Path != "/v2" {
+		return &regError{
+			Status:  http.StatusNotFound,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+	resp.WriteHeader(200)
+	return nil
+}
+
+func (r *registry) root(resp http.ResponseWriter, req *http.Request) {
+	if rerr := r.v2(resp, req); rerr != nil {
+		r.log.Printf("%s %s %d %s %s", req.Method, req.URL, rerr.Status, rerr.Code, rerr.Message)
+		rerr.Write(resp)
+		return
+	}
+	r.log.Printf("%s %s", req.Method, req.URL)
+}
+
+// New returns a handler which implements the docker registry protocol.
+// It should be registered at the site root.
+func New(opts ...Option) http.Handler {
+	r := &registry{
+		log: log.New(os.Stderr, "", log.LstdFlags),
+		blobs: blobs{
+			blobHandler: &memHandler{m: map[string][]byte{}},
+			uploads:     map[string][]byte{},
+			log:         log.New(os.Stderr, "", log.LstdFlags),
+		},
+		manifests: manifests{
+			manifests: map[string]map[string]manifest{},
+			log:       log.New(os.Stderr, "", log.LstdFlags),
+		},
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return http.HandlerFunc(r.root)
+}
+
+// Option describes the available options
+// for creating the registry.
+type Option func(r *registry)
+
+// Logger overrides the logger used to record requests to the registry.
+func Logger(l *log.Logger) Option {
+	return func(r *registry) {
+		r.log = l
+		r.manifests.log = l
+		r.blobs.log = l
+	}
+}
+
+// WithReferrersSupport enables the referrers API endpoint (OCI 1.1+)
+func WithReferrersSupport(enabled bool) Option {
+	return func(r *registry) {
+		r.referrersEnabled = enabled
+	}
+}
+
+func WithWarning(prob float64, msg string) Option {
+	return func(r *registry) {
+		if r.warnings == nil {
+			r.warnings = map[float64]string{}
+		}
+		r.warnings[prob] = msg
+	}
+}
+
+func WithBlobHandler(h BlobHandler) Option {
+	return func(r *registry) {
+		r.blobs.blobHandler = h
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/tls.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/tls.go
@@ -1,0 +1,29 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"net/http/httptest"
+
+	ggcrtest "github.com/google/go-containerregistry/internal/httptest"
+)
+
+// TLS returns an httptest server, with an http client that has been configured to
+// send all requests to the returned server. The TLS certs are generated for the given domain
+// which should correspond to the domain the image is stored in.
+// If you need a transport, Client().Transport is correctly configured.
+func TLS(domain string) (*httptest.Server, error) {
+	return ggcrtest.NewTLSServer(domain, New())
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/static/layer.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/static/layer.go
@@ -1,0 +1,68 @@
+// Copyright 2021 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package static
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// NewLayer returns a layer containing the given bytes, with the given mediaType.
+//
+// Contents will not be compressed.
+func NewLayer(b []byte, mt types.MediaType) v1.Layer {
+	return &staticLayer{b: b, mt: mt}
+}
+
+type staticLayer struct {
+	b  []byte
+	mt types.MediaType
+
+	once sync.Once
+	h    v1.Hash
+}
+
+func (l *staticLayer) Digest() (v1.Hash, error) {
+	var err error
+	// Only calculate digest the first time we're asked.
+	l.once.Do(func() {
+		l.h, _, err = v1.SHA256(bytes.NewReader(l.b))
+	})
+	return l.h, err
+}
+
+func (l *staticLayer) DiffID() (v1.Hash, error) {
+	return l.Digest()
+}
+
+func (l *staticLayer) Compressed() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(l.b)), nil
+}
+
+func (l *staticLayer) Uncompressed() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(l.b)), nil
+}
+
+func (l *staticLayer) Size() (int64, error) {
+	return int64(len(l.b)), nil
+}
+
+func (l *staticLayer) MediaType() (types.MediaType, error) {
+	return l.mt, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -648,6 +648,7 @@ github.com/google/go-containerregistry/pkg/v1/mutate
 github.com/google/go-containerregistry/pkg/v1/partial
 github.com/google/go-containerregistry/pkg/v1/remote
 github.com/google/go-containerregistry/pkg/v1/remote/transport
+github.com/google/go-containerregistry/pkg/v1/static
 github.com/google/go-containerregistry/pkg/v1/stream
 github.com/google/go-containerregistry/pkg/v1/tarball
 github.com/google/go-containerregistry/pkg/v1/types

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -627,6 +627,7 @@ github.com/google/go-containerregistry/internal/and
 github.com/google/go-containerregistry/internal/compression
 github.com/google/go-containerregistry/internal/estargz
 github.com/google/go-containerregistry/internal/gzip
+github.com/google/go-containerregistry/internal/httptest
 github.com/google/go-containerregistry/internal/redact
 github.com/google/go-containerregistry/internal/retry
 github.com/google/go-containerregistry/internal/retry/wait
@@ -640,6 +641,7 @@ github.com/google/go-containerregistry/pkg/legacy
 github.com/google/go-containerregistry/pkg/legacy/tarball
 github.com/google/go-containerregistry/pkg/logs
 github.com/google/go-containerregistry/pkg/name
+github.com/google/go-containerregistry/pkg/registry
 github.com/google/go-containerregistry/pkg/v1
 github.com/google/go-containerregistry/pkg/v1/empty
 github.com/google/go-containerregistry/pkg/v1/layout


### PR DESCRIPTION
Refs: https://github.com/kubernetes/kops/issues/18608

`spec.assets.fileRepository` may now be an `oci://<registry>/<repository>` URL, storing file assets (including nodeup) in an OCI registry instead of an HTTP file server.

`kops get assets --copy` pushes each file asset as an image with a single layer whose blob digest is the sha256 hash of the file, tagged with that hash. Pushing authenticates with the local docker credentials, so any registry that `docker login` (or a credential helper) can reach works.

Nodes download the assets anonymously, addressed directly by digest (`/v2/<repository>/blobs/sha256:<hash>`), so no OCI client is needed on the node: the bootstrap script uses curl and nodeup uses a plain HTTP client. Registries that require a token even for public pulls are handled through the standard `WWW-Authenticate` anonymous token flow. Only registries that allow anonymous pulls of the assets are supported; in exchange, this works the same on every cloud provider.

```yaml
spec:
  assets:
    fileRepository: oci://registry.example.com/assets
```

Assisted by Claude Fable