### PR TITLE
Allow AWS subnets without zones

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -92,13 +92,14 @@ func ValidateRegion(ctx context.Context, region string) error {
 func FindRegion(cluster *kops.Cluster) (string, error) {
 	region := ""
 
-	nodeZones := make(map[string]bool)
 	for _, subnet := range cluster.Spec.Networking.Subnets {
+		if subnet.Zone == "" {
+			continue
+		}
+
 		if len(subnet.Zone) <= 2 {
 			return "", fmt.Errorf("invalid AWS zone: %q in subnet %q", subnet.Zone, subnet.Name)
 		}
-
-		nodeZones[subnet.Zone] = true
 
 		zoneRegion := subnet.Zone[:len(subnet.Zone)-1]
 		if region != "" && zoneRegion != region {
@@ -106,6 +107,10 @@ func FindRegion(cluster *kops.Cluster) (string, error) {
 		}
 
 		region = zoneRegion
+	}
+
+	if region == "" {
+		return "", fmt.Errorf("no AWS subnet zones were specified")
 	}
 
 	return region, nil

--- a/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
@@ -66,6 +66,35 @@ func TestFindRegion(t *testing.T) {
 			t.Fatalf("unexpected region for zone: %q vs %q", expected, region)
 		}
 	}
+
+	t.Run("ignores missing zones when other subnets specify a region", func(t *testing.T) {
+		c := &kops.Cluster{}
+		c.Spec.Networking.Subnets = []kops.ClusterSubnetSpec{
+			{Name: "subnet-a", ID: "subnet-12345678"},
+			{Name: "subnet-b", Zone: "us-east-2b"},
+		}
+
+		region, err := FindRegion(c)
+		if err != nil {
+			t.Fatalf("unexpected error finding region: %v", err)
+		}
+
+		if region != "us-east-2" {
+			t.Fatalf("unexpected region: %q", region)
+		}
+	})
+
+	t.Run("errors when no subnet zones are provided", func(t *testing.T) {
+		c := &kops.Cluster{}
+		c.Spec.Networking.Subnets = []kops.ClusterSubnetSpec{
+			{Name: "subnet-a", ID: "subnet-12345678"},
+		}
+
+		region, err := FindRegion(c)
+		if err == nil {
+			t.Fatalf("expected error finding region, got %q", region)
+		}
+	})
 }
 
 func TestEC2TagSpecification(t *testing.T) {

--- a/upup/pkg/fi/cloudup/subnets.go
+++ b/upup/pkg/fi/cloudup/subnets.go
@@ -82,7 +82,7 @@ func assignCIDRsToSubnets(c *kops.Cluster, cloud fi.Cloud) error {
 					return fmt.Errorf("Subnet %q has configured CIDR %q, but the actual CIDR found was %q", subnet.ID, subnet.CIDR, cloudSubnet.CIDR)
 				}
 
-				if subnet.Zone != cloudSubnet.Zone {
+				if subnet.Zone != "" && subnet.Zone != cloudSubnet.Zone {
 					return fmt.Errorf("Subnet %q has configured Zone %q, but the actual Zone found was %q", subnet.ID, subnet.Zone, cloudSubnet.Zone)
 				}
 

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -93,7 +93,9 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 
 			var zoneNames []string
 			for _, subnet := range cluster.Spec.Networking.Subnets {
-				zoneNames = append(zoneNames, subnet.Zone)
+				if subnet.Zone != "" {
+					zoneNames = append(zoneNames, subnet.Zone)
+				}
 			}
 			err = awsup.ValidateZones(zoneNames, awsCloud)
 			if err != nil {


### PR DESCRIPTION
Fixes #14710.

AWS subnet IDs are enough to identify the subnet. kOps should accept manifests where one or more subnets omit zone as long as at least one subnet still anchors the AWS region.

Changes:
- ignore empty subnet zones when deriving the AWS region
- skip empty zones during AWS zone validation
- allow existing subnet CIDR/zone validation to accept ID-only subnets when the zone is omitted