### PR TITLE
Provision SQS interruption queue for Karpenter

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -999,6 +999,11 @@ func TestKarpenter(t *testing.T) {
 		"aws_s3_object_nodeupscript-karpenter-nodes-default_content",
 		"aws_s3_object_nodeupconfig-karpenter-nodes-single-machinetype_content",
 		"aws_s3_object_nodeupconfig-karpenter-nodes-default_content",
+		"aws_cloudwatch_event_rule_"+test.clusterName+"-Karpenter-InstanceScheduledChange_event_pattern",
+		"aws_cloudwatch_event_rule_"+test.clusterName+"-Karpenter-InstanceStateChange_event_pattern",
+		"aws_cloudwatch_event_rule_"+test.clusterName+"-Karpenter-RebalanceRecommendation_event_pattern",
+		"aws_cloudwatch_event_rule_"+test.clusterName+"-Karpenter-SpotInterruption_event_pattern",
+		"aws_sqs_queue_minimal-example-com-karpenter_policy",
 	)
 	test.runTestTerraformAWS(t)
 }

--- a/pkg/model/awsmodel/karpenter.go
+++ b/pkg/model/awsmodel/karpenter.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsmodel
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"k8s.io/kops/pkg/model"
+	"k8s.io/kops/pkg/model/iam"
+	"k8s.io/kops/pkg/util/stringorset"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+)
+
+type karpenterEvent struct {
+	name    string
+	pattern string
+}
+
+var (
+	_ fi.CloudupModelBuilder = &KarpenterBuilder{}
+
+	karpenterEvents = []karpenterEvent{
+		{
+			name:    "SpotInterruption",
+			pattern: `{"source": ["aws.ec2"],"detail-type": ["EC2 Spot Instance Interruption Warning"]}`,
+		},
+		{
+			name:    "InstanceStateChange",
+			pattern: `{"source": ["aws.ec2"],"detail-type": ["EC2 Instance State-change Notification"]}`,
+		},
+		{
+			name:    "InstanceScheduledChange",
+			pattern: `{"source": ["aws.health"],"detail-type": ["AWS Health Event"],"detail": {"service": ["EC2"],"eventTypeCategory": ["scheduledChange"]}}`,
+		},
+		{
+			name:    "RebalanceRecommendation",
+			pattern: `{"source": ["aws.ec2"],"detail-type": ["EC2 Instance Rebalance Recommendation"]}`,
+		},
+	}
+)
+
+type KarpenterBuilder struct {
+	*AWSModelContext
+
+	Lifecycle fi.Lifecycle
+}
+
+func (b *KarpenterBuilder) Build(c *fi.CloudupModelBuilderContext) error {
+	if b.Cluster.Spec.Karpenter == nil || !b.Cluster.Spec.Karpenter.Enabled {
+		return nil
+	}
+
+	queueName := model.QueueNamePrefix(b.ClusterName()) + "-karpenter"
+
+	policy := iam.NewPolicy(b.ClusterName(), b.AWSPartition, b.Region)
+	arn := arn.ARN{
+		Partition: b.AWSPartition,
+		Service:   "sqs",
+		Region:    b.Region,
+		AccountID: b.AWSAccountID,
+		Resource:  queueName,
+	}
+
+	policy.Statement = append(policy.Statement, &iam.Statement{
+		Effect: iam.StatementEffectAllow,
+		Principal: iam.Principal{
+			Service: new(stringorset.Of("events.amazonaws.com", "sqs.amazonaws.com")),
+		},
+		Action:   stringorset.Of("sqs:SendMessage"),
+		Resource: stringorset.String(arn.String()),
+	})
+	policyJSON, err := policy.AsJSON()
+	if err != nil {
+		return fmt.Errorf("rendering policy as json: %w", err)
+	}
+
+	queue := &awstasks.SQS{
+		Name:                   aws.String(queueName),
+		Lifecycle:              b.Lifecycle,
+		Policy:                 fi.NewStringResource(policyJSON),
+		MessageRetentionPeriod: DefaultMessageRetentionPeriod,
+		Tags:                   b.CloudTags(queueName, false),
+	}
+
+	c.AddTask(queue)
+
+	clusterName := b.ClusterName()
+	clusterNamePrefix := awsup.GetClusterName40(clusterName)
+
+	for _, event := range karpenterEvents {
+		// build rule
+		ruleName := aws.String(clusterNamePrefix + "-Karpenter-" + event.name)
+		pattern := event.pattern
+
+		ruleTask := &awstasks.EventBridgeRule{
+			Name:      ruleName,
+			Lifecycle: b.Lifecycle,
+			Tags:      b.CloudTags(*ruleName, false),
+
+			EventPattern: &pattern,
+			SQSQueue:     queue,
+		}
+
+		c.AddTask(ruleTask)
+
+		// build target
+		targetTask := &awstasks.EventBridgeTarget{
+			Name:      aws.String(*ruleName + "-Target"),
+			Lifecycle: b.Lifecycle,
+
+			Rule:     ruleTask,
+			SQSQueue: queue,
+		}
+
+		c.AddTask(targetTask)
+	}
+
+	return nil
+}

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -1149,6 +1149,11 @@ func AddKarpenterPermissions(p *Policy, useCustomInstanceProfiles bool) error {
 		"iam:ListInstanceProfiles",
 		"pricing:GetProducts",
 		"ssm:GetParameter",
+		// SQS permissions do not support conditions.
+		"sqs:DeleteMessage",
+		"sqs:GetQueueUrl",
+		"sqs:GetQueueAttributes",
+		"sqs:ReceiveMessage",
 	)
 
 	instanceARN := fmt.Sprintf("arn:%s:ec2:*:*:instance/*", p.partition)

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -1198,6 +1198,11 @@ func AddKarpenterPermissions(p *Policy, useCustomInstanceProfiles bool, useCusto
 		"iam:ListInstanceProfiles",
 		"pricing:GetProducts",
 		"ssm:GetParameter",
+		// SQS permissions do not support conditions.
+		"sqs:DeleteMessage",
+		"sqs:GetQueueUrl",
+		"sqs:GetQueueAttributes",
+		"sqs:ReceiveMessage",
 	)
 
 	instanceARN := fmt.Sprintf("arn:%s:ec2:*:*:instance/*", p.partition)

