### PR TITLE
WIP aws: download nodeup from private S3 buckets with curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,23 @@ gcs-publish-ci: gcloud version-dist-ci
 	echo "${GCS_URL}/${VERSION}" > ${UPLOAD}/${LATEST_FILE}
 	gcloud storage cp --cache-control="private, max-age=0, no-transform" ${UPLOAD}/${LATEST_FILE} ${GCS_LOCATION}
 
+# s3-publish-ci is the entry point for AWS CI testing.
+.PHONY: s3-publish-ci
+ifneq ($(AWS_ACCESS_KEY_ID),)
+s3-publish-ci: export AWS_ACCESS_KEY_ID := $(AWS_ACCESS_KEY_ID)
+endif
+ifneq ($(AWS_SECRET_ACCESS_KEY),)
+s3-publish-ci: export AWS_SECRET_ACCESS_KEY := $(AWS_SECRET_ACCESS_KEY)
+endif
+ifneq ($(AWS_SESSION_TOKEN),)
+s3-publish-ci: export AWS_SESSION_TOKEN := $(AWS_SESSION_TOKEN)
+endif
+s3-publish-ci: version-dist-ci
+	@echo "== Uploading kops =="
+	${UPLOAD_CMD} ${UPLOAD}/kops/ ${UPLOAD_DEST}
+	echo "VERSION: ${VERSION}"
+	echo "$(patsubst %/,%,$(UPLOAD_DEST))/${VERSION}" > ${UPLOAD}/${LATEST_FILE}
+
 .PHONY: gen-cli-docs
 gen-cli-docs: kops # Regenerate CLI docs
 	KOPS_STATE_STORE= \

--- a/docs/operations/asset-repository.md
+++ b/docs/operations/asset-repository.md
@@ -41,9 +41,9 @@ spec:
     fileRepository: https://example.com/files
 ```
 
-The repository must allow nodes to perform unauthenticated reads. The repository can
-be public or it can allow read access through network connectivity, such as access
-through a particular AWS Endpoint.
+For an `http://` or `https://` repository, nodes must be able to read without credentials.
+The repository can be public or allow access through network connectivity, such as a
+particular cloud endpoint.
 
 On GCE, the repository can also be a `gs://` URL. Nodes then read it with the credentials of
 their service account, which allows the bucket to be private. The service accounts of the
@@ -53,6 +53,20 @@ instance groups have to be granted `roles/storage.objectViewer` on that bucket.
 spec:
   assets:
     fileRepository: gs://example-bucket/files
+```
+
+{{ kops_feature_table(kops_added_default='1.37') }}
+
+On AWS, the repository can also be an `s3://` URL. Nodes then read it with the credentials of
+their instance profile, which allows the bucket to be private. The instance profiles of the
+instance groups have to be granted `s3:GetObject` on that bucket. This is supported in the
+commercial AWS and AWS GovCloud partitions. Downloading nodeup itself from an `s3://`
+`KOPS_BASE_URL` additionally requires curl 8.0 or newer on the node image.
+
+```yaml
+spec:
+  assets:
+    fileRepository: s3://example-bucket/files
 ```
 
 ## Copying assets into repositories
@@ -65,7 +79,7 @@ When running `kops get assets --copy`, kOps copies assets into their respective 
 they do not already exist there.
 
 For file assets, kOps only supports copying to a repository that is either an S3 or GCS bucket.
-An S3 bucket must be configured using the [regional naming conventions of S3](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
+An S3 bucket must be configured with a prefix of `s3://` or using the [regional naming conventions of S3](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
 A GCS bucket must be configured with a prefix of `https://storage.googleapis.com/` or `gs://`.
 
 ## Listing assets

--- a/docs/releases/1.37-NOTES.md
+++ b/docs/releases/1.37-NOTES.md
@@ -32,6 +32,8 @@ As part of this removal, the `protokube` component, whose only remaining respons
 
 * On AWS, instance roles that require no permissions, such as the bastion role and the default worker node role, no longer have an inline IAM policy. `kops update cluster` deletes the previously created inline policy from such roles. With the Terraform target, the corresponding `aws_iam_role_policy` resources are removed from the configuration and destroyed on the next apply.
 
+* Private cluster asset repositories now support AWS `s3://` URLs in addition to existing GCE `gs://` URLs, both for `KOPS_BASE_URL` (nodeup download) and `spec.assets.fileRepository`. Nodes authenticate with their instance credentials; see the [asset repository documentation](https://kops.sigs.k8s.io/operations/asset-repository/) for the required permissions. The AWS nodeup download requires node images with curl 8.0 or newer.
+
 # Breaking changes
 
 * Support for AWS Classic Load Balancer (CLB) for the API has been removed. Clusters with `spec.api.loadBalancer.class: Classic` (or with no explicit `class`, which previously defaulted to Classic) fail validation, and the long-deprecated `kops create cluster --api-loadbalancer-class` flag has been removed. Existing clusters using a CLB must migrate to a Network Load Balancer (NLB) using kOps 1.36 or earlier before upgrading to kOps 1.37, following the [CLB to NLB migration guide](https://github.com/kubernetes/kops/blob/master/permalinks/acm_nlb.md). Attaching instance groups to externally-managed Classic Load Balancers via `spec.externalLoadBalancers[].loadBalancerName` remains supported.

--- a/hack/dev-build-aws.sh
+++ b/hack/dev-build-aws.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a convenience script for developing kOps on GCE.
-# It builds the code, including nodeup, and uploads to a custom GCS bucket.
+# This is a convenience script for developing kOps on AWS.
+# It builds the code, including nodeup, and uploads to a custom S3 bucket.
 # It also sets KOPS_STATE_STORE and KOPS_BASE_URL to project-isolated values.
-# To use, source the script.  For example `. hack/dev-build-gce.sh` (note the initial `.`)
+# To use, source the script. For example, `. hack/dev-build-aws.sh` (note the initial `.`).
 
 # Can't use set -e in a script we want to source
 #set -e
@@ -37,9 +37,12 @@ aws s3 ls "${UPLOAD_DEST}" || aws s3 mb "${UPLOAD_DEST}" || return
 make kops-install dev-upload-linux-${KOPS_ARCH} || return
 
 # Set KOPS_BASE_URL
-(tools/get_version.sh | grep VERSION | awk '{print $2}') || return
-KOPS_VERSION=$(tools/get_version.sh | grep VERSION | awk '{print $2}')
-export KOPS_BASE_URL=https://${S3_BUCKET_NAME}.s3.amazonaws.com/kops/${KOPS_VERSION}/
+KOPS_VERSION=$(tools/get_version.sh | grep VERSION | awk '{print $2}') || return
+echo "${KOPS_VERSION}"
+# The s3:// form lets nodes use their instance profiles; https:// requires public read access.
+# Grant the cluster instance profiles s3:GetObject on the bucket and use node images with
+# curl >= 8.0.
+export KOPS_BASE_URL=s3://${S3_BUCKET_NAME}/kops/${KOPS_VERSION}/
 
 # Create the state-store bucket if it doesn't exist
 KOPS_STATE_STORE="s3://kops-state-${ACCOUNT_ID}-${USER}"

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -63,11 +64,36 @@ func awsValidateCluster(c *kops.Cluster, strict bool) field.ErrorList {
 
 	allErrs = append(allErrs, awsValidateUseIPBasedNodeNames(c)...)
 
+	allErrs = append(allErrs, awsValidateS3FileRepositoryPartition(c)...)
+
 	if c.Spec.Authentication != nil && c.Spec.Authentication.AWS != nil {
 		allErrs = append(allErrs, awsValidateIAMAuthenticator(field.NewPath("spec", "authentication", "aws"), c.Spec.Authentication.AWS)...)
 	}
 
 	return allErrs
+}
+
+func awsValidateS3FileRepositoryPartition(cluster *kops.Cluster) field.ErrorList {
+	assets := cluster.Spec.Assets
+	if assets == nil || assets.FileRepository == nil || !strings.HasPrefix(*assets.FileRepository, "s3://") {
+		return nil
+	}
+
+	region, err := awsup.FindRegion(cluster)
+	if err != nil {
+		// Subnet validation reports invalid or missing zones separately.
+		return nil
+	}
+
+	fldPath := field.NewPath("spec", "assets", "fileRepository")
+	supported, err := awsup.SupportsS3BootstrapEndpoint(context.TODO(), region)
+	if err != nil {
+		return field.ErrorList{field.Invalid(fldPath, *assets.FileRepository, err.Error())}
+	}
+	if !supported {
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("s3:// fileRepository is not supported in AWS region %q", region))}
+	}
+	return nil
 }
 
 func awsValidateEBSCSIDriver(cluster *kops.Cluster) (allErrs field.ErrorList) {

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -923,6 +923,59 @@ func TestAWSAdditionalRoutes(t *testing.T) {
 	}
 }
 
+func TestAWSValidateS3FileRepository(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		region         string
+		fileRepository string
+		expectedErrors []string
+	}{
+		{
+			name:           "commercial partition",
+			region:         "us-east-1",
+			fileRepository: "s3://example-k8s-assets/kops",
+		},
+		{
+			name:           "GovCloud partition",
+			region:         "us-gov-west-1",
+			fileRepository: "s3://example-k8s-assets/kops",
+		},
+		{
+			name:           "China partition",
+			region:         "cn-north-1",
+			fileRepository: "s3://example-k8s-assets/kops",
+			expectedErrors: []string{"Forbidden::spec.assets.fileRepository"},
+		},
+		{
+			name:           "ISO partition",
+			region:         "us-iso-east-1",
+			fileRepository: "s3://example-k8s-assets/kops",
+			expectedErrors: []string{"Forbidden::spec.assets.fileRepository"},
+		},
+		{
+			name:           "HTTPS repository in ISO partition",
+			region:         "us-iso-east-1",
+			fileRepository: "https://example.com/kops",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fileRepository := tc.fileRepository
+			cluster := &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					CloudProvider: kops.CloudProviderSpec{AWS: &kops.AWSSpec{}},
+					Assets:        &kops.AssetsSpec{FileRepository: &fileRepository},
+					Networking: kops.NetworkingSpec{
+						Subnets: []kops.ClusterSubnetSpec{{Name: "subnet", Zone: tc.region + "a"}},
+					},
+				},
+			}
+
+			errs := awsValidateCluster(cluster, false)
+			testErrors(t, tc.name, errs, tc.expectedErrors)
+		})
+	}
+}
+
 func TestAWSValidateNLBSecurityGroupMode(t *testing.T) {
 	grid := []struct {
 		Input          kops.ClusterSpec

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -797,8 +797,13 @@ func validateFileRepository(s string, fieldPath *field.Path, cloudProvider kops.
 		if cloudProvider != kops.CloudProviderGCE {
 			allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("gs:// fileRepository is only supported on GCE, but the cloud provider is %q", cloudProvider)))
 		}
+	case "s3":
+		// Only AWS instances can authenticate to S3 with their instance profile.
+		if cloudProvider != kops.CloudProviderAWS {
+			allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("s3:// fileRepository is only supported on AWS, but the cloud provider is %q", cloudProvider)))
+		}
 	default:
