### PR TITLE
aws: add option for IP-based node names

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -1273,6 +1273,23 @@ spec:
     elbSecurityGroup: sg-123445678
 ```
 
+### useIPBasedNodeNames
+{{ kops_feature_table(kops_added_default='1.37') }}
+
+*AWS only*
+
+By default, kOps names Kubernetes nodes after the EC2 instance ID (for example `i-0123456789abcdef0`). Setting `useIPBasedNodeNames: true` names nodes after the EC2 private DNS name instead (for example `ip-10-0-0-1.eu-west-1.compute.internal`), restoring the naming used before kOps 1.24.
+
+When enabled, kOps configures managed subnets to launch instances with IP-based EC2 hostnames instead of resource-based ones. Shared subnets are not modified and must be configured with IP-based hostnames (the EC2 default) by their owner. This option is not supported on IPv6-only clusters.
+
+Changing this value only affects newly launched nodes; roll the cluster to rename existing nodes. When changing it on a running cluster, first make sure kops-controller picks up the new configuration, either by rolling the control plane or by deleting the kops-controller pods (`kubectl -n kube-system delete pod -l k8s-app=kops-controller`); nodes launched before that may fail to bootstrap and need replacement.
+
+```yaml
+spec:
+  cloudConfig:
+    useIPBasedNodeNames: true
+```
+
 ### manageStorageClasses
 {{ kops_feature_table(kops_added_default='1.20') }}
 
@@ -1643,6 +1660,7 @@ the removal of fields no longer in use.
 | cloudConfig.openstack                                  | cloudProvider.openstack                                        |
 | cloudConfig.spotinstOrientation                        | cloudProvider.aws.spotinstOrientation                          |
 | cloudConfig.spotinstProduct                            | cloudProvider.aws.spotinstProduct                              |
+| cloudConfig.useIPBasedNodeNames                        | cloudProvider.aws.useIPBasedNodeNames                          |
 | cloudProvider (string)                                 | cloudProvider (map)                                            |
 | configBase                                             | configStore.base                                               |
 | DisableSubnetTags                                      | tagSubnets (value inverted)                                    |

--- a/docs/releases/1.37-NOTES.md
+++ b/docs/releases/1.37-NOTES.md
@@ -8,6 +8,8 @@ This is a document to gather the release notes prior to the release.
 
 * Support for AWS Classic Load Balancer (CLB) for the API, deprecated since kOps 1.26, has been removed. See the breaking changes section below for the required actions.
 
+* On AWS, the new `spec.cloudProvider.aws.useIPBasedNodeNames` field (`spec.cloudConfig.useIPBasedNodeNames` in the v1alpha2 API) names Kubernetes nodes after the EC2 private DNS name (e.g. `ip-10-0-0-1.eu-west-1.compute.internal`) instead of the EC2 instance ID, restoring the naming used before kOps 1.24. Only newly launched nodes are affected; roll the cluster to rename existing nodes.
+
 # Other changes of note
 
 * TODO

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -634,6 +634,11 @@ spec:
                   spotinstProduct:
                     description: Spotinst cloud-config specs
                     type: string
+                  useIPBasedNodeNames:
+                    description: |-
+                      UseIPBasedNodeNames names Kubernetes nodes after the EC2 private DNS name instead of the EC2
+                      instance ID (AWS only).
+                    type: boolean
                   vSphereCoreDNSServer:
                     description: VSphereCoreDNSServer is unused.
                     type: string

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -863,18 +863,19 @@ func (b *KubeletBuilder) buildKubeletServingCertificate(c *fi.NodeupModelBuilder
 	name := "kubelet-server"
 	dir := b.PathSrvKubernetes()
 
-	names, err := b.kubeletNames(c.Context())
-	if err != nil {
-		return err
-	}
-
 	var cert, key fi.Resource
 	if !b.HasAPIServer {
+		var err error
 		cert, key, err = b.GetBootstrapCert(name, fi.CertificateIDCA)
 		if err != nil {
 			return err
 		}
 	} else {
+		names, err := b.kubeletNames(c.Context())
+		if err != nil {
+			return err
+		}
+
 		issueCert := &nodetasks.IssueCert{
 			Name:      name,
 			Signer:    fi.CertificateIDCA,
@@ -925,7 +926,16 @@ func (b *KubeletBuilder) kubeletNames(ctx context.Context) ([]string, error) {
 		return append(addrs, name), nil
 	}
 
+	// The node name goes first when it differs from the instance ID, as it becomes the certificate
+	// CommonName.
 	addrs := []string{b.InstanceID}
+	nodeName, err := b.NodeName()
+	if err != nil {
+		return nil, fmt.Errorf("error getting NodeName: %v", err)
+	}
+	if nodeName != b.InstanceID {
+		addrs = append([]string{nodeName}, addrs...)
+	}
 	config, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error loading AWS config: %v", err)
@@ -934,7 +944,9 @@ func (b *KubeletBuilder) kubeletNames(ctx context.Context) ([]string, error) {
 
 	if localHostname, err := getMetadata(ctx, metadata, "local-hostname"); err == nil {
 		klog.V(2).Infof("Local Hostname: %s", localHostname)
-		addrs = append(addrs, localHostname)
+		if localHostname != addrs[0] {
+			addrs = append(addrs, localHostname)
+		}
 	}
 	if localIPv4, err := getMetadata(ctx, metadata, "local-ipv4"); err == nil {
 		klog.V(2).Infof("Local IPv4: %s", localIPv4)

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -223,6 +223,12 @@ type AWSSpec struct {
 
 	// NodeIPFamilies control the IP families reported for each node.
 	NodeIPFamilies []string `json:"nodeIPFamilies,omitempty"`
+	// UseIPBasedNodeNames names Kubernetes nodes after the EC2 private DNS name, e.g.
+	// ip-10-0-0-1.eu-west-1.compute.internal, instead of the EC2 instance ID. When enabled, managed
+	// subnets launch instances with IP-based EC2 hostnames; shared subnets must be configured with
+	// IP-based hostnames by their owner. Not supported on IPv6-only clusters. Changing this value
+	// only affects newly launched nodes; existing nodes must be replaced to be renamed.
+	UseIPBasedNodeNames *bool `json:"useIPBasedNodeNames,omitempty"`
 	// DisableSecurityGroupIngress disables the Cloud Controller Manager's creation
 	// of an AWS Security Group for each load balancer provisioned for a Service.
 	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -1011,6 +1011,10 @@ type CloudConfiguration struct {
 	// security groups for Network Load Balancers (AWS only). Valid value: "Managed"
 	// +k8s:conversion-gen=false
 	NLBSecurityGroupMode *string `json:"nlbSecurityGroupMode,omitempty"`
+	// UseIPBasedNodeNames names Kubernetes nodes after the EC2 private DNS name instead of the EC2
+	// instance ID (AWS only).
+	// +k8s:conversion-gen=false
+	UseIPBasedNodeNames *bool `json:"useIPBasedNodeNames,omitempty"`
 	// VSphereUsername is unused.
 	// +k8s:conversion-gen=false
 	VSphereUsername *string `json:"vSphereUsername,omitempty"`

--- a/pkg/apis/kops/v1alpha2/conversion.go
+++ b/pkg/apis/kops/v1alpha2/conversion.go
@@ -222,6 +222,13 @@ func Convert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *kops
 			val := *in.CloudConfig.ElbSecurityGroup
 			out.CloudProvider.AWS.ElbSecurityGroup = &val
 		}
+		if in.CloudConfig.UseIPBasedNodeNames != nil {
+			if out.CloudProvider.AWS == nil {
+				return field.Forbidden(field.NewPath("spec").Child("cloudConfig", "useIPBasedNodeNames"), "useIPBasedNodeNames supports only AWS")
+			}
+			val := *in.CloudConfig.UseIPBasedNodeNames
+			out.CloudProvider.AWS.UseIPBasedNodeNames = &val
+		}
 		if in.CloudConfig.NLBSecurityGroupMode != nil {
 			if out.CloudProvider.AWS == nil {
 				return field.Forbidden(field.NewPath("spec").Child("cloudConfig", "nlbSecurityGroupMode"), "nlbSecurityGroupMode supports only AWS")
@@ -462,6 +469,13 @@ func Convert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, out 
 			}
 			val := *aws.DisableSecurityGroupIngress
 			out.CloudConfig.DisableSecurityGroupIngress = &val
+		}
+		if aws.UseIPBasedNodeNames != nil {
+			if out.CloudConfig == nil {
+				out.CloudConfig = &CloudConfiguration{}
+			}
+			val := *aws.UseIPBasedNodeNames
+			out.CloudConfig.UseIPBasedNodeNames = &val
 		}
 		if aws.EBSCSIDriver != nil {
 			if out.CloudConfig == nil {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2318,6 +2318,7 @@ func autoConvert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	// INFO: in.DisableSecurityGroupIngress opted out of conversion generation
 	// INFO: in.ElbSecurityGroup opted out of conversion generation
 	// INFO: in.NLBSecurityGroupMode opted out of conversion generation
+	// INFO: in.UseIPBasedNodeNames opted out of conversion generation
 	// INFO: in.VSphereUsername opted out of conversion generation
 	// INFO: in.VSpherePassword opted out of conversion generation
 	// INFO: in.VSphereServer opted out of conversion generation

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -814,6 +814,11 @@ func (in *CloudConfiguration) DeepCopyInto(out *CloudConfiguration) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.UseIPBasedNodeNames != nil {
+		in, out := &in.UseIPBasedNodeNames, &out.UseIPBasedNodeNames
+		*out = new(bool)
+		**out = **in
+	}
 	if in.VSphereUsername != nil {
 		in, out := &in.VSphereUsername, &out.VSphereUsername
 		*out = new(string)

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -214,6 +214,12 @@ type AWSSpec struct {
 
 	// NodeIPFamilies control the IP families reported for each node.
 	NodeIPFamilies []string `json:"nodeIPFamilies,omitempty"`
+	// UseIPBasedNodeNames names Kubernetes nodes after the EC2 private DNS name, e.g.
+	// ip-10-0-0-1.eu-west-1.compute.internal, instead of the EC2 instance ID. When enabled, managed
+	// subnets launch instances with IP-based EC2 hostnames; shared subnets must be configured with
+	// IP-based hostnames by their owner. Not supported on IPv6-only clusters. Changing this value
+	// only affects newly launched nodes; existing nodes must be replaced to be renamed.
+	UseIPBasedNodeNames *bool `json:"useIPBasedNodeNames,omitempty"`
 	// DisableSecurityGroupIngress disables the Cloud Controller Manager's creation
 	// of an AWS Security Group for each load balancer provisioned for a Service.
 	DisableSecurityGroupIngress *bool `json:"disableSecurityGroupIngress,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1594,6 +1594,7 @@ func autoConvert_v1alpha3_AWSSpec_To_kops_AWSSpec(in *AWSSpec, out *kops.AWSSpec
 		out.WarmPool = nil
 	}
 	out.NodeIPFamilies = in.NodeIPFamilies
