### PR TITLE
aws: download nodeup from private S3 buckets with curl

### DIFF
--- a/docs/operations/asset-repository.md
+++ b/docs/operations/asset-repository.md
@@ -41,9 +41,11 @@ spec:
     fileRepository: https://example.com/files
 ```
 
-The repository must allow nodes to perform unauthenticated reads. The repository can
-be public or it can allow read access through network connectivity, such as access
-through a particular AWS Endpoint.
+For an `http://` or `https://` repository, nodes must be able to read without credentials.
+The repository can be public or allow access through network connectivity, such as a
+particular cloud endpoint.
+
+{{ kops_feature_table(kops_added_default='1.37') }}
 
 On GCE, the repository can also be a `gs://` URL. Nodes then read it with the credentials of
 their service account, which allows the bucket to be private. The service accounts of the
@@ -53,6 +55,20 @@ instance groups have to be granted `roles/storage.objectViewer` on that bucket.
 spec:
   assets:
     fileRepository: gs://example-bucket/files
+```
+
+{{ kops_feature_table(kops_added_default='1.37') }}
+
+On AWS, the repository can also be an `s3://` URL. Nodes then read it with the credentials of
+their instance profile, which allows the bucket to be private. The instance profiles of the
+instance groups have to be granted `s3:GetObject` on that bucket. This is supported in the
+commercial AWS and AWS GovCloud partitions. Downloading nodeup itself from an `s3://`
+`KOPS_BASE_URL` additionally requires curl 8.0 or newer on the node image.
+
+```yaml
+spec:
+  assets:
+    fileRepository: s3://example-bucket/files
 ```
 
 ## Copying assets into repositories
@@ -65,7 +81,7 @@ When running `kops get assets --copy`, kOps copies assets into their respective 
 they do not already exist there.
 
 For file assets, kOps only supports copying to a repository that is either an S3 or GCS bucket.