--- a/tests/integration/update_cluster/karpenter/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-InstanceScheduledChange_event_pattern
+++ b/tests/integration/update_cluster/karpenter/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-InstanceScheduledChange_event_pattern
@@ -1,0 +1,1 @@
+{"source": ["aws.health"],"detail-type": ["AWS Health Event"],"detail": {"service": ["EC2"],"eventTypeCategory": ["scheduledChange"]}}

--- a/tests/integration/update_cluster/karpenter/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-InstanceStateChange_event_pattern
+++ b/tests/integration/update_cluster/karpenter/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-InstanceStateChange_event_pattern
@@ -1,0 +1,1 @@
+{"source": ["aws.ec2"],"detail-type": ["EC2 Instance State-change Notification"]}

--- a/tests/integration/update_cluster/karpenter/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-RebalanceRecommendation_event_pattern
+++ b/tests/integration/update_cluster/karpenter/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-RebalanceRecommendation_event_pattern
@@ -1,0 +1,1 @@
+{"source": ["aws.ec2"],"detail-type": ["EC2 Instance Rebalance Recommendation"]}

--- a/tests/integration/update_cluster/karpenter/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-SpotInterruption_event_pattern
+++ b/tests/integration/update_cluster/karpenter/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-SpotInterruption_event_pattern
@@ -1,0 +1,1 @@
+{"source": ["aws.ec2"],"detail-type": ["EC2 Spot Instance Interruption Warning"]}

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
@@ -152,6 +152,10 @@
         "iam:GetInstanceProfile",
         "iam:ListInstanceProfiles",
         "pricing:GetProducts",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
+        "sqs:GetQueueUrl",
+        "sqs:ReceiveMessage",
         "ssm:GetParameter"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
@@ -181,6 +181,10 @@
         "iam:GetInstanceProfile",
         "iam:ListInstanceProfiles",
         "pricing:GetProducts",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
