### PR TITLE
fix(channels): only treat known ready conditions as health signals

### DIFF
--- a/pkg/applylib/applyset/health.go
+++ b/pkg/applylib/applyset/health.go
@@ -45,8 +45,26 @@ var readyConditionTypes = sets.New(
 	"Ready",           // Pod, Node, and the convention for custom resources
 )
 
-// isHealthy reports whether the object should be considered "healthy"
-// TODO: Replace with kstatus library
+// readyConditionTypesByGroupKind lists additional readiness conditions that only carry their
+// meaning for a specific kind, and would be ambiguous if applied to every object. They are
+// honoured on top of readyConditionTypes for that kind alone.
+var readyConditionTypesByGroupKind = map[schema.GroupKind]sets.Set[string]{
+	// A Deployment reports "Progressing" as "False" when it gave up on a rollout, typically
+	// with reason ProgressDeadlineExceeded. That can happen while the previous replica set
+	// still serves traffic, so "Available" alone would report it as healthy.
+	{Group: "apps", Kind: "Deployment"}: sets.New("Progressing"),
+	// Gateway API resources signal readiness through "Accepted" and "Programmed" rather than
+	// through a "Ready" condition.
+	{Group: "gateway.networking.k8s.io", Kind: "Gateway"}:      sets.New("Accepted", "Programmed"),
+	{Group: "gateway.networking.k8s.io", Kind: "GatewayClass"}: sets.New("Accepted"),
+}
+
+// isHealthy reports whether the object should be considered "healthy".
+//
+// This is a deliberately small set of heuristics: kinds with no readiness signal are assumed
+// healthy, and otherwise readiness is read from the status conditions listed in
+// readyConditionTypes and readyConditionTypesByGroupKind. The kstatus library implements a
+// fuller version of this, should this ever need to grow much beyond the kinds kops applies.
 func isHealthy(u *unstructured.Unstructured) bool {
 	// Check if the resource is scheduled for deletion
 	deletionTimestamp := u.GetDeletionTimestamp()
@@ -76,6 +94,9 @@ func isHealthy(u *unstructured.Unstructured) bool {
 		// No ready signal; assume ready
 		return true
 	}
+
+	// May be nil, which is fine: Has reports false for every type on a nil set.
+	kindReadyConditionTypes := readyConditionTypesByGroupKind[gvk.GroupKind()]
 
 	ready := true
 	statusConditions, found, err := unstructured.NestedFieldNoCopy(u.Object, "status", "conditions")
@@ -119,7 +140,7 @@ func isHealthy(u *unstructured.Unstructured) bool {
 			}
 		}
 
-		if !readyConditionTypes.Has(conditionType) {
+		if !readyConditionTypes.Has(conditionType) && !kindReadyConditionTypes.Has(conditionType) {
 			continue
 		}
 

--- a/pkg/applylib/applyset/health.go
+++ b/pkg/applylib/applyset/health.go
@@ -22,7 +22,27 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+)
+
+// readyConditionTypes lists the status condition types whose "True" status means the object
+// is healthy, and whose "False" status means it is not.
+//
+// Conditions of any other type are ignored, because a "False" status there carries no
+// information about the object's health. Controllers routinely publish conditions that are
+// purely informational (KEDA sets "Paused" to "False" on every ScaledObject it is actively
+// scaling) or that report an abnormal state as "True" (a healthy Node reports "MemoryPressure"
+// as "False"). Treating those as failures marks such objects permanently unhealthy.
+var readyConditionTypes = sets.New(
+	"Available",       // Deployment
+	"ContainersReady", // Pod
+	"Established",     // CustomResourceDefinition
+	"Healthy",         // Commonly used by operators for custom resources
+	"Initialized",     // Pod
+	"NamesAccepted",   // CustomResourceDefinition
+	"PodScheduled",    // Pod
+	"Ready",           // Pod, Node, and the convention for custom resources
 )
 
 // isHealthy reports whether the object should be considered "healthy"
@@ -99,7 +119,9 @@ func isHealthy(u *unstructured.Unstructured) bool {
 			}
 		}
 