+	out.UseIPBasedNodeNames = in.UseIPBasedNodeNames
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
 	out.ElbSecurityGroup = in.ElbSecurityGroup
 	out.NLBSecurityGroupMode = in.NLBSecurityGroupMode
@@ -1655,6 +1656,7 @@ func autoConvert_kops_AWSSpec_To_v1alpha3_AWSSpec(in *kops.AWSSpec, out *AWSSpec
 		out.WarmPool = nil
 	}
 	out.NodeIPFamilies = in.NodeIPFamilies
+	out.UseIPBasedNodeNames = in.UseIPBasedNodeNames
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
 	out.ElbSecurityGroup = in.ElbSecurityGroup
 	out.NLBSecurityGroupMode = in.NLBSecurityGroupMode

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -183,6 +183,11 @@ func (in *AWSSpec) DeepCopyInto(out *AWSSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.UseIPBasedNodeNames != nil {
+		in, out := &in.UseIPBasedNodeNames, &out.UseIPBasedNodeNames
+		*out = new(bool)
+		**out = **in
+	}
 	if in.DisableSecurityGroupIngress != nil {
 		in, out := &in.DisableSecurityGroupIngress, &out.DisableSecurityGroupIngress
 		*out = new(bool)

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -61,6 +61,8 @@ func awsValidateCluster(c *kops.Cluster, strict bool) field.ErrorList {
 
 	allErrs = append(allErrs, awsValidateNLBSecurityGroupMode(c)...)
 
+	allErrs = append(allErrs, awsValidateUseIPBasedNodeNames(c)...)
+
 	if c.Spec.Authentication != nil && c.Spec.Authentication.AWS != nil {
 		allErrs = append(allErrs, awsValidateIAMAuthenticator(field.NewPath("spec", "authentication", "aws"), c.Spec.Authentication.AWS)...)
 	}
@@ -84,6 +86,16 @@ func awsValidateNLBSecurityGroupMode(cluster *kops.Cluster) (allErrs field.Error
 	fldPath := field.NewPath("spec", "cloudProvider", "aws", "nlbSecurityGroupMode")
 	if c.CloudProvider.AWS.NLBSecurityGroupMode != nil {
 		allErrs = append(allErrs, IsValidValue(fldPath, c.CloudProvider.AWS.NLBSecurityGroupMode, []string{"Managed"})...)
+	}
+	return allErrs
+}
+
+func awsValidateUseIPBasedNodeNames(cluster *kops.Cluster) (allErrs field.ErrorList) {
+	c := cluster.Spec
+
+	fldPath := field.NewPath("spec", "cloudProvider", "aws", "useIPBasedNodeNames")
+	if fi.ValueOf(c.CloudProvider.AWS.UseIPBasedNodeNames) && c.IsIPv6Only() {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "IP-based node names are not supported on IPv6-only clusters"))
 	}
 	return allErrs
 }

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -981,3 +981,57 @@ func TestAWSValidateNLBSecurityGroupMode(t *testing.T) {
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
 	}
 }