+        "sqs:GetQueueUrl",
+        "sqs:ReceiveMessage",
         "ssm:GetParameter"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -53,7 +53,7 @@ spec:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: 34bfc2069ea36de0e099580b8ab51e2932386f0951db29df658db3db1008e36e
+    manifestHash: 8b1b611bc6d699c1ca1e5825b05b42004303da61cadaacdb55bee293af4d54a3
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -53,7 +53,7 @@ spec:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: e99c8d21b3acdf2342a854485f596d923694a2027ae8631fed0151f2d4d9c632
+    manifestHash: 8ffe5c4d085d84ca855f43905e09c76ae4fc62c8ec3ac8c802d6cb5b644b67b2
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -2870,6 +2870,8 @@ spec:
           value: https://api.internal.minimal.example.com
         - name: VM_MEMORY_OVERHEAD_PERCENT
           value: "0.075"
+        - name: INTERRUPTION_QUEUE
+          value: minimal-example-com-karpenter
         - name: RESERVED_ENIS
           value: "0"
         - name: IGNORE_DRA_REQUESTS

--- a/tests/integration/update_cluster/karpenter/data/aws_sqs_queue_minimal-example-com-karpenter_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_sqs_queue_minimal-example-com-karpenter_policy
@@ -1,0 +1,16 @@
+{
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-karpenter"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/karpenter/kubernetes.tf
+++ b/tests/integration/update_cluster/karpenter/kubernetes.tf
@@ -250,6 +250,66 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
   vpc_zone_identifier = [aws_subnet.us-test-1a-minimal-example-com.id]
 }
 