-An S3 bucket must be configured using the [regional naming conventions of S3](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
+An S3 bucket must be configured with a prefix of `s3://` or using the [regional naming conventions of S3](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
 A GCS bucket must be configured with a prefix of `https://storage.googleapis.com/` or `gs://`.
 
 ## Listing assets

--- a/docs/releases/1.37-NOTES.md
+++ b/docs/releases/1.37-NOTES.md
@@ -32,6 +32,8 @@ As part of this removal, the `protokube` component, whose only remaining respons
 
 * On AWS, instance roles that require no permissions, such as the bastion role and the default worker node role, no longer have an inline IAM policy. `kops update cluster` deletes the previously created inline policy from such roles. With the Terraform target, the corresponding `aws_iam_role_policy` resources are removed from the configuration and destroyed on the next apply.
 
+* Private cluster asset repositories now support AWS `s3://` URLs in addition to existing GCE `gs://` URLs, both for `KOPS_BASE_URL` (nodeup download) and `spec.assets.fileRepository`. Nodes authenticate with their instance credentials; see the [asset repository documentation](https://kops.sigs.k8s.io/operations/asset-repository/) for the required permissions. The AWS nodeup download requires node images with curl 8.0 or newer.
+
 # Breaking changes
 
 * Support for AWS Classic Load Balancer (CLB) for the API has been removed. Clusters with `spec.api.loadBalancer.class: Classic` (or with no explicit `class`, which previously defaulted to Classic) fail validation, and the long-deprecated `kops create cluster --api-loadbalancer-class` flag has been removed. Existing clusters using a CLB must migrate to a Network Load Balancer (NLB) using kOps 1.36 or earlier before upgrading to kOps 1.37, following the [CLB to NLB migration guide](https://github.com/kubernetes/kops/blob/master/permalinks/acm_nlb.md). Attaching instance groups to externally-managed Classic Load Balancers via `spec.externalLoadBalancers[].loadBalancerName` remains supported.

--- a/hack/dev-build-aws.sh
+++ b/hack/dev-build-aws.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a convenience script for developing kOps on GCE.
-# It builds the code, including nodeup, and uploads to a custom GCS bucket.
+# This is a convenience script for developing kOps on AWS.
+# It builds the code, including nodeup, and uploads to a custom S3 bucket.
 # It also sets KOPS_STATE_STORE and KOPS_BASE_URL to project-isolated values.
-# To use, source the script.  For example `. hack/dev-build-gce.sh` (note the initial `.`)
+# To use, source the script. For example, `. hack/dev-build-aws.sh` (note the initial `.`).
 
 # Can't use set -e in a script we want to source
 #set -e
@@ -37,9 +37,11 @@ aws s3 ls "${UPLOAD_DEST}" || aws s3 mb "${UPLOAD_DEST}" || return
 make kops-install dev-upload-linux-${KOPS_ARCH} || return
 
 # Set KOPS_BASE_URL
-(tools/get_version.sh | grep VERSION | awk '{print $2}') || return
-KOPS_VERSION=$(tools/get_version.sh | grep VERSION | awk '{print $2}')
-export KOPS_BASE_URL=https://${S3_BUCKET_NAME}.s3.amazonaws.com/kops/${KOPS_VERSION}/
+KOPS_VERSION=$(tools/get_version.sh | grep VERSION | awk '{print $2}') || return
+echo "${KOPS_VERSION}"
+# The s3:// form lets nodes use their instance profiles; https:// requires public read access.
+# Grant the cluster instance profiles s3:GetObject on the bucket and use node images with curl >= 8.0.
+export KOPS_BASE_URL=s3://${S3_BUCKET_NAME}/kops/${KOPS_VERSION}/
 
 # Create the state-store bucket if it doesn't exist
 KOPS_STATE_STORE="s3://kops-state-${ACCOUNT_ID}-${USER}"

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -63,11 +64,36 @@ func awsValidateCluster(c *kops.Cluster, strict bool) field.ErrorList {
 
 	allErrs = append(allErrs, awsValidateUseIPBasedNodeNames(c)...)
 
+	allErrs = append(allErrs, awsValidateS3FileRepositoryPartition(c)...)
+
 	if c.Spec.Authentication != nil && c.Spec.Authentication.AWS != nil {
 		allErrs = append(allErrs, awsValidateIAMAuthenticator(field.NewPath("spec", "authentication", "aws"), c.Spec.Authentication.AWS)...)
 	}
 
 	return allErrs
+}
+
+func awsValidateS3FileRepositoryPartition(cluster *kops.Cluster) field.ErrorList {
+	assets := cluster.Spec.Assets
+	if assets == nil || assets.FileRepository == nil || !strings.HasPrefix(*assets.FileRepository, "s3://") {
+		return nil
+	}
+
+	region, err := awsup.FindRegion(cluster)
+	if err != nil {
+		// Subnet validation reports invalid or missing zones separately.
+		return nil
+	}
+
+	fldPath := field.NewPath("spec", "assets", "fileRepository")
+	supported, err := awsup.SupportsS3BootstrapEndpoint(context.TODO(), region)
+	if err != nil {
+		return field.ErrorList{field.Invalid(fldPath, *assets.FileRepository, err.Error())}
+	}
+	if !supported {
+		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("s3:// fileRepository is not supported in AWS region %q", region))}
+	}
+	return nil
 }
 
 func awsValidateEBSCSIDriver(cluster *kops.Cluster) (allErrs field.ErrorList) {

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -923,6 +923,59 @@ func TestAWSAdditionalRoutes(t *testing.T) {
 	}
 }
 
+func TestAWSValidateS3FileRepository(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		region         string
+		fileRepository string
+		expectedErrors []string
+	}{
+		{
+			name:           "commercial partition",
+			region:         "us-east-1",
+			fileRepository: "s3://example-k8s-assets/kops",
+		},
+		{
+			name:           "GovCloud partition",
+			region:         "us-gov-west-1",
+			fileRepository: "s3://example-k8s-assets/kops",
+		},
+		{
+			name:           "China partition",
+			region:         "cn-north-1",
+			fileRepository: "s3://example-k8s-assets/kops",
+			expectedErrors: []string{"Forbidden::spec.assets.fileRepository"},
+		},
+		{
+			name:           "ISO partition",
+			region:         "us-iso-east-1",
+			fileRepository: "s3://example-k8s-assets/kops",
+			expectedErrors: []string{"Forbidden::spec.assets.fileRepository"},
+		},
+		{
+			name:           "HTTPS repository in ISO partition",
+			region:         "us-iso-east-1",
+			fileRepository: "https://example.com/kops",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fileRepository := tc.fileRepository
+			cluster := &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					CloudProvider: kops.CloudProviderSpec{AWS: &kops.AWSSpec{}},
+					Assets:        &kops.AssetsSpec{FileRepository: &fileRepository},
+					Networking: kops.NetworkingSpec{
+						Subnets: []kops.ClusterSubnetSpec{{Name: "subnet", Zone: tc.region + "a"}},
+					},
+				},
+			}
+
+			errs := awsValidateCluster(cluster, false)
+			testErrors(t, tc.name, errs, tc.expectedErrors)
+		})
+	}
+}
+
 func TestAWSValidateNLBSecurityGroupMode(t *testing.T) {
 	grid := []struct {
 		Input          kops.ClusterSpec

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -797,8 +797,13 @@ func validateFileRepository(s string, fieldPath *field.Path, cloudProvider kops.
 		if cloudProvider != kops.CloudProviderGCE {
 			allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("gs:// fileRepository is only supported on GCE, but the cloud provider is %q", cloudProvider)))
 		}
+	case "s3":
+		// Only AWS instances can authenticate to S3 with their instance profile.
+		if cloudProvider != kops.CloudProviderAWS {
+			allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("s3:// fileRepository is only supported on AWS, but the cloud provider is %q", cloudProvider)))
+		}
 	default:
-		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must be an http:// or https:// URL"))
+		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must be an http://, https://, gs://, or s3:// URL"))
 	}
 	if u.Host == "" {
 		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must include a host"))

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -2293,6 +2293,15 @@ func TestValidateFileRepository(t *testing.T) {
 			Input: "http://example.com/files",
 		},
 		{
+			Input:         "s3://example-k8s-assets/kops",
+			CloudProvider: kops.CloudProviderAWS,
+		},
+		{
+			Input:          "s3://example-k8s-assets/kops",
+			CloudProvider:  kops.CloudProviderGCE,
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
 			Input:          "s3://example-k8s-assets/kops",
 			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
 		},

--- a/pkg/assets/assetcopy/copyfile.go
+++ b/pkg/assets/assetcopy/copyfile.go
@@ -176,11 +176,11 @@ func writeFile(ctx context.Context, cluster *kops.Cluster, p vfs.Path, data []by
 	return nil
 }
 
-// buildVFSPath task a recognizable https url and transforms that URL into the equivalent url with the object
-// store prefix.
+// buildVFSPath returns local paths and memfs://, file://, gs://, and s3:// URLs unchanged.
+// It converts recognized S3 or GCS HTTPS URLs to their native VFS form.
 func buildVFSPath(target string) (string, error) {
 	if !strings.Contains(target, "://") || strings.HasPrefix(target, "memfs://") || strings.HasPrefix(target, "file://") ||
-		strings.HasPrefix(target, "gs://") {
+		strings.HasPrefix(target, "gs://") || strings.HasPrefix(target, "s3://") {
 		return target, nil
 	}
 
@@ -207,7 +207,7 @@ func buildVFSPath(target string) (string, error) {
 	if vfsPath == "" {
 		klog.Errorf("Unable to determine VFS path from supplied URL: %s", target)
 		klog.Errorf("S3, Google Cloud Storage, and File Paths are supported.")
-		klog.Errorf("For S3, please make sure that the supplied file repository URL adhere to S3 naming conventions, https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.")
+		klog.Errorf("For S3, please make sure that the supplied file repository URL starts with s3:// or adheres to S3 naming conventions.")
 		klog.Errorf("For GCS, please make sure that the supplied file repository URL starts with gs:// or https://storage.googleapis.com/")
 		if err != nil { // print the S3 error for more details
 			return "", fmt.Errorf("Error Details: %v", err)

--- a/pkg/assets/assetcopy/copyfile_test.go
+++ b/pkg/assets/assetcopy/copyfile_test.go
@@ -52,6 +52,11 @@ func Test_BuildVFSPath(t *testing.T) {
 			true,
 		},
 		{
+			"s3://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			"s3://k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			true,
+		},
+		{
 			"https://foo/k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
 			"",
 			false,

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -442,6 +442,8 @@ func (a *AssetBuilder) remapURL(canonicalURL *url.URL) (*url.URL, error) {
 	}
 
 	fileRepo.Path = path.Join(fileRepo.Path, canonicalURL.Path)
+	// Escape commas, which are legal in a path but separate locations in CompactString.
+	fileRepo.RawPath = strings.ReplaceAll(fileRepo.EscapedPath(), ",", "%2C")
 
 	return fileRepo, nil
 }

--- a/pkg/assets/builder_test.go
+++ b/pkg/assets/builder_test.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -125,6 +126,84 @@ func TestValidate_RemapImage_ContainerRegistry_MappingMultipleTimesConverges(t *
 		if remapped != expected {
 			t.Errorf("Error remapping image (Expecting: %s, got %s, iteration: %d)", expected, remapped, i)
 		}
+	}
+}
+
+func TestRemapURLPathDelimiterEscaping(t *testing.T) {
+	canonicalURL, err := url.Parse("https://artifacts.k8s.io/binaries/kops/1.37.0/linux/arm64/nodeup")
+	if err != nil {
+		t.Fatalf("parsing canonical URL: %v", err)
+	}
+	knownHash := hashing.MustFromString("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+
+	for _, tc := range []struct {
+		name           string
+		fileRepository string
+		expected       string
+	}{
+		{
+			name:           "S3 raw comma",
+			fileRepository: "s3://artifact-bucket/prefix,prod",
+			expected:       "s3://artifact-bucket/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+		{
+			name:           "S3 encoded comma",
+			fileRepository: "s3://artifact-bucket/prefix%2Cprod",
+			expected:       "s3://artifact-bucket/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+		{
+			name:           "GCS raw comma",
+			fileRepository: "gs://artifact-bucket/prefix,prod",
+			expected:       "gs://artifact-bucket/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+		{
+			name:           "GCS encoded comma",
+			fileRepository: "gs://artifact-bucket/prefix%2Cprod",
+			expected:       "gs://artifact-bucket/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+		{
+			name:           "HTTPS raw comma",
+			fileRepository: "https://artifacts.example.com/prefix,prod",
+			expected:       "https://artifacts.example.com/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+		{
+			name:           "HTTPS encoded comma",
+			fileRepository: "https://artifacts.example.com/prefix%2Cprod",
+			expected:       "https://artifacts.example.com/prefix%2Cprod/binaries/kops/1.37.0/linux/arm64/nodeup",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fileRepository := tc.fileRepository
+			builder := NewAssetBuilder(nil, &kops.AssetsSpec{FileRepository: &fileRepository}, false)
+			asset, err := builder.RemapFile(canonicalURL, knownHash)
+			if err != nil {
+				t.Fatalf("remapping file: %v", err)
+			}
+
+			mirrored := BuildMirroredAsset(asset)
+			if len(mirrored.Locations) != 1 {
+				t.Fatalf("expected one location, got %d", len(mirrored.Locations))
+			}
+			if mirrored.Locations[0] != tc.expected {
+				t.Errorf("expected location %q, got %q", tc.expected, mirrored.Locations[0])
+			}
+
+			_, locations, ok := strings.Cut(mirrored.CompactString(), "@")
+			if !ok {
+				t.Fatalf("compact asset does not contain a hash separator")
+			}
+			if split := strings.Split(locations, ","); len(split) != 1 {
+				t.Fatalf("compact asset split into %d locations", len(split))
+			}
+			parsed, err := url.Parse(locations)
+			if err != nil {
+				t.Fatalf("parsing compact asset location: %v", err)
+			}
+			expectedPath := "/prefix,prod/binaries/kops/1.37.0/linux/arm64/nodeup"
+			if parsed.Path != expectedPath {
+				t.Errorf("expected decoded path %q, got %q", expectedPath, parsed.Path)
+			}
+		})
 	}
 }
 

--- a/pkg/commands/toolbox_enroll.go
+++ b/pkg/commands/toolbox_enroll.go
@@ -845,12 +845,16 @@ func (b *ConfigBuilder) GetBootstrapData(ctx context.Context) (*BootstrapData, e
 
 	bootConfig.ConfigBase = new("file:///etc/kubernetes/kops/config")
 
+	vfsContext := clientset.VFSContext()
+
+	if err := nodeupScript.ResolveS3Region(ctx, vfsContext); err != nil {
+		return nil, err
+	}
+
 	nodeupScriptResource, err := nodeupScript.Build()
 	if err != nil {
 		return nil, err
 	}
-
-	vfsContext := clientset.VFSContext()
 
 	// If this is the control plane, we want to copy the config from s3/gcs to the local file system on the target node,
 	// so that we don't need credentials to the state store.

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -148,6 +148,10 @@ func (b *BootstrapScript) kubeEnv(cluster *kops.Cluster, ig *kops.InstanceGroup,
 
 		nodeupScript.CloudProvider = string(cluster.GetCloudProvider())
 
+		if err := nodeupScript.ResolveS3Region(c.Context(), vfs.Context); err != nil {
+			return nil, err
+		}
+
 		scriptResource, err := nodeupScript.Build()
 		if err != nil {
 			return nil, err
@@ -303,6 +307,10 @@ func (b *BootstrapScript) Run(c *fi.CloudupContext) error {
 	nodeupScript.CompressUserData = fi.ValueOf(b.ig.Spec.CompressUserData)
 
 	nodeupScript.CloudProvider = string(c.T.Cluster.GetCloudProvider())
+
+	if err := nodeupScript.ResolveS3Region(c.Context(), vfs.Context); err != nil {
+		return err
+	}
 
 	nodeupScriptResource, err := nodeupScript.Build()
 	if err != nil {

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -20,16 +20,21 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"fmt"
+	"maps"
 	"mime/multipart"
 	"net/textproto"
+	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"text/template"
 
+	"github.com/aws/smithy-go/encoding/httpbinding"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/nodeup"
@@ -38,6 +43,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/utils"
 	"k8s.io/kops/util/pkg/architectures"
+	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kops/util/pkg/vfs/openstackconfig"
 )
 
@@ -68,6 +74,20 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+{{- if UseS3Download }}
+# Fetch a path from the instance metadata service. args: token, path
+imds-get() {
+  curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 \
+    -H "X-aws-ec2-metadata-token: $1" "http://169.254.169.254/latest/$2"
+}
+
+# Extract a string field from a JSON object. args: json, field
+json-field() {
+  local pattern="\"$2\"[[:space:]]*:[[:space:]]*\"([^\"]+)\""
+  [[ $1 =~ $pattern ]] && printf '%s' "${BASH_REMATCH[1]}"
+}
+{{- end }}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   echo "== Downloading $1 with hash $2 from $3 =="
@@ -95,6 +115,31 @@ download-or-bust() {
       if ! token=$(curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 -H 'Metadata-Flavor: Google' "${metadata_server}/computeMetadata/v1/instance/service-accounts/default/token" | grep -o '"access_token" *: *"[^"]*"' | cut -d '"' -f 4); then
         echo "== Failed to get a service account token =="
       elif ! echo "Authorization: Bearer ${token}" | curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 -H @- "https://storage.googleapis.com/${url#gs://}"; then
+        echo "== Failed to download ${url} =="
+      elif ! validate-hash "${file}" "${hash}"; then
+        echo "== Failed to validate hash for ${url} =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} with hash ${hash} =="
+        return 0
+      fi
+{{- else if UseS3Download }}
+      local imds_token profile creds access_key secret_key session_token
+      echo "== Downloading ${url} =="
+      # Use the IP of the metadata server, to not depend on DNS this early in boot
+      if ! imds_token=$(curl -s -f -X PUT --noproxy '*' --connect-timeout 2 --max-time 5 -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' "http://169.254.169.254/latest/api/token"); then
+        echo "== Failed to get an IMDS token =="
+      elif ! profile=$(imds-get "${imds_token}" meta-data/iam/security-credentials/ | head -n 1); then
+        echo "== Failed to get the instance profile name =="
+      elif ! creds=$(imds-get "${imds_token}" "meta-data/iam/security-credentials/${profile}"); then
+        echo "== Failed to get the instance profile credentials =="
+      elif ! access_key=$(json-field "${creds}" AccessKeyId) || ! secret_key=$(json-field "${creds}" SecretAccessKey) || ! session_token=$(json-field "${creds}" Token); then
+        echo "== Failed to parse the instance profile credentials =="
+      # Pass credentials through stdin so they do not appear in files, logs, or process arguments.
+      elif ! printf 'user "%s:%s"\nheader "x-amz-security-token: %s"\n' "${access_key}" "${secret_key}" "${session_token}" |
+        curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 \
+          --config - --aws-sigv4 "aws:amz:{{ S3Region }}:s3" \
+          "https://s3.{{ S3Region }}.amazonaws.com/${url#s3://}"; then
         echo "== Failed to download ${url} =="
       elif ! validate-hash "${file}" "${hash}"; then
         echo "== Failed to validate hash for ${url} =="
@@ -204,10 +249,46 @@ type NodeUpScript struct {
 	CloudProvider        string
 	ProxyEnv             func() (string, error)
 	EnvironmentVariables func() (string, error)
+
+	// S3Region is baked into the script because SigV4 requires the bucket's actual region, which
+	// an s3:// URL does not include.
+	S3Region string
 }
 
 func funcEmptyString() (string, error) {
 	return "", nil
+}
+
+func (b *NodeUpScript) nodeUpSource(arch architectures.Architecture) (string, error) {
+	asset := b.NodeUpAssets[arch]
+	if asset == nil {
+		return "", nil
+	}
+
+	locations := slices.Clone(asset.Locations)
+	for i, location := range locations {
+		if !strings.HasPrefix(location, "s3://") {
+			continue
+		}
+		escaped, err := escapeS3Location(location)
+		if err != nil {
+			return "", fmt.Errorf("escaping nodeup source %q: %w", location, err)
+		}
+		locations[i] = escaped
+	}
+	return strings.Join(locations, ","), nil
+}
+
+func escapeS3Location(location string) (string, error) {
+	u, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("parsing S3 location: %w", err)
+	}
+	if u.Scheme != "s3" || u.Host == "" {
+		return "", fmt.Errorf("invalid S3 location")
+	}
+
+	return "s3://" + u.Host + httpbinding.EscapePath(u.Path, false), nil
 }
 
 func (b *NodeUpScript) Build() (fi.Resource, error) {
@@ -218,12 +299,13 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 		b.EnvironmentVariables = funcEmptyString
 	}
 
+	if b.useS3Download() && b.S3Region == "" {
+		return nil, fmt.Errorf("ResolveS3Region must be called before building a nodeup script with an s3:// source")
+	}
+
 	functions := template.FuncMap{
-		"NodeUpSourceAmd64": func() string {
-			if b.NodeUpAssets[architectures.ArchitectureAmd64] != nil {
-				return strings.Join(b.NodeUpAssets[architectures.ArchitectureAmd64].Locations, ",")
-			}
-			return ""
+		"NodeUpSourceAmd64": func() (string, error) {
+			return b.nodeUpSource(architectures.ArchitectureAmd64)
 		},
 		"NodeUpSourceHashAmd64": func() string {
 			if b.NodeUpAssets[architectures.ArchitectureAmd64] != nil {
@@ -231,11 +313,8 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 			}
 			return ""
 		},
-		"NodeUpSourceArm64": func() string {
-			if b.NodeUpAssets[architectures.ArchitectureArm64] != nil {
-				return strings.Join(b.NodeUpAssets[architectures.ArchitectureArm64].Locations, ",")
-			}
-			return ""
+		"NodeUpSourceArm64": func() (string, error) {
+			return b.nodeUpSource(architectures.ArchitectureArm64)
 		},
 		"NodeUpSourceHashArm64": func() string {
 			if b.NodeUpAssets[architectures.ArchitectureArm64] != nil {
@@ -271,6 +350,8 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 		"EnvironmentVariables": b.EnvironmentVariables,
 
 		"UseGCSDownload": b.useGCSDownload,
+		"UseS3Download":  b.useS3Download,
+		"S3Region":       func() string { return b.S3Region },
 	}
 
 	return newTemplateResource("nodeup", nodeUpTemplate, functions, nil)
@@ -279,17 +360,59 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 // useGCSDownload reports whether nodeup is downloaded from a GCS bucket, which has to be done
 // with the credentials of the instance service account.
 func (b *NodeUpScript) useGCSDownload() bool {
-	for _, asset := range b.NodeUpAssets {
+	return b.firstLocationWithScheme("gs://") != ""
+}
+
+func (b *NodeUpScript) firstLocationWithScheme(scheme string) string {
+	// Sort architectures so region selection is deterministic and independent of KOPS_ARCH.
+	for _, arch := range slices.Sorted(maps.Keys(b.NodeUpAssets)) {
+		asset := b.NodeUpAssets[arch]
 		if asset == nil {
 			continue
 		}
 		for _, location := range asset.Locations {
-			if strings.HasPrefix(location, "gs://") {
-				return true
+			if strings.HasPrefix(location, scheme) {
+				return location
 			}
 		}
 	}
-	return false
+	return ""
+}
+
+// S3 downloads require an AWS instance profile.
+func (b *NodeUpScript) useS3Download() bool {
+	return b.CloudProvider == string(kops.CloudProviderAWS) && b.firstLocationWithScheme("s3://") != ""
+}
+
+// ResolveS3Region resolves the bucket region because SigV4 requires it but s3:// URLs omit it.
+func (b *NodeUpScript) ResolveS3Region(ctx context.Context, vfsContext *vfs.VFSContext) error {
+	if b.CloudProvider != string(kops.CloudProviderAWS) {
+		return nil
+	}
+	location := b.firstLocationWithScheme("s3://")
+	if location == "" {
+		return nil
+	}
+	p, err := vfsContext.BuildVfsPath(location)
+	if err != nil {
+		return fmt.Errorf("building path for %q: %w", location, err)
+	}
+	s3Path, ok := p.(*vfs.S3Path)
+	if !ok {
+		return fmt.Errorf("unexpected path type %T for %q", p, location)
+	}
+	b.S3Region, err = s3Path.Region(ctx)
+	if err != nil {
+		return fmt.Errorf("getting the region of %q: %w", location, err)
+	}
+	supported, err := awsup.SupportsS3BootstrapEndpoint(ctx, b.S3Region)
+	if err != nil {
+		return err
+	}
+	if !supported {
+		return fmt.Errorf("downloading nodeup from an s3:// URL is not supported in AWS region %q", b.S3Region)
+	}
+	return nil
 }
 
 func gzipBase64(data string) (string, error) {

--- a/pkg/model/resources/nodeup_test.go
+++ b/pkg/model/resources/nodeup_test.go
@@ -37,19 +37,33 @@ func Test_NodeUpTabs(t *testing.T) {
 	}
 }
 
+func singleNodeUpAsset(location string) map[architectures.Architecture]*assets.MirroredAsset {
+	return map[architectures.Architecture]*assets.MirroredAsset{
+		architectures.ArchitectureAmd64: {
+			Locations: []string{location},
+			Hash:      hashing.MustFromString("9acf6a83b249649354bb15b04250fabce0f8ff2377f2f0d4788e3fdda3f572a3"),
+		},
+	}
+}
+
+func renderNodeUpScript(t *testing.T, script *NodeUpScript) string {
+	t.Helper()
+	resource, err := script.Build()
+	if err != nil {
+		t.Fatalf("building nodeup script: %v", err)
+	}
+	rendered, err := fi.ResourceAsString(resource)
+	if err != nil {
+		t.Fatalf("rendering nodeup script: %v", err)
+	}
+	verifyShellSyntax(t, rendered)
+	return rendered
+}
+
 func Test_GCSDownload(t *testing.T) {
 	// The authenticated GCS download is rendered only when the nodeup sources are gs:// URLs.
 	gcsMarker := "Authorization: Bearer"
 	standardMarker := "wget --compression=auto"
-
-	nodeUpAssets := func(location string) map[architectures.Architecture]*assets.MirroredAsset {
-		return map[architectures.Architecture]*assets.MirroredAsset{
-			architectures.ArchitectureAmd64: {
-				Locations: []string{location},
-				Hash:      hashing.MustFromString("9acf6a83b249649354bb15b04250fabce0f8ff2377f2f0d4788e3fdda3f572a3"),
-			},
-		}
-	}
 
 	for _, tc := range []struct {
 		name      string
@@ -70,28 +84,139 @@ func Test_GCSDownload(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			script := &NodeUpScript{
 				CloudProvider: "gce",
-				NodeUpAssets:  nodeUpAssets(tc.location),
+				NodeUpAssets:  singleNodeUpAsset(tc.location),
 			}
-			resource, err := script.Build()
-			if err != nil {
-				t.Fatalf("building nodeup script: %v", err)
-			}
-			rendered, err := fi.ResourceAsString(resource)
-			if err != nil {
-				t.Fatalf("rendering nodeup script: %v", err)
-			}
+			rendered := renderNodeUpScript(t, script)
 			if got := strings.Contains(rendered, gcsMarker); got != tc.expectGCS {
 				t.Errorf("authenticated GCS download rendered=%v, expected %v", got, tc.expectGCS)
 			}
 			if got := strings.Contains(rendered, standardMarker); got != !tc.expectGCS {
 				t.Errorf("standard download commands rendered=%v, expected %v", got, !tc.expectGCS)
 			}
-			verifyShellSyntax(t, rendered)
 		})
 	}
 }
 
-// verifyShellSyntax parses the rendered script with bash, as the GCS download has no golden file.
+func TestEscapeS3Location(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		location  string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "plain path",
+			location: "s3://artifact-bucket/kops/1.37.0/linux/amd64/nodeup",
+			expected: "s3://artifact-bucket/kops/1.37.0/linux/amd64/nodeup",
+		},
+		{
+			name:     "plus sign",
+			location: "s3://artifact-bucket/kops/1.37.0+abcdef/linux/amd64/nodeup",
+			expected: "s3://artifact-bucket/kops/1.37.0%2Babcdef/linux/amd64/nodeup",
+		},
+		{
+			name:     "existing escape",
+			location: "s3://artifact-bucket/kops/1.37.0%2Babcdef/linux/amd64/nodeup",
+			expected: "s3://artifact-bucket/kops/1.37.0%2Babcdef/linux/amd64/nodeup",
+		},
+		{
+			name:     "reserved and unicode characters",
+			location: "s3://artifact-bucket/space here/100%25/%3F%23/雪,nodeup",
+			expected: "s3://artifact-bucket/space%20here/100%25/%3F%23/%E9%9B%AA%2Cnodeup",
+		},
+		{
+			name:     "path separators",
+			location: "s3://artifact-bucket/a//b/nodeup",
+			expected: "s3://artifact-bucket/a//b/nodeup",
+		},
+		{
+			name:      "invalid escape",
+			location:  "s3://artifact-bucket/100%/nodeup",
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := escapeS3Location(tc.location)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error escaping %q", tc.location)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("escaping %q: %v", tc.location, err)
+			}
+			if actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func Test_S3Download(t *testing.T) {
+	s3Marker := "--aws-sigv4"
+	standardMarker := "wget --compression=auto"
+
+	for _, tc := range []struct {
+		name           string
+		cloudProvider  string
+		location       string
+		expectedSource string
+		expectS3       bool
+	}{
+		{
+			name:           "s3 source",
+			cloudProvider:  "aws",
+			location:       "s3://artifact-bucket/kops/1.34.0+abcdef/linux/amd64/nodeup",
+			expectedSource: "NODEUP_URL_AMD64=s3://artifact-bucket/kops/1.34.0%2Babcdef/linux/amd64/nodeup",
+			expectS3:       true,
+		},
+		{
+			name:          "default https source",
+			cloudProvider: "aws",
+			location:      "https://artifacts.k8s.io/binaries/kops/1.34.0/linux/amd64/nodeup",
+			expectS3:      false,
+		},
+		{
+			name:          "s3 source on another cloud provider",
+			cloudProvider: "hetzner",
+			location:      "s3://artifact-bucket/kops/1.34.0/linux/amd64/nodeup",
+			expectS3:      false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := &NodeUpScript{
+				CloudProvider: tc.cloudProvider,
+				NodeUpAssets:  singleNodeUpAsset(tc.location),
+				S3Region:      "us-east-2",
+			}
+			rendered := renderNodeUpScript(t, script)
+			if got := strings.Contains(rendered, s3Marker); got != tc.expectS3 {
+				t.Errorf("authenticated S3 download rendered=%v, expected %v", got, tc.expectS3)
+			}
+			if tc.expectS3 && !strings.Contains(rendered, "https://s3.us-east-2.amazonaws.com/") {
+				t.Errorf("authenticated S3 download does not use the bucket region")
+			}
+			if tc.expectedSource != "" && !strings.Contains(rendered, tc.expectedSource) {
+				t.Errorf("rendered script does not contain escaped source %q", tc.expectedSource)
+			}
+			if got := strings.Contains(rendered, standardMarker); got != !tc.expectS3 {
+				t.Errorf("standard download commands rendered=%v, expected %v", got, !tc.expectS3)
+			}
+		})
+	}
+}
+
+func Test_S3DownloadRequiresRegion(t *testing.T) {
+	script := &NodeUpScript{
+		CloudProvider: "aws",
+		NodeUpAssets:  singleNodeUpAsset("s3://artifact-bucket/kops/1.34.0/linux/amd64/nodeup"),
+	}
+	if _, err := script.Build(); err == nil {
+		t.Errorf("expected an error building an s3:// nodeup script without a resolved region")
+	}
+}
+
 func verifyShellSyntax(t *testing.T, script string) {
 	t.Helper()
 

--- a/upup/pkg/fi/assetstore.go
+++ b/upup/pkg/fi/assetstore.go
@@ -201,7 +201,7 @@ func hashFromHTTPHeader(url string) (*hashing.Hash, error) {
 
 // Add an asset into the store, in one of the recognized formats (see Assets in types package)
 func (a *AssetStore) Add(ctx context.Context, id string) error {
-	if strings.HasPrefix(id, "http://") || strings.HasPrefix(id, "https://") || strings.HasPrefix(id, "gs://") {
+	if strings.HasPrefix(id, "http://") || strings.HasPrefix(id, "https://") || strings.HasPrefix(id, "gs://") || strings.HasPrefix(id, "s3://") {
 		return a.addURLs(ctx, strings.Split(id, ","), nil)
 	}
 	i := strings.Index(id, "@http://")
@@ -210,6 +210,9 @@ func (a *AssetStore) Add(ctx context.Context, id string) error {
 	}
 	if i == -1 {
 		i = strings.Index(id, "@gs://")
+	}
+	if i == -1 {
+		i = strings.Index(id, "@s3://")
 	}
 	if i != -1 {
 		urls := strings.Split(id[i+1:], ",")

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -120,6 +120,19 @@ func FindRegion(cluster *kops.Cluster) (string, error) {
 	return region, nil
 }
 
+// SupportsS3BootstrapEndpoint reports whether the region uses the amazonaws.com partition DNS
+// suffix hard-coded by the nodeup bootstrap script. EC2 uses the same partition suffix as S3 and
+// can be resolved without a bucket.
+func SupportsS3BootstrapEndpoint(ctx context.Context, region string) (bool, error) {
+	resolver := ec2.NewDefaultEndpointResolverV2()
+	endpoint, err := resolver.ResolveEndpoint(ctx, ec2.EndpointParameters{Region: aws.String(region)})
+	if err != nil {
+		return false, fmt.Errorf("resolving EC2 endpoint for region %q: %w", region, err)
+	}
+
+	return endpoint.URI.Hostname() == fmt.Sprintf("ec2.%s.amazonaws.com", region), nil
+}
+
 // FindEC2Tag find the value of the tag with the specified key
 func FindEC2Tag(tags []ec2types.Tag, key string) (string, bool) {
 	for _, tag := range tags {

--- a/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
@@ -119,6 +119,32 @@ func TestFindRegion(t *testing.T) {
 	}
 }
 
+func TestSupportsS3BootstrapEndpoint(t *testing.T) {
+	for _, tc := range []struct {
+		region    string
+		supported bool
+	}{
+		{region: "us-east-1", supported: true},
+		{region: "us-gov-west-1", supported: true},
+		{region: "cn-north-1"},
+		{region: "us-iso-east-1"},
+		{region: "us-isob-east-1"},
+		{region: "eu-isoe-west-1"},
+		{region: "us-isof-south-1"},
+		{region: "eusc-de-east-1"},
+	} {
+		t.Run(tc.region, func(t *testing.T) {
+			supported, err := SupportsS3BootstrapEndpoint(context.Background(), tc.region)
+			if err != nil {
+				t.Fatalf("checking S3 bootstrap endpoint support: %v", err)
+			}
+			if supported != tc.supported {
+				t.Errorf("supported=%v, expected %v", supported, tc.supported)
+			}
+		})
+	}
+}
+
 func TestEC2TagSpecification(t *testing.T) {
 	cases := []struct {
 		Name          string

--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -31,6 +31,7 @@ import (
 	"cloud.google.com/go/storage"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/util/pkg/hashing"
+	"k8s.io/kops/util/pkg/vfs"
 )
 
 const downloadTimeout = 3 * time.Minute
@@ -83,33 +84,11 @@ func downloadURLToFile(ctx context.Context, url string, destPath string, hash *h
 // downloadURLToWriter streams the file at the given url to dest.
 // If hash is non-nil, it will also verify that it matches the downloaded bytes.
 func downloadURLToWriter(ctx context.Context, desturl string, dest io.Writer, hash *hashing.Hash) (*hashing.Hash, error) {
-	var reader io.ReadCloser
 	u, err := url.Parse(desturl)
 	if err != nil {
 		return nil, fmt.Errorf("Invalud URL for file %q: %v", desturl, err)
 	}
-	if u.Scheme != "gs" {
-		reader, err = OpenURL(desturl)
-		if err != nil {
-			return nil, err
-		}
-		defer reader.Close()
-	} else {
-		bucketName := u.Host
-		objectName := strings.TrimPrefix(u.Path, "/")
 
-		client, err := storage.NewClient(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to create client %q: %v", desturl, err)
-		}
-		defer client.Close()
-
-		reader, err = client.Bucket(bucketName).Object(objectName).NewReader(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to open reader on object %q: %v", desturl, err)
-		}
-		defer reader.Close()
-	}
 	start := time.Now()
 	defer func() {
 		klog.V(2).Infof("Downloading %q took %q", desturl, time.Since(start))
@@ -123,8 +102,49 @@ func downloadURLToWriter(ctx context.Context, desturl string, dest io.Writer, ha
 	hasher := algorithm.NewHasher()
 	writer := io.MultiWriter(dest, hasher)
 
-	if _, err := io.Copy(writer, reader); err != nil {
-		return nil, fmt.Errorf("error downloading HTTP content from %q: %v", desturl, err)
+	switch u.Scheme {
+	case "gs":
+		bucketName := u.Host
+		objectName := strings.TrimPrefix(u.Path, "/")
+
+		client, err := storage.NewClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create client %q: %v", desturl, err)
+		}
+		defer client.Close()
+
+		reader, err := client.Bucket(bucketName).Object(objectName).NewReader(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to open reader on object %q: %v", desturl, err)
+		}
+		defer reader.Close()
+
+		if _, err := io.Copy(writer, reader); err != nil {
+			return nil, fmt.Errorf("error downloading HTTP content from %q: %v", desturl, err)
+		}
+	case "s3":
+		// vfs resolves the bucket region and signs the request with the ambient AWS credentials.
+		p, err := vfs.Context.BuildVfsPath(desturl)
+		if err != nil {
+			return nil, fmt.Errorf("building path for %q: %w", desturl, err)
+		}
+		s3Path, ok := p.(*vfs.S3Path)
+		if !ok {
+			return nil, fmt.Errorf("unexpected path type %T for %q", p, desturl)
+		}
+		if _, err := s3Path.WriteToWithContext(ctx, writer); err != nil {
+			return nil, fmt.Errorf("error downloading content from %q: %w", desturl, err)
+		}
+	default:
+		reader, err := OpenURL(desturl)
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Close()
+
+		if _, err := io.Copy(writer, reader); err != nil {
+			return nil, fmt.Errorf("error downloading HTTP content from %q: %v", desturl, err)
+		}
 	}
 
 	actual := &hashing.Hash{


### PR DESCRIPTION
When KOPS_BASE_URL is an s3:// URL, the bootstrap script downloads nodeup with curl 8.0 or newer, signing the request with instance profile credentials from IMDS using curl's native AWS SigV4 support. The credentials are piped through --config -, so they never reach disk, process arguments, or console logs.

The s3:// URL does not carry the bucket region required by SigV4, so kOps resolves it through VFS before rendering the bootstrap script. Validation rejects AWS partitions whose endpoints are incompatible with the generated download URL.

spec.assets.fileRepository now accepts an s3:// URL on AWS. Nodeup reads these assets through VFS using instance credentials, and remapped repository paths escape delimiter commas before compact asset serialization.

hack/dev-build-aws.sh stages developer builds under an s3:// base URL, so the bucket it creates no longer needs public read access.

/cc @rifelpet @ameukam 