### PR TITLE
aws: Generate EC2NodeClass block device mapping for root volume

### DIFF
--- a/docs/operations/karpenter.md
+++ b/docs/operations/karpenter.md
@@ -61,6 +61,7 @@ The generated `EC2NodeClass` uses:
 
 * `amiFamily: Custom`
 * the InstanceGroup image translated into `amiSelectorTerms`
+* the InstanceGroup `spec.rootVolume` translated into `blockDeviceMappings`
 * the kOps node instance profile
 * the kOps node security groups
 * the subnets tagged for the InstanceGroup
@@ -109,4 +110,6 @@ Delete the generated NodePool before running `kops update cluster` after adding 
 * Generated `EC2NodeClass` objects use `spec.amiFamily: Custom`.
 * `spec.instanceStorePolicy` configuration is not supported in `EC2NodeClass`.
 * `spec.kubelet` settings that affect Karpenter scheduling (`maxPods`, `systemReserved`, `kubeReserved`) are mapped to `EC2NodeClass.spec.kubelet` so Karpenter computes node allocatable capacity correctly. Other `spec.kubelet` settings are applied via the nodeup bootstrap script but are not surfaced to `EC2NodeClass`.
+* `spec.rootVolume.optimization` has no `EC2NodeClass` equivalent and is ignored on Karpenter-managed InstanceGroups. Modern instance types are EBS-optimized by default.
+* `spec.volumes` and `spec.volumeMounts` (additional, non-root volumes) are not mapped to `EC2NodeClass.spec.blockDeviceMappings`.
 * The Karpenter controller policy grants `iam:PassRole` only for the kOps-managed node role. When a Karpenter-managed InstanceGroup uses a custom `spec.iam.profile`, kOps cannot determine the role inside the custom instance profile, so the policy allows passing any role to EC2 instead.

--- a/pkg/model/components/addonmanifests/karpenter/iam.go
+++ b/pkg/model/components/addonmanifests/karpenter/iam.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/kops/pkg/model/iam"
+	"k8s.io/kops/upup/pkg/fi"
 )
 
 // ServiceAccount represents the service-account used by Karpenter.
@@ -36,14 +37,24 @@ func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, erro
 	// Instance groups with custom IAM instance profiles contain roles with names that kOps
 	// cannot predict.
 	useCustomInstanceProfiles := false
