### PR TITLE
Enable nri mounting on kindnet in kops

### DIFF
--- a/pkg/model/components/kindnet.go
+++ b/pkg/model/components/kindnet.go
@@ -36,7 +36,7 @@ func (b *KindnetOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.0.0"
+		c.Version = "v1.0.1"
 	}
 
 	if c.Masquerade == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -186,7 +186,7 @@ spec:
       logLevel: 2
       masquerade:
         enabled: false
-      version: v1.0.0
+      version: v1.0.1
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: e3d21154b357215cefc8c183edeaf76fc92095509f8c1c90d4fc5b2e36aac018
+    manifestHash: 7ef53ee7af5d7f1b5daa357ba2d8e1679c1f238147b87ec2e50b39b0296dba44
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: 6bb2eef717e9b77664f55e3029343bb375dba58595c5cbedbff2eaebae108e66
+    manifestHash: e3d21154b357215cefc8c183edeaf76fc92095509f8c1c90d4fc5b2e36aac018
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -123,7 +123,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/networking/kindnet:v1.0.0
+        image: registry.k8s.io/networking/kindnet:v1.0.1
         name: kindnet-cni
         resources:
           requests:
@@ -144,7 +144,7 @@ spec:
         - sh
         - -c
         - cat /opt/cni/bin/cni-kindnet > /cni/cni-kindnet ; chmod +x /cni/cni-kindnet
-        image: registry.k8s.io/networking/kindnet:v1.0.0
+        image: registry.k8s.io/networking/kindnet:v1.0.1
         name: install-cni-bin
         volumeMounts:
         - mountPath: /cni

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -136,6 +136,8 @@ spec:
           name: cni-cfg
         - mountPath: /var/lib/cni-kindnet
           name: var-lib-kindnet
+        - mountPath: /var/run/nri
+          name: nri-plugin
       hostNetwork: true
       initContainers:
       - command:
@@ -164,3 +166,6 @@ spec:
           path: /var/lib/cni-kindnet
           type: DirectoryOrCreate
         name: var-lib-kindnet
+      - hostPath:
+          path: /var/run/nri
+        name: nri-plugin

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -184,7 +184,7 @@ spec:
         - 172.20.0.0/16
         - 100.96.0.0/11
         - 100.64.0.0/13
-      version: v1.0.0
+      version: v1.0.1
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: 8eec5430c6c2d0a29696015bc2679de0bf2f2444f6a6f103ac54f03bdb5a4114
+    manifestHash: b2b86f6ee2ccdce348f919a20a29172f813eb6820831c6a11b66470f8a2833fd
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: b2b86f6ee2ccdce348f919a20a29172f813eb6820831c6a11b66470f8a2833fd
+    manifestHash: 40eafac9d59f831a8522df7cf28341ee40d670ca0d7684220ecc5e409d5e18e1
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -137,6 +137,8 @@ spec:
           name: cni-cfg
         - mountPath: /var/lib/cni-kindnet
           name: var-lib-kindnet
+        - mountPath: /var/run/nri
+          name: nri-plugin
       hostNetwork: true
       initContainers:
       - command:
@@ -165,3 +167,6 @@ spec:
           path: /var/lib/cni-kindnet
           type: DirectoryOrCreate
         name: var-lib-kindnet
+      - hostPath:
+          path: /var/run/nri
+        name: nri-plugin

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -124,7 +124,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/networking/kindnet:v1.0.0
+        image: registry.k8s.io/networking/kindnet:v1.0.1
         name: kindnet-cni
         resources:
           requests:
@@ -145,7 +145,7 @@ spec:
         - sh
         - -c
         - cat /opt/cni/bin/cni-kindnet > /cni/cni-kindnet ; chmod +x /cni/cni-kindnet
-        image: registry.k8s.io/networking/kindnet:v1.0.0
+        image: registry.k8s.io/networking/kindnet:v1.0.1
         name: install-cni-bin
         volumeMounts:
         - mountPath: /cni

--- a/upup/models/cloudup/resources/addons/networking.kindnet/k8s-1.32.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kindnet/k8s-1.32.yaml.template
@@ -149,6 +149,8 @@ spec:
           mountPath: /etc/cni/net.d
         - name: var-lib-kindnet
           mountPath: /var/lib/cni-kindnet
+        - name: nri-plugin
+          mountPath: /var/run/nri
         resources:
           requests:
             cpu: "100m"
@@ -168,6 +170,9 @@ spec:
         hostPath:
           path: /var/lib/cni-kindnet
           type: DirectoryOrCreate
+      - name: nri-plugin
+        hostPath:
+          path: /var/run/nri
 {{- if .Networking.Kindnet.AdminNetworkPolicies }}
 ---
 apiVersion: apiextensions.k8s.io/v1


### PR DESCRIPTION
Kindnet allows for the use of nri to enable fast local insertions of pods rather than waiting on pod informers. Enable by mounting the NRI socket into kindnet.