### PR TITLE
gce: download nodeup from private GCS buckets with curl

### DIFF
--- a/docs/operations/asset-repository.md
+++ b/docs/operations/asset-repository.md
@@ -45,6 +45,16 @@ The repository must allow nodes to perform unauthenticated reads. The repository
 be public or it can allow read access through network connectivity, such as access
 through a particular AWS Endpoint.
 
+On GCE, the repository can also be a `gs://` URL. Nodes then read it with the credentials of
+their service account, which allows the bucket to be private. The service accounts of the
+instance groups have to be granted `roles/storage.objectViewer` on that bucket.
+
+```yaml
+spec:
+  assets:
+    fileRepository: gs://example-bucket/files
+```
+
 ## Copying assets into repositories
 
 {{ kops_feature_table(kops_added_default='1.22') }}
@@ -56,7 +66,7 @@ they do not already exist there.
 
 For file assets, kOps only supports copying to a repository that is either an S3 or GCS bucket.
 An S3 bucket must be configured using the [regional naming conventions of S3](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
-A GCS bucket must be configured with a prefix of `https://storage.googleapis.com/`.
+A GCS bucket must be configured with a prefix of `https://storage.googleapis.com/` or `gs://`.
 
 ## Listing assets
 

--- a/hack/dev-build-gce.sh
+++ b/hack/dev-build-gce.sh
@@ -37,7 +37,10 @@ make kops-install dev-upload-linux-${KOPS_ARCH} || return
 # Set KOPS_BASE_URL
 (tools/get_version.sh | grep VERSION | awk '{print $2}') || return
 KOPS_VERSION=$(tools/get_version.sh | grep VERSION | awk '{print $2}')
-export KOPS_BASE_URL=https://storage.googleapis.com/${UPLOAD_DEST_BUCKET}/kops/${KOPS_VERSION}/
+# Use the gs:// form so that nodes fetch artifacts with their service-account credentials; the
+# https:// form only works for publicly readable buckets. The service accounts of the cluster
+# need to be granted roles/storage.objectViewer on the bucket.
+export KOPS_BASE_URL=gs://${UPLOAD_DEST_BUCKET}/kops/${KOPS_VERSION}/
 
 # Create the state-store bucket if it doesn't exist
 KOPS_STATE_STORE="gs://kops-state-$(gcloud config get-value project)"

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -230,7 +230,7 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 			allErrs = append(allErrs, field.Forbidden(fieldPath.Child("assets", "containerProxy"), "containerProxy cannot be used in conjunction with containerRegistry"))
 		}
 		if spec.Assets.FileRepository != nil {
-			allErrs = append(allErrs, validateFileRepository(*spec.Assets.FileRepository, fieldPath.Child("assets", "fileRepository"))...)
+			allErrs = append(allErrs, validateFileRepository(*spec.Assets.FileRepository, fieldPath.Child("assets", "fileRepository"), c.GetCloudProvider())...)
 		}
 	}
 
@@ -778,7 +778,7 @@ func validateFileAssetSpec(v *kops.FileAssetSpec, fieldPath *field.Path) field.E
 	return allErrs
 }
 
