### PR TITLE
Automated cherry pick of #18641: rolling-update: restore 5s delay between pod eviction retries

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -690,6 +690,9 @@ func (c *RollingUpdateCluster) drainNode(ctx context.Context, u *cloudinstances.
 		ErrOut:              os.Stderr,
 		Timeout:             c.DrainTimeout,
 
+		// The zero value would retry evictions without any delay
+		EvictErrorRetryDelay: 5 * time.Second,
+
 		// We want to proceed even when pods are using emptyDir volumes
 		DeleteEmptyDirData: true,
 	}


### PR DESCRIPTION
Cherry pick of #18641 on release-1.36.

#18641: rolling-update: restore 5s delay between pod eviction retries

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```