### PR TITLE
azure: support terraform provider azurerm v5

### DIFF
--- a/tests/integration/update_cluster/gossip-azure/kubernetes.tf
+++ b/tests/integration/update_cluster/gossip-azure/kubernetes.tf
@@ -123,7 +123,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "control-plane-eastus-1-maste
   location  = "eastus"
   name      = "control-plane-eastus-1.masters.gossip.k8s.local"
   network_interface {
-    enable_ip_forwarding = true
     ip_configuration {
       application_security_group_ids         = [azurerm_application_security_group.control-plane-gossip-k8s-local.id]
       load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.api-gossip-k8s-local-backend-pool.id]
@@ -135,8 +134,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "control-plane-eastus-1-maste
       }
       subnet_id = azurerm_subnet.gossip-k8s-local.id
     }
-    name    = "control-plane-eastus-1.masters.gossip.k8s.local"
-    primary = true
+    ip_forwarding_enabled = true
+    name                  = "control-plane-eastus-1.masters.gossip.k8s.local"
+    primary               = true
   }
   os_disk {
     caching              = "ReadWrite"
@@ -177,7 +177,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "nodes-eastus-1-gossip-k8s-lo
   location  = "eastus"
   name      = "nodes-eastus-1.gossip.k8s.local"
   network_interface {
-    enable_ip_forwarding = true
     ip_configuration {
       application_security_group_ids = [azurerm_application_security_group.nodes-gossip-k8s-local.id]
       name                           = "nodes-eastus-1.gossip.k8s.local"
@@ -188,8 +187,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "nodes-eastus-1-gossip-k8s-lo
       }
       subnet_id = azurerm_subnet.gossip-k8s-local.id
     }
-    name    = "nodes-eastus-1.gossip.k8s.local"
-    primary = true
+    ip_forwarding_enabled = true
+    name                  = "nodes-eastus-1.gossip.k8s.local"
+    primary               = true
   }
   os_disk {
     caching              = "ReadWrite"
@@ -493,183 +493,163 @@ resource "azurerm_route_table" "gossip-k8s-local" {
 }
 
 resource "azurerm_storage_blob" "cluster-completed-spec" {
-  name                   = "tests/gossip.k8s.local/cluster-completed.spec"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_cluster-completed.spec_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/cluster-completed.spec"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_cluster-completed.spec_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "etcd-cluster-spec-events" {
-  name                   = "tests/gossip.k8s.local/backups/etcd/events/control/etcd-cluster-spec"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_etcd-cluster-spec-events_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/backups/etcd/events/control/etcd-cluster-spec"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_etcd-cluster-spec-events_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "etcd-cluster-spec-main" {
-  name                   = "tests/gossip.k8s.local/backups/etcd/main/control/etcd-cluster-spec"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_etcd-cluster-spec-main_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/backups/etcd/main/control/etcd-cluster-spec"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_etcd-cluster-spec-main_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-azure-cloud-config-addons-k8s-io-k8s-1-31" {
-  name                   = "tests/gossip.k8s.local/addons/azure-cloud-config.addons.k8s.io/k8s-1.31.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-config.addons.k8s.io-k8s-1.31_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/addons/azure-cloud-config.addons.k8s.io/k8s-1.31.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-config.addons.k8s.io-k8s-1.31_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-azure-cloud-controller-addons-k8s-io-k8s-1-31" {
-  name                   = "tests/gossip.k8s.local/addons/azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/addons/azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-azuredisk-csi-driver-addons-k8s-io-k8s-1-31" {
-  name                   = "tests/gossip.k8s.local/addons/azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/addons/azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-bootstrap" {
-  name                   = "tests/gossip.k8s.local/addons/bootstrap-channel.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/addons/bootstrap-channel.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-bootstrap_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-coredns-addons-k8s-io-k8s-1-12" {
-  name                   = "tests/gossip.k8s.local/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-dns-controller-addons-k8s-io-k8s-1-12" {
-  name                   = "tests/gossip.k8s.local/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-kops-controller-addons-k8s-io-k8s-1-16" {
-  name                   = "tests/gossip.k8s.local/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-kubelet-api-rbac-addons-k8s-io-k8s-1-9" {
-  name                   = "tests/gossip.k8s.local/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-limit-range-addons-k8s-io" {
-  name                   = "tests/gossip.k8s.local/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-limit-range.addons.k8s.io_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-limit-range.addons.k8s.io_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "gossip-k8s-local-addons-storage-azure-addons-k8s-io-k8s-1-31" {
-  name                   = "tests/gossip.k8s.local/addons/storage-azure.addons.k8s.io/k8s-1.31.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-storage-azure.addons.k8s.io-k8s-1.31_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/addons/storage-azure.addons.k8s.io/k8s-1.31.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_gossip.k8s.local-addons-storage-azure.addons.k8s.io-k8s-1.31_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "kops-version-txt" {
-  name                   = "tests/gossip.k8s.local/kops-version.txt"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_kops-version.txt_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/kops-version.txt"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_kops-version.txt_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "manifests-channels-kops-channels" {
-  name                   = "tests/gossip.k8s.local/manifests/channels/kops-channels.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_manifests-channels-kops-channels_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/manifests/channels/kops-channels.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_manifests-channels-kops-channels_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "manifests-etcdmanager-events-control-plane-eastus-1" {
-  name                   = "tests/gossip.k8s.local/manifests/etcd/events-control-plane-eastus-1.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/manifests/etcd/events-control-plane-eastus-1.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "manifests-etcdmanager-main-control-plane-eastus-1" {
-  name                   = "tests/gossip.k8s.local/manifests/etcd/main-control-plane-eastus-1.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/manifests/etcd/main-control-plane-eastus-1.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "manifests-static-kube-apiserver-healthcheck" {
-  name                   = "tests/gossip.k8s.local/manifests/static/kube-apiserver-healthcheck.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_manifests-static-kube-apiserver-healthcheck_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_manifests-static-kube-apiserver-healthcheck_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "nodeupconfig-control-plane-eastus-1" {
-  name                   = "tests/gossip.k8s.local/igconfig/control-plane/control-plane-eastus-1/nodeupconfig.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/igconfig/control-plane/control-plane-eastus-1/nodeupconfig.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "nodeupconfig-nodes-eastus-1" {
-  name                   = "tests/gossip.k8s.local/igconfig/node/nodes-eastus-1/nodeupconfig.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_nodeupconfig-nodes-eastus-1_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/gossip.k8s.local/igconfig/node/nodes-eastus-1/nodeupconfig.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_nodeupconfig-nodes-eastus-1_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_subnet" "gossip-k8s-local" {
@@ -710,7 +690,7 @@ terraform {
     azurerm = {
       "configuration_aliases" = [azurerm.files]
       "source"                = "hashicorp/azurerm"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_azure/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_azure/kubernetes.tf
@@ -123,7 +123,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "control-plane-eastus-1-maste
   location  = "eastus"
   name      = "control-plane-eastus-1.masters.minimal-azure.example.com"
   network_interface {
-    enable_ip_forwarding = true
     ip_configuration {
       application_security_group_ids         = [azurerm_application_security_group.control-plane-minimal-azure-example-com.id]
       load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.api-minimal-azure-example-com-backend-pool.id]
@@ -135,8 +134,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "control-plane-eastus-1-maste
       }
       subnet_id = azurerm_subnet.eastus.id
     }
-    name    = "control-plane-eastus-1.masters.minimal-azure.example.com"
-    primary = true
+    ip_forwarding_enabled = true
+    name                  = "control-plane-eastus-1.masters.minimal-azure.example.com"
+    primary               = true
   }
   os_disk {
     caching              = "ReadWrite"
@@ -177,7 +177,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "nodes-minimal-azure-example-
   location  = "eastus"
   name      = "nodes.minimal-azure.example.com"
   network_interface {
-    enable_ip_forwarding = true
     ip_configuration {
       application_security_group_ids = [azurerm_application_security_group.nodes-minimal-azure-example-com.id]
       name                           = "nodes.minimal-azure.example.com"
@@ -188,8 +187,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "nodes-minimal-azure-example-
       }
       subnet_id = azurerm_subnet.eastus.id
     }
-    name    = "nodes.minimal-azure.example.com"
-    primary = true
+    ip_forwarding_enabled = true
+    name                  = "nodes.minimal-azure.example.com"
+    primary               = true
   }
   os_disk {
     caching              = "ReadWrite"
@@ -493,183 +493,163 @@ resource "azurerm_route_table" "minimal-azure-example-com" {
 }
 
 resource "azurerm_storage_blob" "cluster-completed-spec" {
-  name                   = "tests/minimal-azure.example.com/cluster-completed.spec"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_cluster-completed.spec_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/cluster-completed.spec"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_cluster-completed.spec_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "etcd-cluster-spec-events" {
-  name                   = "tests/minimal-azure.example.com/backups/etcd/events/control/etcd-cluster-spec"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_etcd-cluster-spec-events_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_etcd-cluster-spec-events_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "etcd-cluster-spec-main" {
-  name                   = "tests/minimal-azure.example.com/backups/etcd/main/control/etcd-cluster-spec"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_etcd-cluster-spec-main_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_etcd-cluster-spec-main_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "kops-version-txt" {
-  name                   = "tests/minimal-azure.example.com/kops-version.txt"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_kops-version.txt_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/kops-version.txt"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_kops-version.txt_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "manifests-channels-kops-channels" {
-  name                   = "tests/minimal-azure.example.com/manifests/channels/kops-channels.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_manifests-channels-kops-channels_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/manifests/channels/kops-channels.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_manifests-channels-kops-channels_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "manifests-etcdmanager-events-control-plane-eastus-1" {
-  name                   = "tests/minimal-azure.example.com/manifests/etcd/events-control-plane-eastus-1.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/manifests/etcd/events-control-plane-eastus-1.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_manifests-etcdmanager-events-control-plane-eastus-1_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "manifests-etcdmanager-main-control-plane-eastus-1" {
-  name                   = "tests/minimal-azure.example.com/manifests/etcd/main-control-plane-eastus-1.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/manifests/etcd/main-control-plane-eastus-1.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_manifests-etcdmanager-main-control-plane-eastus-1_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "manifests-static-kube-apiserver-healthcheck" {
-  name                   = "tests/minimal-azure.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_manifests-static-kube-apiserver-healthcheck_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_manifests-static-kube-apiserver-healthcheck_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-azure-cloud-config-addons-k8s-io-k8s-1-31" {
-  name                   = "tests/minimal-azure.example.com/addons/azure-cloud-config.addons.k8s.io/k8s-1.31.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-config.addons.k8s.io-k8s-1.31_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/addons/azure-cloud-config.addons.k8s.io/k8s-1.31.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-config.addons.k8s.io-k8s-1.31_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-azure-cloud-controller-addons-k8s-io-k8s-1-31" {
-  name                   = "tests/minimal-azure.example.com/addons/azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/addons/azure-cloud-controller.addons.k8s.io/k8s-1.31.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-azure-cloud-controller.addons.k8s.io-k8s-1.31_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-azuredisk-csi-driver-addons-k8s-io-k8s-1-31" {
-  name                   = "tests/minimal-azure.example.com/addons/azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/addons/azuredisk-csi-driver.addons.k8s.io/k8s-1.31.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-azuredisk-csi-driver.addons.k8s.io-k8s-1.31_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-bootstrap" {
-  name                   = "tests/minimal-azure.example.com/addons/bootstrap-channel.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/addons/bootstrap-channel.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-bootstrap_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-coredns-addons-k8s-io-k8s-1-12" {
-  name                   = "tests/minimal-azure.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-coredns.addons.k8s.io-k8s-1.12_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-coredns.addons.k8s.io-k8s-1.12_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-dns-controller-addons-k8s-io-k8s-1-12" {
-  name                   = "tests/minimal-azure.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-kops-controller-addons-k8s-io-k8s-1-16" {
-  name                   = "tests/minimal-azure.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-kubelet-api-rbac-addons-k8s-io-k8s-1-9" {
-  name                   = "tests/minimal-azure.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-limit-range-addons-k8s-io" {
-  name                   = "tests/minimal-azure.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-limit-range.addons.k8s.io_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-limit-range.addons.k8s.io_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "minimal-azure-example-com-addons-storage-azure-addons-k8s-io-k8s-1-31" {
-  name                   = "tests/minimal-azure.example.com/addons/storage-azure.addons.k8s.io/k8s-1.31.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-storage-azure.addons.k8s.io-k8s-1.31_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/addons/storage-azure.addons.k8s.io/k8s-1.31.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_minimal-azure.example.com-addons-storage-azure.addons.k8s.io-k8s-1.31_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "nodeupconfig-control-plane-eastus-1" {
-  name                   = "tests/minimal-azure.example.com/igconfig/control-plane/control-plane-eastus-1/nodeupconfig.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/igconfig/control-plane/control-plane-eastus-1/nodeupconfig.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_nodeupconfig-control-plane-eastus-1_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_storage_blob" "nodeupconfig-nodes" {
-  name                   = "tests/minimal-azure.example.com/igconfig/node/nodes/nodeupconfig.yaml"
-  provider               = azurerm.files
-  source                 = "${path.module}/data/azurerm_storage_blob_nodeupconfig-nodes_source"
-  storage_account_name   = "teststorage"
-  storage_container_name = "testcontainer"
-  type                   = "Block"
+  name                 = "tests/minimal-azure.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider             = azurerm.files
+  source               = "${path.module}/data/azurerm_storage_blob_nodeupconfig-nodes_source"
+  storage_container_id = "/subscriptions/sub-321/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/teststorage/blobServices/default/containers/testcontainer"
+  type                 = "Block"
 }
 
 resource "azurerm_subnet" "eastus" {
@@ -710,7 +690,7 @@ terraform {
     azurerm = {
       "configuration_aliases" = [azurerm.files]
       "source"                = "hashicorp/azurerm"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -786,6 +786,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 					args["subscription_id"] = storageAccountID.SubscriptionID
 				}
 			}
+			tf.AzureStorageAccountID = azureSpec.StorageAccountID
 			tf.EnsureTerraformProvider("azurerm", args)
 		}
 

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset_terraform.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset_terraform.go
@@ -59,10 +59,10 @@ type terraformAzureVMScaleSetIPConfiguration struct {
 }
 
 type terraformAzureVMScaleSetNetworkInterface struct {
-	Name               *string                                    `cty:"name"`
-	Primary            *bool                                      `cty:"primary"`
-	EnableIPForwarding *bool                                      `cty:"enable_ip_forwarding"`
-	IPConfiguration    []*terraformAzureVMScaleSetIPConfiguration `cty:"ip_configuration"`
+	Name                *string                                    `cty:"name"`
+	Primary             *bool                                      `cty:"primary"`
+	IPForwardingEnabled *bool                                      `cty:"ip_forwarding_enabled"`
+	IPConfiguration     []*terraformAzureVMScaleSetIPConfiguration `cty:"ip_configuration"`
 }
 
 type terraformAzureVMScaleSetIdentity struct {
@@ -144,9 +144,9 @@ func (*VMScaleSet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *
 	}
 	tf.NetworkInterface = []*terraformAzureVMScaleSetNetworkInterface{
 		{
-			Name:               e.Name,
-			Primary:            new(true),
-			EnableIPForwarding: new(true),
+			Name:                e.Name,
+			Primary:             new(true),
+			IPForwardingEnabled: new(true),
 			IPConfiguration: []*terraformAzureVMScaleSetIPConfiguration{
 				ipConfig,
 			},

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -283,7 +283,7 @@ func (t *TerraformTarget) writeTerraform(buf *bytes.Buffer) {
 			},
 			"azurerm": {
 				"source":  "hashicorp/azurerm",
-				"version": ">= 4.0.0",
+				"version": ">= 5.0.0",
 			},
 		}
 

--- a/upup/pkg/fi/cloudup/terraformWriter/writer.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/writer.go
@@ -40,6 +40,12 @@ type TerraformWriter struct {
 	// Providers is a list of TF Providers we need for writing files
 	Providers map[string]*TerraformProvider
 
+	// AzureStorageAccountID is the Azure Resource Manager ID of the storage
+	// account holding the cluster's state blobs. It is needed to build the
+	// storage_container_id argument of azurerm_storage_blob resources, which
+	// the azurerm provider requires as of v5.0.
+	AzureStorageAccountID string
+
 	// Files is a map of TF resource Files that should be created
 	Files map[string][]byte
 }

--- a/util/pkg/vfs/azureblob_terraform.go
+++ b/util/pkg/vfs/azureblob_terraform.go
@@ -24,12 +24,11 @@ import (
 )
 
 type terraformAzureBlobFile struct {
-	Name                 string                   `cty:"name"`
-	StorageAccountName   string                   `cty:"storage_account_name"`
-	StorageContainerName string                   `cty:"storage_container_name"`
-	Type                 string                   `cty:"type"`
-	Source               *terraformWriter.Literal `cty:"source"`
-	Provider             *terraformWriter.Literal `cty:"provider"`
+	Name               string                   `cty:"name"`
+	StorageContainerID string                   `cty:"storage_container_id"`
+	Type               string                   `cty:"type"`
+	Source             *terraformWriter.Literal `cty:"source"`
+	Provider           *terraformWriter.Literal `cty:"provider"`
 }
 
 func (p *AzureBlobPath) RenderTerraform(w *terraformWriter.TerraformWriter, name string, data io.Reader, acl ACL) error {
@@ -43,6 +42,9 @@ func (p *AzureBlobPath) RenderTerraform(w *terraformWriter.TerraformWriter, name
 	if p.account == "" {
 		return fmt.Errorf("Azure storage account is not set on path %q", p.Path())
 	}
+	if w.AzureStorageAccountID == "" {
+		return fmt.Errorf("Azure storage account ID is not set; it is required to render blob %q", p.Path())
+	}
 
 	source, err := w.AddFilePath("azurerm_storage_blob", name, "source", bytes, false)
 	if err != nil {
@@ -50,12 +52,11 @@ func (p *AzureBlobPath) RenderTerraform(w *terraformWriter.TerraformWriter, name
 	}
 
 	tf := &terraformAzureBlobFile{
-		Name:                 p.key,
-		StorageAccountName:   p.account,
-		StorageContainerName: p.container,
-		Type:                 "Block",
-		Source:               source,
-		Provider:             terraformWriter.LiteralTokens("azurerm", "files"),
+		Name:               p.key,
+		StorageContainerID: w.AzureStorageAccountID + "/blobServices/default/containers/" + p.container,
+		Type:               "Block",
+		Source:             source,
+		Provider:           terraformWriter.LiteralTokens("azurerm", "files"),
 	}
 	return w.RenderResource("azurerm_storage_blob", name, tf)
 }

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -255,14 +255,14 @@ func (p *MemFSPath) renderTerraformAzure(w *terraformWriter.TerraformWriter, nam
 	}
 
 	// memfs:// paths don't encode an Azure account or container, so this
-	// fallback (only used in integration tests) hard-codes test placeholders.
+	// fallback (only used in integration tests) hard-codes a test placeholder
+	// container on the storage account from the cluster spec.
 	tf := &terraformAzureBlobFile{
-		Name:                 p.location,
-		StorageAccountName:   "teststorage",
-		StorageContainerName: "testcontainer",
-		Type:                 "Block",
-		Source:               source,
-		Provider:             terraformWriter.LiteralTokens("azurerm", "files"),
+		Name:               p.location,
+		StorageContainerID: w.AzureStorageAccountID + "/blobServices/default/containers/testcontainer",
+		Type:               "Block",
+		Source:             source,
+		Provider:           terraformWriter.LiteralTokens("azurerm", "files"),
 	}
 	return w.RenderResource("azurerm_storage_blob", name, tf)
 }


### PR DESCRIPTION
The azurerm provider v5.0.0 (released 2026-07-28) removed the `enable_ip_forwarding` argument from `azurerm_linux_virtual_machine_scale_set` (renamed to `ip_forwarding_enabled`) and replaced `storage_account_name` and `storage_container_name` on `azurerm_storage_blob` with a required `storage_container_id`. This broke `terraform validate` for the generated Azure config, as seen in the `pull-kops-verify-terraform` job.

This updates the generated Terraform to the new argument names, builds the storage container ID from the storage account resource ID already present in the cluster spec, and bumps the generated provider version constraint to `>= 5.0.0`. Note that existing clusters will need to upgrade the provider, and the blob resources will show as replacements on the first plan due to the ID-based arguments.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/18623/pull-kops-verify-terraform/2082337742150176768

/cc @rifelpet @ameukam @upodroid 