### PR TITLE
Automated cherry pick of #18645: etcd-manager: compute kops-utils-cp image at use time

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -246,8 +246,6 @@ spec:
     emptyDir: {}
 `
 
-var kopsUtilsImage = "registry.k8s.io/kops/kops-utils-cp:" + kopsversion.KopsVersionImageTag()
-
 // buildPod creates the pod spec, based on the EtcdClusterSpec
 func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instanceGroupName string) (*v1.Pod, error) {
 	var pod *v1.Pod
@@ -290,6 +288,9 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 			}
 		}
 	} else {
+		// Computed here rather than at process init, because kops.Version can be overridden at
+		// runtime (e.g. from KOPS_BASE_URL).
+		kopsUtilsImage := "registry.k8s.io/kops/kops-utils-cp:" + kopsversion.KopsVersionImageTag()
 		utilMounts := []v1.VolumeMount{
 			{
 				MountPath: "/opt",

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd/assets.yaml
+++ b/tests/integration/update_cluster/containerd/assets.yaml
@@ -54,8 +54,8 @@ images:
   download: registry.k8s.io/kops/dns-controller:1.34.0-beta.1
 - canonical: registry.k8s.io/kops/kops-controller:1.34.0-beta.1
   download: registry.k8s.io/kops/kops-controller:1.34.0-beta.1
-- canonical: registry.k8s.io/kops/kops-utils-cp:1.36.1
-  download: registry.k8s.io/kops/kops-utils-cp:1.36.1
+- canonical: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
+  download: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
 - canonical: registry.k8s.io/kops/kube-apiserver-healthcheck:1.34.0-beta.1
   download: registry.k8s.io/kops/kube-apiserver-healthcheck:1.34.0-beta.1
 - canonical: registry.k8s.io/kube-apiserver:v1.32.0

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -61,7 +61,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -128,7 +128,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -152,7 +152,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.36.1
+    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.36.1
+    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.36.1
+    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.36.1
+    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.36.1
+    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.36.1
+    image: kops.k8s.io/remapped-image/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -57,7 +57,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -124,7 +124,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -148,7 +148,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -58,7 +58,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -125,7 +125,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -149,7 +149,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -58,7 +58,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -125,7 +125,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -149,7 +149,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -60,7 +60,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -127,7 +127,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -151,7 +151,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -60,7 +60,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -127,7 +127,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -151,7 +151,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -59,7 +59,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -126,7 +126,7 @@ spec:
     - --src=/opt/etcd-v3.5.31/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-5-31
     resources: {}
     volumeMounts:
@@ -150,7 +150,7 @@ spec:
     - --src=/opt/etcd-v3.6.12/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.36.1
+    image: registry.k8s.io/kops/kops-utils-cp:1.34.0-beta.1
     name: init-etcd-symlinks-3-6-12
     resources: {}
     volumeMounts:


### PR DESCRIPTION
Cherry pick of #18645 on release-1.36.

#18645: etcd-manager: compute kops-utils-cp image at use time

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```