+	// The generated EC2NodeClass block device mapping carries the root volume encryption key, which
+	// Karpenter has to be authorized to use.
+	useCustomerManagedKeys := false
 	for _, ig := range b.AllInstanceGroups {
-		if ig.IsKarpenterManaged() && ig.Spec.IAM != nil && ig.Spec.IAM.Profile != nil {
+		if !ig.IsKarpenterManaged() {
+			continue
+		}
+		if ig.Spec.IAM != nil && ig.Spec.IAM.Profile != nil {
 			useCustomInstanceProfiles = true
-			break
+		}
+		if rootVolume := ig.Spec.RootVolume; rootVolume != nil {
+			if fi.ValueOf(rootVolume.Encryption) && fi.ValueOf(rootVolume.EncryptionKey) != "" {
+				useCustomerManagedKeys = true
+			}
 		}
 	}
 
-	if err := iam.AddKarpenterPermissions(p, useCustomInstanceProfiles); err != nil {
+	if err := iam.AddKarpenterPermissions(p, useCustomInstanceProfiles, useCustomerManagedKeys); err != nil {
 		return nil, err
 	}
 

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -1146,10 +1146,19 @@ func AddClusterAutoscalerPermissions(p *Policy, useStaticInstanceList bool) {
 // Karpenter never creates or mutates instance profiles.
 // useCustomInstanceProfiles indicates that instance groups use custom IAM instance profiles,
 // which contain roles with names that kOps cannot predict.
-func AddKarpenterPermissions(p *Policy, useCustomInstanceProfiles bool) error {
+// useCustomerManagedKeys indicates that instance groups encrypt their root volume with a
+// customer managed KMS key, which Karpenter has to be authorized to use.
+func AddKarpenterPermissions(p *Policy, useCustomInstanceProfiles bool, useCustomerManagedKeys bool) error {
 	ec2Service, err := IAMServiceEC2(p.region)
 	if err != nil {
 		return err
+	}
+
+	// Launching an instance whose root volume is encrypted with a customer managed key requires the
+	// launching principal to be authorized on that key; EC2 makes the KMS calls on Karpenter's
+	// behalf. The key policy also has to allow this role; kOps does not manage the key policy.
+	if useCustomerManagedKeys {
+		addKMSIAMPolicies(p, false)
 	}
 
 	// AllowRegionalReadActions, AllowSSMReadActions, AllowPricingReadActions and

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -403,16 +403,23 @@ func TestAddKarpenterPermissions(t *testing.T) {
 	tests := []struct {
 		name                      string
 		useCustomInstanceProfiles bool
+		useCustomerManagedKeys    bool
 		wantPassRoleResource      string
+		wantKMS                   bool
 	}{
 		{name: "managed instance profiles", useCustomInstanceProfiles: false, wantPassRoleResource: "arn:aws:iam::*:role/nodes.c.example.com"},
 		{name: "custom instance profiles", useCustomInstanceProfiles: true, wantPassRoleResource: "arn:aws:iam::*:role/*"},
+		{name: "customer managed keys", useCustomInstanceProfiles: false, useCustomerManagedKeys: true, wantPassRoleResource: "arn:aws:iam::*:role/nodes.c.example.com", wantKMS: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := NewPolicy("c.example.com", "aws", "us-east-1")
-			if err := AddKarpenterPermissions(p, tc.useCustomInstanceProfiles); err != nil {
+			if err := AddKarpenterPermissions(p, tc.useCustomInstanceProfiles, tc.useCustomerManagedKeys); err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if hasKMS := p.unconditionalAction.Has("kms:CreateGrant"); hasKMS != tc.wantKMS {
+				t.Errorf("expected KMS permissions present=%t, got %t", tc.wantKMS, hasKMS)
 			}
 
 			var passRole *Statement

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
@@ -138,6 +138,24 @@
     },
     {
       "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "ec2.us-test-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "ec2:DescribeCapacityReservations",
         "ec2:DescribeImages",
         "ec2:DescribeInstanceStatus",
@@ -151,6 +169,8 @@
         "ec2:DescribeSubnets",
         "iam:GetInstanceProfile",
         "iam:ListInstanceProfiles",
+        "kms:CreateGrant",
+        "kms:DescribeKey",
         "pricing:GetProducts",
         "ssm:GetParameter"
       ],

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -53,7 +53,7 @@ spec:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: 1a6bac068315662278d536bdf5ad2bafe6f7a74750c65bf27c337015c2af9846
+    manifestHash: d9eefee32298e11308f1a1688de3af60d373acbd0cd2e9e1045eacd1d2927933
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -53,7 +53,7 @@ spec:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: 1a6bac068315662278d536bdf5ad2bafe6f7a74750c65bf27c337015c2af9846
+    manifestHash: bea197f9bcf7b50c619ba9a50a6911611d485ca9bc5f75163045f63220a04d91
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -2999,6 +2999,16 @@ spec:
   - name: images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20220404
     owner: "099720109477"
   associatePublicIPAddress: true
+  blockDeviceMappings:
+  - deviceName: /dev/xvda
+    ebs:
+      deleteOnTermination: true
+      encrypted: true
+      iops: 3000
+      throughput: 125
+      volumeSize: 128Gi
+      volumeType: gp3
+    rootVolume: true
   instanceProfile: nodes.minimal.example.com
   kubelet:
     kubeReserved:
@@ -3229,6 +3239,17 @@ spec:
   - name: images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20220404
     owner: "099720109477"
   associatePublicIPAddress: true
+  blockDeviceMappings:
+  - deviceName: /dev/xvda
+    ebs:
+      deleteOnTermination: true
+      encrypted: true
+      iops: 4000
+      kmsKeyID: arn:aws-test:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
+      throughput: 200
+      volumeSize: 200Gi
+      volumeType: gp3
+    rootVolume: true
   instanceProfile: nodes.minimal.example.com
   securityGroupSelectorTerms:
   - tags:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -2999,6 +2999,16 @@ spec:
   - name: images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20220404
     owner: "099720109477"
   associatePublicIPAddress: true
+  blockDeviceMappings:
+  - deviceName: /dev/xvda
+    ebs:
+      deleteOnTermination: true
+      encrypted: true
+      iops: 3000
+      throughput: 125
+      volumeSize: 128Gi
+      volumeType: gp3
+    rootVolume: true
   instanceProfile: nodes.minimal.example.com
   kubelet:
     kubeReserved:
@@ -3229,6 +3239,17 @@ spec:
   - name: images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20220404
     owner: "099720109477"
   associatePublicIPAddress: true
+  blockDeviceMappings:
+  - deviceName: /dev/xvda
+    ebs:
+      deleteOnTermination: true
+      encrypted: true
+      iops: 4000
+      kmsKeyID: arn:aws:kms:us-test-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab
+      throughput: 200
+      volumeSize: 200Gi
+      volumeType: gp3
+    rootVolume: true
   instanceProfile: nodes.minimal.example.com
   securityGroupSelectorTerms:
   - tags:

--- a/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
@@ -99,6 +99,12 @@ spec:
   minSize: 2
   maxSize: 10
   role: Node
+  rootVolumeSize: 200
+  rootVolumeType: gp3
+  rootVolumeIops: 4000
+  rootVolumeThroughput: 200
+  rootVolumeEncryption: true
+  rootVolumeEncryptionKey: arn:aws-test:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
   subnets:
   - us-test-1a
 

--- a/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
@@ -99,6 +99,12 @@ spec:
   minSize: 2
   maxSize: 10
   role: Node
+  rootVolumeSize: 200
+  rootVolumeType: gp3
+  rootVolumeIops: 4000
+  rootVolumeThroughput: 200
+  rootVolumeEncryption: true
+  rootVolumeEncryptionKey: arn:aws:kms:us-test-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab
   subnets:
   - us-test-1a
 

--- a/upup/pkg/fi/cloudup/template_functions_karpenter.go
+++ b/upup/pkg/fi/cloudup/template_functions_karpenter.go
@@ -22,8 +22,12 @@ import (
 	"strconv"
 	"strings"
 
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
 	"k8s.io/kops/pkg/apis/kops"
 	kopsutil "k8s.io/kops/pkg/apis/kops/util"
+	"k8s.io/kops/pkg/model/awsmodel"
+	"k8s.io/kops/pkg/model/defaults"
 	"k8s.io/kops/pkg/nodelabels"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -53,6 +57,7 @@ type karpenterEC2NodeClassSpec struct {
 	AMIFamily                string                         `json:"amiFamily"`
 	AMISelectorTerms         []karpenterAMITerm             `json:"amiSelectorTerms"`
 	AssociatePublicIPAddress *bool                          `json:"associatePublicIPAddress,omitempty"`
+	BlockDeviceMappings      []karpenterBlockDeviceMapping  `json:"blockDeviceMappings,omitempty"`
 	Tags                     map[string]string              `json:"tags,omitempty"`
 	SubnetSelectorTerms      []karpenterSelectorTerm        `json:"subnetSelectorTerms"`
 	SecurityGroupTerms       []karpenterSelectorTerm        `json:"securityGroupSelectorTerms"`
@@ -68,6 +73,28 @@ type karpenterKubeletConfiguration struct {
 	MaxPods        *int32            `json:"maxPods,omitempty"`
 	SystemReserved map[string]string `json:"systemReserved,omitempty"`
 	KubeReserved   map[string]string `json:"kubeReserved,omitempty"`
+}
+
+// karpenterBlockDeviceMapping maps to EC2NodeClass.spec.blockDeviceMappings[]. kOps
+// emits exactly one mapping, for the root volume, built from the InstanceGroup's
+// spec.rootVolume with the same defaults the ASG launch template applies.
+type karpenterBlockDeviceMapping struct {
+	DeviceName string                   `json:"deviceName,omitempty"`
+	EBS        *karpenterBlockDeviceEBS `json:"ebs,omitempty"`
+	// RootVolume tells Karpenter which mapping backs the kubelet root dir. With
+	// amiFamily: Custom Karpenter cannot infer it, and without the flag it computes
+	// node ephemeral-storage capacity from its own default rather than this volume.
+	RootVolume *bool `json:"rootVolume,omitempty"`
+}
+
+type karpenterBlockDeviceEBS struct {
+	DeleteOnTermination *bool   `json:"deleteOnTermination,omitempty"`
+	Encrypted           *bool   `json:"encrypted,omitempty"`
+	IOPS                *int64  `json:"iops,omitempty"`
+	KMSKeyID            *string `json:"kmsKeyID,omitempty"`
+	Throughput          *int64  `json:"throughput,omitempty"`
+	VolumeSize          string  `json:"volumeSize,omitempty"`
+	VolumeType          string  `json:"volumeType,omitempty"`
 }
 
 type karpenterAMITerm struct {
@@ -200,6 +227,14 @@ func (tf *TemplateFunctions) buildKarpenterEC2NodeClass(ig *kops.InstanceGroup) 
 	if err != nil {
 		return nil, fmt.Errorf("reading userData for %q: %w", ig.Name, err)
 	}
+	rootDeviceName, err := tf.karpenterRootDeviceName(ig.Spec.Image)
+	if err != nil {
+		return nil, fmt.Errorf("resolving root device for %q: %w", ig.Name, err)
+	}
+	blockDeviceMappings, err := buildKarpenterBlockDeviceMappings(ig, rootDeviceName)
+	if err != nil {
+		return nil, fmt.Errorf("building blockDeviceMappings for %q: %w", ig.Name, err)
+	}
 
 	subnetTerms := []karpenterSelectorTerm{
 		{
@@ -235,6 +270,7 @@ func (tf *TemplateFunctions) buildKarpenterEC2NodeClass(ig *kops.InstanceGroup) 
 			AMIFamily:                "Custom",
 			AMISelectorTerms:         amiSelectorTerms,
 			AssociatePublicIPAddress: associatePublicIP,
+			BlockDeviceMappings:      blockDeviceMappings,
 			Tags:                     tags,
 			SubnetSelectorTerms:      subnetTerms,
 			SecurityGroupTerms:       securityGroupTerms,
@@ -258,6 +294,103 @@ func buildKarpenterKubeletConfiguration(ig *kops.InstanceGroup) *karpenterKubele
 		return nil
 	}
 	return kubelet
+}
+
+func buildKarpenterBlockDeviceMappings(ig *kops.InstanceGroup, rootDeviceName string) ([]karpenterBlockDeviceMapping, error) {
+	volumeSize, err := defaults.DefaultInstanceGroupVolumeSize(ig.Spec.Role)
+	if err != nil {
+		return nil, err
+	}
+	var volumeType ec2types.VolumeType
+	deleteOnTermination := awsmodel.DefaultVolumeDeleteOnTermination
+	encryption := awsmodel.DefaultVolumeEncryption
+	var encryptionKey *string
+	var iops, throughput *int32
+
+	if rootVolume := ig.Spec.RootVolume; rootVolume != nil {
+		if fi.ValueOf(rootVolume.Size) > 0 {
+			volumeSize = fi.ValueOf(rootVolume.Size)
+		}
+		volumeType = ec2types.VolumeType(fi.ValueOf(rootVolume.Type))
+		if rootVolume.Encryption != nil {
+			encryption = fi.ValueOf(rootVolume.Encryption)
+		}
+		// As in the ASG path, the key is only honoured when encryption is set explicitly, not when
+		// it is merely defaulted to true, and an empty key is dropped rather than sent to EC2.
+		if fi.ValueOf(rootVolume.Encryption) && fi.ValueOf(rootVolume.EncryptionKey) != "" {
+			encryptionKey = rootVolume.EncryptionKey
+		}
+		iops = rootVolume.IOPS
+		throughput = rootVolume.Throughput
+	}
+	if volumeType == "" {
+		volumeType = awsmodel.DefaultVolumeType
+	}
+
+	// IOPS and throughput are only meaningful for some volume types, and each has a
+	// minimum below which EC2 rejects the request.
+	switch volumeType {
+	case ec2types.VolumeTypeIo1, ec2types.VolumeTypeIo2:
+		if fi.ValueOf(iops) < awsmodel.DefaultVolumeIonIops {
+			iops = new(int32(awsmodel.DefaultVolumeIonIops))
+		}
+		throughput = nil
+	case ec2types.VolumeTypeGp3:
+		if fi.ValueOf(iops) < awsmodel.DefaultVolumeGp3Iops {
+			iops = new(int32(awsmodel.DefaultVolumeGp3Iops))
+		}
+		if fi.ValueOf(throughput) < awsmodel.DefaultVolumeGp3Throughput {
+			throughput = new(int32(awsmodel.DefaultVolumeGp3Throughput))
+		}
+	default:
+		iops = nil
+		throughput = nil
+	}
+
+	ebs := &karpenterBlockDeviceEBS{
+		DeleteOnTermination: new(deleteOnTermination),
+		Encrypted:           new(encryption),
+		KMSKeyID:            encryptionKey,
+		VolumeSize:          fmt.Sprintf("%dGi", volumeSize),
+		VolumeType:          string(volumeType),
+	}
+	if iops != nil {
+		ebs.IOPS = new(int64(fi.ValueOf(iops)))
+	}
+	if throughput != nil {
+		ebs.Throughput = new(int64(fi.ValueOf(throughput)))
+	}
+
+	return []karpenterBlockDeviceMapping{
+		{
+			DeviceName: rootDeviceName,
+			EBS:        ebs,
+			RootVolume: new(true),
+		},
+	}, nil
+}
+
+// karpenterRootDeviceName resolves the root device name of the InstanceGroup image, so
+// that the generated block device mapping overrides the image's root volume rather than
+// attaching an additional one. The name varies between images (/dev/xvda, /dev/sda1),
+// so it has to come from the image itself.
+func (tf *TemplateFunctions) karpenterRootDeviceName(image string) (string, error) {
+	cloud, ok := tf.cloud.(awsup.AWSCloud)
+	if !ok {
+		return "", fmt.Errorf("expected an AWS cloud, got %T", tf.cloud)
+	}
+	resolved, err := cloud.ResolveImage(image)
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve image %q: %w", image, err)
+	}
+	if resolved == nil {
+		return "", fmt.Errorf("unable to resolve image %q: not found", image)
+	}
+	rootDeviceName := fi.ValueOf(resolved.RootDeviceName)
+	if rootDeviceName == "" {
+		return "", fmt.Errorf("image %q has no root device name", image)
+	}
+	return rootDeviceName, nil
 }
 
 func (tf *TemplateFunctions) buildKarpenterNodePool(ig *kops.InstanceGroup) (*karpenterNodePool, error) {

--- a/upup/pkg/fi/cloudup/template_functions_karpenter.go
+++ b/upup/pkg/fi/cloudup/template_functions_karpenter.go
@@ -22,8 +22,12 @@ import (
 	"strconv"
 	"strings"
 
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
 	"k8s.io/kops/pkg/apis/kops"
 	kopsutil "k8s.io/kops/pkg/apis/kops/util"
+	"k8s.io/kops/pkg/model/awsmodel"
+	"k8s.io/kops/pkg/model/defaults"
 	"k8s.io/kops/pkg/nodelabels"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -53,6 +57,7 @@ type karpenterEC2NodeClassSpec struct {
 	AMIFamily                string                         `json:"amiFamily"`
 	AMISelectorTerms         []karpenterAMITerm             `json:"amiSelectorTerms"`
 	AssociatePublicIPAddress *bool                          `json:"associatePublicIPAddress,omitempty"`
+	BlockDeviceMappings      []karpenterBlockDeviceMapping  `json:"blockDeviceMappings,omitempty"`
 	Tags                     map[string]string              `json:"tags,omitempty"`
 	SubnetSelectorTerms      []karpenterSelectorTerm        `json:"subnetSelectorTerms"`
 	SecurityGroupTerms       []karpenterSelectorTerm        `json:"securityGroupSelectorTerms"`
@@ -68,6 +73,28 @@ type karpenterKubeletConfiguration struct {
 	MaxPods        *int32            `json:"maxPods,omitempty"`
 	SystemReserved map[string]string `json:"systemReserved,omitempty"`
 	KubeReserved   map[string]string `json:"kubeReserved,omitempty"`
+}
+
+// karpenterBlockDeviceMapping maps to EC2NodeClass.spec.blockDeviceMappings[]. kOps
+// emits exactly one mapping, for the root volume, built from the InstanceGroup's
+// spec.rootVolume with the same defaults the ASG launch template applies.
+type karpenterBlockDeviceMapping struct {
+	DeviceName string                   `json:"deviceName,omitempty"`
+	EBS        *karpenterBlockDeviceEBS `json:"ebs,omitempty"`
+	// RootVolume tells Karpenter which mapping backs the kubelet root dir. With
+	// amiFamily: Custom Karpenter cannot infer it, and without the flag it computes
+	// node ephemeral-storage capacity from its own default rather than this volume.
+	RootVolume *bool `json:"rootVolume,omitempty"`
+}
+
+type karpenterBlockDeviceEBS struct {
+	DeleteOnTermination *bool   `json:"deleteOnTermination,omitempty"`
+	Encrypted           *bool   `json:"encrypted,omitempty"`
+	IOPS                *int64  `json:"iops,omitempty"`
+	KMSKeyID            *string `json:"kmsKeyID,omitempty"`
+	Throughput          *int64  `json:"throughput,omitempty"`
+	VolumeSize          string  `json:"volumeSize,omitempty"`
+	VolumeType          string  `json:"volumeType,omitempty"`
 }
 
 type karpenterAMITerm struct {
@@ -200,6 +227,14 @@ func (tf *TemplateFunctions) buildKarpenterEC2NodeClass(ig *kops.InstanceGroup) 
 	if err != nil {
 		return nil, fmt.Errorf("reading userData for %q: %w", ig.Name, err)
 	}
+	rootDeviceName, err := tf.karpenterRootDeviceName(ig.Spec.Image)
+	if err != nil {
+		return nil, fmt.Errorf("resolving root device for %q: %w", ig.Name, err)
+	}
+	blockDeviceMappings, err := buildKarpenterBlockDeviceMappings(ig, rootDeviceName)
+	if err != nil {
+		return nil, fmt.Errorf("building blockDeviceMappings for %q: %w", ig.Name, err)
+	}
 
 	subnetTerms := []karpenterSelectorTerm{
 		{
@@ -235,6 +270,7 @@ func (tf *TemplateFunctions) buildKarpenterEC2NodeClass(ig *kops.InstanceGroup) 
 			AMIFamily:                "Custom",
 			AMISelectorTerms:         amiSelectorTerms,
 			AssociatePublicIPAddress: associatePublicIP,
+			BlockDeviceMappings:      blockDeviceMappings,
 			Tags:                     tags,
 			SubnetSelectorTerms:      subnetTerms,
 			SecurityGroupTerms:       securityGroupTerms,
@@ -258,6 +294,103 @@ func buildKarpenterKubeletConfiguration(ig *kops.InstanceGroup) *karpenterKubele
 		return nil
 	}
 	return kubelet
+}
+
+func buildKarpenterBlockDeviceMappings(ig *kops.InstanceGroup, rootDeviceName string) ([]karpenterBlockDeviceMapping, error) {
+	volumeSize, err := defaults.DefaultInstanceGroupVolumeSize(ig.Spec.Role)
+	if err != nil {
+		return nil, err
+	}
+	var volumeType ec2types.VolumeType
+	deleteOnTermination := awsmodel.DefaultVolumeDeleteOnTermination
+	encryption := awsmodel.DefaultVolumeEncryption
+	var encryptionKey *string
+	var iops, throughput *int32
+
+	if rootVolume := ig.Spec.RootVolume; rootVolume != nil {
+		if fi.ValueOf(rootVolume.Size) > 0 {
+			volumeSize = fi.ValueOf(rootVolume.Size)
+		}
+		volumeType = ec2types.VolumeType(fi.ValueOf(rootVolume.Type))
+		if rootVolume.Encryption != nil {
+			encryption = fi.ValueOf(rootVolume.Encryption)
+		}
+		// As in the ASG path, the key is only honoured when encryption is set
+		// explicitly, not when it is merely defaulted to true.
+		if fi.ValueOf(rootVolume.Encryption) && rootVolume.EncryptionKey != nil {
+			encryptionKey = rootVolume.EncryptionKey
+		}
+		iops = rootVolume.IOPS
+		throughput = rootVolume.Throughput
+	}
+	if volumeType == "" {
+		volumeType = awsmodel.DefaultVolumeType
+	}
+
+	// IOPS and throughput are only meaningful for some volume types, and each has a
+	// minimum below which EC2 rejects the request.
+	switch volumeType {
+	case ec2types.VolumeTypeIo1, ec2types.VolumeTypeIo2:
+		if fi.ValueOf(iops) < awsmodel.DefaultVolumeIonIops {
+			iops = new(int32(awsmodel.DefaultVolumeIonIops))
+		}
+		throughput = nil
+	case ec2types.VolumeTypeGp3:
+		if fi.ValueOf(iops) < awsmodel.DefaultVolumeGp3Iops {
+			iops = new(int32(awsmodel.DefaultVolumeGp3Iops))
+		}
+		if fi.ValueOf(throughput) < awsmodel.DefaultVolumeGp3Throughput {
+			throughput = new(int32(awsmodel.DefaultVolumeGp3Throughput))
+		}
+	default:
+		iops = nil
+		throughput = nil
+	}
+
+	ebs := &karpenterBlockDeviceEBS{
+		DeleteOnTermination: new(deleteOnTermination),
+		Encrypted:           new(encryption),
+		KMSKeyID:            encryptionKey,
+		VolumeSize:          fmt.Sprintf("%dGi", volumeSize),
+		VolumeType:          string(volumeType),
+	}
+	if iops != nil {
+		ebs.IOPS = new(int64(fi.ValueOf(iops)))
+	}
+	if throughput != nil {
+		ebs.Throughput = new(int64(fi.ValueOf(throughput)))
+	}
+
+	return []karpenterBlockDeviceMapping{
+		{
+			DeviceName: rootDeviceName,
+			EBS:        ebs,
+			RootVolume: new(true),
+		},
+	}, nil
+}
+
+// karpenterRootDeviceName resolves the root device name of the InstanceGroup image, so
+// that the generated block device mapping overrides the image's root volume rather than
+// attaching an additional one. The name varies between images (/dev/xvda, /dev/sda1),
+// so it has to come from the image itself.
+func (tf *TemplateFunctions) karpenterRootDeviceName(image string) (string, error) {
+	cloud, ok := tf.cloud.(awsup.AWSCloud)
+	if !ok {
+		return "", fmt.Errorf("expected an AWS cloud, got %T", tf.cloud)
+	}
+	resolved, err := cloud.ResolveImage(image)
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve image %q: %w", image, err)
+	}
+	if resolved == nil {
+		return "", fmt.Errorf("unable to resolve image %q: not found", image)
+	}
+	rootDeviceName := fi.ValueOf(resolved.RootDeviceName)
+	if rootDeviceName == "" {
+		return "", fmt.Errorf("image %q has no root device name", image)
+	}
+	return rootDeviceName, nil
 }
 
 func (tf *TemplateFunctions) buildKarpenterNodePool(ig *kops.InstanceGroup) (*karpenterNodePool, error) {

--- a/upup/pkg/fi/cloudup/template_functions_karpenter_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_karpenter_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 )
@@ -293,6 +295,189 @@ func TestBuildKarpenterKubeletConfiguration(t *testing.T) {
 				t.Errorf("expected %#v, got %#v", g.expected, actual)
 			}
 		})
+	}
+}
+
+func TestBuildKarpenterBlockDeviceMappings(t *testing.T) {
+	// rootEBS returns the defaults every case starts from, so that each case below
+	// only has to state what it changes.
+	rootEBS := func(mutators ...func(*karpenterBlockDeviceEBS)) *karpenterBlockDeviceEBS {
+		ebs := &karpenterBlockDeviceEBS{
+			DeleteOnTermination: new(true),
+			Encrypted:           new(true),
+			IOPS:                new(int64(3000)),
+			Throughput:          new(int64(125)),
+			VolumeSize:          "128Gi",
+			VolumeType:          "gp3",
+		}
+		for _, mutate := range mutators {
+			mutate(ebs)
+		}
+		return ebs
+	}
+
+	grid := []struct {
+		desc        string
+		role        kops.InstanceGroupRole
+		rootVolume  *kops.InstanceRootVolumeSpec
+		expected    *karpenterBlockDeviceEBS
+		expectError bool
+	}{
+		{
+			desc:     "no rootVolume uses the kOps defaults",
+			expected: rootEBS(),
+		},
+		{
+			desc:       "empty rootVolume uses the kOps defaults",
+			rootVolume: &kops.InstanceRootVolumeSpec{},
+			expected:   rootEBS(),
+		},
+		{
+			desc:       "explicit size",
+			rootVolume: &kops.InstanceRootVolumeSpec{Size: new(int32(200))},
+			expected:   rootEBS(func(e *karpenterBlockDeviceEBS) { e.VolumeSize = "200Gi" }),
+		},
+		{
+			desc:       "zero size falls back to the role default",
+			rootVolume: &kops.InstanceRootVolumeSpec{Size: new(int32(0))},
+			expected:   rootEBS(),
+		},
+		{
+			desc:     "control plane role default size",
+			role:     kops.InstanceGroupRoleControlPlane,
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) { e.VolumeSize = "64Gi" }),
+		},
+		{
+			desc:       "gp2 drops iops and throughput",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("gp2"), IOPS: new(int32(4000)), Throughput: new(int32(200))},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.VolumeType = "gp2"
+				e.IOPS = nil
+				e.Throughput = nil
+			}),
+		},
+		{
+			desc:       "standard drops iops and throughput",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("standard")},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.VolumeType = "standard"
+				e.IOPS = nil
+				e.Throughput = nil
+			}),
+		},
+		{
+			desc:       "io2 below the iops floor is raised",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("io2"), IOPS: new(int32(50))},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.VolumeType = "io2"
+				e.IOPS = new(int64(100))
+				e.Throughput = nil
+			}),
+		},
+		{
+			desc:       "io1 above the iops floor is kept",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("io1"), IOPS: new(int32(5000)), Throughput: new(int32(200))},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.VolumeType = "io1"
+				e.IOPS = new(int64(5000))
+				e.Throughput = nil
+			}),
+		},
+		{
+			desc:       "gp3 below the floors is raised",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("gp3"), IOPS: new(int32(100)), Throughput: new(int32(50))},
+			expected:   rootEBS(),
+		},
+		{
+			desc:       "gp3 above the floors is kept",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("gp3"), IOPS: new(int32(6000)), Throughput: new(int32(250))},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.IOPS = new(int64(6000))
+				e.Throughput = new(int64(250))
+			}),
+		},
+		{
+			desc: "encryption disabled drops the key",
+			rootVolume: &kops.InstanceRootVolumeSpec{
+				Encryption:    new(false),
+				EncryptionKey: new("arn:aws:kms:us-test-1:123456789012:key/test"),
+			},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) { e.Encrypted = new(false) }),
+		},
+		{
+			desc: "encryption enabled keeps the key",
+			rootVolume: &kops.InstanceRootVolumeSpec{
+				Encryption:    new(true),
+				EncryptionKey: new("arn:aws:kms:us-test-1:123456789012:key/test"),
+			},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.KMSKeyID = new("arn:aws:kms:us-test-1:123456789012:key/test")
+			}),
+		},
+		{
+			// Matches the ASG launch template path, which only honours the key when
+			// encryption is set explicitly rather than defaulted.
+			desc:       "encryption key without explicit encryption is ignored",
+			rootVolume: &kops.InstanceRootVolumeSpec{EncryptionKey: new("arn:aws:kms:us-test-1:123456789012:key/test")},
+			expected:   rootEBS(),
+		},
+		{
+			// The Karpenter IAM policy grants KMS access on the same condition, so an
+			// empty key must be dropped here rather than emitted as kmsKeyID: "".
+			desc: "empty encryption key is dropped",
+			rootVolume: &kops.InstanceRootVolumeSpec{
+				Encryption:    new(true),
+				EncryptionKey: new(""),
+			},
+			expected: rootEBS(),
+		},
+		{
+			desc:        "unknown role",
+			role:        kops.InstanceGroupRole("Bogus"),
+			expectError: true,
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.desc, func(t *testing.T) {
+			role := g.role
+			if role == "" {
+				role = kops.InstanceGroupRoleNode
+			}
+			ig := &kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					Role:       role,
+					RootVolume: g.rootVolume,
+				},
+			}
+			actual, err := buildKarpenterBlockDeviceMappings(ig, "/dev/xvda")
+			if g.expectError {
+				if err == nil {
+					t.Fatalf("expected an error, got %#v", actual)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			expected := []karpenterBlockDeviceMapping{
+				{
+					DeviceName: "/dev/xvda",
+					EBS:        g.expected,
+					RootVolume: new(true),
+				},
+			}
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("unexpected blockDeviceMappings, diff=%v", diff)
+			}
+		})
+	}
+}
+
+func TestKarpenterRootDeviceNameWithoutAWSCloud(t *testing.T) {
+	tf := &TemplateFunctions{}
+	if _, err := tf.karpenterRootDeviceName("ami-12345678"); err == nil {
+		t.Errorf("expected an error when the cloud is not an AWS cloud")
 	}
 }
 