-		// TODO: Check conditionType?
+		if !readyConditionTypes.Has(conditionType) {
+			continue
+		}
 
 		switch conditionStatus {
 		case "True":

--- a/pkg/applylib/applyset/health_test.go
+++ b/pkg/applylib/applyset/health_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applyset
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestIsHealthy(t *testing.T) {
+	grid := []struct {
+		name   string
+		object map[string]interface{}
+		want   bool
+	}{
+		{
+			name: "no ready signal for kind",
+			object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]interface{}{"name": "cm"},
+			},
+			want: true,
+		},
+		{
+			name: "scheduled for deletion",
+			object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name":              "deploy",
+					"deletionTimestamp": "2026-01-01T00:00:00Z",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no status conditions",
+			object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "deploy"},
+			},
+			want: true,
+		},
+		{
+			name: "null status conditions",
+			object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "deploy"},
+				"status":     map[string]interface{}{"conditions": nil},
+			},
+			want: true,
+		},
+		{
+			name: "available deployment that is still progressing",
+			object: deploymentWithConditions(
+				condition("Available", "True"),
+				condition("Progressing", "True"),
+			),
+			want: true,
+		},
+		{
+			name: "unavailable deployment",
+			object: deploymentWithConditions(
+				condition("Available", "False"),
+				condition("Progressing", "True"),
+			),
+			want: false,
+		},
+		{
+			name: "deployment reporting a replica failure",
+			object: deploymentWithConditions(
+				condition("Available", "True"),
+				// ReplicaFailure is abnormal-true, so it is not a readiness signal.
+				condition("ReplicaFailure", "True"),
+			),
+			want: true,
+		},
+		{
+			name: "healthy node with negative pressure conditions",
+			object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Node",
+				"metadata":   map[string]interface{}{"name": "node"},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						condition("MemoryPressure", "False"),
+						condition("DiskPressure", "False"),
+						condition("PIDPressure", "False"),
+						condition("Ready", "True"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "idle KEDA scaled object",
+			object: map[string]interface{}{
+				"apiVersion": "keda.sh/v1alpha1",
+				"kind":       "ScaledObject",
+				"metadata":   map[string]interface{}{"name": "scaler"},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						condition("Ready", "True"),
+						// KEDA reports these on a perfectly healthy object.
+						condition("Active", "False"),
+						condition("Fallback", "False"),
+						condition("Paused", "False"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "KEDA scaled object that is not ready",
+			object: map[string]interface{}{
+				"apiVersion": "keda.sh/v1alpha1",
+				"kind":       "ScaledObject",
+				"metadata":   map[string]interface{}{"name": "scaler"},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						condition("Ready", "False"),
+						condition("Paused", "False"),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "object with only unrecognized conditions",
+			object: map[string]interface{}{
+				"apiVersion": "example.com/v1",
+				"kind":       "Widget",
+				"metadata":   map[string]interface{}{"name": "widget"},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						condition("Paused", "False"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "established CRD",
+			object: map[string]interface{}{
+				"apiVersion": "apiextensions.k8s.io/v1",
+				"kind":       "CustomResourceDefinition",
+				"metadata":   map[string]interface{}{"name": "widgets.example.com"},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						condition("Established", "True"),
+						condition("NamesAccepted", "True"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "CRD whose names were rejected",
+			object: map[string]interface{}{
+				"apiVersion": "apiextensions.k8s.io/v1",
+				"kind":       "CustomResourceDefinition",
+				"metadata":   map[string]interface{}{"name": "widgets.example.com"},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						condition("Established", "True"),
+						condition("NamesAccepted", "False"),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:   "unknown ready status is not treated as a failure",
+			object: deploymentWithConditions(condition("Available", "Unknown")),
+			want:   true,
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.name, func(t *testing.T) {
+			u := &unstructured.Unstructured{Object: g.object}
+			if got := isHealthy(u); got != g.want {
+				t.Errorf("isHealthy() = %v, want %v", got, g.want)
+			}
+		})
+	}
+}
+
+func condition(conditionType, status string) map[string]interface{} {
+	return map[string]interface{}{
+		"type":   conditionType,
+		"status": status,
+	}
+}
+
+func deploymentWithConditions(conditions ...map[string]interface{}) map[string]interface{} {
+	list := make([]interface{}, 0, len(conditions))
+	for _, c := range conditions {
+		list = append(list, c)
+	}
+	return map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "deploy"},
+		"status":     map[string]interface{}{"conditions": list},
+	}
+}

--- a/pkg/applylib/applyset/health_test.go
+++ b/pkg/applylib/applyset/health_test.go
@@ -94,6 +94,59 @@ func TestIsHealthy(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "available deployment that gave up on its rollout",
+			object: deploymentWithConditions(
+				condition("Available", "True"),
+				condition("Progressing", "False"),
+			),
+			want: false,
+		},
+		{
+			name: "progressing is only a readiness signal for Deployments",
+			object: map[string]interface{}{
+				"apiVersion": "example.com/v1",
+				"kind":       "Widget",
+				"metadata":   map[string]interface{}{"name": "widget"},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						condition("Ready", "True"),
+						condition("Progressing", "False"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "programmed gateway",
+			object: gatewayWithConditions("Gateway",
+				condition("Accepted", "True"),
+				condition("Programmed", "True"),
+			),
+			want: true,
+		},
+		{
+			name: "gateway that is accepted but not programmed",
+			object: gatewayWithConditions("Gateway",
+				condition("Accepted", "True"),
+				condition("Programmed", "False"),
+			),
+			want: false,
+		},
+		{
+			name: "accepted gateway class",
+			object: gatewayWithConditions("GatewayClass",
+				condition("Accepted", "True"),
+			),
+			want: true,
+		},
+		{
+			name: "rejected gateway class",
+			object: gatewayWithConditions("GatewayClass",
+				condition("Accepted", "False"),
+			),
+			want: false,
+		},
+		{
 			name: "healthy node with negative pressure conditions",
 			object: map[string]interface{}{
 				"apiVersion": "v1",
@@ -211,15 +264,28 @@ func condition(conditionType, status string) map[string]interface{} {
 	}
 }
 
-func deploymentWithConditions(conditions ...map[string]interface{}) map[string]interface{} {
-	list := make([]interface{}, 0, len(conditions))
-	for _, c := range conditions {
-		list = append(list, c)
+func gatewayWithConditions(kind string, conditions ...map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       kind,
+		"metadata":   map[string]interface{}{"name": "gw"},
+		"status":     map[string]interface{}{"conditions": toList(conditions)},
 	}
+}
+
+func deploymentWithConditions(conditions ...map[string]interface{}) map[string]interface{} {
 	return map[string]interface{}{
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
 		"metadata":   map[string]interface{}{"name": "deploy"},
-		"status":     map[string]interface{}{"conditions": list},
+		"status":     map[string]interface{}{"conditions": toList(conditions)},
 	}
+}
+
+func toList(conditions []map[string]interface{}) []interface{} {
+	list := make([]interface{}, 0, len(conditions))
+	for _, c := range conditions {
+		list = append(list, c)
+	}
+	return list
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`isHealthy()` marked an object unhealthy on *any* `status.conditions` entry with a `"False"` status, regardless of the condition type — the code carried a `// TODO: Check conditionType?` at exactly that spot.

Plenty of controllers publish conditions where `"False"` carries no readiness meaning:

* KEDA sets `Paused: "False"` on every `ScaledObject`/`ScaledJob` it is actively scaling, plus `Active: "False"` while idle and `Fallback: "False"` when no fallback is configured.
* A perfectly healthy `Node` reports `MemoryPressure`, `DiskPressure` and `PIDPressure` as `"False"`.

Objects like these are permanently unhealthy, so any addon containing one can never be applied successfully:

```
health.go:110] status.conditions indicates object ScaledJob.keda.sh:gitea-runner/gitea-actions-runner is not ready: {"status":"False","type":"Paused"}
apply_channel.go:119] error in apply iteration (will retry in 5s): applying "s3://.../addon.yaml": updating "gitea-actions-runner": error applying update: not all objects were healthy
```

Since #18433 the kops-channels pod derives its readiness from the result of the last apply iteration, so this now also leaves the pod permanently not ready and `kops validate cluster` failing:

```
Pod  kube-system/kops-channels-i-04575c45245649442  system-node-critical pod "kops-channels-i-04575c45245649442" is not ready (kops-channels)
```

This PR only considers condition types whose `"True"` status means the object is healthy (`Available`, `Ready`, `Established`, …) and ignores everything else.

Abnormal-true conditions (`Degraded`, `ReplicaFailure`, the Node pressure conditions) are deliberately *not* interpreted as failures. That matches the current behaviour — a `"True"` status has never marked an object unhealthy — and keeps this change to fixing the false negatives rather than introducing new ways for an apply to fail.

The `// TODO: Replace with kstatus library` above `isHealthy()` still stands; this is a targeted fix, not that replacement.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Adds `health_test.go`, which the package did not have. The table covers the KEDA and Node cases above, plus the existing behaviours worth pinning down: deletion timestamp, absent and null `status.conditions`, the kinds short-circuited by GVK, an unavailable Deployment, and a CRD with `NamesAccepted: "False"`. Reverting the type check turns 3 of the cases red.