-		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must be an http:// or https:// URL"))
+		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must be an http://, https://, gs://, or s3:// URL"))
 	}
 	if u.Host == "" {
 		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must include a host"))

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -2293,6 +2293,15 @@ func TestValidateFileRepository(t *testing.T) {
 			Input: "http://example.com/files",
 		},
 		{
+			Input:         "s3://example-k8s-assets/kops",
+			CloudProvider: kops.CloudProviderAWS,
+		},
+		{
+			Input:          "s3://example-k8s-assets/kops",
+			CloudProvider:  kops.CloudProviderGCE,
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
 			Input:          "s3://example-k8s-assets/kops",
 			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
 		},

--- a/pkg/assets/assetcopy/copyfile.go
+++ b/pkg/assets/assetcopy/copyfile.go
@@ -176,11 +176,11 @@ func writeFile(ctx context.Context, cluster *kops.Cluster, p vfs.Path, data []by
 	return nil
 }
 
-// buildVFSPath task a recognizable https url and transforms that URL into the equivalent url with the object
-// store prefix.
+// buildVFSPath returns local paths and memfs://, file://, gs://, and s3:// URLs unchanged. It
+// converts recognized S3 or GCS HTTPS URLs to their native VFS form.
 func buildVFSPath(target string) (string, error) {
 	if !strings.Contains(target, "://") || strings.HasPrefix(target, "memfs://") || strings.HasPrefix(target, "file://") ||
-		strings.HasPrefix(target, "gs://") {
+		strings.HasPrefix(target, "gs://") || strings.HasPrefix(target, "s3://") {
 		return target, nil
 	}
 
@@ -207,7 +207,7 @@ func buildVFSPath(target string) (string, error) {
 	if vfsPath == "" {
 		klog.Errorf("Unable to determine VFS path from supplied URL: %s", target)
 		klog.Errorf("S3, Google Cloud Storage, and File Paths are supported.")
-		klog.Errorf("For S3, please make sure that the supplied file repository URL adhere to S3 naming conventions, https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.")
+		klog.Errorf("For S3, please make sure that the supplied file repository URL starts with s3:// or adheres to S3 naming conventions, https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.")
 		klog.Errorf("For GCS, please make sure that the supplied file repository URL starts with gs:// or https://storage.googleapis.com/")
 		if err != nil { // print the S3 error for more details
 			return "", fmt.Errorf("Error Details: %v", err)

--- a/pkg/assets/assetcopy/copyfile_test.go
+++ b/pkg/assets/assetcopy/copyfile_test.go
@@ -52,6 +52,11 @@ func Test_BuildVFSPath(t *testing.T) {
 			true,
 		},
 		{
+			"s3://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			"s3://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			true,
+		},
+		{
 			"https://foo/k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
 			"",
 			false,

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -442,8 +442,7 @@ func (a *AssetBuilder) remapURL(canonicalURL *url.URL) (*url.URL, error) {
 	}
 
 	fileRepo.Path = path.Join(fileRepo.Path, canonicalURL.Path)
-	// Escape commas, which Go leaves alone because they are legal in a path, but which
-	// CompactString uses to separate locations.
+	// Escape commas, which are legal in a path but separate locations in CompactString.
 	fileRepo.RawPath = strings.ReplaceAll(fileRepo.EscapedPath(), ",", "%2C")
 
 	return fileRepo, nil

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -442,6 +442,10 @@ func (a *AssetBuilder) remapURL(canonicalURL *url.URL) (*url.URL, error) {
 	}
 
 	fileRepo.Path = path.Join(fileRepo.Path, canonicalURL.Path)
+	// Joining changes Path without updating the parsed RawPath. Rebuild RawPath and escape commas,
+	// which CompactString uses to separate locations.
+	fileRepo.RawPath = ""
+	fileRepo.RawPath = strings.ReplaceAll(fileRepo.EscapedPath(), ",", "%2C")
 
 	return fileRepo, nil
 }

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -442,9 +442,8 @@ func (a *AssetBuilder) remapURL(canonicalURL *url.URL) (*url.URL, error) {
 	}
 
 	fileRepo.Path = path.Join(fileRepo.Path, canonicalURL.Path)
-	// Joining changes Path without updating the parsed RawPath. Rebuild RawPath and escape commas,
-	// which CompactString uses to separate locations.
-	fileRepo.RawPath = ""
+	// Escape commas, which Go leaves alone because they are legal in a path, but which
+	// CompactString uses to separate locations.
 	fileRepo.RawPath = strings.ReplaceAll(fileRepo.EscapedPath(), ",", "%2C")
 
 	return fileRepo, nil

--- a/pkg/assets/builder_test.go
+++ b/pkg/assets/builder_test.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -125,6 +126,84 @@ func TestValidate_RemapImage_ContainerRegistry_MappingMultipleTimesConverges(t *
 		if remapped != expected {
 			t.Errorf("Error remapping image (Expecting: %s, got %s, iteration: %d)", expected, remapped, i)
 		}
+	}
+}
+
+func TestRemapURLPathDelimiterEscaping(t *testing.T) {
+	canonicalURL, err := url.Parse("https://artifacts.k8s.io/binaries/kops/1.37.0/linux/arm64/nodeup")
+	if err != nil {
+		t.Fatalf("parsing canonical URL: %v", err)
+	}
+	knownHash := hashing.MustFromString("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+
+	for _, tc := range []struct {
+		name           string
+		fileRepository string
+		expected       string
+	}{
+		{
+			name:           "S3 raw comma",
+			fileRepository: "s3://artifact-bucket/prefix,prod",
+			expected:       "s3://artifact-bucket/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+		{
+			name:           "S3 encoded comma",
+			fileRepository: "s3://artifact-bucket/prefix%2Cprod",
+			expected:       "s3://artifact-bucket/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+		{
+			name:           "GCS raw comma",
+			fileRepository: "gs://artifact-bucket/prefix,prod",
+			expected:       "gs://artifact-bucket/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+		{
+			name:           "GCS encoded comma",
+			fileRepository: "gs://artifact-bucket/prefix%2Cprod",
+			expected:       "gs://artifact-bucket/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+		{
+			name:           "HTTPS raw comma",
+			fileRepository: "https://artifacts.example.com/prefix,prod",
+			expected:       "https://artifacts.example.com/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+		{
+			name:           "HTTPS encoded comma",
+			fileRepository: "https://artifacts.example.com/prefix%2Cprod",
+			expected:       "https://artifacts.example.com/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fileRepository := tc.fileRepository
+			builder := NewAssetBuilder(nil, &kops.AssetsSpec{FileRepository: &fileRepository}, false)
+			asset, err := builder.RemapFile(canonicalURL, knownHash)
+			if err != nil {
+				t.Fatalf("remapping file: %v", err)
+			}
+
+			mirrored := BuildMirroredAsset(asset)
+			if len(mirrored.Locations) != 1 {
+				t.Fatalf("expected one location, got %d", len(mirrored.Locations))
+			}
+			if mirrored.Locations[0] != tc.expected {
+				t.Errorf("expected location %q, got %q", tc.expected, mirrored.Locations[0])
+			}
+
+			_, locations, ok := strings.Cut(mirrored.CompactString(), "@")
+			if !ok {
+				t.Fatalf("compact asset does not contain a hash separator")
+			}
+			if split := strings.Split(locations, ","); len(split) != 1 {
+				t.Fatalf("compact asset split into %d locations", len(split))
+			}
+			parsed, err := url.Parse(locations)
+			if err != nil {
+				t.Fatalf("parsing compact asset location: %v", err)
+			}
+			expectedPath := "/prefix,prod/binaries/kops/1.37.0/linux/arm64/nodeup"
+			if parsed.Path != expectedPath {
+				t.Errorf("expected decoded path %q, got %q", expectedPath, parsed.Path)
+			}
+		})
 	}
 }
 

--- a/pkg/commands/toolbox_enroll.go
+++ b/pkg/commands/toolbox_enroll.go
@@ -845,12 +845,16 @@ func (b *ConfigBuilder) GetBootstrapData(ctx context.Context) (*BootstrapData, e
 
 	bootConfig.ConfigBase = new("file:///etc/kubernetes/kops/config")
 
+	vfsContext := clientset.VFSContext()
+
+	if err := nodeupScript.ResolveS3Region(ctx, vfsContext); err != nil {
+		return nil, err
+	}
+
 	nodeupScriptResource, err := nodeupScript.Build()
 	if err != nil {
 		return nil, err
 	}
-
-	vfsContext := clientset.VFSContext()
 
 	// If this is the control plane, we want to copy the config from s3/gcs to the local file system on the target node,
 	// so that we don't need credentials to the state store.

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -148,6 +148,10 @@ func (b *BootstrapScript) kubeEnv(cluster *kops.Cluster, ig *kops.InstanceGroup,
 
 		nodeupScript.CloudProvider = string(cluster.GetCloudProvider())
 
+		if err := nodeupScript.ResolveS3Region(c.Context(), vfs.Context); err != nil {
+			return nil, err
+		}
+
 		scriptResource, err := nodeupScript.Build()
 		if err != nil {
 			return nil, err
@@ -303,6 +307,10 @@ func (b *BootstrapScript) Run(c *fi.CloudupContext) error {
 	nodeupScript.CompressUserData = fi.ValueOf(b.ig.Spec.CompressUserData)
 
 	nodeupScript.CloudProvider = string(c.T.Cluster.GetCloudProvider())
+
+	if err := nodeupScript.ResolveS3Region(c.Context(), vfs.Context); err != nil {
+		return err
+	}
 
 	nodeupScriptResource, err := nodeupScript.Build()
 	if err != nil {

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -74,6 +74,20 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+{{- if UseS3Download }}
+# Fetch a path from the instance metadata service. args: token, path
+imds-get() {
+  curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 \
+    -H "X-aws-ec2-metadata-token: $1" "http://169.254.169.254/latest/$2"
+}
+
+# Extract a string field from a JSON object. args: json, field
+json-field() {
+  local pattern="\"$2\"[[:space:]]*:[[:space:]]*\"([^\"]+)\""
+  [[ $1 =~ $pattern ]] && printf '%s' "${BASH_REMATCH[1]}"
+}
+{{- end }}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   echo "== Downloading $1 with hash $2 from $3 =="
@@ -110,38 +124,30 @@ download-or-bust() {
         return 0
       fi
 {{- else if UseS3Download }}
-      # Use the IP of the metadata server, to not depend on DNS this early in boot
-      local imds_server="http://169.254.169.254"
-      local imds_token profile creds field pattern
-      local -A aws_credentials=()
+      local imds_token profile creds
       echo "== Downloading ${url} =="
-      if ! imds_token=$(curl -s -f -X PUT --noproxy '*' --connect-timeout 2 --max-time 5 -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' "${imds_server}/latest/api/token"); then
+      # Use the IP of the metadata server, to not depend on DNS this early in boot
+      if ! imds_token=$(curl -s -f -X PUT --noproxy '*' --connect-timeout 2 --max-time 5 -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' "http://169.254.169.254/latest/api/token"); then
         echo "== Failed to get an IMDS token =="
-      elif ! profile=$(curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 -H "X-aws-ec2-metadata-token: ${imds_token}" "${imds_server}/latest/meta-data/iam/security-credentials/" | head -n 1); then
+      elif ! profile=$(imds-get "${imds_token}" meta-data/iam/security-credentials/ | head -n 1); then
         echo "== Failed to get the instance profile name =="
-      elif ! creds=$(curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 -H "X-aws-ec2-metadata-token: ${imds_token}" "${imds_server}/latest/meta-data/iam/security-credentials/${profile}"); then
+      elif ! creds=$(imds-get "${imds_token}" "meta-data/iam/security-credentials/${profile}"); then
         echo "== Failed to get the instance profile credentials =="
+      # Pass credentials through stdin so they do not appear in files, logs, or process arguments.
+      elif ! printf 'user "%s:%s"\nheader "x-amz-security-token: %s"\n' \
+        "$(json-field "${creds}" AccessKeyId)" \
+        "$(json-field "${creds}" SecretAccessKey)" \
+        "$(json-field "${creds}" Token)" |
+        curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 \
+          --config - --aws-sigv4 "aws:amz:{{ S3Region }}:s3" \
+          "https://s3.{{ S3Region }}.amazonaws.com/${url#s3://}"; then
+        echo "== Failed to download ${url} =="
+      elif ! validate-hash "${file}" "${hash}"; then
+        echo "== Failed to validate hash for ${url} =="
+        rm -f "${file}"
       else
-        for field in AccessKeyId SecretAccessKey Token; do
-          pattern="\"${field}\"[[:space:]]*:[[:space:]]*\"([^\"]+)\""
-          if [[ ${creds} =~ ${pattern} ]]; then
-            aws_credentials["${field}"]="${BASH_REMATCH[1]}"
-          fi
-        done
-        # Pass credentials through stdin so they do not appear in files, logs, or process arguments.
-        if ! printf 'user "%s:%s"\nheader "x-amz-security-token: %s"\n' \
-          "${aws_credentials[AccessKeyId]:-}" "${aws_credentials[SecretAccessKey]:-}" "${aws_credentials[Token]:-}" |
-          curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 \
-            --config - --aws-sigv4 "aws:amz:{{ S3Region }}:s3" \
-            "https://s3.{{ S3Region }}.amazonaws.com/${url#s3://}"; then
-          echo "== Failed to download ${url} =="
-        elif ! validate-hash "${file}" "${hash}"; then
-          echo "== Failed to validate hash for ${url} =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} with hash ${hash} =="
-          return 0
-        fi
+        echo "== Downloaded ${url} with hash ${hash} =="
+        return 0
       fi
 {{- else }}
       commands=(

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -124,7 +124,7 @@ download-or-bust() {
         return 0
       fi
 {{- else if UseS3Download }}
-      local imds_token profile creds
+      local imds_token profile creds access_key secret_key session_token
       echo "== Downloading ${url} =="
       # Use the IP of the metadata server, to not depend on DNS this early in boot
       if ! imds_token=$(curl -s -f -X PUT --noproxy '*' --connect-timeout 2 --max-time 5 -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' "http://169.254.169.254/latest/api/token"); then
@@ -133,11 +133,10 @@ download-or-bust() {
         echo "== Failed to get the instance profile name =="
       elif ! creds=$(imds-get "${imds_token}" "meta-data/iam/security-credentials/${profile}"); then
         echo "== Failed to get the instance profile credentials =="
+      elif ! access_key=$(json-field "${creds}" AccessKeyId) || ! secret_key=$(json-field "${creds}" SecretAccessKey) || ! session_token=$(json-field "${creds}" Token); then
+        echo "== Failed to parse the instance profile credentials =="
       # Pass credentials through stdin so they do not appear in files, logs, or process arguments.
-      elif ! printf 'user "%s:%s"\nheader "x-amz-security-token: %s"\n' \
-        "$(json-field "${creds}" AccessKeyId)" \
-        "$(json-field "${creds}" SecretAccessKey)" \
-        "$(json-field "${creds}" Token)" |
+      elif ! printf 'user "%s:%s"\nheader "x-amz-security-token: %s"\n' "${access_key}" "${secret_key}" "${session_token}" |
         curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 \
           --config - --aws-sigv4 "aws:amz:{{ S3Region }}:s3" \
           "https://s3.{{ S3Region }}.amazonaws.com/${url#s3://}"; then

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -20,16 +20,21 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"fmt"
+	"maps"
 	"mime/multipart"
 	"net/textproto"
+	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"text/template"
 
+	"github.com/aws/smithy-go/encoding/httpbinding"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/nodeup"
@@ -38,6 +43,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/utils"
 	"k8s.io/kops/util/pkg/architectures"
+	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kops/util/pkg/vfs/openstackconfig"
 )
 
@@ -102,6 +108,40 @@ download-or-bust() {
       else
         echo "== Downloaded ${url} with hash ${hash} =="
         return 0
+      fi
+{{- else if UseS3Download }}
+      # Use the IP of the metadata server, to not depend on DNS this early in boot
+      local imds_server="http://169.254.169.254"
+      local imds_token profile creds field pattern
+      local -A aws_credentials=()
+      echo "== Downloading ${url} =="
+      if ! imds_token=$(curl -s -f -X PUT --noproxy '*' --connect-timeout 2 --max-time 5 -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' "${imds_server}/latest/api/token"); then
+        echo "== Failed to get an IMDS token =="
+      elif ! profile=$(curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 -H "X-aws-ec2-metadata-token: ${imds_token}" "${imds_server}/latest/meta-data/iam/security-credentials/" | head -n 1); then
+        echo "== Failed to get the instance profile name =="
+      elif ! creds=$(curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 -H "X-aws-ec2-metadata-token: ${imds_token}" "${imds_server}/latest/meta-data/iam/security-credentials/${profile}"); then
+        echo "== Failed to get the instance profile credentials =="
+      else
+        for field in AccessKeyId SecretAccessKey Token; do
+          pattern="\"${field}\"[[:space:]]*:[[:space:]]*\"([^\"]+)\""
+          if [[ ${creds} =~ ${pattern} ]]; then
+            aws_credentials["${field}"]="${BASH_REMATCH[1]}"
+          fi
+        done
+        # Pass credentials through stdin so they do not appear in files, logs, or process arguments.
+        if ! printf 'user "%s:%s"\nheader "x-amz-security-token: %s"\n' \
+          "${aws_credentials[AccessKeyId]:-}" "${aws_credentials[SecretAccessKey]:-}" "${aws_credentials[Token]:-}" |
+          curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 \
+            --config - --aws-sigv4 "aws:amz:{{ S3Region }}:s3" \
+            "https://s3.{{ S3Region }}.amazonaws.com/${url#s3://}"; then
+          echo "== Failed to download ${url} =="
+        elif ! validate-hash "${file}" "${hash}"; then
+          echo "== Failed to validate hash for ${url} =="
+          rm -f "${file}"
+        else
+          echo "== Downloaded ${url} with hash ${hash} =="
+          return 0
+        fi
       fi
 {{- else }}
       commands=(
@@ -204,10 +244,58 @@ type NodeUpScript struct {
 	CloudProvider        string
 	ProxyEnv             func() (string, error)
 	EnvironmentVariables func() (string, error)
+
+	// S3Region is baked into the script because SigV4 requires the bucket's actual region, which
+	// an s3:// URL does not include.
+	S3Region string
 }
 
 func funcEmptyString() (string, error) {
 	return "", nil
+}
+
+func (b *NodeUpScript) nodeUpSource(arch architectures.Architecture, useS3Download bool) (string, error) {
+	asset := b.NodeUpAssets[arch]
+	if asset == nil {
+		return "", nil
+	}
+
+	if !useS3Download {
+		return strings.Join(asset.Locations, ","), nil
+	}
+
+	locations := slices.Clone(asset.Locations)
+	for i, location := range locations {
+		if !strings.HasPrefix(location, "s3://") {
+			continue
+		}
+		escaped, err := escapeS3Location(location)
+		if err != nil {
+			return "", fmt.Errorf("escaping nodeup source %q: %w", location, err)
+		}
+		locations[i] = escaped
+	}
+	return strings.Join(locations, ","), nil
+}
+
+func (b *NodeUpScript) nodeUpHash(arch architectures.Architecture) string {
+	asset := b.NodeUpAssets[arch]
+	if asset == nil {
+		return ""
+	}
+	return asset.Hash.Hex()
+}
+
+func escapeS3Location(location string) (string, error) {
+	u, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("parsing S3 location: %w", err)
+	}
+	if u.Scheme != "s3" || u.Host == "" {
+		return "", fmt.Errorf("invalid S3 location")
+	}
+
+	return "s3://" + u.Host + httpbinding.EscapePath(u.Path, false), nil
 }
 
 func (b *NodeUpScript) Build() (fi.Resource, error) {
@@ -218,31 +306,21 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 		b.EnvironmentVariables = funcEmptyString
 	}
 
+	useGCSDownload := b.useGCSDownload()
+	useS3Download := !useGCSDownload && b.useS3Download()
+	if useS3Download && b.S3Region == "" {
+		return nil, fmt.Errorf("ResolveS3Region must be called before building a nodeup script with an s3:// source")
+	}
+
 	functions := template.FuncMap{
-		"NodeUpSourceAmd64": func() string {
-			if b.NodeUpAssets[architectures.ArchitectureAmd64] != nil {
-				return strings.Join(b.NodeUpAssets[architectures.ArchitectureAmd64].Locations, ",")
-			}
-			return ""
+		"NodeUpSourceAmd64": func() (string, error) {
+			return b.nodeUpSource(architectures.ArchitectureAmd64, useS3Download)
 		},
-		"NodeUpSourceHashAmd64": func() string {
-			if b.NodeUpAssets[architectures.ArchitectureAmd64] != nil {
-				return b.NodeUpAssets[architectures.ArchitectureAmd64].Hash.Hex()
-			}
-			return ""
+		"NodeUpSourceHashAmd64": func() string { return b.nodeUpHash(architectures.ArchitectureAmd64) },
+		"NodeUpSourceArm64": func() (string, error) {
+			return b.nodeUpSource(architectures.ArchitectureArm64, useS3Download)
 		},
-		"NodeUpSourceArm64": func() string {
-			if b.NodeUpAssets[architectures.ArchitectureArm64] != nil {
-				return strings.Join(b.NodeUpAssets[architectures.ArchitectureArm64].Locations, ",")
-			}
-			return ""
-		},
-		"NodeUpSourceHashArm64": func() string {
-			if b.NodeUpAssets[architectures.ArchitectureArm64] != nil {
-				return b.NodeUpAssets[architectures.ArchitectureArm64].Hash.Hex()
-			}
-			return ""
-		},
+		"NodeUpSourceHashArm64": func() string { return b.nodeUpHash(architectures.ArchitectureArm64) },
 
 		"KubeEnv": func() (string, error) {
 			bootConfigData, err := utils.YamlMarshal(b.BootConfig)
@@ -270,7 +348,9 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 		"ProxyEnv":             b.ProxyEnv,
 		"EnvironmentVariables": b.EnvironmentVariables,
 
-		"UseGCSDownload": b.useGCSDownload,
+		"UseGCSDownload": func() bool { return useGCSDownload },
+		"UseS3Download":  func() bool { return useS3Download },
+		"S3Region":       func() string { return b.S3Region },
 	}
 
 	return newTemplateResource("nodeup", nodeUpTemplate, functions, nil)
@@ -279,17 +359,59 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 // useGCSDownload reports whether nodeup is downloaded from a GCS bucket, which has to be done
 // with the credentials of the instance service account.
 func (b *NodeUpScript) useGCSDownload() bool {
-	for _, asset := range b.NodeUpAssets {
+	return b.firstLocationWithScheme("gs://") != ""
+}
+
+func (b *NodeUpScript) firstLocationWithScheme(scheme string) string {
+	// Sort architectures so region selection is deterministic and independent of KOPS_ARCH.
+	for _, arch := range slices.Sorted(maps.Keys(b.NodeUpAssets)) {
+		asset := b.NodeUpAssets[arch]
 		if asset == nil {
 			continue
 		}
 		for _, location := range asset.Locations {
-			if strings.HasPrefix(location, "gs://") {
-				return true
+			if strings.HasPrefix(location, scheme) {
+				return location
 			}
 		}
 	}
-	return false
+	return ""
+}
+
+// S3 downloads require an AWS instance profile.
+func (b *NodeUpScript) useS3Download() bool {
+	return b.CloudProvider == string(kops.CloudProviderAWS) && b.firstLocationWithScheme("s3://") != ""
+}
+
+// ResolveS3Region resolves the bucket region because SigV4 requires it but s3:// URLs omit it.
+func (b *NodeUpScript) ResolveS3Region(ctx context.Context, vfsContext *vfs.VFSContext) error {
+	if b.CloudProvider != string(kops.CloudProviderAWS) {
+		return nil
+	}
+	location := b.firstLocationWithScheme("s3://")
+	if location == "" {
+		return nil
+	}
+	p, err := vfsContext.BuildVfsPath(location)
+	if err != nil {
+		return fmt.Errorf("building path for %q: %w", location, err)
+	}
+	s3Path, ok := p.(*vfs.S3Path)
+	if !ok {
+		return fmt.Errorf("unexpected path type %T for %q", p, location)
+	}
+	b.S3Region, err = s3Path.Region(ctx)
+	if err != nil {
+		return fmt.Errorf("getting the region of %q: %w", location, err)
+	}
+	supported, err := awsup.SupportsS3BootstrapEndpoint(ctx, b.S3Region)
+	if err != nil {
+		return err
+	}
+	if !supported {
+		return fmt.Errorf("downloading nodeup from an s3:// URL is not supported in AWS region %q", b.S3Region)
+	}
+	return nil
 }
 
 func gzipBase64(data string) (string, error) {

--- a/pkg/model/resources/nodeup_test.go
+++ b/pkg/model/resources/nodeup_test.go
@@ -37,19 +37,33 @@ func Test_NodeUpTabs(t *testing.T) {
 	}
 }
 
+func singleNodeUpAsset(location string) map[architectures.Architecture]*assets.MirroredAsset {
+	return map[architectures.Architecture]*assets.MirroredAsset{
+		architectures.ArchitectureAmd64: {
+			Locations: []string{location},
+			Hash:      hashing.MustFromString("9acf6a83b249649354bb15b04250fabce0f8ff2377f2f0d4788e3fdda3f572a3"),
+		},
+	}
+}
+
+func renderNodeUpScript(t *testing.T, script *NodeUpScript) string {
+	t.Helper()
+	resource, err := script.Build()
+	if err != nil {
+		t.Fatalf("building nodeup script: %v", err)
+	}
+	rendered, err := fi.ResourceAsString(resource)
+	if err != nil {
+		t.Fatalf("rendering nodeup script: %v", err)
+	}
+	verifyShellSyntax(t, rendered)
+	return rendered
+}
+
 func Test_GCSDownload(t *testing.T) {
 	// The authenticated GCS download is rendered only when the nodeup sources are gs:// URLs.
 	gcsMarker := "Authorization: Bearer"
 	standardMarker := "wget --compression=auto"
-
-	nodeUpAssets := func(location string) map[architectures.Architecture]*assets.MirroredAsset {
-		return map[architectures.Architecture]*assets.MirroredAsset{
-			architectures.ArchitectureAmd64: {
-				Locations: []string{location},
-				Hash:      hashing.MustFromString("9acf6a83b249649354bb15b04250fabce0f8ff2377f2f0d4788e3fdda3f572a3"),
-			},
-		}
-	}
 
 	for _, tc := range []struct {
 		name      string
@@ -70,28 +84,139 @@ func Test_GCSDownload(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			script := &NodeUpScript{
 				CloudProvider: "gce",
-				NodeUpAssets:  nodeUpAssets(tc.location),
+				NodeUpAssets:  singleNodeUpAsset(tc.location),
 			}
-			resource, err := script.Build()
-			if err != nil {
-				t.Fatalf("building nodeup script: %v", err)
-			}
-			rendered, err := fi.ResourceAsString(resource)
-			if err != nil {
-				t.Fatalf("rendering nodeup script: %v", err)
-			}
+			rendered := renderNodeUpScript(t, script)
 			if got := strings.Contains(rendered, gcsMarker); got != tc.expectGCS {
 				t.Errorf("authenticated GCS download rendered=%v, expected %v", got, tc.expectGCS)
 			}
 			if got := strings.Contains(rendered, standardMarker); got != !tc.expectGCS {
 				t.Errorf("standard download commands rendered=%v, expected %v", got, !tc.expectGCS)
 			}
-			verifyShellSyntax(t, rendered)
 		})
 	}
 }
 
-// verifyShellSyntax parses the rendered script with bash, as the GCS download has no golden file.
+func TestEscapeS3Location(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		location  string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "plain path",
+			location: "s3://artifact-bucket/kops/1.37.0/linux/amd64/nodeup",
+			expected: "s3://artifact-bucket/kops/1.37.0/linux/amd64/nodeup",
+		},
+		{
+			name:     "plus sign",
+			location: "s3://artifact-bucket/kops/1.37.0+abcdef/linux/amd64/nodeup",
+			expected: "s3://artifact-bucket/kops/1.37.0%2Babcdef/linux/amd64/nodeup",
+		},
+		{
+			name:     "existing escape",
+			location: "s3://artifact-bucket/kops/1.37.0%2Babcdef/linux/amd64/nodeup",
+			expected: "s3://artifact-bucket/kops/1.37.0%2Babcdef/linux/amd64/nodeup",
+		},
+		{
+			name:     "reserved and unicode characters",
+			location: "s3://artifact-bucket/space here/100%25/%3F%23/雪,nodeup",
+			expected: "s3://artifact-bucket/space%20here/100%25/%3F%23/%E9%9B%AA%2Cnodeup",
+		},
+		{
+			name:     "path separators",
+			location: "s3://artifact-bucket/a//b/nodeup",
+			expected: "s3://artifact-bucket/a//b/nodeup",
+		},
+		{
+			name:      "invalid escape",
+			location:  "s3://artifact-bucket/100%/nodeup",
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := escapeS3Location(tc.location)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error escaping %q", tc.location)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("escaping %q: %v", tc.location, err)
+			}
+			if actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func Test_S3Download(t *testing.T) {
+	s3Marker := "--aws-sigv4"
+	standardMarker := "wget --compression=auto"
+
+	for _, tc := range []struct {
+		name           string
+		cloudProvider  string
+		location       string
+		expectedSource string
+		expectS3       bool
+	}{
+		{
+			name:           "s3 source",
+			cloudProvider:  "aws",
+			location:       "s3://artifact-bucket/kops/1.34.0+abcdef/linux/amd64/nodeup",
+			expectedSource: "NODEUP_URL_AMD64=s3://artifact-bucket/kops/1.34.0%2Babcdef/linux/amd64/nodeup",
+			expectS3:       true,
+		},
+		{
+			name:          "default https source",
+			cloudProvider: "aws",
+			location:      "https://artifacts.k8s.io/binaries/kops/1.34.0/linux/amd64/nodeup",
+			expectS3:      false,
+		},
+		{
+			name:          "s3 source on another cloud provider",
+			cloudProvider: "hetzner",
+			location:      "s3://artifact-bucket/kops/1.34.0/linux/amd64/nodeup",
+			expectS3:      false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := &NodeUpScript{
+				CloudProvider: tc.cloudProvider,
+				NodeUpAssets:  singleNodeUpAsset(tc.location),
+				S3Region:      "us-east-2",
+			}
+			rendered := renderNodeUpScript(t, script)
+			if got := strings.Contains(rendered, s3Marker); got != tc.expectS3 {
+				t.Errorf("authenticated S3 download rendered=%v, expected %v", got, tc.expectS3)
+			}
+			if tc.expectS3 && !strings.Contains(rendered, "https://s3.us-east-2.amazonaws.com/") {
+				t.Errorf("authenticated S3 download does not use the bucket region")
+			}
+			if tc.expectedSource != "" && !strings.Contains(rendered, tc.expectedSource) {
+				t.Errorf("rendered script does not contain escaped source %q", tc.expectedSource)
+			}
+			if got := strings.Contains(rendered, standardMarker); got != !tc.expectS3 {
+				t.Errorf("standard download commands rendered=%v, expected %v", got, !tc.expectS3)
+			}
+		})
+	}
+}
+
+func Test_S3DownloadRequiresRegion(t *testing.T) {
+	script := &NodeUpScript{
+		CloudProvider: "aws",
+		NodeUpAssets:  singleNodeUpAsset("s3://artifact-bucket/kops/1.34.0/linux/amd64/nodeup"),
+	}
+	if _, err := script.Build(); err == nil {
+		t.Errorf("expected an error building an s3:// nodeup script without a resolved region")
+	}
+}
+
 func verifyShellSyntax(t *testing.T, script string) {
 	t.Helper()
 

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.307.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5
+	github.com/aws/smithy-go v1.27.3
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/spf13/pflag v1.0.10
@@ -93,7 +94,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 // indirect
-	github.com/aws/smithy-go v1.27.3 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.10.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect

--- a/tests/e2e/kubetest2-kops/aws/s3.go
+++ b/tests/e2e/kubetest2-kops/aws/s3.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go"
 	"k8s.io/klog/v2"
 )
 
@@ -50,6 +51,7 @@ type BucketType string
 const (
 	BucketTypeStateStore     BucketType = "state"
 	BucketTypeDiscoveryStore BucketType = "discovery"
+	BucketTypeStagingStore   BucketType = "staging"
 )
 
 // NewAWSClient returns a new instance of awsClient configured to work in the default region (us-east-2).
@@ -70,15 +72,11 @@ func NewClient(ctx context.Context, region string) (*Client, error) {
 func (c Client) BucketName(ctx context.Context, bucketType BucketType) (string, error) {
 	// Construct the bucket name based on the ProwJob ID (if running in Prow) or AWS account ID (if running outside
 	// Prow) and a timestamp. When BUILD_ID is set we use it in place of time.Now() so that multiple kubetest2-kops
-	// invocations within the same CI job (e.g. upgrade tests) resolve to the same bucket name.
-	var suffix string
-	if jobID := os.Getenv("BUILD_ID"); jobID != "" {
-		if len(jobID) > 14 {
-			suffix = jobID[:14]
-		} else {
-			suffix = jobID
-		}
-	} else {
+	// invocations within the same CI job (e.g. upgrade tests) resolve to the same bucket name. Use
+	// the full build ID because truncating its low-order digits can make jobs started in the same
+	// millisecond collide, allowing one job to delete another's bucket.
+	suffix := os.Getenv("BUILD_ID")
+	if suffix == "" {
 		callerIdentity, err := c.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 		if err != nil {
 			return "", fmt.Errorf("building AWS STS presigned request: %w", err)
@@ -98,7 +96,7 @@ func (c Client) BucketName(ctx context.Context, bucketType BucketType) (string, 
 	return bucket, nil
 }
 
-// EnsureS3Bucket creates a new S3 bucket with the given name and public read permissions.
+// EnsureS3Bucket creates an S3 bucket, optionally with public read access.
 func (c Client) EnsureS3Bucket(ctx context.Context, region, bucketName string, publicRead bool) error {
 	bucketName = strings.TrimPrefix(bucketName, "s3://")
 	klog.Infof("Creating bucket %s in region %s", bucketName, region)
@@ -112,14 +110,11 @@ func (c Client) EnsureS3Bucket(ctx context.Context, region, bucketName string, p
 	},
 	)
 	if err != nil {
-		var exists *types.BucketAlreadyExists
-		if errors.As(err, &exists) {
-			klog.Infof("Bucket %s already exists\n", bucketName)
-		} else {
-			klog.Infof("Error creating bucket %s, err: %v\n", bucketName, err)
+		var owned *types.BucketAlreadyOwnedByYou
+		if !errors.As(err, &owned) {
+			return fmt.Errorf("creating bucket %s: %w", bucketName, err)
 		}
-
-		return fmt.Errorf("creating bucket %s: %w", bucketName, err)
+		klog.Infof("Bucket %s already exists in this account", bucketName)
 	}
 
 	// Wait for the bucket to be created
@@ -134,26 +129,21 @@ func (c Client) EnsureS3Bucket(ctx context.Context, region, bucketName string, p
 		return fmt.Errorf("waiting for bucket %s to exist: %w", bucketName, err)
 	}
 
-	klog.Infof("Bucket %s created successfully", bucketName)
+	klog.Infof("Bucket %s is ready", bucketName)
 
 	if publicRead {
-		err = c.setPublicAccessBlock(ctx, bucketName)
-		if err != nil {
+		if err := c.setPublicAccessBlock(ctx, bucketName); err != nil {
 			klog.Errorf("Failed to disable public access block policies on bucket %s, err: %v", bucketName, err)
-
 			return fmt.Errorf("disabling public access block policies for bucket %s: %w", bucketName, err)
 		}
 
 		// Wait for public access block settings to propagate before setting the policy
 		time.Sleep(10 * time.Second)
 
-		err = c.setPublicReadPolicy(ctx, bucketName)
-		if err != nil {
+		if err := c.setPublicReadPolicy(ctx, bucketName); err != nil {
 			klog.Errorf("Failed to set public read policy on bucket %s, err: %v", bucketName, err)
-
 			return fmt.Errorf("setting public read policy for bucket %s: %w", bucketName, err)
 		}
-
 		klog.Infof("Public read policy set on bucket %s", bucketName)
 	}
 
@@ -162,6 +152,15 @@ func (c Client) EnsureS3Bucket(ctx context.Context, region, bucketName string, p
 
 // DeleteS3Bucket deletes a S3 bucket with the given name.
 func (c Client) DeleteS3Bucket(ctx context.Context, bucketName string) error {
+	return c.deleteS3Bucket(ctx, bucketName, false)
+}
+
+// DeleteS3BucketAndContents deletes all objects from an S3 bucket before deleting the bucket.
+func (c Client) DeleteS3BucketAndContents(ctx context.Context, bucketName string) error {
+	return c.deleteS3Bucket(ctx, bucketName, true)
+}
+
+func (c Client) deleteS3Bucket(ctx context.Context, bucketName string, empty bool) error {
 	bucketName = strings.TrimPrefix(bucketName, "s3://")
 
 	// Resolve the bucket's actual region to avoid 301 PermanentRedirect errors.
@@ -169,21 +168,31 @@ func (c Client) DeleteS3Bucket(ctx context.Context, bucketName string) error {
 	// zones, which can differ from the region where the bucket was created.
 	bucketRegion, err := c.getBucketRegion(ctx, bucketName)
 	if err != nil {
+		if isNoSuchBucket(err) {
+			// Teardown may run without creating every bucket it knows about.
+			return nil
+		}
 		klog.Infof("Could not determine region for bucket %s: %v", bucketName, err)
 	}
 
-	regionOpt := func(o *s3.Options) {
-		if bucketRegion != "" {
-			o.Region = bucketRegion
+	client := c.s3Client
+	if bucketRegion != "" {
+		options := c.s3Client.Options()
+		options.Region = bucketRegion
+		client = s3.New(options)
+	}
+
+	if empty {
+		if err := emptyS3Bucket(ctx, client, bucketName); err != nil {
+			return err
 		}
 	}
 
-	_, err = c.s3Client.DeleteBucket(ctx, &s3.DeleteBucketInput{
+	_, err = client.DeleteBucket(ctx, &s3.DeleteBucketInput{
 		Bucket: aws.String(bucketName),
-	}, regionOpt)
+	})
 	if err != nil {
-		var noBucket *types.NoSuchBucket
-		if errors.As(err, &noBucket) {
+		if isNoSuchBucket(err) {
 			klog.Infof("Bucket %s does not exist.", bucketName)
 
 			return nil
@@ -193,7 +202,7 @@ func (c Client) DeleteS3Bucket(ctx context.Context, bucketName string) error {
 		return fmt.Errorf("deleting bucket %s: %w", bucketName, err)
 	}
 
-	err = s3.NewBucketNotExistsWaiter(c.s3Client).Wait(
+	err = s3.NewBucketNotExistsWaiter(client).Wait(
 		ctx, &s3.HeadBucketInput{
 			Bucket: aws.String(bucketName),
 		},
@@ -205,8 +214,51 @@ func (c Client) DeleteS3Bucket(ctx context.Context, bucketName string) error {
 	}
 
 	klog.Infof("Bucket %s deleted", bucketName)
-
 	return nil
+}
+
+func emptyS3Bucket(ctx context.Context, client *s3.Client, bucketName string) error {
+	for {
+		result, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket: aws.String(bucketName),
+		})
+		if err != nil {
+			if isNoSuchBucket(err) {
+				return nil
+			}
+			return fmt.Errorf("listing objects in bucket %s: %w", bucketName, err)
+		}
+
+		if len(result.Contents) == 0 {
+			return nil
+		}
+
+		objects := make([]types.ObjectIdentifier, len(result.Contents))
+		for i, object := range result.Contents {
+			objects[i] = types.ObjectIdentifier{Key: object.Key}
+		}
+		deleteResult, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(bucketName),
+			Delete: &types.Delete{Objects: objects, Quiet: aws.Bool(true)},
+		})
+		if err != nil {
+			return fmt.Errorf("deleting objects from bucket %s: %w", bucketName, err)
+		}
+		if len(deleteResult.Errors) > 0 {
+			objectError := deleteResult.Errors[0]
+			return fmt.Errorf("deleting object %q from bucket %s: %s: %s",
+				aws.ToString(objectError.Key), bucketName, aws.ToString(objectError.Code), aws.ToString(objectError.Message))
+		}
+	}
+}
+
+func isNoSuchBucket(err error) bool {
+	var noBucket *types.NoSuchBucket
+	if errors.As(err, &noBucket) {
+		return true
+	}
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && (apiErr.ErrorCode() == "NoSuchBucket" || apiErr.ErrorCode() == "NotFound")
 }
 
 // getBucketRegion resolves the AWS region where the bucket resides.

--- a/tests/e2e/kubetest2-kops/aws/s3_test.go
+++ b/tests/e2e/kubetest2-kops/aws/s3_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+func TestStagingBucketName(t *testing.T) {
+	t.Setenv("BUILD_ID", "12345678901234567890")
+	name, err := (Client{}).BucketName(context.Background(), BucketTypeStagingStore)
+	if err != nil {
+		t.Fatalf("building bucket name: %v", err)
+	}
+	if expected := "k8s-infra-kops-staging-12345678901234567890"; name != expected {
+		t.Errorf("expected %q, got %q", expected, name)
+	}
+	if len(name) > 63 {
+		t.Errorf("bucket name %q is longer than the 63 character limit", name)
+	}
+}
+
+// Teardown can run without --build, so a missing staging bucket must be a no-op.
+func TestDeleteMissingS3Bucket(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message></Error>`)
+	}))
+	defer server.Close()
+
+	c := Client{s3Client: s3.New(s3.Options{
+		Region:           defaultRegion,
+		BaseEndpoint:     aws.String(server.URL),
+		Credentials:      aws.AnonymousCredentials{},
+		UsePathStyle:     true,
+		RetryMaxAttempts: 1,
+	})}
+
+	if err := c.deleteS3Bucket(context.Background(), "does-not-exist", true); err != nil {
+		t.Errorf("deleting a bucket that does not exist: %v", err)
+	}
+	if len(requests) != 1 || !strings.Contains(requests[0], "location") {
+		t.Errorf("expected the bucket location request only, got %v", requests)
+	}
+}
+
+func TestIsNoSuchBucket(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "typed", err: &types.NoSuchBucket{}, want: true},
+		{name: "generic code", err: &smithy.GenericAPIError{Code: "NoSuchBucket"}, want: true},
+		{name: "generic not found", err: &smithy.GenericAPIError{Code: "NotFound"}, want: true},
+		{name: "other", err: errors.New("other")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNoSuchBucket(tc.err); got != tc.want {
+				t.Errorf("isNoSuchBucket() = %v, expected %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/e2e/kubetest2-kops/builder/build.go
+++ b/tests/e2e/kubetest2-kops/builder/build.go
@@ -46,9 +46,9 @@ type BuildResults struct {
 // Build will build the kops artifacts and publish them to the stage location
 func (b *BuildOptions) Build() (*BuildResults, error) {
 	// We expect to upload to a subdirectory with a version identifier
-	gcsLocation := b.StageLocation
-	if !strings.HasSuffix(gcsLocation, "/") {
-		gcsLocation += "/"
+	stageLocation := b.StageLocation
+	if !strings.HasSuffix(stageLocation, "/") {
+		stageLocation += "/"
 	}
 
 	results := &BuildResults{}
@@ -83,43 +83,47 @@ func (b *BuildOptions) Build() (*BuildResults, error) {
 		return results, nil
 	}
 
-	args := []string{"make", "gcs-publish-ci"}
-	cmd := exec.Command(args[0], args[1:]...)
-	env := []string{
-		fmt.Sprintf("HOME=%v", os.Getenv("HOME")),
-		fmt.Sprintf("PATH=%v", os.Getenv("PATH")),
-		fmt.Sprintf("GCS_LOCATION=%v", gcsLocation),
-		fmt.Sprintf("GOPATH=%v", os.Getenv("GOPATH")),
+	target, publishEnv, err := publishConfig(stageLocation)
+	if err != nil {
+		return nil, err
 	}
-	// We need to "forward" some variables, in particular the variables like "CI" that change the version we use
-	for _, k := range []string{"CI"} {
-		v := os.Getenv(k)
-		if v != "" {
-			env = append(env, fmt.Sprintf("%s=%s", k, v))
+
+	args := []string{"make", target}
+	cmd := exec.Command(args[0], args[1:]...)
+	var env []string
+	if strings.HasPrefix(stageLocation, "s3://") {
+		// The AWS credential chain may use profiles, web identity, or container credentials.
+		env = os.Environ()
+	} else {
+		env = []string{
+			"HOME=" + os.Getenv("HOME"),
+			"PATH=" + os.Getenv("PATH"),
+			"GOPATH=" + os.Getenv("GOPATH"),
+		}
+		if ci := os.Getenv("CI"); ci != "" {
+			env = append(env, "CI="+ci)
 		}
 	}
-	cmd.SetEnv(env...)
+	cmd.SetEnv(append(env, publishEnv...)...)
 	cmd.SetDir(b.KopsRoot)
 	exec.InheritOutput(cmd)
-	klog.Infof("Executing %q (in %v) with env %v", strings.Join(args, " "), b.KopsRoot, env)
+	klog.Infof("Executing %q in %v with stage location %s", strings.Join(args, " "), b.KopsRoot, stageLocation)
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}
 
-	// Get the full path (including subdirectory) that we uploaded to
-	// It is written by gcs-publish-ci to .build/upload/latest-ci.txt
+	// The publish target records the uploaded path in .build/upload/latest-ci.txt.
 	latestPath := filepath.Join(b.KopsRoot, ".build", "upload", "latest-ci.txt")
 	kopsBaseURL, err := os.ReadFile(latestPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %w", latestPath, err)
 	}
-	u, err := url.Parse(strings.TrimSpace(string(kopsBaseURL)))
+	baseURL, err := publishedBaseURL(string(kopsBaseURL))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse url %q from file %q: %w", string(kopsBaseURL), latestPath, err)
+		return nil, fmt.Errorf("reading URL from file %q: %w", latestPath, err)
 	}
-	u.Path = strings.ReplaceAll(u.Path, "//", "/")
 	results = &BuildResults{
-		KopsBaseURL: u.String(),
+		KopsBaseURL: baseURL,
 	}
 
 	// Write some meta files so that other tooling can know e.g. KOPS_BASE_URL
@@ -134,4 +138,31 @@ func (b *BuildOptions) Build() (*BuildResults, error) {
 	klog.Infof("wrote file %q with %q", p, results.KopsBaseURL)
 
 	return results, nil
+}
+
+func publishConfig(stageLocation string) (string, []string, error) {
+	switch {
+	case strings.HasPrefix(stageLocation, "gs://"):
+		return "gcs-publish-ci", []string{"GCS_LOCATION=" + stageLocation}, nil
+	case strings.HasPrefix(stageLocation, "s3://"):
+		return "s3-publish-ci", []string{
+			"UPLOAD_DEST=" + stageLocation,
+			"UPLOAD_ARGS=",
+		}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported stage location %q", stageLocation)
+	}
+}
+
+func publishedBaseURL(value string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return "", fmt.Errorf("parsing URL %q: %w", value, err)
+	}
+	u.Path = strings.ReplaceAll(u.Path, "//", "/")
+	if u.Scheme == "s3" {
+		u.Scheme = "https"
+		u.Host += ".s3.amazonaws.com"
+	}
+	return u.String(), nil
 }

--- a/tests/e2e/kubetest2-kops/builder/build.go
+++ b/tests/e2e/kubetest2-kops/builder/build.go
@@ -154,15 +154,13 @@ func publishConfig(stageLocation string) (string, []string, error) {
 	}
 }
 
+// publishedBaseURL cleans up the location the publish target recorded. s3:// locations are kept
+// as-is so that nodes download the artifacts with their instance profile credentials.
 func publishedBaseURL(value string) (string, error) {
 	u, err := url.Parse(strings.TrimSpace(value))
 	if err != nil {
 		return "", fmt.Errorf("parsing URL %q: %w", value, err)
 	}
 	u.Path = strings.ReplaceAll(u.Path, "//", "/")
-	if u.Scheme == "s3" {
-		u.Scheme = "https"
-		u.Host += ".s3.amazonaws.com"
-	}
 	return u.String(), nil
 }

--- a/tests/e2e/kubetest2-kops/builder/build_test.go
+++ b/tests/e2e/kubetest2-kops/builder/build_test.go
@@ -82,7 +82,12 @@ func TestPublishedBaseURL(t *testing.T) {
 		},
 		{
 			value:    "s3://bucket/path/version",
-			expected: "https://bucket.s3.amazonaws.com/path/version",
+			expected: "s3://bucket/path/version",
+		},
+		{
+			// The publish target joins a location that already ends in a slash.
+			value:    "https://storage.googleapis.com/bucket/path//version",
+			expected: "https://storage.googleapis.com/bucket/path/version",
 		},
 	} {
 		actual, err := publishedBaseURL(tc.value)

--- a/tests/e2e/kubetest2-kops/builder/build_test.go
+++ b/tests/e2e/kubetest2-kops/builder/build_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPublishConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		location string
+		target   string
+		env      []string
+		wantErr  bool
+	}{
+		{
+			name:     "GCS",
+			location: "gs://bucket/path/",
+			target:   "gcs-publish-ci",
+			env:      []string{"GCS_LOCATION=gs://bucket/path/"},
+		},
+		{
+			name:     "S3",
+			location: "s3://bucket/path/",
+			target:   "s3-publish-ci",
+			env: []string{
+				"UPLOAD_DEST=s3://bucket/path/",
+				"UPLOAD_ARGS=",
+			},
+		},
+		{
+			name:     "unsupported",
+			location: "https://example.com/path/",
+			wantErr:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			target, env, err := publishConfig(tc.location)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("building publish config: %v", err)
+			}
+			if target != tc.target {
+				t.Errorf("expected target %q, got %q", tc.target, target)
+			}
+			if !reflect.DeepEqual(env, tc.env) {
+				t.Errorf("expected env %v, got %v", tc.env, env)
+			}
+		})
+	}
+}
+
+func TestPublishedBaseURL(t *testing.T) {
+	for _, tc := range []struct {
+		value    string
+		expected string
+	}{
+		{
+			value:    "https://storage.googleapis.com/bucket/path/version",
+			expected: "https://storage.googleapis.com/bucket/path/version",
+		},
+		{
+			value:    "s3://bucket/path/version",
+			expected: "https://bucket.s3.amazonaws.com/path/version",
+		},
+	} {
+		actual, err := publishedBaseURL(tc.value)
+		if err != nil {
+			t.Fatalf("converting %q: %v", tc.value, err)
+		}
+		if actual != tc.expected {
+			t.Errorf("expected %q, got %q", tc.expected, actual)
+		}
+	}
+}

--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deployer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -36,7 +37,12 @@ const (
 	defaultGCSPath = "gs://k8s-staging-kops/pulls/%v/pull-%v"
 )
 
-func (d *deployer) Build() error {
+func (d *deployer) Build() (retErr error) {
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, d.deleteStagingStore())
+		}
+	}()
 	if err := d.init(); err != nil {
 		return err
 	}
@@ -48,7 +54,7 @@ func (d *deployer) Build() error {
 		klog.Infof("setting kops base url to %q from build results", results.KopsBaseURL)
 		d.KopsBaseURL = results.KopsBaseURL
 		// In PreTestCmd, we need KOPS_BASE_URL to be set for kops calls
-		os.Setenv("KOPS_BASE_URL", d.maybeGSURL(d.KopsBaseURL))
+		os.Setenv("KOPS_BASE_URL", d.canonicalizeBaseURL(d.KopsBaseURL))
 	}
 
 	if results.KubernetesBaseURL != "" {
@@ -111,8 +117,27 @@ func (d *deployer) verifyBuildFlags() error {
 		d.BuildOptions.KubeRoot = KubeRoot
 	}
 	if d.StageLocation != "" {
-		if !strings.HasPrefix(d.StageLocation, "gs://") {
-			return errors.New("stage-location must be a gs:// path")
+		isGCS := strings.HasPrefix(d.StageLocation, "gs://")
+		isS3 := strings.HasPrefix(d.StageLocation, "s3://")
+		if !isGCS && !isS3 {
+			return errors.New("stage-location must be a gs:// or s3:// path")
+		}
+		if isS3 && d.CloudProvider != "aws" {
+			return errors.New("s3:// stage-location is only supported on AWS")
+		}
+		if isS3 && d.BuildOptions.BuildKubernetes {
+			return errors.New("building Kubernetes requires a gs:// stage-location")
+		}
+	} else if d.CloudProvider == "aws" && !d.BuildOptions.BuildKubernetes {
+		d.StageLocation = d.stagingStore()
+		if !strings.HasPrefix(d.StageLocation, "s3://") {
+			return errors.New("KOPS_STAGING_BUCKET must be an s3:// path for an AWS build")
+		}
+		if os.Getenv("KOPS_STAGING_BUCKET") == "" {
+			klog.Infof("creating staging bucket %s to hold kOps build artifacts", d.StageLocation)
+			if err := d.aws.EnsureS3Bucket(context.Background(), d.region, d.StageLocation, true); err != nil {
+				return err
+			}
 		}
 	} else if d.boskos != nil {
 		d.StageLocation = d.stagingStore()
@@ -128,7 +153,11 @@ func (d *deployer) verifyBuildFlags() error {
 		d.StageLocation = stageLocation
 	}
 	if !d.BuildOptions.BuildKubernetes && d.KopsBaseURL == "" && os.Getenv("KOPS_BASE_URL") == "" {
-		d.KopsBaseURL = strings.Replace(d.StageLocation, "gs://", "https://storage.googleapis.com/", 1)
+		if strings.HasPrefix(d.StageLocation, "gs://") {
+			d.KopsBaseURL = strings.Replace(d.StageLocation, "gs://", "https://storage.googleapis.com/", 1)
+		} else {
+			d.KopsBaseURL = d.StageLocation
+		}
 	}
 
 	if d.KopsVersionMarker != "" && !d.BuildOptions.BuildKubernetes {

--- a/tests/e2e/kubetest2-kops/deployer/build_test.go
+++ b/tests/e2e/kubetest2-kops/deployer/build_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"k8s.io/kops/tests/e2e/kubetest2-kops/builder"
+)
+
+func TestVerifyBuildFlagsWithExistingAWSStagingBucket(t *testing.T) {
+	t.Setenv("KOPS_STAGING_BUCKET", "s3://existing-staging")
+	d := &deployer{
+		CloudProvider: "aws",
+		BuildOptions:  &builder.BuildOptions{},
+	}
+	if err := d.verifyBuildFlags(); err != nil {
+		t.Fatalf("verifying build flags: %v", err)
+	}
+	if d.StageLocation != "s3://existing-staging" {
+		t.Errorf("unexpected stage location %q", d.StageLocation)
+	}
+	if d.KopsBaseURL != d.StageLocation {
+		t.Errorf("expected KopsBaseURL %q, got %q", d.StageLocation, d.KopsBaseURL)
+	}
+	if d.createStagingStore {
+		t.Error("existing staging bucket must not be deleted during teardown")
+	}
+}
+
+func TestVerifyBuildFlagsRejectsGCSStagingBucketOnAWS(t *testing.T) {
+	t.Setenv("KOPS_STAGING_BUCKET", "gs://existing-staging")
+	d := &deployer{
+		CloudProvider: "aws",
+		BuildOptions:  &builder.BuildOptions{},
+	}
+	err := d.verifyBuildFlags()
+	if err == nil || !strings.Contains(err.Error(), "must be an s3://") {
+		t.Fatalf("expected an S3 staging bucket error, got %v", err)
+	}
+}
+
+func TestVerifyBuildFlagsRejectsInvalidS3Usage(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		cloudProvider string
+		buildK8s      bool
+		errorText     string
+	}{
+		{
+			name:          "non-AWS provider",
+			cloudProvider: "gce",
+			errorText:     "only supported on AWS",
+		},
+		{
+			name:          "Kubernetes build",
+			cloudProvider: "aws",
+			buildK8s:      true,
+			errorText:     "requires a gs://",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.buildK8s {
+				gopath := t.TempDir()
+				t.Setenv("GOPATH", gopath)
+				if err := os.MkdirAll(filepath.Join(gopath, "src", "k8s.io", "kubernetes"), 0o755); err != nil {
+					t.Fatalf("creating Kubernetes checkout: %v", err)
+				}
+			}
+			d := &deployer{
+				CloudProvider: tc.cloudProvider,
+				StageLocation: "s3://staging",
+				BuildOptions:  &builder.BuildOptions{BuildKubernetes: tc.buildK8s},
+			}
+			err := d.verifyBuildFlags()
+			if err == nil || !strings.Contains(err.Error(), tc.errorText) {
+				t.Fatalf("expected error containing %q, got %v", tc.errorText, err)
+			}
+		})
+	}
+}

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -163,6 +163,11 @@ func (d *deployer) initialize() error {
 		if _, found := os.LookupEnv("KOPS_DISCOVERY_STORE"); !found {
 			d.createDiscoveryStore = true
 		}
+		// --build and --down derive the same ephemeral bucket name across separate invocations.
+		// Caller-provided buckets are never created or deleted.
+		if os.Getenv("KOPS_STAGING_BUCKET") == "" {
+			d.createStagingStore = true
+		}
 	case "gce":
 		if d.boskos != nil || os.Getenv("KOPS_STATE_STORE") == "" || os.Getenv("KOPS_STAGING_BUCKET") == "" {
 			d.createStateStore = true
@@ -302,9 +307,9 @@ func (d *deployer) env() []string {
 	}
 
 	if d.KopsBaseURL != "" {
-		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.maybeGSURL(d.KopsBaseURL)))
+		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.canonicalizeBaseURL(d.KopsBaseURL)))
 	} else if baseURL := os.Getenv("KOPS_BASE_URL"); baseURL != "" {
-		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.maybeGSURL(baseURL)))
+		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.canonicalizeBaseURL(baseURL)))
 	}
 
 	if kopsBin := d.resolvedKopsBinaryPath(); kopsBin != "" {
@@ -339,15 +344,13 @@ func (d *deployer) env() []string {
 // gcsPublicPrefix is the https form of a GCS bucket, as used for the staged build artifacts.
 const gcsPublicPrefix = "https://storage.googleapis.com/"
 
-// maybeGSURL converts baseURL from the public GCS https form to the gs:// form on GCE, so that
-// nodes download the staged artifacts with their instance service-account credentials. Any other
-// URL, and any other cloud provider, passes through unchanged. Only kops invocations get the gs://
-// form; the scripts that download the kops binary run outside the deployer and keep using https.
-func (d *deployer) maybeGSURL(baseURL string) string {
-	if d.CloudProvider != "gce" || !strings.HasPrefix(baseURL, gcsPublicPrefix) {
-		return baseURL
+// canonicalizeBaseURL converts a public GCS URL to gs:// on GCE so nodes download staged artifacts
+// with their service-account credentials. Other URLs and cloud providers pass through unchanged.
+func (d *deployer) canonicalizeBaseURL(baseURL string) string {
+	if d.CloudProvider == "gce" && strings.HasPrefix(baseURL, gcsPublicPrefix) {
+		return "gs://" + strings.TrimPrefix(baseURL, gcsPublicPrefix)
 	}
-	return "gs://" + strings.TrimPrefix(baseURL, gcsPublicPrefix)
+	return baseURL
 }
 
 // featureFlags returns the kops feature flags to set
@@ -506,6 +509,14 @@ func (d *deployer) stagingStore() string {
 	sb := os.Getenv("KOPS_STAGING_BUCKET")
 	if sb == "" {
 		switch d.CloudProvider {
+		case "aws":
+			ctx := context.Background()
+			bucketName, err := d.aws.BucketName(ctx, aws.BucketTypeStagingStore)
+			if err != nil {
+				klog.Fatalf("Failed to generate bucket name: %v", err)
+				return ""
+			}
+			sb = "s3://" + bucketName
 		case "gce":
 			sb = "gs://" + gce.GCSBucketName(d.GCPProject, "staging")
 		}

--- a/tests/e2e/kubetest2-kops/deployer/common_test.go
+++ b/tests/e2e/kubetest2-kops/deployer/common_test.go
@@ -18,7 +18,7 @@ package deployer
 
 import "testing"
 
-func TestMaybeGSURL(t *testing.T) {
+func TestCanonicalizeBaseURL(t *testing.T) {
 	cases := []struct {
 		name          string
 		cloudProvider string
@@ -38,8 +38,26 @@ func TestMaybeGSURL(t *testing.T) {
 			expected:      "https://storage.googleapis.com/k8s-staging-kops/kops/1.34.0/",
 		},
 		{
+			name:          "aws with S3 staged artifacts",
+			cloudProvider: "aws",
+			baseURL:       "https://example-bucket.s3.us-east-2.amazonaws.com/kops/1.34.0/",
+			expected:      "https://example-bucket.s3.us-east-2.amazonaws.com/kops/1.34.0/",
+		},
+		{
+			name:          "gce with S3 staged artifacts is left alone",
+			cloudProvider: "gce",
+			baseURL:       "https://example-bucket.s3.us-east-2.amazonaws.com/kops/1.34.0/",
+			expected:      "https://example-bucket.s3.us-east-2.amazonaws.com/kops/1.34.0/",
+		},
+		{
 			name:          "gce with a non-GCS url",
 			cloudProvider: "gce",
+			baseURL:       "https://artifacts.k8s.io/binaries/kops/1.34.0/",
+			expected:      "https://artifacts.k8s.io/binaries/kops/1.34.0/",
+		},
+		{
+			name:          "aws with a non-S3 url",
+			cloudProvider: "aws",
 			baseURL:       "https://artifacts.k8s.io/binaries/kops/1.34.0/",
 			expected:      "https://artifacts.k8s.io/binaries/kops/1.34.0/",
 		},
@@ -49,13 +67,19 @@ func TestMaybeGSURL(t *testing.T) {
 			baseURL:       "gs://k8s-staging-kops/kops/1.34.0/",
 			expected:      "gs://k8s-staging-kops/kops/1.34.0/",
 		},
+		{
+			name:          "aws with an already converted url",
+			cloudProvider: "aws",
+			baseURL:       "s3://example-bucket/kops/1.34.0/",
+			expected:      "s3://example-bucket/kops/1.34.0/",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			d := &deployer{CloudProvider: tc.cloudProvider}
-			if actual := d.maybeGSURL(tc.baseURL); actual != tc.expected {
-				t.Errorf("maybeGSURL(%q) = %q, expected %q", tc.baseURL, actual, tc.expected)
+			if actual := d.canonicalizeBaseURL(tc.baseURL); actual != tc.expected {
+				t.Errorf("canonicalizeBaseURL(%q) = %q, expected %q", tc.baseURL, actual, tc.expected)
 			}
 		})
 	}

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -44,7 +44,7 @@ type deployer struct {
 
 	KopsRoot string `flag:"kops-root" desc:"Path to root of the kops repo. Used with --build."`
 
-	StageLocation string `flag:"stage-location" desc:"Storage location for kops artifacts. Only gs:// paths are supported."`
+	StageLocation string `flag:"stage-location" desc:"Storage location for kops artifacts. gs:// and s3:// paths are supported."`
 
 	KopsVersionMarker    string `flag:"kops-version-marker" desc:"The URL to the kops version marker. Conflicts with --build and --kops-binary-path"`
 	KopsBaseURL          string `flag:"-"`
@@ -100,6 +100,7 @@ type deployer struct {
 
 	createStateStore     bool
 	createDiscoveryStore bool
+	createStagingStore   bool
 	stateStoreName       string
 	discoveryStoreName   string
 	stagingStoreName     string

--- a/tests/e2e/kubetest2-kops/deployer/down.go
+++ b/tests/e2e/kubetest2-kops/deployer/down.go
@@ -18,6 +18,7 @@ package deployer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -28,7 +29,13 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
+// Down deletes the cluster and its staged artifacts, so scenarios must use them first.
 func (d *deployer) Down() error {
+	return errors.Join(d.down(), d.deleteStagingStore())
+}
+
+// down preserves staged artifacts while Up cleans leaked cluster resources.
+func (d *deployer) down() error {
 	if err := d.init(); err != nil {
 		return err
 	}
@@ -98,5 +105,16 @@ func (d *deployer) Down() error {
 			return fmt.Errorf("down failed to release boskos project: %s", err)
 		}
 	}
+	return nil
+}
+
+func (d *deployer) deleteStagingStore() error {
+	if !d.createStagingStore {
+		return nil
+	}
+	if err := d.aws.DeleteS3BucketAndContents(context.Background(), d.stagingStore()); err != nil {
+		return err
+	}
+	d.createStagingStore = false
 	return nil
 }

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -50,9 +50,14 @@ const (
 	awsDefaultArmNodeSize         = "c6g.large"
 )
 
-func (d *deployer) Up() error {
+func (d *deployer) Up() (retErr error) {
 	ctx := context.TODO()
 
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, d.deleteStagingStore())
+		}
+	}()
 	if err := d.init(); err != nil {
 		return err
 	}
@@ -70,14 +75,14 @@ func (d *deployer) Up() error {
 
 	// PreTestCmd inherits the process environment rather than d.env().
 	if d.KopsBaseURL != "" {
-		os.Setenv("KOPS_BASE_URL", d.maybeGSURL(d.KopsBaseURL))
+		os.Setenv("KOPS_BASE_URL", d.canonicalizeBaseURL(d.KopsBaseURL))
 	}
 
 	if d.terraform == nil {
 		klog.Info("Cleaning up any leaked resources from previous cluster")
 		// Intentionally ignore errors:
 		// Either the cluster didn't exist or something failed that the next cluster creation will catch
-		_ = d.Down()
+		_ = d.down()
 	}
 
 	switch d.CloudProvider {

--- a/tests/e2e/scenarios/lib/upgrade.sh
+++ b/tests/e2e/scenarios/lib/upgrade.sh
@@ -67,21 +67,32 @@ function kops-upgrade() {
 
     export KOPS_BASE_URL
 
-    echo "Cleaning up any leaked resources from previous cluster"
     # For KOPS_VERSION_B, the value "latest" means build of the tree
     if [[ "${KOPS_VERSION_B}" == "latest" ]]; then
-        kops-acquire-latest
-        KOPS_BASE_URL_B="${KOPS_BASE_URL}"
-        KOPS_B="${KOPS}"
+        # --down deletes staged artifacts, so acquire version B after cleanup. Build its binary
+        # now because cleanup itself uses version B. Periodic jobs only download the binary.
+        if [[ "${JOB_TYPE-}" == "periodic" ]]; then
+            kops-acquire-latest
+            KOPS_B="${KOPS}"
+        else
+            make -C "${REPO_ROOT}" crossbuild-kops-linux-amd64
+            KOPS_B="${REPO_ROOT}/.build/dist/linux/amd64/kops"
+        fi
     else
         KOPS_BASE_URL=$(kops-base-from-marker "${KOPS_VERSION_B}")
-        KOPS_BASE_URL_B="${KOPS_BASE_URL}"
         KOPS_B=$(kops-download-from-base)
     fi
 
+    echo "Cleaning up any leaked resources from previous cluster"
     ${KUBETEST2} \
         --down \
         --kops-binary-path="${KOPS_B}" || echo "kubetest2 down failed"
+
+    if [[ "${KOPS_VERSION_B}" == "latest" ]]; then
+        kops-acquire-latest
+        KOPS_B="${KOPS}"
+    fi
+    KOPS_BASE_URL_B="${KOPS_BASE_URL}"
 
     # First kOps version may be a released version. If so, it is prefixed with v
     if [[ "${KOPS_VERSION_A:0:1}" == "v" ]]; then

--- a/upup/pkg/fi/assetstore.go
+++ b/upup/pkg/fi/assetstore.go
@@ -201,23 +201,21 @@ func hashFromHTTPHeader(url string) (*hashing.Hash, error) {
 
 // Add an asset into the store, in one of the recognized formats (see Assets in types package)
 func (a *AssetStore) Add(ctx context.Context, id string) error {
-	if strings.HasPrefix(id, "http://") || strings.HasPrefix(id, "https://") || strings.HasPrefix(id, "gs://") {
-		return a.addURLs(ctx, strings.Split(id, ","), nil)
-	}
-	i := strings.Index(id, "@http://")
-	if i == -1 {
-		i = strings.Index(id, "@https://")
-	}
-	if i == -1 {
-		i = strings.Index(id, "@gs://")
-	}
-	if i != -1 {
-		urls := strings.Split(id[i+1:], ",")
-		hash, err := hashing.FromString(id[:i])
-		if err != nil {
-			return err
+	schemes := [...]string{"http://", "https://", "gs://", "s3://"}
+	for _, scheme := range schemes {
+		if strings.HasPrefix(id, scheme) {
+			return a.addURLs(ctx, strings.Split(id, ","), nil)
 		}
-		return a.addURLs(ctx, urls, hash)
+	}
+
+	for _, scheme := range schemes {
+		if i := strings.Index(id, "@"+scheme); i != -1 {
+			hash, err := hashing.FromString(id[:i])
+			if err != nil {
+				return err
+			}
+			return a.addURLs(ctx, strings.Split(id[i+1:], ","), hash)
+		}
 	}
 	// TODO: local files!
 	return fmt.Errorf("unknown asset format: %q", id)

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -120,6 +120,19 @@ func FindRegion(cluster *kops.Cluster) (string, error) {
 	return region, nil
 }
 
+// SupportsS3BootstrapEndpoint reports whether the region uses the amazonaws.com partition DNS
+// suffix hard-coded by the nodeup bootstrap script. EC2 uses the same partition suffix as S3 and
+// can be resolved without a bucket.
+func SupportsS3BootstrapEndpoint(ctx context.Context, region string) (bool, error) {
+	resolver := ec2.NewDefaultEndpointResolverV2()
+	endpoint, err := resolver.ResolveEndpoint(ctx, ec2.EndpointParameters{Region: aws.String(region)})
+	if err != nil {
+		return false, fmt.Errorf("resolving EC2 endpoint for region %q: %w", region, err)
+	}
+
+	return endpoint.URI.Hostname() == fmt.Sprintf("ec2.%s.amazonaws.com", region), nil
+}
+
 // FindEC2Tag find the value of the tag with the specified key
 func FindEC2Tag(tags []ec2types.Tag, key string) (string, bool) {
 	for _, tag := range tags {

--- a/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
@@ -119,6 +119,32 @@ func TestFindRegion(t *testing.T) {
 	}
 }
 
+func TestSupportsS3BootstrapEndpoint(t *testing.T) {
+	for _, tc := range []struct {
+		region    string
+		supported bool
+	}{
+		{region: "us-east-1", supported: true},
+		{region: "us-gov-west-1", supported: true},
+		{region: "cn-north-1"},
+		{region: "us-iso-east-1"},
+		{region: "us-isob-east-1"},
+		{region: "eu-isoe-west-1"},
+		{region: "us-isof-south-1"},
+		{region: "eusc-de-east-1"},
+	} {
+		t.Run(tc.region, func(t *testing.T) {
+			supported, err := SupportsS3BootstrapEndpoint(context.Background(), tc.region)
+			if err != nil {
+				t.Fatalf("checking S3 bootstrap endpoint support: %v", err)
+			}
+			if supported != tc.supported {
+				t.Errorf("supported=%v, expected %v", supported, tc.supported)
+			}
+		})
+	}
+}
+
 func TestEC2TagSpecification(t *testing.T) {
 	cases := []struct {
 		Name          string

--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -31,6 +31,7 @@ import (
 	"cloud.google.com/go/storage"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/util/pkg/hashing"
+	"k8s.io/kops/util/pkg/vfs"
 )
 
 const downloadTimeout = 3 * time.Minute
@@ -82,39 +83,17 @@ func downloadURLToFile(ctx context.Context, url string, destPath string, hash *h
 
 // downloadURLToWriter streams the file at the given url to dest.
 // If hash is non-nil, it will also verify that it matches the downloaded bytes.
-func downloadURLToWriter(ctx context.Context, desturl string, dest io.Writer, hash *hashing.Hash) (*hashing.Hash, error) {
-	var reader io.ReadCloser
-	u, err := url.Parse(desturl)
+func downloadURLToWriter(ctx context.Context, sourceURL string, dest io.Writer, hash *hashing.Hash) (*hashing.Hash, error) {
+	u, err := url.Parse(sourceURL)
 	if err != nil {
-		return nil, fmt.Errorf("Invalud URL for file %q: %v", desturl, err)
+		return nil, fmt.Errorf("invalid URL for file %q: %w", sourceURL, err)
 	}
-	if u.Scheme != "gs" {
-		reader, err = OpenURL(desturl)
-		if err != nil {
-			return nil, err
-		}
-		defer reader.Close()
-	} else {
-		bucketName := u.Host
-		objectName := strings.TrimPrefix(u.Path, "/")
 
-		client, err := storage.NewClient(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to create client %q: %v", desturl, err)
-		}
-		defer client.Close()
-
-		reader, err = client.Bucket(bucketName).Object(objectName).NewReader(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to open reader on object %q: %v", desturl, err)
-		}
-		defer reader.Close()
-	}
 	start := time.Now()
 	defer func() {
-		klog.V(2).Infof("Downloading %q took %q", desturl, time.Since(start))
+		klog.V(2).Infof("Downloading %q took %q", sourceURL, time.Since(start))
 	}()
-	klog.V(2).Infof("Downloading %q", desturl)
+	klog.V(2).Infof("Downloading %q", sourceURL)
 
 	algorithm := hashing.HashAlgorithmSHA256
 	if hash != nil {
@@ -123,8 +102,49 @@ func downloadURLToWriter(ctx context.Context, desturl string, dest io.Writer, ha
 	hasher := algorithm.NewHasher()
 	writer := io.MultiWriter(dest, hasher)
 
-	if _, err := io.Copy(writer, reader); err != nil {
-		return nil, fmt.Errorf("error downloading HTTP content from %q: %v", desturl, err)
+	switch u.Scheme {
+	case "gs":
+		bucketName := u.Host
+		objectName := strings.TrimPrefix(u.Path, "/")
+
+		client, err := storage.NewClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client for %q: %w", sourceURL, err)
+		}
+		defer client.Close()
+
+		reader, err := client.Bucket(bucketName).Object(objectName).NewReader(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open reader on object %q: %w", sourceURL, err)
+		}
+		defer reader.Close()
+
+		if _, err := io.Copy(writer, reader); err != nil {
+			return nil, fmt.Errorf("error downloading content from %q: %w", sourceURL, err)
+		}
+	case "s3":
+		// vfs resolves the bucket region and signs the request with the ambient AWS credentials.
+		p, err := vfs.Context.BuildVfsPath(sourceURL)
+		if err != nil {
+			return nil, fmt.Errorf("building path for %q: %w", sourceURL, err)
+		}
+		s3Path, ok := p.(*vfs.S3Path)
+		if !ok {
+			return nil, fmt.Errorf("unexpected path type %T for %q", p, sourceURL)
+		}
+		if _, err := s3Path.WriteToWithContext(ctx, writer); err != nil {
+			return nil, fmt.Errorf("error downloading content from %q: %w", sourceURL, err)
+		}
+	default:
+		reader, err := OpenURL(sourceURL)
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Close()
+
+		if _, err := io.Copy(writer, reader); err != nil {
+			return nil, fmt.Errorf("error downloading content from %q: %w", sourceURL, err)
+		}
 	}
 
 	actual := &hashing.Hash{
@@ -132,7 +152,7 @@ func downloadURLToWriter(ctx context.Context, desturl string, dest io.Writer, ha
 		HashValue: hasher.Sum(nil),
 	}
 	if hash != nil && !actual.Equal(hash) {
-		return nil, fmt.Errorf("downloaded from %q but hash did not match expected %q", desturl, hash)
+		return nil, fmt.Errorf("downloaded from %q but hash did not match expected %q", sourceURL, hash)
 	}
 	return actual, nil
 }


### PR DESCRIPTION
When KOPS_BASE_URL is an s3:// URL, the bootstrap script downloads nodeup with curl 8.0 or newer, signing the request with instance profile credentials from IMDS using curl's native AWS SigV4 support. The credentials are piped through --config -, so they never reach disk, process arguments, or console logs.

The s3:// URL does not carry the bucket region required by SigV4, so kOps resolves it through VFS before rendering the bootstrap script. Validation rejects AWS partitions whose endpoints are incompatible with the generated download URL.

spec.assets.fileRepository now accepts an s3:// URL on AWS. Nodeup reads these assets through VFS using instance credentials, and remapped repository paths escape delimiter commas before compact asset serialization.

The e2e tooling stages AWS pull artifacts in S3 to exercise this path. The kubetest2 deployer creates a staging bucket for AWS builds and deletes it during --down. Its name is derived from the whole BUILD_ID, so every invocation of a test run derives the same name without passing state between them, and no scenario script has to signal the teardown.