### PR TITLE
disable tpm for GCE scale tests

### DIFF
--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -283,6 +283,11 @@ spec:
                 description: DetailedInstanceMonitoring defines if detailed-monitoring
                   is enabled (AWS only)
                 type: boolean
+              disableTPM:
+                description: |-
+                  DisableTPM bypasses GCE TPM authentication during node bootstrap.
+                  The default is false.
+                type: boolean
               externalLoadBalancers:
                 description: ExternalLoadBalancers define loadbalancers that should
                   be attached to this instance group

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -242,6 +242,9 @@ type InstanceGroupSpec struct {
 	//   'STANDARD': (default) standard provisioning with user controlled run time, no discounts
 	//   'SPOT': heavily discounted, no guaranteed run time.
 	GCPProvisioningModel *string `json:"gcpProvisioningModel,omitempty"`
+	// DisableTPM bypasses GCE TPM authentication during node bootstrap.
+	// The default is false.
+	DisableTPM bool `json:"disableTPM,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/model/features.go
+++ b/pkg/apis/kops/model/features.go
@@ -45,6 +45,14 @@ func UseKopsControllerForNodeConfig(cluster *kops.Cluster) bool {
 	return !cluster.UsesLegacyGossip() || cluster.UsesLoadBalancerForKopsController()
 }
 
+// UseKopsControllerForInstanceGroupNodeConfig checks if nodeup should retrieve its configuration from kops-controller.
+func UseKopsControllerForInstanceGroupNodeConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) bool {
+	if cluster.GetCloudProvider() == kops.CloudProviderGCE && instanceGroup.Spec.DisableTPM {
+		return false
+	}
+	return UseKopsControllerForNodeConfig(cluster)
+}
+
 // UseCiliumEtcd is true if we are using the Cilium etcd cluster.
 func UseCiliumEtcd(cluster *kops.Cluster) bool {
 	if cluster.Spec.Networking.Cilium == nil {

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -184,6 +184,9 @@ type InstanceGroupSpec struct {
 	//   'STANDARD': (default) standard provisioning with user controlled run time, no discounts
 	//   'SPOT': heavily discounted, no guaranteed run time.
 	GCPProvisioningModel *string `json:"gcpProvisioningModel,omitempty"`
+	// DisableTPM bypasses GCE TPM authentication during node bootstrap.
+	// The default is false.
+	DisableTPM bool `json:"disableTPM,omitempty"`
 }
 
 // InstanceMetadataOptions defines the EC2 instance metadata service options (AWS Only)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4696,6 +4696,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	}
 	out.MaxInstanceLifetime = in.MaxInstanceLifetime
 	out.GCPProvisioningModel = in.GCPProvisioningModel
+	out.DisableTPM = in.DisableTPM
 	return nil
 }
 
@@ -4872,6 +4873,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	}
 	out.MaxInstanceLifetime = in.MaxInstanceLifetime
 	out.GCPProvisioningModel = in.GCPProvisioningModel
+	out.DisableTPM = in.DisableTPM
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/instancegroup.go
+++ b/pkg/apis/kops/v1alpha3/instancegroup.go
@@ -159,6 +159,9 @@ type InstanceGroupSpec struct {
 	//   'STANDARD': (default) standard provisioning with user controlled run time, no discounts
 	//   'SPOT': heavily discounted, no guaranteed run time.
 	GCPProvisioningModel *string `json:"gcpProvisioningModel,omitempty"`
+	// DisableTPM bypasses GCE TPM authentication during node bootstrap.
+	// The default is false.
+	DisableTPM bool `json:"disableTPM,omitempty"`
 }
 
 // InstanceRootVolumeSpec specifies options for an instance's root volume.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5072,6 +5072,7 @@ func autoConvert_v1alpha3_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	}
 	out.MaxInstanceLifetime = in.MaxInstanceLifetime
 	out.GCPProvisioningModel = in.GCPProvisioningModel
+	out.DisableTPM = in.DisableTPM
 	return nil
 }
 
@@ -5261,6 +5262,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha3_InstanceGroupSpec(in *kops.I
 	}
 	out.MaxInstanceLifetime = in.MaxInstanceLifetime
 	out.GCPProvisioningModel = in.GCPProvisioningModel
+	out.DisableTPM = in.DisableTPM
 	return nil
 }
 

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -383,7 +383,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 		}
 	}
 
-	useConfigServer := kopsmodel.UseKopsControllerForNodeConfig(cluster) && !ig.HasAPIServer()
+	useConfigServer := kopsmodel.UseKopsControllerForInstanceGroupNodeConfig(cluster, ig) && !ig.HasAPIServer()
 	if useConfigServer {
 		bootConfig.ConfigServer = buildConfigServerOptions(cluster.ObjectMeta.Name, config.CAs[fi.CertificateIDCA], bootConfig.APIServerIPs)
 		delete(config.CAs, fi.CertificateIDCA)

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -193,6 +193,7 @@ if [[ "${CLOUD_PROVIDER}" == "gce" ]]; then
   KUBETEST2_ARGS+=("--control-plane-instance-group-overrides=spec.rootVolume.iops=10000")
   KUBETEST2_ARGS+=("--control-plane-instance-group-overrides=spec.rootVolume.throughput=1000")
   KUBETEST2_ARGS+=("--control-plane-instance-group-overrides=spec.associatePublicIP=true")
+  KUBETEST2_ARGS+=("--node-instance-group-overrides=spec.disableTPM=true")
 elif [[ "${CLOUD_PROVIDER}" == "aws" ]]; then
   KUBETEST2_ARGS+=("--control-plane-instance-group-overrides=spec.rootVolume.type=io2")
 fi


### PR DESCRIPTION
The 5k release-blocking job is experiencing a high rate of infra errors due to TPM failures.

Fixes: https://github.com/kubernetes/kops/issues/18586

https://testgrid.k8s.io/sig-scalability-gce#gce-master-scale-performance-5000

This PR enables disabling TPMs on node Instance Groups.

@serathius @Jefftree @hakman 