### PR TITLE
Automated cherry pick of #18631: hetzner: Ignore WellKnownServices when comparing load balancers

### DIFF
--- a/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
@@ -117,10 +117,11 @@ func (v *LoadBalancer) Find(c *fi.CloudupContext) (*LoadBalancer, error) {
 	for _, loadbalancer := range loadbalancers {
 		if loadbalancer.Name == fi.ValueOf(v.Name) {
 			matches := &LoadBalancer{
-				Lifecycle: v.Lifecycle,
-				Name:      new(loadbalancer.Name),
-				ID:        new(loadbalancer.ID),
-				Labels:    loadbalancer.Labels,
+				Lifecycle:         v.Lifecycle,
+				Name:              new(loadbalancer.Name),
+				ID:                new(loadbalancer.ID),
+				Labels:            loadbalancer.Labels,
+				WellKnownServices: v.WellKnownServices,
 			}
 
 			if loadbalancer.Location != nil {


### PR DESCRIPTION
Cherry pick of #18631 on release-1.36.

#18631: hetzner: Ignore WellKnownServices when comparing load balancers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```