-func validateFileRepository(s string, fieldPath *field.Path) field.ErrorList {
+func validateFileRepository(s string, fieldPath *field.Path, cloudProvider kops.CloudProviderID) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	u, err := url.Parse(s)
@@ -786,7 +786,14 @@ func validateFileRepository(s string, fieldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("cannot parse fileRepository URL: %v", err)))
 		return allErrs
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
+	switch u.Scheme {
+	case "http", "https":
+	case "gs":
+		// Only GCE instances can authenticate to GCS with their service account.
+		if cloudProvider != kops.CloudProviderGCE {
+			allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("gs:// fileRepository is only supported on GCE, but the cloud provider is %q", cloudProvider)))
+		}
+	default:
 		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must be an http:// or https:// URL"))
 	}
 	if u.Host == "" {

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -2211,6 +2211,7 @@ func TestValidateAzureBlobAccountUniformity(t *testing.T) {
 func TestValidateFileRepository(t *testing.T) {
 	grid := []struct {
 		Input          string
+		CloudProvider  kops.CloudProviderID
 		ExpectedErrors []string
 	}{
 		{
@@ -2221,6 +2222,16 @@ func TestValidateFileRepository(t *testing.T) {
 		},
 		{
 			Input:          "s3://example-k8s-assets/kops",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
+			// Nodes download from GCS with the credentials of their service account.
+			Input:         "gs://example-k8s-assets/kops",
+			CloudProvider: kops.CloudProviderGCE,
+		},
+		{
+			Input:          "gs://example-k8s-assets/kops",
+			CloudProvider:  kops.CloudProviderAWS,
 			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
 		},
 		{
@@ -2241,7 +2252,7 @@ func TestValidateFileRepository(t *testing.T) {
 		},
 	}
 	for _, g := range grid {
-		errs := validateFileRepository(g.Input, field.NewPath("spec", "assets", "fileRepository"))
+		errs := validateFileRepository(g.Input, field.NewPath("spec", "assets", "fileRepository"), g.CloudProvider)
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
 	}
 }

--- a/pkg/assets/assetcopy/copyfile.go
+++ b/pkg/assets/assetcopy/copyfile.go
@@ -179,7 +179,8 @@ func writeFile(ctx context.Context, cluster *kops.Cluster, p vfs.Path, data []by
 // buildVFSPath task a recognizable https url and transforms that URL into the equivalent url with the object
 // store prefix.
 func buildVFSPath(target string) (string, error) {
-	if !strings.Contains(target, "://") || strings.HasPrefix(target, "memfs://") || strings.HasPrefix(target, "file://") {
+	if !strings.Contains(target, "://") || strings.HasPrefix(target, "memfs://") || strings.HasPrefix(target, "file://") ||
+		strings.HasPrefix(target, "gs://") {
 		return target, nil
 	}
 
@@ -192,10 +193,8 @@ func buildVFSPath(target string) (string, error) {
 	if err == nil {
 		vfsPath = s3VfsPath
 	} else {
-		// These matches only cover a subset of the URLs that you can use, but I am uncertain how to cover more of the possible
-		// options.
-		// This code parses the HOST and determines gs URLs.
-		// For instance you can have the bucket name in the gs url hostname.
+		// Convert a GCS URL in the https://storage.googleapis.com/<bucket>/<path> form to the
+		// equivalent gs:// vfsPath. The gs:// form itself was already passed through above.
 		u, err := url.Parse(target)
 		if err != nil {
 			return "", fmt.Errorf("Unable to parse Google Cloud Storage URL: %q", target)
@@ -209,7 +208,7 @@ func buildVFSPath(target string) (string, error) {
 		klog.Errorf("Unable to determine VFS path from supplied URL: %s", target)
 		klog.Errorf("S3, Google Cloud Storage, and File Paths are supported.")
 		klog.Errorf("For S3, please make sure that the supplied file repository URL adhere to S3 naming conventions, https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.")
-		klog.Errorf("For GCS, please make sure that the supplied file repository URL adheres to https://storage.googleapis.com/")
+		klog.Errorf("For GCS, please make sure that the supplied file repository URL starts with gs:// or https://storage.googleapis.com/")
 		if err != nil { // print the S3 error for more details
 			return "", fmt.Errorf("Error Details: %v", err)
 		}

--- a/pkg/assets/assetcopy/copyfile_test.go
+++ b/pkg/assets/assetcopy/copyfile_test.go
@@ -67,6 +67,11 @@ func Test_BuildVFSPath(t *testing.T) {
 			"gs://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
 			true,
 		},
+		{
+			"gs://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			"gs://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			true,
+		},
 	}
 
 	for _, test := range grid {

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -87,7 +87,45 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      {{ CopyCheckUrlBlock }}
+{{- if UseGCSDownload }}
+      # Use the IP of the metadata server, to not depend on DNS this early in boot
+      local metadata_server="http://169.254.169.254"
+      local token
+      echo "== Downloading ${url} =="
+      # Pipe the service account token to curl, to keep it out of the logs
+      if ! token=$(curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 -H 'Metadata-Flavor: Google' "${metadata_server}/computeMetadata/v1/instance/service-accounts/default/token" | grep -o '"access_token" *: *"[^"]*"' | cut -d '"' -f 4); then
+        echo "== Failed to get a service account token =="
+      elif ! echo "Authorization: Bearer ${token}" | curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 -H @- "https://storage.googleapis.com/${url#gs://}"; then
+        echo "== Failed to download ${url} =="
+      elif ! validate-hash "${file}" "${hash}"; then
+        echo "== Failed to validate hash for ${url} =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} with hash ${hash} =="
+        return 0
+      fi
+{{- else }}
+      commands=(
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+      )
+      for cmd in "${commands[@]}"; do
+        echo "== Downloading ${url} using ${cmd} =="
+        if ! (${cmd} "${url}"); then
+          echo "== Failed to download ${url} using ${cmd} =="
+          continue
+        fi
+        if ! validate-hash "${file}" "${hash}"; then
+          echo "== Failed to validate hash for ${url} =="
+          rm -f "${file}"
+        else
+          echo "== Downloaded ${url} with hash ${hash} =="
+          return 0
+        fi
+      done
+{{- end }}
     done
 
     echo "== All downloads failed; sleeping before retrying =="
@@ -232,57 +270,27 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 
 		"ProxyEnv":             b.ProxyEnv,
 		"EnvironmentVariables": b.EnvironmentVariables,
-		"CopyCheckUrlBlock":    b.copyCheckUrlBlock,
+
+		"UseGCSDownload": b.useGCSDownload,
 	}
 
 	return newTemplateResource("nodeup", nodeUpTemplate, functions, nil)
 }
 
-func (b *NodeUpScript) copyCheckUrlBlock() (string, error) {
-	if b.CloudProvider == string(kops.CloudProviderGCE) {
-		return `commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
-          echo "== Failed to download ${url} using ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Failed to validate hash for ${url} =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} with hash ${hash} =="
-          return 0
-        fi
-      done`, nil
-	} else {
-		return `commands=(
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd} "${url}"); then
-          echo "== Failed to download ${url} using ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Failed to validate hash for ${url} =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} with hash ${hash} =="
-          return 0
-        fi
-      done`, nil
+// useGCSDownload reports whether nodeup is downloaded from a GCS bucket, which has to be done
+// with the credentials of the instance service account.
+func (b *NodeUpScript) useGCSDownload() bool {
+	for _, asset := range b.NodeUpAssets {
+		if asset == nil {
+			continue
+		}
+		for _, location := range asset.Locations {
+			if strings.HasPrefix(location, "gs://") {
+				return true
+			}
+		}
 	}
+	return false
 }
 
 func gzipBase64(data string) (string, error) {

--- a/pkg/model/resources/nodeup_test.go
+++ b/pkg/model/resources/nodeup_test.go
@@ -17,8 +17,16 @@ limitations under the License.
 package resources
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"k8s.io/kops/pkg/assets"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/util/pkg/architectures"
+	"k8s.io/kops/util/pkg/hashing"
 )
 
 func Test_NodeUpTabs(t *testing.T) {
@@ -26,5 +34,77 @@ func Test_NodeUpTabs(t *testing.T) {
 		if strings.Contains(line, "\t") {
 			t.Errorf("NodeUpTemplate contains unexpected character %q on line %d: %q", "\t", i, line)
 		}
+	}
+}
+
+func Test_GCSDownload(t *testing.T) {
+	// The authenticated GCS download is rendered only when the nodeup sources are gs:// URLs.
+	gcsMarker := "Authorization: Bearer"
+	standardMarker := "wget --compression=auto"
+
+	nodeUpAssets := func(location string) map[architectures.Architecture]*assets.MirroredAsset {
+		return map[architectures.Architecture]*assets.MirroredAsset{
+			architectures.ArchitectureAmd64: {
+				Locations: []string{location},
+				Hash:      hashing.MustFromString("9acf6a83b249649354bb15b04250fabce0f8ff2377f2f0d4788e3fdda3f572a3"),
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name      string
+		location  string
+		expectGCS bool
+	}{
+		{
+			name:      "gs source",
+			location:  "gs://artifact-bucket/kops/1.34.0/linux/amd64/nodeup",
+			expectGCS: true,
+		},
+		{
+			name:      "default https source",
+			location:  "https://artifacts.k8s.io/binaries/kops/1.34.0/linux/amd64/nodeup",
+			expectGCS: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := &NodeUpScript{
+				CloudProvider: "gce",
+				NodeUpAssets:  nodeUpAssets(tc.location),
+			}
+			resource, err := script.Build()
+			if err != nil {
+				t.Fatalf("building nodeup script: %v", err)
+			}
+			rendered, err := fi.ResourceAsString(resource)
+			if err != nil {
+				t.Fatalf("rendering nodeup script: %v", err)
+			}
+			if got := strings.Contains(rendered, gcsMarker); got != tc.expectGCS {
+				t.Errorf("authenticated GCS download rendered=%v, expected %v", got, tc.expectGCS)
+			}
+			if got := strings.Contains(rendered, standardMarker); got != !tc.expectGCS {
+				t.Errorf("standard download commands rendered=%v, expected %v", got, !tc.expectGCS)
+			}
+			verifyShellSyntax(t, rendered)
+		})
+	}
+}
+
+// verifyShellSyntax parses the rendered script with bash, as the GCS download has no golden file.
+func verifyShellSyntax(t *testing.T, script string) {
+	t.Helper()
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not found in PATH")
+	}
+
+	path := filepath.Join(t.TempDir(), "nodeup.sh")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("writing rendered script: %v", err)
+	}
+	if output, err := exec.Command(bash, "-n", path).CombinedOutput(); err != nil {
+		t.Errorf("rendered script is not valid bash: %v\n%s", err, output)
 	}
 }

--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -48,7 +48,7 @@ func (d *deployer) Build() error {
 		klog.Infof("setting kops base url to %q from build results", results.KopsBaseURL)
 		d.KopsBaseURL = results.KopsBaseURL
 		// In PreTestCmd, we need KOPS_BASE_URL to be set for kops calls
-		os.Setenv("KOPS_BASE_URL", d.KopsBaseURL)
+		os.Setenv("KOPS_BASE_URL", d.maybeGSURL(d.KopsBaseURL))
 	}
 
 	if results.KubernetesBaseURL != "" {

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -302,9 +302,9 @@ func (d *deployer) env() []string {
 	}
 
 	if d.KopsBaseURL != "" {
-		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.KopsBaseURL))
+		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.maybeGSURL(d.KopsBaseURL)))
 	} else if baseURL := os.Getenv("KOPS_BASE_URL"); baseURL != "" {
-		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", os.Getenv("KOPS_BASE_URL")))
+		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.maybeGSURL(baseURL)))
 	}
 
 	if kopsBin := d.resolvedKopsBinaryPath(); kopsBin != "" {
@@ -334,6 +334,20 @@ func (d *deployer) env() []string {
 		}
 	}
 	return vars
+}
+
+// gcsPublicPrefix is the https form of a GCS bucket, as used for the staged build artifacts.
+const gcsPublicPrefix = "https://storage.googleapis.com/"
+
+// maybeGSURL converts baseURL from the public GCS https form to the gs:// form on GCE, so that
+// nodes download the staged artifacts with their instance service-account credentials. Any other
+// URL, and any other cloud provider, passes through unchanged. Only kops invocations get the gs://
+// form; the scripts that download the kops binary run outside the deployer and keep using https.
+func (d *deployer) maybeGSURL(baseURL string) string {
+	if d.CloudProvider != "gce" || !strings.HasPrefix(baseURL, gcsPublicPrefix) {
+		return baseURL
+	}
+	return "gs://" + strings.TrimPrefix(baseURL, gcsPublicPrefix)
 }
 
 // featureFlags returns the kops feature flags to set

--- a/tests/e2e/kubetest2-kops/deployer/common_test.go
+++ b/tests/e2e/kubetest2-kops/deployer/common_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import "testing"
+
+func TestMaybeGSURL(t *testing.T) {
+	cases := []struct {
+		name          string
+		cloudProvider string
+		baseURL       string
+		expected      string
+	}{
+		{
+			name:          "gce staged artifacts",
+			cloudProvider: "gce",
+			baseURL:       "https://storage.googleapis.com/k8s-staging-kops/kops/1.34.0/",
+			expected:      "gs://k8s-staging-kops/kops/1.34.0/",
+		},
+		{
+			name:          "aws staged artifacts are left alone",
+			cloudProvider: "aws",
+			baseURL:       "https://storage.googleapis.com/k8s-staging-kops/kops/1.34.0/",
+			expected:      "https://storage.googleapis.com/k8s-staging-kops/kops/1.34.0/",
+		},
+		{
+			name:          "gce with a non-GCS url",
+			cloudProvider: "gce",
+			baseURL:       "https://artifacts.k8s.io/binaries/kops/1.34.0/",
+			expected:      "https://artifacts.k8s.io/binaries/kops/1.34.0/",
+		},
+		{
+			name:          "gce with an already converted url",
+			cloudProvider: "gce",
+			baseURL:       "gs://k8s-staging-kops/kops/1.34.0/",
+			expected:      "gs://k8s-staging-kops/kops/1.34.0/",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &deployer{CloudProvider: tc.cloudProvider}
+			if actual := d.maybeGSURL(tc.baseURL); actual != tc.expected {
+				t.Errorf("maybeGSURL(%q) = %q, expected %q", tc.baseURL, actual, tc.expected)
+			}
+		})
+	}
+}

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -70,7 +70,7 @@ func (d *deployer) Up() error {
 
 	// PreTestCmd inherits the process environment rather than d.env().
 	if d.KopsBaseURL != "" {
-		os.Setenv("KOPS_BASE_URL", d.KopsBaseURL)
+		os.Setenv("KOPS_BASE_URL", d.maybeGSURL(d.KopsBaseURL))
 	}
 
 	if d.terraform == nil {

--- a/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_master-us-test1-a-gossip-k8s-local_metadata_user-data
+++ b/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_master-us-test1-a-gossip-k8s-local_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_nodes-gossip-k8s-local_metadata_user-data
+++ b/tests/integration/update_cluster/gossip-gce/data/google_compute_instance_template_nodes-gossip-k8s-local_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_master-us-test1-a-minimal-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_master-us-test1-a-minimal-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_nodes-minimal-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_nodes-minimal-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_nodes-minimal-gce-ilb-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_nodes-minimal-gce-ilb-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-cilium-etcd-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-cilium-etcd-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/google_compute_instance_template_nodes-minimal-gce-ilb-cilium-etcd-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/google_compute_instance_template_nodes-minimal-gce-ilb-cilium-etcd-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_nodes-minimal-gce-plb-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_nodes-minimal-gce-plb-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_apiserver-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_apiserver-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-apiserver-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_nodes-minimal-gce-plb-apiserver-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/google_compute_instance_template_nodes-minimal-gce-plb-apiserver-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi

--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_user-data
+++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_user-data
@@ -48,15 +48,14 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
       commands=(
-        "gcloud storage cp ${url} ${file}"
-        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
-        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10 ${url}"
-        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10 ${url}"
+        "curl -f --compressed -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O ${file} --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo ${file} --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O ${file} --connect-timeout=20 --tries=6 --wait=10"
       )
       for cmd in "${commands[@]}"; do
         echo "== Downloading ${url} using ${cmd} =="
-        if ! (${cmd}); then
+        if ! (${cmd} "${url}"); then
           echo "== Failed to download ${url} using ${cmd} =="
           continue
         fi


### PR DESCRIPTION
**What this PR does / why we need it**:

#18466 added support for fetching `nodeup` from a private GCS bucket by prepending `gcloud storage cp` to the bootstrap script's download list, which requires the gcloud CLI on the node image. This uses plain `curl` instead, authenticated with the instance service account token from the metadata server. The token is piped in via `-H @-`, so it never reaches the disk, the process arguments, or the serial console.

Since the download URLs are known when the script is generated, the method is chosen there rather than by testing the URL scheme at boot. Scripts using the default `https` sources are unchanged on every provider, and the GCE golden files return to their pre-#18466 form.

Two follow-ons make it usable and tested: `spec.assets.fileRepository` now accepts a `gs://` URL on GCE, so node assets can live in the same private bucket (validation still rejects it elsewhere, as only GCE instances can authenticate to GCS), and GCE e2e jobs now pass kops the `gs://` form of the staged artifacts so the path is covered by CI.

/cc @cheftako @justinsb @rifelpet 