### PR TITLE
scalability: support PRE_TEST_CMD environment variable

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -164,7 +164,7 @@ KUBETEST2_ARGS+=("--cloud-provider=${CLOUD_PROVIDER}")
 KUBETEST2_ARGS+=("--cluster-name=${CLUSTER_NAME:-}")
 KUBETEST2_ARGS+=("--admin-access=${ADMIN_ACCESS:-}")
 KUBETEST2_ARGS+=("--env=KOPS_FEATURE_FLAGS=${KOPS_FEATURE_FLAGS}")
-KUBETEST2_ARGS+=("--pre-test-cmd=${REPO_ROOT}/tests/e2e/scenarios/scalability/pre-test.sh")
+KUBETEST2_ARGS+=("--pre-test-cmd=${PRE_TEST_CMD:-${REPO_ROOT}/tests/e2e/scenarios/scalability/pre-test.sh}")
 if [[ -n "${KUBE_FEATURE_GATES:-}" ]]; then
   KUBETEST2_ARGS+=("--kubernetes-feature-gates=${KUBE_FEATURE_GATES}")
 fi


### PR DESCRIPTION
This PR allows running a custom pre-test script, by passing the path through the env variable PRE_TEST_CMD.

If not passed, the default pre-script will run `{REPO_ROOT}/tests/e2e/scenarios/scalability/pre-test.sh}`