### PR TITLE
Validate etcd version compatibility before allowing kOps downgrade

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -274,7 +274,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 		}
 	}
 
-	etcdVersions := etcdSupportedVersions()
+	etcdVersions := EtcdSupportedVersions()
 	if etcdCluster.Image != "" {
 		// With a custom image, only the selected version's binaries are made
 		// available in the pod; restoring backups, which can require the

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -63,13 +63,13 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 			etcdCluster.Backups.BackupStore = join(base, "backups", "etcd", etcdCluster.Name)
 		}
 
-		if !etcdVersionIsSupported(etcdCluster.Version) {
+		if !EtcdVersionIsSupported(etcdCluster.Version) {
 			if etcdCluster.Image != "" {
 				klog.Warningf("etcd version %q is not bundled by kOps and has not been tested; using binaries from custom image %q", etcdCluster.Version, etcdCluster.Image)
 			} else {
 				klog.Warningf("Unsupported etcd version %q detected; please update etcd version.", etcdCluster.Version)
 				var versions []string
-				for _, v := range etcdSupportedVersions() {
+				for _, v := range EtcdSupportedVersions() {
 					versions = append(versions, v.Version)
 				}
 				klog.Warningf("Supported etcd versions: %s", strings.Join(versions, ", "))
@@ -90,14 +90,15 @@ type etcdVersion struct {
 
 // etcdLatestImages lists the latest etcd patch image bundled by kops for each
 // supported minor. All earlier patch versions within the same minor are
-// generated as SymlinkToVersion entries by etcdSupportedVersions.
+// generated as SymlinkToVersion entries by EtcdSupportedVersions.
 var etcdLatestImages = []etcdVersion{
 	{Version: components.LatestEtcd35Version, Image: "registry.k8s.io/etcd:v" + components.LatestEtcd35Version},
 	{Version: components.LatestEtcd36Version, Image: "registry.k8s.io/etcd:v" + components.LatestEtcd36Version},
 	{Version: components.LatestEtcd37Version, Image: "registry.k8s.io/etcd:v" + components.LatestEtcd37Version},
 }
 
-func etcdSupportedVersions() []etcdVersion {
+// EtcdSupportedVersions returns every etcd version bundled by this build of kOps.
+func EtcdSupportedVersions() []etcdVersion {
 	var versions []etcdVersion
 	for _, latest := range etcdLatestImages {
 		sv := semver.MustParse(latest.Version)
@@ -115,9 +116,10 @@ func etcdSupportedVersions() []etcdVersion {
 	return versions
 }
 
-func etcdVersionIsSupported(version string) bool {
+// EtcdVersionIsSupported reports whether this build of kOps bundles the given etcd version.
+func EtcdVersionIsSupported(version string) bool {
 	version = strings.TrimPrefix(version, "v")
-	for _, etcdVersion := range etcdSupportedVersions() {
+	for _, etcdVersion := range EtcdSupportedVersions() {
 		if etcdVersion.Version == version {
 			return true
 		}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -274,28 +274,31 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 		return nil, fmt.Errorf("error parsing configStore.base %q: %v", cluster.Spec.ConfigStore.Base, err)
 	}
 
-	if !c.AllowKopsDowngrade {
-		kopsVersionUpdatedBytes, err := configBase.Join(registry.PathKopsVersionUpdated).ReadFile(ctx)
-		if err == nil {
-			kopsVersionUpdated := strings.TrimSpace(string(kopsVersionUpdatedBytes))
-			version, err := semver.Parse(kopsVersionUpdated)
-			if err != nil {
-				return nil, fmt.Errorf("error parsing last kops version updated: %v", err)
-			}
-			if version.GT(semver.MustParse(kopsbase.Version)) {
-				fmt.Printf("\n")
-				fmt.Printf("%s\n", starline)
-				fmt.Printf("\n")
-				fmt.Printf("The cluster was last updated by kops version %s\n", kopsVersionUpdated)
-				fmt.Printf("To permit updating by the older version %s, run with the --allow-kops-downgrade flag\n", kopsbase.Version)
-				fmt.Printf("\n")
-				fmt.Printf("%s\n", starline)
-				fmt.Printf("\n")
-				return nil, fmt.Errorf("kops version older than last used to update the cluster")
-			}
-		} else if err != os.ErrNotExist {
-			return nil, fmt.Errorf("error reading last kops version used to update: %v", err)
+	var kopsVersionUpdated string
+	kopsVersionUpdatedBytes, err := configBase.Join(registry.PathKopsVersionUpdated).ReadFile(ctx)
+	if err == nil {
+		kopsVersionUpdated = strings.TrimSpace(string(kopsVersionUpdatedBytes))
+		version, err := semver.Parse(kopsVersionUpdated)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing last kops version updated: %v", err)
 		}
+		if !c.AllowKopsDowngrade && version.GT(semver.MustParse(kopsbase.Version)) {
+			fmt.Printf("\n")
+			fmt.Printf("%s\n", starline)
+			fmt.Printf("\n")
+			fmt.Printf("The cluster was last updated by kops version %s\n", kopsVersionUpdated)
+			fmt.Printf("To permit updating by the older version %s, run with the --allow-kops-downgrade flag\n", kopsbase.Version)
+			fmt.Printf("\n")
+			fmt.Printf("%s\n", starline)
+			fmt.Printf("\n")
+			return nil, fmt.Errorf("kops version older than last used to update the cluster")
+		}
+	} else if err != os.ErrNotExist {
+		return nil, fmt.Errorf("error reading last kops version used to update: %v", err)
+	}
+
+	if err := c.validateEtcdVersionSupported(kopsVersionUpdated); err != nil {
+		return nil, err
 	}
 
 	cloud := c.Cloud
@@ -1087,6 +1090,40 @@ func (c *ApplyClusterCmd) validateKubernetesVersion() error {
 		if os.Getenv("KOPS_RUN_OBSOLETE_VERSION") == "" {
 			return fmt.Errorf("kubernetes upgrade is required")
 		}
+	}
+
+	return nil
+}
+
+// validateEtcdVersionSupported checks that every etcd version currently recorded in the
+// cluster spec is one that this build of kops actually bundles. A newer kops version can
+// write a newer etcd patch version into the cluster spec than an older kops release ever
+// knew about; applying with that older release would otherwise only fail once etcd-manager
+// starts on a control-plane node and can't find the requested etcd binary, so we catch it
+// here instead, before any changes are applied.
+func (c *ApplyClusterCmd) validateEtcdVersionSupported(kopsVersionUpdated string) error {
+	for _, etcdCluster := range c.Cluster.Spec.EtcdClusters {
+		if etcdCluster.Version == "" || etcdCluster.Image != "" {
+			// Nothing recorded yet, or the cluster brings its own etcd binaries.
+			continue
+		}
+		if etcdmanager.EtcdVersionIsSupported(etcdCluster.Version) {
+			continue
+		}
+
+		fmt.Printf("\n")
+		fmt.Printf("%s\n", starline)
+		fmt.Printf("\n")
+		fmt.Printf("The %q etcd cluster is configured to run etcd version %s, which kops version %s does not bundle.\n", etcdCluster.Name, etcdCluster.Version, kopsbase.Version)
+		if kopsVersionUpdated != "" {
+			fmt.Printf("This version was set by kops version %s, which last updated the cluster.\n", kopsVersionUpdated)
+		}
+		fmt.Printf("Applying with this kops version would leave etcd-manager unable to find the required etcd binary at start-up.\n")
+		fmt.Printf("Use a kops version that bundles etcd %s for this cluster, or update the cluster's etcd version before downgrading kops.\n", etcdCluster.Version)
+		fmt.Printf("\n")
+		fmt.Printf("%s\n", starline)
+		fmt.Printf("\n")
+		return fmt.Errorf("etcd version %q configured for etcd cluster %q is not supported by kops version %s", etcdCluster.Version, etcdCluster.Name, kopsbase.Version)
 	}
 
 	return nil

--- a/upup/pkg/fi/cloudup/apply_cluster_test.go
+++ b/upup/pkg/fi/cloudup/apply_cluster_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudup
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	kopsbase "k8s.io/kops"
+	kopsapi "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/model/components"
+)
+
+func TestValidateEtcdVersionSupported(t *testing.T) {
+	latest36 := components.LatestEtcd36Version
+	sv := semver.MustParse(latest36)
+	unsupported36 := fmt.Sprintf("%d.%d.%d", sv.Major, sv.Minor, sv.Patch+1)
+
+	tests := []struct {
+		name               string
+		etcdClusters       []kopsapi.EtcdClusterSpec
+		kopsVersionUpdated string
+		expectError        bool
+		expectErrContains  []string
+	}{
+		{
+			name: "bundled version",
+			etcdClusters: []kopsapi.EtcdClusterSpec{
+				{Name: "main", Version: latest36},
+			},
+		},
+		{
+			name:         "no version recorded yet",
+			etcdClusters: []kopsapi.EtcdClusterSpec{{Name: "main"}},
+		},
+		{
+			name: "unsupported version",
+			etcdClusters: []kopsapi.EtcdClusterSpec{
+				{Name: "main", Version: unsupported36},
+			},
+			expectError:       true,
+			expectErrContains: []string{"main", unsupported36},
+		},
+		{
+			name: "unsupported version with last-updated context",
+			etcdClusters: []kopsapi.EtcdClusterSpec{
+				{Name: "events", Version: unsupported36},
+			},
+			kopsVersionUpdated: "1.34.1",
+			expectError:        true,
+			expectErrContains:  []string{"events", unsupported36},
+		},
+		{
+			name: "unsupported version with custom image is not blocked",
+			etcdClusters: []kopsapi.EtcdClusterSpec{
+				{Name: "main", Version: unsupported36, Image: "gcr.io/etcd-development/etcd:v" + unsupported36},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := &ApplyClusterCmd{
+				Cluster: &kopsapi.Cluster{
+					Spec: kopsapi.ClusterSpec{
+						EtcdClusters: test.etcdClusters,
+					},
+				},
+			}
+
+			err := c.validateEtcdVersionSupported(test.kopsVersionUpdated)
+			if test.expectError {
+				if err == nil {
+					t.Fatalf("expected an error, got none")
+				}
+				for _, s := range test.expectErrContains {
+					if !strings.Contains(err.Error(), s) {
+						t.Errorf("expected error to contain %q, got: %v", s, err)
+					}
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateEtcdVersionSupported_CurrentVersion sanity-checks that the running kops
+// version's own name shows up in the error, since that's the version the operator would
+// need to change (e.g. by not downgrading further).
+func TestValidateEtcdVersionSupported_CurrentVersion(t *testing.T) {
+	c := &ApplyClusterCmd{
+		Cluster: &kopsapi.Cluster{
+			Spec: kopsapi.ClusterSpec{
+				EtcdClusters: []kopsapi.EtcdClusterSpec{
+					{Name: "main", Version: "0.0.1"},
+				},
+			},
+		},
+	}
+
+	err := c.validateEtcdVersionSupported("")
+	if err == nil {
+		t.Fatalf("expected an error, got none")
+	}
+	if !strings.Contains(err.Error(), kopsbase.Version) {
+		t.Errorf("expected error to contain the running kops version %q, got: %v", kopsbase.Version, err)
+	}
+}


### PR DESCRIPTION
## What this does

Downgrading kOps to a version that doesn't bundle the etcd version
currently recorded for a cluster currently fails deep inside
etcd-manager with an opaque "unknown etcd version: not found" error
on the master node -- after cloud resources may have already been
changed.

This adds a pre-flight check, run right after the existing
`--allow-kops-downgrade` guard, that validates every etcd cluster's
recorded version against the target kOps version's supported etcd
versions before any changes are applied. On a mismatch it fails with
a clear message naming the etcd cluster, the unsupported version, the
running kOps version, and (when known) the last kOps version that
updated the cluster.

## Changes

- `pkg/model/components/etcdmanager`: exported `EtcdSupportedVersions`
  / `EtcdVersionIsSupported` (previously unexported) so this logic can
  be reused instead of duplicated
- `upup/pkg/fi/cloudup/apply_cluster.go`: new
  `validateEtcdVersionSupported` pre-flight check, called
  unconditionally right after the existing downgrade guard

## Testing

- `go build ./...` and `gofmt -l .` clean
- `go vet` clean across touched packages
- New table-driven tests in `upup/pkg/fi/cloudup/apply_cluster_test.go`
  covering: a bundled version, an empty/unset version, an unsupported
  version (with and without last-updated context), the custom-Image
  escape hatch, and a check that the running kOps version's own name
  appears in the error
- Full `cmd/kops` integration suite passes, no fixture regressions
  (this only adds a pre-flight guard, no manifest changes)

Fixes #18038