### PR TITLE
Allow specifying number of nodes that can be unready during validation

### DIFF
--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -263,7 +263,7 @@ func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, opti
 
 	var clusterValidator validation.ClusterValidator
 	if !options.CloudOnly {
-		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, nil, nil, restConfig, k8sClient)
+		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, nil, nil, 0, restConfig, k8sClient)
 		if err != nil {
 			return fmt.Errorf("cannot create cluster validator: %v", err)
 		}

--- a/cmd/kops/rolling-update_cluster.go
+++ b/cmd/kops/rolling-update_cluster.go
@@ -460,7 +460,7 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 			return fmt.Errorf("getting rest config: %w", err)
 		}
 
-		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, nil, nil, restConfig, k8sClient)
+		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, nil, nil, 0, restConfig, k8sClient)
 		if err != nil {
 			return fmt.Errorf("cannot create cluster validator: %v", err)
 		}

--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -69,6 +69,8 @@ type ValidateClusterOptions struct {
 	interval           time.Duration
 	kubeconfig         string
 
+	MaxUnreadyNodes int
+
 	// filterInstanceGroups is a function that returns true if the instance group should be validated
 	filterInstanceGroups func(ig *kopsapi.InstanceGroup) bool
 
@@ -81,6 +83,7 @@ type ValidateClusterOptions struct {
 func (o *ValidateClusterOptions) InitDefaults() {
 	o.output = OutputTable
 	o.interval = 10 * time.Second
+	o.MaxUnreadyNodes = 0
 }
 
 func NewCmdValidateCluster(f *util.Factory, out io.Writer) *cobra.Command {
@@ -117,6 +120,7 @@ func NewCmdValidateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().IntVar(&options.count, "count", options.count, "Number of consecutive successful validations required")
 	cmd.Flags().DurationVar(&options.interval, "interval", options.interval, "Time in duration to wait between validation attempts")
 	cmd.Flags().StringVar(&options.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file")
+	cmd.Flags().IntVar(&options.MaxUnreadyNodes, "max-unready-nodes", options.MaxUnreadyNodes, "The maximum number of non-ready worker nodes tolerated during validation")
 
 	options.CreateKubecfgOptions.AddCommonFlags(cmd.Flags())
 
@@ -175,7 +179,7 @@ func RunValidateCluster(ctx context.Context, f *util.Factory, out io.Writer, opt
 
 	timeout := time.Now().Add(options.wait)
 
-	validator, err := validation.NewClusterValidator(cluster, cloud, list, options.filterInstanceGroups, options.filterPodsForValidation, restConfig, k8sClient)
+	validator, err := validation.NewClusterValidator(cluster, cloud, list, options.filterInstanceGroups, options.filterPodsForValidation, options.MaxUnreadyNodes, restConfig, k8sClient)
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error creating validatior: %v", err)
 	}

--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -29,14 +29,15 @@ kops validate cluster [CLUSTER] [flags]
 ### Options
 
 ```
-      --api-server string   Override the API server used when communicating with the cluster kube-apiserver
-      --count int           Number of consecutive successful validations required
-  -h, --help                help for cluster
-      --interval duration   Time in duration to wait between validation attempts (default 10s)
-      --kubeconfig string   Path to the kubeconfig file
-  -o, --output string       Output format. One of json|yaml|table. (default "table")
-      --use-kubeconfig      Use the server endpoint from the local kubeconfig instead of inferring from cluster name
-      --wait duration       Amount of time to wait for the cluster to become ready
+      --api-server string       Override the API server used when communicating with the cluster kube-apiserver
+      --count int               Number of consecutive successful validations required
+  -h, --help                    help for cluster
+      --interval duration       Time in duration to wait between validation attempts (default 10s)
+      --kubeconfig string       Path to the kubeconfig file
+      --max-unready-nodes int   The maximum number of non-ready worker nodes tolerated during validation
+  -o, --output string           Output format. One of json|yaml|table. (default "table")
+      --use-kubeconfig          Use the server endpoint from the local kubeconfig instead of inferring from cluster name
+      --wait duration           Amount of time to wait for the cluster to become ready
 ```
 
 ### Options inherited from parent commands

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -231,14 +231,7 @@ func (v *clusterValidatorImpl) Validate(ctx context.Context) (*ValidationCluster
 
 	readyNodes, nodeInstanceGroupMapping := validation.validateNodes(cloudGroups, v.allInstanceGroups, v.filterInstanceGroups, toleratedNodes)
 
-	nodeByAddress := map[string]string{}
-	for _, node := range nodeList.Items {
-		for _, nodeAddress := range node.Status.Addresses {
-			nodeByAddress[nodeAddress.Address] = node.Name
-		}
-	}
-
-	if err := validation.collectPodFailures(ctx, v.k8sClient, readyNodes, nodeByAddress, nodeInstanceGroupMapping, v.filterPodsForValidation, toleratedNodes); err != nil {
+	if err := validation.collectPodFailures(ctx, v.k8sClient, readyNodes, nodeInstanceGroupMapping, v.filterPodsForValidation, toleratedNodes); err != nil {
 		return nil, fmt.Errorf("cannot get pod health for %q: %v", v.cluster.Name, err)
 	}
 
@@ -251,7 +244,7 @@ var masterStaticPods = []string{
 	"kube-scheduler",
 }
 
-func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kubernetes.Interface, readyNodes []v1.Node, nodeByAddress map[string]string, nodeInstanceGroupMapping map[string]*kops.InstanceGroup, podValidationFilter func(pod *v1.Pod) bool, toleratedNodes map[string]bool) error {
+func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kubernetes.Interface, readyNodes []v1.Node, nodeInstanceGroupMapping map[string]*kops.InstanceGroup, podValidationFilter func(pod *v1.Pod) bool, toleratedNodes map[string]bool) error {
 	log := klog.FromContext(ctx)
 
 	masterWithoutPod := map[string]map[string]bool{}
@@ -272,8 +265,8 @@ func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kuber
 		pod := obj.(*v1.Pod)
 
 		app := pod.GetLabels()["k8s-app"]
-		if pod.Namespace == "kube-system" && masterWithoutPod[nodeByAddress[pod.Status.HostIP]][app] {
-			delete(masterWithoutPod[nodeByAddress[pod.Status.HostIP]], app)
+		if pod.Namespace == "kube-system" && masterWithoutPod[pod.Spec.NodeName][app] {
+			delete(masterWithoutPod[pod.Spec.NodeName], app)
 		}
 
 		// Ignore pods that we don't want to validate
@@ -292,11 +285,10 @@ func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kuber
 
 		var podNode *kops.InstanceGroup
 		if priority == "system-node-critical" {
-			podNode = nodeInstanceGroupMapping[nodeByAddress[pod.Status.HostIP]]
+			podNode = nodeInstanceGroupMapping[pod.Spec.NodeName]
 		}
 
-		nodeName := nodeByAddress[pod.Status.HostIP]
-		if toleratedNodes[nodeName] {
+		if toleratedNodes[pod.Spec.NodeName] {
 			return nil
 		}
 

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -73,6 +73,8 @@ type clusterValidatorImpl struct {
 
 	// filterPodsForValidation is a function that returns true if the pod should be validated
 	filterPodsForValidation func(pod *v1.Pod) bool
+
+	maxUnreadyNodes int
 }
 
 func (v *ValidationCluster) addError(failure *ValidationError) {
@@ -109,7 +111,7 @@ func hasPlaceHolderIP(host string) (string, error) {
 	return "", nil
 }
 
-func NewClusterValidator(cluster *kops.Cluster, cloud fi.Cloud, instanceGroupList *kops.InstanceGroupList, filterInstanceGroups func(ig *kops.InstanceGroup) bool, filterPodsForValidation func(pod *v1.Pod) bool, restConfig *rest.Config, k8sClient kubernetes.Interface) (ClusterValidator, error) {
+func NewClusterValidator(cluster *kops.Cluster, cloud fi.Cloud, instanceGroupList *kops.InstanceGroupList, filterInstanceGroups func(ig *kops.InstanceGroup) bool, filterPodsForValidation func(pod *v1.Pod) bool, maxUnreadyNodes int, restConfig *rest.Config, k8sClient kubernetes.Interface) (ClusterValidator, error) {
 	var allInstanceGroups []*kops.InstanceGroup
 
 	for i := range instanceGroupList.Items {
@@ -143,6 +145,7 @@ func NewClusterValidator(cluster *kops.Cluster, cloud fi.Cloud, instanceGroupLis
 		k8sClient:               k8sClient,
 		filterInstanceGroups:    filterInstanceGroups,
 		filterPodsForValidation: filterPodsForValidation,
+		maxUnreadyNodes:         maxUnreadyNodes,
 	}, nil
 }
 
@@ -188,9 +191,54 @@ func (v *clusterValidatorImpl) Validate(ctx context.Context) (*ValidationCluster
 		return nil, err
 	}
 
-	readyNodes, nodeInstanceGroupMapping := validation.validateNodes(cloudGroups, v.allInstanceGroups, v.filterInstanceGroups)
+	var toleratedNodes map[string]bool
+	if v.maxUnreadyNodes > 0 {
+		var notReadyWorkerNodes []string
+		for _, cloudGroup := range cloudGroups {
+			if cloudGroup.InstanceGroup != nil && cloudGroup.InstanceGroup.Spec.Role == kops.InstanceGroupRoleNode {
+				var allMembers []*cloudinstances.CloudInstance
+				allMembers = append(allMembers, cloudGroup.Ready...)
+				allMembers = append(allMembers, cloudGroup.NeedUpdate...)
 
-	if err := validation.collectPodFailures(ctx, v.k8sClient, readyNodes, nodeInstanceGroupMapping, v.filterPodsForValidation); err != nil {
+				for _, member := range allMembers {
+					if member.Status == cloudinstances.CloudInstanceStatusDetached {
+						continue
+					}
+					if member.State == cloudinstances.WarmPool {
+						continue
+					}
+
+					if member.Node == nil || !isNodeReady(member.Node) {
+						if member.Node != nil {
+							notReadyWorkerNodes = append(notReadyWorkerNodes, member.Node.Name)
+						} else {
+							notReadyWorkerNodes = append(notReadyWorkerNodes, member.ID)
+						}
+					}
+				}
+			}
+		}
+
+		if len(notReadyWorkerNodes) > 0 && len(notReadyWorkerNodes) <= v.maxUnreadyNodes {
+			toleratedNodes = make(map[string]bool)
+			for _, n := range notReadyWorkerNodes {
+				toleratedNodes[n] = true
+			}
+			sort.Strings(notReadyWorkerNodes)
+			klog.Warningf("Tolerating %d non-ready worker node(s): %s", len(notReadyWorkerNodes), strings.Join(notReadyWorkerNodes, ", "))
+		}
+	}
+
+	readyNodes, nodeInstanceGroupMapping := validation.validateNodes(cloudGroups, v.allInstanceGroups, v.filterInstanceGroups, toleratedNodes)
+
+	nodeByAddress := map[string]string{}
+	for _, node := range nodeList.Items {
+		for _, nodeAddress := range node.Status.Addresses {
+			nodeByAddress[nodeAddress.Address] = node.Name
+		}
+	}
+
+	if err := validation.collectPodFailures(ctx, v.k8sClient, readyNodes, nodeByAddress, nodeInstanceGroupMapping, v.filterPodsForValidation, toleratedNodes); err != nil {
 		return nil, fmt.Errorf("cannot get pod health for %q: %v", v.cluster.Name, err)
 	}
 
@@ -203,25 +251,18 @@ var masterStaticPods = []string{
 	"kube-scheduler",
 }
 
-func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kubernetes.Interface, nodes []v1.Node,
-	nodeInstanceGroupMapping map[string]*kops.InstanceGroup, podValidationFilter func(pod *v1.Pod) bool,
-) error {
+func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kubernetes.Interface, readyNodes []v1.Node, nodeByAddress map[string]string, nodeInstanceGroupMapping map[string]*kops.InstanceGroup, podValidationFilter func(pod *v1.Pod) bool, toleratedNodes map[string]bool) error {
 	log := klog.FromContext(ctx)
 
 	masterWithoutPod := map[string]map[string]bool{}
-	nodeByAddress := map[string]string{}
 
-	for _, node := range nodes {
+	for _, node := range readyNodes {
 		labels := node.GetLabels()
 		if _, found := labels["node-role.kubernetes.io/control-plane"]; found {
 			masterWithoutPod[node.Name] = map[string]bool{}
 			for _, pod := range masterStaticPods {
 				masterWithoutPod[node.Name][pod] = true
 			}
-		}
-
-		for _, nodeAddress := range node.Status.Addresses {
-			nodeByAddress[nodeAddress.Address] = node.Name
 		}
 	}
 
@@ -252,6 +293,11 @@ func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kuber
 		var podNode *kops.InstanceGroup
 		if priority == "system-node-critical" {
 			podNode = nodeInstanceGroupMapping[nodeByAddress[pod.Status.HostIP]]
+		}
+
+		nodeName := nodeByAddress[pod.Status.HostIP]
+		if toleratedNodes[nodeName] {
+			return nil
 		}
 
 		if pod.Status.Phase == v1.PodPending {
@@ -307,7 +353,7 @@ func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kuber
 	return nil
 }
 
-func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances.CloudInstanceGroup, groups []*kops.InstanceGroup, shouldValidateInstanceGroup func(ig *kops.InstanceGroup) bool) ([]v1.Node, map[string]*kops.InstanceGroup) {
+func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances.CloudInstanceGroup, groups []*kops.InstanceGroup, shouldValidateInstanceGroup func(ig *kops.InstanceGroup) bool, toleratedNodes map[string]bool) ([]v1.Node, map[string]*kops.InstanceGroup) {
 	var readyNodes []v1.Node
 	groupsSeen := map[string]bool{}
 	nodeInstanceGroupMapping := map[string]*kops.InstanceGroup{}
@@ -357,7 +403,7 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 					nodeExpectedToJoin = false
 				}
 
-				if nodeExpectedToJoin {
+				if nodeExpectedToJoin && !toleratedNodes[member.ID] {
 					v.addError(&ValidationError{
 						Kind:          "Machine",
 						Name:          member.ID,
@@ -390,7 +436,7 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 
 			switch n.Role {
 			case "control-plane", "apiserver", "node":
-				if !ready {
+				if !ready && !toleratedNodes[node.Name] {
 					v.addError(&ValidationError{
 						Kind:          "Node",
 						Name:          node.Name,

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -557,6 +557,7 @@ func Test_ValidateMasterStaticPods(t *testing.T) {
 				"phase":             string(v1.PodRunning),
 				"priorityClassName": "system-cluster-critical",
 				"hostip":            "1.2.3.4",
+				"nodeName":          "master-1a",
 			},
 			{
 				"name":              fmt.Sprintf("pod-b-%d", i),
@@ -566,6 +567,7 @@ func Test_ValidateMasterStaticPods(t *testing.T) {
 				"phase":             string(v1.PodRunning),
 				"priorityClassName": "system-cluster-critical",
 				"hostip":            "5.6.7.8",
+				"nodeName":          "master-1b",
 			},
 		}...)
 		expectedFailures = append(expectedFailures, &ValidationError{
@@ -736,7 +738,7 @@ func Test_ValidatePodFailure(t *testing.T) {
 	} {
 		for _, priority := range []string{"node", "cluster"} {
 			for _, namespace := range []string{"kube-system", "otherNamespace"} {
-				for _, hostIp := range []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"} {
+				for hostIp, nodeName := range map[string]string{"1.2.3.4": "node-1a", "5.6.7.8": "node-1b", "9.10.11.12": "node-1c"} {
 					t.Run(fmt.Sprintf("%s-%s-%s", tc.name, priority, namespace), func(t *testing.T) {
 						v, err := testValidate(t, groups, makePodList(
 							[]map[string]string{
@@ -747,6 +749,7 @@ func Test_ValidatePodFailure(t *testing.T) {
 									"ready":             "false",
 									"phase":             string(tc.phase),
 									"hostip":            hostIp,
+									"nodeName":          nodeName,
 								},
 							},
 						))
@@ -799,6 +802,7 @@ func dummyPod(podMap map[string]string) v1.Pod {
 		},
 		Spec: v1.PodSpec{
 			PriorityClassName: podMap["priorityClassName"],
+			NodeName:          podMap["nodeName"],
 		},
 		Status: v1.PodStatus{
 			Phase: v1.PodPhase(podMap["phase"]),
@@ -1096,6 +1100,7 @@ func Test_ValidateAllowedNotReadyNodes(t *testing.T) {
 				"ready":             "false",
 				"phase":             string(v1.PodRunning),
 				"hostip":            "5.6.7.8",
+				"nodeName":          "node-1b",
 			},
 		})
 

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -71,6 +71,10 @@ func (c *MockCloud) GetCloudGroups(cluster *kopsapi.Cluster, instancegroups []*k
 }
 
 func testValidate(t *testing.T, groups map[string]*cloudinstances.CloudInstanceGroup, objects []runtime.Object) (*ValidationCluster, error) {
+	return testValidateWithTolerance(t, groups, objects, 0)
+}
+
+func testValidateWithTolerance(t *testing.T, groups map[string]*cloudinstances.CloudInstanceGroup, objects []runtime.Object, maxUnreadyNodes int) (*ValidationCluster, error) {
 	ctx := context.TODO()
 
 	cluster := &kopsapi.Cluster{
@@ -133,7 +137,7 @@ func testValidate(t *testing.T, groups map[string]*cloudinstances.CloudInstanceG
 	restConfig := &rest.Config{
 		Host: "https://api.testcluster.k8s.local",
 	}
-	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, nil, nil, restConfig, fake.NewClientset(objects...))
+	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, nil, nil, maxUnreadyNodes, restConfig, fake.NewClientset(objects...))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +172,7 @@ func Test_ValidateCloudGroupMissing(t *testing.T) {
 	restConfig := &rest.Config{
 		Host: "https://api.testcluster.k8s.local",
 	}
-	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, nil, nil, restConfig, fake.NewClientset())
+	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, nil, nil, 0, restConfig, fake.NewClientset())
 	require.NoError(t, err)
 	v, err := validator.Validate(ctx)
 	require.NoError(t, err)
@@ -912,4 +916,370 @@ func Test_ValidateDetachedNodesNotValidated(t *testing.T) {
 	if !assert.Empty(t, v.Failures) {
 		printDebug(t, v)
 	}
+}
+
+func Test_ValidateAllowedNotReadyNodes(t *testing.T) {
+	t.Run("tolerates single worker node failure when within limit", func(t *testing.T) {
+		groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+		groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+			InstanceGroup: &kopsapi.InstanceGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleNode},
+			},
+			MinSize:    2,
+			TargetSize: 2,
+			Ready: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00001",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1a"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			NeedUpdate: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00002",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1b"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionFalse},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		v, err := testValidateWithTolerance(t, groups, nil, 1)
+		require.NoError(t, err)
+		assert.Empty(t, v.Failures)
+	})
+
+	t.Run("tolerates worker node failures when within max limit", func(t *testing.T) {
+		groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+		groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+			InstanceGroup: &kopsapi.InstanceGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleNode},
+			},
+			MinSize:    2,
+			TargetSize: 2, // 2 worker nodes total
+			Ready: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00001",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1a"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			NeedUpdate: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00002",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1b"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionFalse},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// 1 allowed unready node.
+		v, err := testValidateWithTolerance(t, groups, nil, 1)
+		require.NoError(t, err)
+		assert.Empty(t, v.Failures)
+	})
+
+	t.Run("tolerates single machine not joined when within limit", func(t *testing.T) {
+		groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+		groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+			InstanceGroup: &kopsapi.InstanceGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleNode},
+			},
+			MinSize:    2,
+			TargetSize: 2,
+			Ready: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00001",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1a"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			NeedUpdate: []*cloudinstances.CloudInstance{
+				{
+					ID:   "i-00002",
+					Node: nil,
+				},
+			},
+		}
+
+		v, err := testValidateWithTolerance(t, groups, nil, 1)
+		require.NoError(t, err)
+		assert.Empty(t, v.Failures)
+	})
+
+	t.Run("tolerates multiple failures on the same worker node", func(t *testing.T) {
+		groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+		groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+			InstanceGroup: &kopsapi.InstanceGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleNode},
+			},
+			MinSize:    2,
+			TargetSize: 2,
+			Ready: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00001",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   "node-1a",
+							Labels: map[string]string{v1.LabelHostname: "node-1a"},
+						},
+						Status: v1.NodeStatus{
+							Addresses: []v1.NodeAddress{
+								{Address: "1.2.3.4"},
+							},
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			NeedUpdate: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00002",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   "node-1b",
+							Labels: map[string]string{v1.LabelHostname: "node-1b"},
+						},
+						Status: v1.NodeStatus{
+							Addresses: []v1.NodeAddress{
+								{Address: "5.6.7.8"},
+							},
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionFalse},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		pods := makePodList([]map[string]string{
+			{
+				"name":              "pod1",
+				"namespace":         "kube-system",
+				"priorityClassName": "system-node-critical",
+				"ready":             "false",
+				"phase":             string(v1.PodRunning),
+				"hostip":            "5.6.7.8",
+			},
+		})
+
+		v, err := testValidateWithTolerance(t, groups, pods, 1)
+		require.NoError(t, err)
+		assert.Empty(t, v.Failures)
+	})
+
+	t.Run("does not tolerate when count of failing nodes exceeds limit", func(t *testing.T) {
+		groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+		groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+			InstanceGroup: &kopsapi.InstanceGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleNode},
+			},
+			MinSize:    3,
+			TargetSize: 3,
+			Ready: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00001",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1a"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			NeedUpdate: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00002",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1b"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionFalse},
+							},
+						},
+					},
+				},
+				{
+					ID: "i-00003",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1c"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionFalse},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		v, err := testValidateWithTolerance(t, groups, nil, 1)
+		require.NoError(t, err)
+		assert.Len(t, v.Failures, 2)
+	})
+
+	t.Run("does not tolerate worker node failures when exceeding max limit", func(t *testing.T) {
+		groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+		groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+			InstanceGroup: &kopsapi.InstanceGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleNode},
+			},
+			MinSize:    2,
+			TargetSize: 2,
+			Ready: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00001",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1a"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			NeedUpdate: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00002",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1b"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionFalse},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// 0 allowed unready nodes.
+		v, err := testValidateWithTolerance(t, groups, nil, 0)
+		require.NoError(t, err)
+		assert.Len(t, v.Failures, 1)
+	})
+
+	t.Run("does not tolerate control-plane node failure", func(t *testing.T) {
+		groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+		groups["master-1"] = &cloudinstances.CloudInstanceGroup{
+			InstanceGroup: &kopsapi.InstanceGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "master-1"},
+				Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleControlPlane},
+			},
+			MinSize:    2,
+			TargetSize: 2,
+			Ready: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00001",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "master-1a"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			NeedUpdate: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00002",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "master-1b"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionFalse},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		v, err := testValidateWithTolerance(t, groups, nil, 1)
+		require.NoError(t, err)
+		assert.Len(t, v.Failures, 1)
+	})
+
+	t.Run("does not tolerate InstanceGroup sizing mismatches", func(t *testing.T) {
+		groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+		groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+			InstanceGroup: &kopsapi.InstanceGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       kopsapi.InstanceGroupSpec{Role: kopsapi.InstanceGroupRoleNode},
+			},
+			MinSize:    2,
+			TargetSize: 3,
+			Ready: []*cloudinstances.CloudInstance{
+				{
+					ID: "i-00001",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1a"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionTrue},
+							},
+						},
+					},
+				},
+				{
+					ID: "i-00002",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1b"},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{Type: "Ready", Status: v1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		v, err := testValidateWithTolerance(t, groups, nil, 1)
+		require.NoError(t, err)
+		assert.Len(t, v.Failures, 1)
+		assert.Equal(t, "InstanceGroup", v.Failures[0].Kind)
+	})
 }


### PR DESCRIPTION
Implements kubeup's ALLOWED_NOTREADY_NODES equivalent via a --max-unready-nodes flag, tolerating up to N not-ready worker nodes (and their pods, matched by Spec.NodeName) during validation. Replaces #18585.