--- a/upup/pkg/fi/cloudup/template_functions_karpenter_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_karpenter_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 )
@@ -293,6 +295,179 @@ func TestBuildKarpenterKubeletConfiguration(t *testing.T) {
 				t.Errorf("expected %#v, got %#v", g.expected, actual)
 			}
 		})
+	}
+}
+
+func TestBuildKarpenterBlockDeviceMappings(t *testing.T) {
+	// rootEBS returns the defaults every case starts from, so that each case below
+	// only has to state what it changes.
+	rootEBS := func(mutators ...func(*karpenterBlockDeviceEBS)) *karpenterBlockDeviceEBS {
+		ebs := &karpenterBlockDeviceEBS{
+			DeleteOnTermination: new(true),
+			Encrypted:           new(true),
+			IOPS:                new(int64(3000)),
+			Throughput:          new(int64(125)),
+			VolumeSize:          "128Gi",
+			VolumeType:          "gp3",
+		}
+		for _, mutate := range mutators {
+			mutate(ebs)
+		}
+		return ebs
+	}
+
+	grid := []struct {
+		desc        string
+		role        kops.InstanceGroupRole
+		rootVolume  *kops.InstanceRootVolumeSpec
+		expected    *karpenterBlockDeviceEBS
+		expectError bool
+	}{
+		{
+			desc:     "no rootVolume uses the kOps defaults",
+			expected: rootEBS(),
+		},
+		{
+			desc:       "empty rootVolume uses the kOps defaults",
+			rootVolume: &kops.InstanceRootVolumeSpec{},
+			expected:   rootEBS(),
+		},
+		{
+			desc:       "explicit size",
+			rootVolume: &kops.InstanceRootVolumeSpec{Size: new(int32(200))},
+			expected:   rootEBS(func(e *karpenterBlockDeviceEBS) { e.VolumeSize = "200Gi" }),
+		},
+		{
+			desc:       "zero size falls back to the role default",
+			rootVolume: &kops.InstanceRootVolumeSpec{Size: new(int32(0))},
+			expected:   rootEBS(),
+		},
+		{
+			desc:     "control plane role default size",
+			role:     kops.InstanceGroupRoleControlPlane,
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) { e.VolumeSize = "64Gi" }),
+		},
+		{
+			desc:       "gp2 drops iops and throughput",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("gp2"), IOPS: new(int32(4000)), Throughput: new(int32(200))},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.VolumeType = "gp2"
+				e.IOPS = nil
+				e.Throughput = nil
+			}),
+		},
+		{
+			desc:       "standard drops iops and throughput",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("standard")},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.VolumeType = "standard"
+				e.IOPS = nil
+				e.Throughput = nil
+			}),
+		},
+		{
+			desc:       "io2 below the iops floor is raised",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("io2"), IOPS: new(int32(50))},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.VolumeType = "io2"
+				e.IOPS = new(int64(100))
+				e.Throughput = nil
+			}),
+		},
+		{
+			desc:       "io1 above the iops floor is kept",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("io1"), IOPS: new(int32(5000)), Throughput: new(int32(200))},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.VolumeType = "io1"
+				e.IOPS = new(int64(5000))
+				e.Throughput = nil
+			}),
+		},
+		{
+			desc:       "gp3 below the floors is raised",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("gp3"), IOPS: new(int32(100)), Throughput: new(int32(50))},
+			expected:   rootEBS(),
+		},
+		{
+			desc:       "gp3 above the floors is kept",
+			rootVolume: &kops.InstanceRootVolumeSpec{Type: new("gp3"), IOPS: new(int32(6000)), Throughput: new(int32(250))},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.IOPS = new(int64(6000))
+				e.Throughput = new(int64(250))
+			}),
+		},
+		{
+			desc: "encryption disabled drops the key",
+			rootVolume: &kops.InstanceRootVolumeSpec{
+				Encryption:    new(false),
+				EncryptionKey: new("arn:aws:kms:us-test-1:123456789012:key/test"),
+			},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) { e.Encrypted = new(false) }),
+		},
+		{
+			desc: "encryption enabled keeps the key",
+			rootVolume: &kops.InstanceRootVolumeSpec{
+				Encryption:    new(true),
+				EncryptionKey: new("arn:aws:kms:us-test-1:123456789012:key/test"),
+			},
+			expected: rootEBS(func(e *karpenterBlockDeviceEBS) {
+				e.KMSKeyID = new("arn:aws:kms:us-test-1:123456789012:key/test")
+			}),
+		},
+		{
+			// Matches the ASG launch template path, which only honours the key when
+			// encryption is set explicitly rather than defaulted.
+			desc:       "encryption key without explicit encryption is ignored",
+			rootVolume: &kops.InstanceRootVolumeSpec{EncryptionKey: new("arn:aws:kms:us-test-1:123456789012:key/test")},
+			expected:   rootEBS(),
+		},
+		{
+			desc:        "unknown role",
+			role:        kops.InstanceGroupRole("Bogus"),
+			expectError: true,
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.desc, func(t *testing.T) {
+			role := g.role
+			if role == "" {
+				role = kops.InstanceGroupRoleNode
+			}
+			ig := &kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					Role:       role,
+					RootVolume: g.rootVolume,
+				},
+			}
+			actual, err := buildKarpenterBlockDeviceMappings(ig, "/dev/xvda")
+			if g.expectError {
+				if err == nil {
+					t.Fatalf("expected an error, got %#v", actual)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			expected := []karpenterBlockDeviceMapping{
+				{
+					DeviceName: "/dev/xvda",
+					EBS:        g.expected,
+					RootVolume: new(true),
+				},
+			}
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("unexpected blockDeviceMappings, diff=%v", diff)
+			}
+		})
+	}
+}
+
+func TestKarpenterRootDeviceNameWithoutAWSCloud(t *testing.T) {
+	tf := &TemplateFunctions{}
+	if _, err := tf.karpenterRootDeviceName("ami-12345678"); err == nil {
+		t.Errorf("expected an error when the cloud is not an AWS cloud")
 	}
 }
 


### PR DESCRIPTION
Currently, the Karpenter add-on ignores instance group root volume configurations, resulting in EC2 instances spinning up with whatever the AMI default root volume is - this fixes that.

Potential follow up, as noted in docs update: handle instance group `spec.volumes` and `spec.volumeMounts`.