+resource "aws_cloudwatch_event_rule" "minimal-example-com-Karpenter-InstanceScheduledChange" {
+  event_pattern = file("${path.module}/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-InstanceScheduledChange_event_pattern")
+  name          = "minimal.example.com-Karpenter-InstanceScheduledChange"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com-Karpenter-InstanceScheduledChange"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "minimal-example-com-Karpenter-InstanceStateChange" {
+  event_pattern = file("${path.module}/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-InstanceStateChange_event_pattern")
+  name          = "minimal.example.com-Karpenter-InstanceStateChange"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com-Karpenter-InstanceStateChange"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "minimal-example-com-Karpenter-RebalanceRecommendation" {
+  event_pattern = file("${path.module}/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-RebalanceRecommendation_event_pattern")
+  name          = "minimal.example.com-Karpenter-RebalanceRecommendation"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com-Karpenter-RebalanceRecommendation"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "minimal-example-com-Karpenter-SpotInterruption" {
+  event_pattern = file("${path.module}/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-SpotInterruption_event_pattern")
+  name          = "minimal.example.com-Karpenter-SpotInterruption"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com-Karpenter-SpotInterruption"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+}
+
+resource "aws_cloudwatch_event_target" "minimal-example-com-Karpenter-InstanceScheduledChange-Target" {
+  arn  = aws_sqs_queue.minimal-example-com-karpenter.arn
+  rule = aws_cloudwatch_event_rule.minimal-example-com-Karpenter-InstanceScheduledChange.id
+}
+
+resource "aws_cloudwatch_event_target" "minimal-example-com-Karpenter-InstanceStateChange-Target" {
+  arn  = aws_sqs_queue.minimal-example-com-karpenter.arn
+  rule = aws_cloudwatch_event_rule.minimal-example-com-Karpenter-InstanceStateChange.id
+}
+
+resource "aws_cloudwatch_event_target" "minimal-example-com-Karpenter-RebalanceRecommendation-Target" {
+  arn  = aws_sqs_queue.minimal-example-com-karpenter.arn
+  rule = aws_cloudwatch_event_rule.minimal-example-com-Karpenter-RebalanceRecommendation.id
+}
+
+resource "aws_cloudwatch_event_target" "minimal-example-com-Karpenter-SpotInterruption-Target" {
+  arn  = aws_sqs_queue.minimal-example-com-karpenter.arn
+  rule = aws_cloudwatch_event_rule.minimal-example-com-Karpenter-SpotInterruption.id
+}
+
 resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
   availability_zone = "us-test-1a"
   encrypted         = false
@@ -997,6 +1057,17 @@ resource "aws_security_group_rule" "from-nodes-minimal-example-com-ingress-udp-1
   source_security_group_id = aws_security_group.nodes-minimal-example-com.id
   to_port                  = 65535
   type                     = "ingress"
+}
+
+resource "aws_sqs_queue" "minimal-example-com-karpenter" {
+  message_retention_seconds = 300
+  name                      = "minimal-example-com-karpenter"
+  policy                    = file("${path.module}/data/aws_sqs_queue_minimal-example-com-karpenter_policy")
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal-example-com-karpenter"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_subnet" "us-test-1a-minimal-example-com" {

--- a/tests/integration/update_cluster/karpenter/kubernetes.tf
+++ b/tests/integration/update_cluster/karpenter/kubernetes.tf
@@ -250,6 +250,66 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
   vpc_zone_identifier = [aws_subnet.us-test-1a-minimal-example-com.id]
 }
 
+resource "aws_cloudwatch_event_rule" "minimal-example-com-Karpenter-InstanceScheduledChange" {
+  event_pattern = file("${path.module}/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-InstanceScheduledChange_event_pattern")
+  name          = "minimal.example.com-Karpenter-InstanceScheduledChange"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com-Karpenter-InstanceScheduledChange"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "minimal-example-com-Karpenter-InstanceStateChange" {
+  event_pattern = file("${path.module}/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-InstanceStateChange_event_pattern")
+  name          = "minimal.example.com-Karpenter-InstanceStateChange"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com-Karpenter-InstanceStateChange"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "minimal-example-com-Karpenter-RebalanceRecommendation" {
+  event_pattern = file("${path.module}/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-RebalanceRecommendation_event_pattern")
+  name          = "minimal.example.com-Karpenter-RebalanceRecommendation"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com-Karpenter-RebalanceRecommendation"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "minimal-example-com-Karpenter-SpotInterruption" {
+  event_pattern = file("${path.module}/data/aws_cloudwatch_event_rule_minimal.example.com-Karpenter-SpotInterruption_event_pattern")
+  name          = "minimal.example.com-Karpenter-SpotInterruption"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com-Karpenter-SpotInterruption"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+}
+
+resource "aws_cloudwatch_event_target" "minimal-example-com-Karpenter-InstanceScheduledChange-Target" {
+  arn  = aws_sqs_queue.minimal-example-com-karpenter.arn
+  rule = aws_cloudwatch_event_rule.minimal-example-com-Karpenter-InstanceScheduledChange.id
+}
+
+resource "aws_cloudwatch_event_target" "minimal-example-com-Karpenter-InstanceStateChange-Target" {
+  arn  = aws_sqs_queue.minimal-example-com-karpenter.arn
+  rule = aws_cloudwatch_event_rule.minimal-example-com-Karpenter-InstanceStateChange.id
+}
+
+resource "aws_cloudwatch_event_target" "minimal-example-com-Karpenter-RebalanceRecommendation-Target" {
+  arn  = aws_sqs_queue.minimal-example-com-karpenter.arn
+  rule = aws_cloudwatch_event_rule.minimal-example-com-Karpenter-RebalanceRecommendation.id
+}
+
+resource "aws_cloudwatch_event_target" "minimal-example-com-Karpenter-SpotInterruption-Target" {
+  arn  = aws_sqs_queue.minimal-example-com-karpenter.arn
+  rule = aws_cloudwatch_event_rule.minimal-example-com-Karpenter-SpotInterruption.id
+}
+
 resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-example-com" {
   availability_zone = "us-test-1a"
   encrypted         = false
@@ -991,6 +1051,17 @@ resource "aws_security_group_rule" "from-nodes-minimal-example-com-ingress-udp-1
   source_security_group_id = aws_security_group.nodes-minimal-example-com.id
   to_port                  = 65535
   type                     = "ingress"
+}
+
+resource "aws_sqs_queue" "minimal-example-com-karpenter" {
+  message_retention_seconds = 300
+  name                      = "minimal-example-com-karpenter"
+  policy                    = file("${path.module}/data/aws_sqs_queue_minimal-example-com-karpenter_policy")
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal-example-com-karpenter"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_subnet" "us-test-1a-minimal-example-com" {

--- a/upup/models/cloudup/resources/addons/karpenter.sh/helm-values.yaml
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/helm-values.yaml
@@ -26,6 +26,7 @@ replicas: 1
 settings:
   clusterEndpoint: "{{ printf \"https://{{ APIInternalName }}\" }}"
   clusterName: "{{ printf \"{{ ClusterName }}\" }}"
+  interruptionQueue: "{{ printf \"{{ KarpenterQueueName }}\" }}"
 tolerations:
 - key: node-role.kubernetes.io/master
   operator: Exists

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -2800,6 +2800,8 @@ spec:
           value: https://{{ APIInternalName }}
         - name: VM_MEMORY_OVERHEAD_PERCENT
           value: "0.075"
+        - name: INTERRUPTION_QUEUE
+          value: '{{ KarpenterQueueName }}'
         - name: RESERVED_ENIS
           value: "0"
         - name: IGNORE_DRA_REQUESTS

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -644,6 +644,13 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 				})
 			}
 
