### PR TITLE
Tolerate unready nodes during scalability test validation

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -69,6 +69,7 @@ type deployer struct {
 	ValidationWait     time.Duration `flag:"validation-wait" desc:"time to wait for newly created cluster to pass validation"`
 	ValidationCount    int           `flag:"validation-count" desc:"how many times should a validation pass"`
 	ValidationInterval time.Duration `flag:"validation-interval" desc:"time in duration to wait between validation attempts"`
+	MaxUnreadyNodes    int           `flag:"max-unready-nodes" desc:"maximum number of non-ready worker nodes tolerated during validation, helpful to set when running scale tests"`
 	MaxNodesToDump     string        `flag:"max-nodes-to-dump" desc:"max number of nodes to dump logs from, helpful to set when running scale tests"`
 	NodeDumpTimeout    time.Duration `flag:"node-dump-timeout" desc:"timeout for connecting to and dumping logs from a single node, helpful to raise when running scale tests"`
 

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -384,6 +384,9 @@ func (d *deployer) IsUp() (bool, error) {
 	if d.ValidationInterval > 10*time.Second {
 		args = append(args, "--interval", d.ValidationInterval.String())
 	}
+	if d.MaxUnreadyNodes > 0 {
+		args = append(args, "--max-unready-nodes", strconv.Itoa(d.MaxUnreadyNodes))
+	}
 	klog.Info(strings.Join(args, " "))
 
 	cmd := exec.Command(args[0], args[1:]...)

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -160,6 +160,10 @@ KUBETEST2_ARGS=()
 KUBETEST2_ARGS+=("-v=2")
 KUBETEST2_ARGS+=("--max-nodes-to-dump=${MAX_NODES_TO_DUMP:-5}")
 KUBETEST2_ARGS+=("--node-dump-timeout=${NODE_DUMP_TIMEOUT:-5m}")
+# Tolerate up to 2 nodes failing to join on 5k clusters.
+if [[ "${KUBE_NODE_COUNT:-100}" -ge 5000 ]]; then
+  KUBETEST2_ARGS+=("--max-unready-nodes=${MAX_UNREADY_NODES:-2}")
+fi
 KUBETEST2_ARGS+=("--cloud-provider=${CLOUD_PROVIDER}")
 KUBETEST2_ARGS+=("--cluster-name=${CLUSTER_NAME:-}")
 KUBETEST2_ARGS+=("--admin-access=${ADMIN_ACCESS:-}")


### PR DESCRIPTION
Pass --max-unready-nodes to `kops validate cluster` in the scalability scenario so 5k scale runs tolerate a few worker nodes that fail to join.

## Testing

Verified on the 100-node scale presubmit that the deployer forwards the flag to the real validate call and the job passed: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/18616/pull-kops-gce-master-scale-performance-100/2079611887690977280

```
I0721 17:06:51.491656   15588 up.go:390] /home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops validate cluster --name pr18616-kops-gce-master-scale-performance-100.k8s.local --count 3 --wait 1h15m0s --interval 1m0s --max-unready-nodes 5
```