### PR TITLE
rolling-update: log reason for InstanceGroup needing update

### DIFF
--- a/pkg/cloudinstances/cloud_instance_group.go
+++ b/pkg/cloudinstances/cloud_instance_group.go
@@ -88,6 +88,7 @@ func (group *CloudInstanceGroup) AdjustNeedUpdate() {
 			if makeNotReady {
 				group.NeedUpdate = append(group.NeedUpdate, member)
 				member.Status = CloudInstanceStatusNeedsUpdate
+				fmt.Printf("InstanceGroup %s needs update: node %s has needs-update annotation\n", group.HumanName, member.Node.Name)
 			} else {
 				newReady = append(newReady, member)
 			}

--- a/pkg/resources/spotinst/resources.go
+++ b/pkg/resources/spotinst/resources.go
@@ -380,6 +380,7 @@ func registerCloudInstances(instanceGroup *cloudinstances.CloudInstanceGroup, no
 		status := cloudinstances.CloudInstanceStatusUpToDate
 		if newInstanceGroupName != currentInstanceGroupName {
 			status = cloudinstances.CloudInstanceStatusNeedsUpdate
+			fmt.Printf("InstanceGroup %s needs update: instance %s was created before last group update\n", currentInstanceGroupName, instance.Id())
 		}
 		if _, err := instanceGroup.NewCloudInstance(
 			instance.Id(), status, nodeMap[instance.Id()]); err != nil {

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -1045,6 +1045,7 @@ func awsBuildCloudInstanceGroup(ctx context.Context, c AWSCloud, cluster *kops.C
 			}
 			instanceSeen[*id] = true
 			addCloudInstanceData(cm, instances[aws.ToString(id)])
+			fmt.Printf("InstanceGroup %s needs update: instance %s is detached\n", cg.HumanName, *id)
 		}
 	}
 
@@ -1070,6 +1071,7 @@ func buildCloudInstance(i autoscalingtypes.Instance, instances map[string]*ec2ty
 	status := cloudinstances.CloudInstanceStatusUpToDate
 	if newConfigName != currentConfigName {
 		status = cloudinstances.CloudInstanceStatusNeedsUpdate
+		fmt.Printf("InstanceGroup %s needs update: instance %s launch configuration is behind\n", cg.HumanName, id)
 	}
 	cm, err := cg.NewCloudInstance(id, status, nodeMap[id])
 	if err != nil {

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -231,6 +231,7 @@ func GetCloudGroups(c GCECloud, cluster *kops.Cluster, instancegroups []*kops.In
 					g.Ready = append(g.Ready, cm)
 				} else {
 					g.NeedUpdate = append(g.NeedUpdate, cm)
+					fmt.Printf("InstanceGroup %s needs update: instance %s instance template is behind\n", g.HumanName, cm.ID)
 				}
 			}
 

--- a/upup/pkg/fi/cloudup/hetzner/cloud.go
+++ b/upup/pkg/fi/cloudup/hetzner/cloud.go
@@ -376,6 +376,7 @@ func buildCloudInstanceGroup(ig *kops.InstanceGroup, sg []*hcloud.Server, nodeMa
 		status := cloudinstances.CloudInstanceStatusUpToDate
 		if _, ok := server.Labels[TagKubernetesInstanceNeedsUpdate]; ok {
 			status = cloudinstances.CloudInstanceStatusNeedsUpdate
+			fmt.Printf("InstanceGroup %s needs update: server %s has %s label\n", cloudInstanceGroup.HumanName, server.Name, TagKubernetesInstanceNeedsUpdate)
 		}
 
 		id := strconv.FormatInt(server.ID, 10)

--- a/upup/pkg/fi/cloudup/openstack/server_group.go
+++ b/upup/pkg/fi/cloudup/openstack/server_group.go
@@ -114,6 +114,7 @@ func osBuildCloudInstanceGroup(c OpenstackCloud, cluster *kops.Cluster, ig *kops
 		status := cloudinstances.CloudInstanceStatusUpToDate
 		if generationName != observedName || instance.Status == errorStatus {
 			status = cloudinstances.CloudInstanceStatusNeedsUpdate
+			fmt.Printf("InstanceGroup %s needs update: instance %s generation mismatch or in error state\n", cg.HumanName, instance.ID)
 		}
 		cm, err := cg.NewCloudInstance(instance.ID, status, nodeMap[instance.ID])
 		if err != nil {

--- a/upup/pkg/fi/cloudup/scaleway/cloud.go
+++ b/upup/pkg/fi/cloudup/scaleway/cloud.go
@@ -399,6 +399,7 @@ func buildCloudGroup(s *scwCloudImplementation, ig *kops.InstanceGroup, sg []*in
 		for _, tag := range server.Tags {
 			if tag == TagNeedsUpdate {
 				status = cloudinstances.CloudInstanceStatusNeedsUpdate
+				fmt.Printf("InstanceGroup %s needs update: server %s has %s tag\n", cloudInstanceGroup.HumanName, server.Name, TagNeedsUpdate)
 			}
 		}
 		cloudInstance, err := cloudInstanceGroup.NewCloudInstance(server.ID, status, nodeMap[server.ID])


### PR DESCRIPTION
Fixes #14122

When `kops rolling-update cluster` runs, InstanceGroups can end up in
`NeedsUpdate` state for several different reasons (launch
template/config drift, detached instances, the
`kops.k8s.io/needs-update` annotation, provider-specific tags/labels,
etc.), but there was no user-facing indication of *why* a particular
InstanceGroup or instance needed an update.

As suggested by @olemarkus in the issue, this adds a `fmt.Printf()`
line at each point where an instance is marked `NeedsUpdate`,
stating the specific reason. Existing `klog` calls are left
untouched where they're already at the right verbosity (e.g. the
`klog.V(4)` launch-template-version logs in `aws_cloud.go`) — this
is purely additive, no logic changes.

This is inspired by #16079 (@guerzon, 2023), which took the same
approach but never got a maintainer review and was closed by the
stale-bot after 90 days of inactivity — not a technical rejection.

Providers covered:
- AWS (launch config/template drift, detached instances)
- GCP (instance template drift)
- Hetzner (needs-update label)
- OpenStack (generation mismatch / error state)
- Scaleway (needs-update tag)
- Spotinst (instance created before last group update) - new coverage, missing from the original PR

Karpenter-managed instance groups are intentionally not touched:
that code path (`buildKarpenterGroup`) no longer has a `NeedsUpdate`
branch - Karpenter nodes are tracked via the generic
`kops.k8s.io/needs-update` annotation path instead.