### PR TITLE
gce: open control-plane node-exporter port (tcp/9100)

### DIFF
--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -143,6 +143,7 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				fmt.Sprintf("tcp:%d", wellknownports.KubeSchedulerMetricsPort),
 				fmt.Sprintf("tcp:%d", wellknownports.KubeProxyMetricsPort),
 				fmt.Sprintf("tcp:%d", wellknownports.EtcdMetricsPort),
+				fmt.Sprintf("tcp:%d", wellknownports.NodeExporterMetricsPort),
 			},
 		}
 		if b.Cluster.UsesLegacyGossip() {

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -118,6 +118,9 @@ const (
 
 	// KubeControllerManagerMetricsPort is used by kube-controller-manager to expose metrics
 	KubeControllerManagerMetricsPort = 10257
+
+	// NodeExporterMetricsPort is used by node-exporter to expose node metrics
+	NodeExporterMetricsPort = 9100
 )
 
 type PortRange struct {

--- a/tests/integration/update_cluster/gossip-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-gce/kubernetes.tf
@@ -354,6 +354,10 @@ resource "google_compute_firewall" "node-to-master-gossip-k8s-local" {
     protocol = "tcp"
   }
   allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["3993"]
     protocol = "udp"
   }

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -411,6 +411,10 @@ resource "google_compute_firewall" "node-to-master-ha-gce-example-com" {
     ports    = ["2382"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-ha-gce-example-com"
   network     = google_compute_network.ha-gce-example-com.name

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -331,6 +331,10 @@ resource "google_compute_firewall" "node-to-master-minimal-example-com" {
     ports    = ["2382"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-example-com"
   network     = google_compute_network.minimal-example-com.name

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -299,6 +299,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
     ports    = ["2382"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-example-com"
   network     = google_compute_network.minimal-gce-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -349,6 +349,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
     ports    = ["2382"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-example-com"
   network     = google_compute_network.minimal-gce-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -325,6 +325,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-ilb-example-com" 
     ports    = ["2382"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-ilb-example-com"
   network     = google_compute_network.minimal-gce-ilb-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/kubernetes.tf
@@ -386,6 +386,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-ilb-cilium-etcd-e
     protocol = "tcp"
   }
   allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["8472"]
     protocol = "udp"
   }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -325,6 +325,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-
     ports    = ["2382"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-with-a-very-very-very-very-ve-96dqvi"
   network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -307,6 +307,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-
     ports    = ["2382"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-with-a-very-very-very-very-ve-96dqvi"
   network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -329,6 +329,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-plb-example-com" 
     ports    = ["2382"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-plb-example-com"
   network     = google_compute_network.minimal-gce-plb-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
@@ -337,6 +337,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-plb-apiserver-exa
     ports    = ["2382"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-plb-apiserver-example-com"
   network     = google_compute_network.minimal-gce-plb-apiserver-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -307,6 +307,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-private-example-c
     ports    = ["2382"]
     protocol = "tcp"
   }
+  allow {
+    ports    = ["9100"]
+    protocol = "tcp"
+  }
   disabled    = false
   name        = "node-to-master-minimal-gce-private-example-com"
   network     = google_compute_network.minimal-gce-private-example-com.name


### PR DESCRIPTION
We open the other control-plane metrics ports to nodes but not 9100, so in-cluster Prometheus can't scrape node-exporter (https://github.com/kubernetes/perf-tests/blob/d14a402a9540e4c8ba34717e428bfd2cf31a41a8/clusterloader2/pkg/prometheus/manifests/exporters/node_exporter/node-exporter-daemonset.yaml#L31-L32) on the control plane. This adds it.

/assign @serathius @hakman 