### PR TITLE
Replace gsutil with gcloud storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,24 +246,24 @@ upload: version-dist # Upload kops to S3
 
 # gcs-upload builds kops and uploads to GCS
 .PHONY: gcs-upload
-gcs-upload: gsutil version-dist
+gcs-upload: gcloud version-dist
 	@echo "== Uploading kops =="
-	gsutil -h "Cache-Control:private, max-age=0, no-transform" -m cp -n -r ${UPLOAD}/kops/* ${GCS_LOCATION}
+	gcloud storage cp --cache-control="private, max-age=0, no-transform" --no-clobber --recursive ${UPLOAD}/kops/* ${GCS_LOCATION}
 
 # gcs-upload-tag runs gcs-upload to upload, then uploads a version-marker to LATEST_FILE
 .PHONY: gcs-upload-and-tag
-gcs-upload-and-tag: gsutil gcs-upload
+gcs-upload-and-tag: gcloud gcs-upload
 	echo "${GCS_URL}${VERSION}" > ${UPLOAD}/latest.txt
-	gsutil -h "Cache-Control:private, max-age=0, no-transform" cp ${UPLOAD}/latest.txt ${GCS_LOCATION}${LATEST_FILE}
+	gcloud storage cp --cache-control="private, max-age=0, no-transform" ${UPLOAD}/latest.txt ${GCS_LOCATION}${LATEST_FILE}
 
 # gcs-publish-ci is the entry point for CI testing
 .PHONY: gcs-publish-ci
-gcs-publish-ci: gsutil version-dist-ci
+gcs-publish-ci: gcloud version-dist-ci
 	@echo "== Uploading kops =="
-	gsutil -h "Cache-Control:private, max-age=0, no-transform" -m cp -n -r ${UPLOAD}/kops/* ${GCS_LOCATION}
+	gcloud storage cp --cache-control="private, max-age=0, no-transform" --no-clobber --recursive ${UPLOAD}/kops/* ${GCS_LOCATION}
 	echo "VERSION: ${VERSION}"
 	echo "${GCS_URL}/${VERSION}" > ${UPLOAD}/${LATEST_FILE}
-	gsutil -h "Cache-Control:private, max-age=0, no-transform" cp ${UPLOAD}/${LATEST_FILE} ${GCS_LOCATION}
+	gcloud storage cp --cache-control="private, max-age=0, no-transform" ${UPLOAD}/${LATEST_FILE} ${GCS_LOCATION}
 
 .PHONY: gen-cli-docs
 gen-cli-docs: kops # Regenerate CLI docs
@@ -504,9 +504,9 @@ verify-crds:
 verify-versions:
 	hack/verify-versions.sh
 
-.PHONY: gsutil
-gsutil:
-	hack/install-gsutil.sh
+.PHONY: gcloud
+gcloud:
+	hack/install-gcloud.sh
 
 .PHONY: check-markdown-links
 check-markdown-links:

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -106,7 +106,7 @@ It (currently) takes about 30 minutes to run.
 
 The following tools are prerequisites:
 
-* [`gsutil`](https://cloud.google.com/storage/docs/gsutil_install)
+* [`gcloud`](https://cloud.google.com/sdk/docs/install)
 * [`kpromo`](https://github.com/kubernetes-sigs/promo-tools)
 
 Currently, we send the image and non-image artifact promotion PRs separately.
@@ -145,7 +145,7 @@ git checkout -b kops_artifacts_${VERSION}
 
 rm -rf ./k8s-staging-kops/kops/releases
 mkdir -p ./k8s-staging-kops/kops/releases/${VERSION}/
-gsutil rsync -r  gs://k8s-staging-kops/kops/releases/${VERSION}/ ./k8s-staging-kops/kops/releases/${VERSION}/
+gcloud storage rsync -r gs://k8s-staging-kops/kops/releases/${VERSION}/ ./k8s-staging-kops/kops/releases/${VERSION}/
 
 kpromo manifest files --src k8s-staging-kops/kops/releases/ >> artifacts/manifests/k8s-staging-kops/${VERSION}.yaml
 

--- a/docs/getting_started/gce.md
+++ b/docs/getting_started/gce.md
@@ -17,7 +17,7 @@ kOps needs a state store, to hold the configuration for your clusters.  The simp
 for Google Cloud is to store it in a Google Cloud Storage bucket in the same account, so that's how we'll
 start.
 
-So, just create an empty bucket - you can use any (available) name - e.g. `gsutil mb gs://kubernetes-clusters/`
+So, just create an empty bucket - you can use any (available) name - e.g. `gcloud storage buckets create gs://kubernetes-clusters/`
 
 Further, rather than typing the `--state` argument every time, it's much easier to export the `KOPS_STATE_STORE`
 environment variable:

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -42,12 +42,12 @@ Example:
 https://gcsweb.k8s.io/gcs/kubernetes-jenkins/pr-logs/pull/kops/16204/presubmit-kops-aws-scale-amazonvpc-using-cl2/1742962895290896384/artifacts/otlp/
 ```
 
-Download these files to a local directory, either with `gsutil` or through a web browser
+Download these files to a local directory, either with `gcloud storage` or through a web browser
 
 ```
 mkdir /tmp/job-traces
 
-gsutil cp -r gs://kubernetes-jenkins/pr-logs/pull/kops/16204/presubmit-kops-aws-scale-amazonvpc-using-cl2/1742962895290896384/artifacts/otlp/ /tmp/job-traces
+gcloud storage cp -r gs://kubernetes-jenkins/pr-logs/pull/kops/16204/presubmit-kops-aws-scale-amazonvpc-using-cl2/1742962895290896384/artifacts/otlp/ /tmp/job-traces
 ```
 
 Then run the trace server as normal:

--- a/hack/dev-build-gce.sh
+++ b/hack/dev-build-gce.sh
@@ -31,7 +31,7 @@ export KOPS_ARCH
 # Build and upload to bucket
 UPLOAD_DEST_BUCKET="kops-dev-$(gcloud config get-value project)-${USER}"
 export UPLOAD_DEST=gs://${UPLOAD_DEST_BUCKET}
-gcloud storage ls "${UPLOAD_DEST}" || gcloud buckets create "${UPLOAD_DEST}" || return
+gcloud storage ls "${UPLOAD_DEST}" || gcloud storage buckets create "${UPLOAD_DEST}" || return
 make kops-install dev-upload-linux-${KOPS_ARCH} || return
 
 # Set KOPS_BASE_URL
@@ -42,6 +42,6 @@ export KOPS_BASE_URL=https://storage.googleapis.com/${UPLOAD_DEST_BUCKET}/kops/$
 # Create the state-store bucket if it doesn't exist
 KOPS_STATE_STORE="gs://kops-state-$(gcloud config get-value project)"
 export KOPS_STATE_STORE
-gcloud storage ls "${KOPS_STATE_STORE}" || gcloud buckets create "${KOPS_STATE_STORE}" || return
+gcloud storage ls "${KOPS_STATE_STORE}" || gcloud storage buckets create "${KOPS_STATE_STORE}" || return
 
 echo "SUCCESS"

--- a/hack/install-gcloud.sh
+++ b/hack/install-gcloud.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if ! command -v gsutil &> /dev/null; then
+if ! command -v gcloud &> /dev/null; then
     curl https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -o /tmp/google-cloud-sdk.tar.gz
     tar xzf /tmp/google-cloud-sdk.tar.gz -C /
     rm /tmp/google-cloud-sdk.tar.gz
@@ -27,7 +27,6 @@ if ! command -v gsutil &> /dev/null; then
         --usage-reporting=false \
         --quiet
     ln -s /google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
-    ln -s /google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil
     gcloud info
     gcloud config list
     gcloud auth list

--- a/hack/upload
+++ b/hack/upload
@@ -33,13 +33,13 @@ fi
 
 if [[ "${DEST:0:5}" == "gs://" ]]; then
   bucket=$(echo "${DEST}" | cut -d/ -f1-3)
-  acl_flag="${PUBLIC:+-a public-read}"
+  acl_flag="${PUBLIC:+--predefined-acl=publicRead}"
   # GCS buckets with UBLA enabled error on attempts to set ACLs
   # ref: https://cloud.google.com/storage/docs/uniform-bucket-level-access#enabled
-  if gsutil ubla get "${bucket}" | grep -q "Enabled: True" 2>/dev/null; then
+  if [[ "$(gcloud storage buckets describe "${bucket}" --format="value(uniform_bucket_level_access)" 2>/dev/null)" == "True" ]]; then
     acl_flag=""
   fi
-  gsutil -h "Cache-Control:private,max-age=0" rsync -r ${acl_flag} ${SRC} ${DEST}
+  gcloud storage rsync --recursive --cache-control="private,max-age=0" ${acl_flag} ${SRC} ${DEST}
   exit 0
 fi
 

--- a/tests/e2e/kubetest2-kops/deployer/publish.go
+++ b/tests/e2e/kubetest2-kops/deployer/publish.go
@@ -53,9 +53,8 @@ func (d *deployer) PostTest(testErr error) error {
 	}
 
 	args := []string{
-		"gsutil",
-		"-h", "Cache-Control:private, max-age=0, no-transform",
-		"cp",
+		"gcloud", "storage", "cp",
+		"--cache-control", "private, max-age=0, no-transform",
 		tempSrc.Name(),
 		d.PublishVersionMarker,
 	}

--- a/tests/e2e/kubetest2-kops/gce/gcs.go
+++ b/tests/e2e/kubetest2-kops/gce/gcs.go
@@ -42,10 +42,10 @@ func GCSBucketName(projectID, prefix string) string {
 
 func EnsureGCSBucket(bucketPath, region, projectID string, public bool) error {
 	lsArgs := []string{
-		"gsutil", "ls", "-b",
+		"gcloud", "storage", "ls", "--buckets",
 	}
 	if projectID != "" {
-		lsArgs = append(lsArgs, "-p", projectID)
+		lsArgs = append(lsArgs, "--project", projectID)
 	}
 	lsArgs = append(lsArgs, bucketPath)
 
@@ -55,19 +55,26 @@ func EnsureGCSBucket(bucketPath, region, projectID string, public bool) error {
 	output, err := exec.CombinedOutputLines(cmd)
 	if err == nil {
 		return nil
-	} else if len(output) != 1 || !strings.Contains(output[0], "BucketNotFound") {
+	}
+	notFound := false
+	for _, line := range output {
+		if strings.Contains(line, "not found: 404") {
+			notFound = true
+		}
+	}
+	if !notFound {
 		klog.Info(output)
 		return err
 	}
 
 	mbArgs := []string{
-		"gsutil", "mb",
+		"gcloud", "storage", "buckets", "create",
 	}
 	if projectID != "" {
-		mbArgs = append(mbArgs, "-p", projectID)
+		mbArgs = append(mbArgs, "--project", projectID)
 	}
 	if region != "" {
-		mbArgs = append(mbArgs, "-l", region)
+		mbArgs = append(mbArgs, "--location", region)
 	}
 	mbArgs = append(mbArgs, bucketPath)
 
@@ -82,7 +89,8 @@ func EnsureGCSBucket(bucketPath, region, projectID string, public bool) error {
 
 	if public {
 		iamArgs := []string{
-			"gsutil", "iam", "ch", "allUsers:objectViewer",
+			"gcloud", "storage", "buckets", "add-iam-policy-binding",
+			"--member=allUsers", "--role=roles/storage.objectViewer",
 		}
 		iamArgs = append(iamArgs, bucketPath)
 		klog.Info(strings.Join(iamArgs, " "))
@@ -100,9 +108,9 @@ func EnsureGCSBucket(bucketPath, region, projectID string, public bool) error {
 
 func DeleteGCSBucket(bucketPath, projectID string) error {
 	rmArgs := []string{
-		"gsutil",
-		"-u", projectID,
-		"rm", "-r", bucketPath,
+		"gcloud", "storage", "rm", "--recursive",
+		"--billing-project", projectID,
+		bucketPath,
 	}
 
 	klog.Info(strings.Join(rmArgs, " "))


### PR DESCRIPTION
`gsutil` is in maintenance mode and `gcloud storage` is the recommended replacement. This migrates the remaining `gsutil` usages, and also fixes an invalid `gcloud buckets create` command in `hack/dev-build-gce.sh` (introduced in #18466, the correct command is `gcloud storage buckets create`).

Changes:
* `hack/dev-build-gce.sh`: fix `gcloud buckets create` to `gcloud storage buckets create`
* `Makefile`: `gcs-upload`, `gcs-upload-and-tag` and `gcs-publish-ci` now use `gcloud storage cp`. The `-m` flag is dropped as `gcloud storage` parallelizes by default.
* `hack/install-gsutil.sh` is renamed to `hack/install-gcloud.sh` and checks for `gcloud` instead of `gsutil`
* `hack/upload`: the UBLA check uses `gcloud storage buckets describe`, the sync uses `gcloud storage rsync`
* `tests/e2e/kubetest2-kops`: bucket create/delete/IAM and version marker publishing use the `gcloud storage` equivalents. Note: the bucket existence check now matches gcloud's `not found: 404` error instead of gsutil's `BucketNotFound`.
* docs: update `gsutil` commands in the OpenTelemetry, release process and GCE getting started pages

Historical release notes still mention `gsutil` and are left unchanged.

Assisted by Claude Fable