+
+func TestAWSValidateUseIPBasedNodeNames(t *testing.T) {
+	grid := []struct {
+		Input          kops.ClusterSpec
+		ExpectedErrors []string
+	}{
+		{
+			Input: kops.ClusterSpec{
+				CloudProvider: kops.CloudProviderSpec{
+					AWS: &kops.AWSSpec{},
+				},
+			},
+		},
+		{
+			Input: kops.ClusterSpec{
+				CloudProvider: kops.CloudProviderSpec{
+					AWS: &kops.AWSSpec{
+						UseIPBasedNodeNames: new(true),
+					},
+				},
+			},
+		},
+		{
+			Input: kops.ClusterSpec{
+				CloudProvider: kops.CloudProviderSpec{
+					AWS: &kops.AWSSpec{
+						UseIPBasedNodeNames: new(true),
+					},
+				},
+				Networking: kops.NetworkingSpec{
+					NonMasqueradeCIDR: "::/0",
+				},
+			},
+			ExpectedErrors: []string{"Forbidden::spec.cloudProvider.aws.useIPBasedNodeNames"},
+		},
+		{
+			Input: kops.ClusterSpec{
+				CloudProvider: kops.CloudProviderSpec{
+					AWS: &kops.AWSSpec{
+						UseIPBasedNodeNames: new(false),
+					},
+				},
+				Networking: kops.NetworkingSpec{
+					NonMasqueradeCIDR: "::/0",
+				},
+			},
+		},
+	}
+	for _, g := range grid {
+		cluster := &kops.Cluster{Spec: g.Input}
+		errs := awsValidateUseIPBasedNodeNames(cluster)
+		testErrors(t, g.Input, errs, g.ExpectedErrors)
+	}
+}

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -182,6 +182,11 @@ func (in *AWSSpec) DeepCopyInto(out *AWSSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.UseIPBasedNodeNames != nil {
+		in, out := &in.UseIPBasedNodeNames, &out.UseIPBasedNodeNames
+		*out = new(bool)
+		**out = **in
+	}
 	if in.DisableSecurityGroupIngress != nil {
 		in, out := &in.DisableSecurityGroupIngress, &out.DisableSecurityGroupIngress
 		*out = new(bool)

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -121,6 +121,8 @@ type Config struct {
 	NLBSecurityGroupMode *string `json:"nlbSecurityGroupMode,omitempty"`
 	// NodeIPFamilies controls the IP families reported for each node.
 	NodeIPFamilies []string `json:"nodeIPFamilies,omitempty"`
+	// UseIPBasedNodeNames names the node after the EC2 private DNS name instead of the instance ID.
+	UseIPBasedNodeNames bool `json:"useIPBasedNodeNames,omitempty"`
 	// WarmPoolImages are the container images to pre-pull during instance pre-initialization
 	WarmPoolImages []string `json:"warmPoolImages,omitempty"`
 
@@ -294,6 +296,8 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 			config.NLBSecurityGroupMode = aws.NLBSecurityGroupMode
 			config.NodeIPFamilies = aws.NodeIPFamilies
 		}
+
+		config.UseIPBasedNodeNames = aws.UseIPBasedNodeNames != nil && *aws.UseIPBasedNodeNames
 	}
 
 	if cluster.Spec.CloudProvider.Azure != nil {

--- a/pkg/bootstrap/awsbootstrap/names.go
+++ b/pkg/bootstrap/awsbootstrap/names.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsbootstrap
+
+import "strings"
+
+// PrivateDNSName returns the DNS name that EC2 generates for an IP-named instance from its primary
+// private IPv4 address: ip-a-b-c-d.ec2.internal in us-east-1 and
+// ip-a-b-c-d.<region>.compute.internal in all other regions. With IP-based node names, both nodeup
+// and kops-controller derive the node name with this formula, guaranteeing that the name the node
+// registers with matches the name its certificates are issued for.
+func PrivateDNSName(privateIPv4, region string) string {
+	domain := region + ".compute.internal"
+	if region == "us-east-1" {
+		domain = "ec2.internal"
+	}
+	return "ip-" + strings.ReplaceAll(privateIPv4, ".", "-") + "." + domain
+}

--- a/pkg/bootstrap/awsbootstrap/names_test.go
+++ b/pkg/bootstrap/awsbootstrap/names_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsbootstrap
+
+import "testing"
+
+func TestPrivateDNSName(t *testing.T) {
+	grid := []struct {
+		privateIPv4 string
+		region      string
+		expected    string
+	}{
+		{"10.24.34.0", "us-east-1", "ip-10-24-34-0.ec2.internal"},
+		{"10.24.34.0", "us-west-2", "ip-10-24-34-0.us-west-2.compute.internal"},
+		{"10.99.1.236", "eu-central-1", "ip-10-99-1-236.eu-central-1.compute.internal"},
+		{"10.0.0.1", "us-gov-west-1", "ip-10-0-0-1.us-gov-west-1.compute.internal"},
+		{"172.20.1.2", "cn-north-1", "ip-172-20-1-2.cn-north-1.compute.internal"},
+	}
+	for _, g := range grid {
+		actual := PrivateDNSName(g.privateIPv4, g.region)
+		if actual != g.expected {
+			t.Errorf("PrivateDNSName(%q, %q) = %q, expected %q", g.privateIPv4, g.region, actual, g.expected)
+		}
+	}
+}

--- a/pkg/bootstrap/awsbootstrap/verifier.go
+++ b/pkg/bootstrap/awsbootstrap/verifier.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -52,6 +53,8 @@ type AWSVerifierOptions struct {
 	NodesRoles []string `json:"nodesRoles"`
 	// Region is the AWS region of the cluster.
 	Region string
+	// UseIPBasedNodeNames names nodes after the EC2 private DNS name instead of the instance ID.
+	UseIPBasedNodeNames bool `json:"useIPBasedNodeNames,omitempty"`
 }
 
 type awsVerifier struct {
@@ -331,8 +334,22 @@ func (a awsVerifier) verifyCallerIdentity(ctx context.Context, callerIdentity *G
 		return nil, fmt.Errorf("cannot determine challenge endpoint for instance id: %s", instanceID)
 	}
 
+	nodeName := addrs[0]
+	if a.opt.UseIPBasedNodeNames {
+		// Derive the node name with the same formula nodeup uses, so that the certificates are
+		// issued for the exact name the node registers with, whatever the VPC DNS configuration.
+		privateIPv4 := aws.ToString(instance.PrivateIpAddress)
+		if privateIPv4 == "" {
+			return nil, fmt.Errorf("instance %q has no private IPv4 address", instanceID)
+		}
+		nodeName = PrivateDNSName(privateIPv4, a.opt.Region)
+		if !slices.Contains(addrs, nodeName) {
+			addrs = append(addrs, nodeName)
+		}
+	}
+
 	result := &bootstrap.VerifyResult{
-		NodeName:          addrs[0],
+		NodeName:          nodeName,
 		CertificateNames:  addrs,
 		ChallengeEndpoint: challengeEndpoints[0],
 	}
@@ -470,8 +487,8 @@ func buildSTSRequestValidator(ctx context.Context, stsClient *sts.Client) (*stsR
 	return &stsRequestValidator{Host: u.Host}, nil
 }
 
-// GetInstanceCertificateNames returns the instance hostname and addresses that should go into certificates.
-// The first value is the node name and any additional values are the DNS name and IP addresses.
+// GetInstanceCertificateNames returns the instance names and addresses that should go into
+// certificates: the instance ID, the private DNS name and the IP addresses.
 func GetInstanceCertificateNames(instances *ec2.DescribeInstancesOutput) (addrs []string, err error) {
 	if len(instances.Reservations) != 1 {
 		return nil, fmt.Errorf("too many reservations returned for the single instance-id")

--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -289,7 +289,9 @@ func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		}
 
 		if b.Cluster.Spec.ExternalCloudControllerManager != nil {
-			subnet.ResourceBasedNaming = new(true)
+			// With IP-based node names, instances must get IP-based EC2 hostnames, as the node name
+			// is the EC2 PrivateDnsName.
+			subnet.ResourceBasedNaming = new(!fi.ValueOf(b.Cluster.Spec.CloudProvider.AWS.UseIPBasedNodeNames))
 		}
 
 		if subnetSpec.CIDR != "" {

--- a/tests/integration/conversion/aws/v1alpha2.yaml
+++ b/tests/integration/conversion/aws/v1alpha2.yaml
@@ -34,6 +34,7 @@ spec:
     - ipv6
     spotinstOrientation: spot-orientation
     spotinstProduct: spot-product
+    useIPBasedNodeNames: true
   cloudProvider: aws
   configBase: memfs://clusters.example.com/minimal.example.com
   egressProxy:

--- a/tests/integration/conversion/aws/v1alpha3.yaml
+++ b/tests/integration/conversion/aws/v1alpha3.yaml
@@ -40,6 +40,7 @@ spec:
         replicas: 14
       spotinstOrientation: spot-orientation
       spotinstProduct: spot-product
+      useIPBasedNodeNames: true
       warmPool:
         enableLifecycleHook: true
   configStore:

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -942,8 +942,9 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 				}
 			}
 			config.Server.Provider.AWS = &awsbootstrap.AWSVerifierOptions{
-				NodesRoles: nodesRoles.List(),
-				Region:     tf.Region,
+				NodesRoles:          nodesRoles.List(),
+				Region:              tf.Region,
+				UseIPBasedNodeNames: fi.ValueOf(cluster.Spec.CloudProvider.AWS.UseIPBasedNodeNames),
 			}
 
 		case kops.CloudProviderGCE:

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -163,7 +163,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 		}
 	}
 
-	err = evaluateSpec(&nodeupConfig, bootConfig.CloudProvider)
+	err = evaluateSpec(&nodeupConfig, bootConfig.CloudProvider, region)
 	if err != nil {
 		return err
 	}
@@ -455,8 +455,8 @@ func completeWarmingLifecycleAction(ctx context.Context, cloud *awsup.Cloud, mod
 	return nil
 }
 
-func evaluateSpec(nodeupConfig *nodeup.Config, cloudProvider api.CloudProviderID) error {
-	hostnameOverride, err := evaluateHostnameOverride(cloudProvider)
+func evaluateSpec(nodeupConfig *nodeup.Config, cloudProvider api.CloudProviderID, region string) error {
+	hostnameOverride, err := evaluateHostnameOverride(cloudProvider, nodeupConfig.UseIPBasedNodeNames, region)
 	if err != nil {
 		return err
 	}
@@ -474,15 +474,45 @@ func evaluateSpec(nodeupConfig *nodeup.Config, cloudProvider api.CloudProviderID
 	return nil
 }
 
-func evaluateHostnameOverride(cloudProvider api.CloudProviderID) (string, error) {
+func evaluateHostnameOverride(cloudProvider api.CloudProviderID, useIPBasedNodeNames bool, region string) (string, error) {
 	switch cloudProvider {
 	case api.CloudProviderAWS:
 		instanceIDBytes, err := vfs.Context.ReadFile("metadata://aws/meta-data/instance-id")
 		if err != nil {
 			return "", fmt.Errorf("error reading instance-id from AWS metadata: %v", err)
 		}
+		instanceID := string(instanceIDBytes)
 
-		return string(instanceIDBytes), nil
+		if !useIPBasedNodeNames {
+			return instanceID, nil
+		}
+
+		// The node name is the DNS name that EC2 generates for IP-named instances, built from the
+		// primary private IPv4 address. kops-controller derives it with the same formula when
+		// issuing certificates, so the two always agree. IMDS local-hostname is not usable for
+		// this: with a custom DHCP domain it differs from the generated name.
+		//
+		// An instance launched with a resource-based hostname keeps a resource-based name (it can
+		// only change while the instance is stopped), so an IP-based node name would not match its
+		// EC2 hostname; fail rather than join a misconfigured instance.
+		hostnameBytes, err := vfs.Context.ReadFile("metadata://aws/meta-data/local-hostname")
+		if err != nil {
+			return "", fmt.Errorf("error reading local-hostname from AWS metadata: %v", err)
+		}
+		if strings.HasPrefix(string(hostnameBytes), instanceID) {
+			return "", fmt.Errorf("instance %s was launched with a resource-based hostname; useIPBasedNodeNames requires subnets that assign IP-based hostnames", instanceID)
+		}
+
+		localIPv4Bytes, err := vfs.Context.ReadFile("metadata://aws/meta-data/local-ipv4")
+		if err != nil {
+			return "", fmt.Errorf("error reading local-ipv4 from AWS metadata: %v", err)
+		}
+		localIPv4 := string(localIPv4Bytes)
+		if net.ParseIP(localIPv4).To4() == nil {
+			return "", fmt.Errorf("local-ipv4 from AWS metadata is not a valid IPv4 address: %q", localIPv4)
+		}
+
+		return awsbootstrap.PrivateDNSName(localIPv4, region), nil
 
 	case api.CloudProviderGCE:
 		// This lets us tolerate broken hostnames (i.e. systemd)


### PR DESCRIPTION
Add spec.cloudProvider.aws.useIPBasedNodeNames (v1alpha2: spec.cloudConfig.useIPBasedNodeNames) to name Kubernetes nodes after the EC2 private DNS name instead of the EC2 instance ID, restoring the naming used before kOps 1.24.

When enabled, managed subnets launch instances with IP-based EC2 hostnames. The node name is derived from the primary private IPv4 address using the fixed format of EC2 IP-based hostnames; nodeup builds it from instance metadata and kops-controller derives it with the same formula when issuing certificates, so the two always agree without any extra IAM permissions or bootstrap protocol changes. IMDS local-hostname is not usable for this, as it follows the DHCP options domain rather than the EC2-generated name. nodeup fails fast on instances launched with resource-based hostnames.

IP-based node names are not supported on IPv6-only clusters.

Fixes: #14035

/cc @rifelpet @ameukam 