+			if c.Cluster.Spec.Karpenter != nil && c.Cluster.Spec.Karpenter.Enabled {
+				l.Builders = append(l.Builders, &awsmodel.KarpenterBuilder{
+					AWSModelContext: awsModelContext,
+					Lifecycle:       clusterLifecycle,
+				})
+			}
+
 		case kops.CloudProviderDO:
 			doModelContext := &domodel.DOModelContext{
 				KopsModelContext: modelContext,

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -501,6 +501,9 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["KarpenterEC2NodeClass"] = tf.KarpenterEC2NodeClass
 	dest["KarpenterInstanceGroups"] = tf.KarpenterInstanceGroups
 	dest["KarpenterNodePool"] = tf.KarpenterNodePool
+	dest["KarpenterQueueName"] = func() string {
+		return truncate.TruncateString(strings.ReplaceAll(tf.ClusterName(), ".", "-"), truncate.TruncateStringOptions{MaxLength: 75, AlwaysAddHash: false}) + "-karpenter"
+	}
 
 	return nil
 }

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -495,6 +495,9 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["KarpenterEC2NodeClass"] = tf.KarpenterEC2NodeClass
 	dest["KarpenterInstanceGroups"] = tf.KarpenterInstanceGroups
 	dest["KarpenterNodePool"] = tf.KarpenterNodePool
+	dest["KarpenterQueueName"] = func() string {
+		return truncate.TruncateString(strings.ReplaceAll(tf.ClusterName(), ".", "-"), truncate.TruncateStringOptions{MaxLength: 75, AlwaysAddHash: false}) + "-karpenter"
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

When Karpenter is enabled, kOps doesn't provision an SQS queue for it, so Karpenter never receives interruption events (spot interruptions, instance state changes, scheduled maintenance, rebalance recommendations). `nodeTerminationHandler` can't be enabled alongside Karpenter either, since validation blocks that combination, so clusters running Karpenter currently get no interruption handling at all.

- Adds a `KarpenterBuilder` that provisions an SQS queue plus the EventBridge rules/targets for the four interruption event types, mirroring what's already done for `NodeTerminationHandler`'s queue.
- Passes the queue name into the addon via a new `KarpenterQueueName` template function, used in both the Helm values (`settings.interruptionQueue`) and the static manifest (`INTERRUPTION_QUEUE` env var).
- Adds the SQS permissions Karpenter needs to read from the queue (`DeleteMessage`, `GetQueueUrl`, `GetQueueAttributes`, `ReceiveMessage`) to `AddKarpenterPermissions`, added unconditionally since SQS actions don't support resource-level conditions.

Fixes #18016

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` (clean aside from pre-existing vendor files)
- [x] `go vet ./pkg/model/... ./cmd/kops/... ./upup/pkg/fi/cloudup/...`
- [x] `go test ./pkg/model/iam/... ./pkg/model/awsmodel/... ./pkg/model/components/addonmanifests/karpenter/... ./upup/pkg/fi/cloudup/...`
- [x] `go test ./cmd/kops/...` (updated `TestKarpenter` golden fixtures to include the new SQS queue, EventBridge rules/targets, and IAM policy changes)