### PR TITLE
hetzner: Ignore WellKnownServices when comparing load balancers

### DIFF
--- a/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
@@ -117,10 +117,11 @@ func (v *LoadBalancer) Find(c *fi.CloudupContext) (*LoadBalancer, error) {
 	for _, loadbalancer := range loadbalancers {
 		if loadbalancer.Name == fi.ValueOf(v.Name) {
 			matches := &LoadBalancer{
-				Lifecycle: v.Lifecycle,
-				Name:      new(loadbalancer.Name),
-				ID:        new(loadbalancer.ID),
-				Labels:    loadbalancer.Labels,
+				Lifecycle:         v.Lifecycle,
+				Name:              new(loadbalancer.Name),
+				ID:                new(loadbalancer.ID),
+				Labels:            loadbalancer.Labels,
+				WellKnownServices: v.WellKnownServices,
 			}
 
 			if loadbalancer.Location != nil {


### PR DESCRIPTION
`kops update cluster` always wants to apply changes to the api loadbalancer because the WellKnownServices are not copied to the local representation of the loadbalancer.
Copying the WellKnownServices to the local LoadBalancer object fixes this.