### PR TITLE
test(e2e): stage AWS pull artifacts in S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,19 @@ gcs-publish-ci: gcloud version-dist-ci
 	echo "${GCS_URL}/${VERSION}" > ${UPLOAD}/${LATEST_FILE}
 	gcloud storage cp --cache-control="private, max-age=0, no-transform" ${UPLOAD}/${LATEST_FILE} ${GCS_LOCATION}
 
+# s3-publish-ci is the entry point for AWS CI testing.
+# Credentials reach the aws CLI through AWS_SHARED_CREDENTIALS_FILE or similar
+# pointers that are not unexported, but AWS_REGION must be restored explicitly.
+.PHONY: s3-publish-ci
+ifneq ($(AWS_REGION),)
+s3-publish-ci: export AWS_REGION := $(AWS_REGION)
+endif
+s3-publish-ci: version-dist-ci
+	@echo "== Uploading kops =="
+	${UPLOAD_CMD} ${UPLOAD}/kops/ ${UPLOAD_DEST}
+	echo "VERSION: ${VERSION}"
+	echo "$(patsubst %/,%,$(UPLOAD_DEST))/${VERSION}" > ${UPLOAD}/${LATEST_FILE}
+
 .PHONY: gen-cli-docs
 gen-cli-docs: kops # Regenerate CLI docs
 	KOPS_STATE_STORE= \

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.307.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5
+	github.com/aws/smithy-go v1.27.3
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/spf13/pflag v1.0.10
@@ -93,7 +94,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 // indirect
-	github.com/aws/smithy-go v1.27.3 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.10.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect

--- a/tests/e2e/kubetest2-kops/aws/s3.go
+++ b/tests/e2e/kubetest2-kops/aws/s3.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go"
 	"k8s.io/klog/v2"
 )
 
@@ -50,6 +51,7 @@ type BucketType string
 const (
 	BucketTypeStateStore     BucketType = "state"
 	BucketTypeDiscoveryStore BucketType = "discovery"
+	BucketTypeStagingStore   BucketType = "staging"
 )
 
 // NewAWSClient returns a new instance of awsClient configured to work in the default region (us-east-2).
@@ -68,17 +70,14 @@ func NewClient(ctx context.Context, region string) (*Client, error) {
 
 // BucketName constructs an unique bucket name using the AWS account ID in the default region (us-east-2).
 func (c Client) BucketName(ctx context.Context, bucketType BucketType) (string, error) {
-	// Construct the bucket name based on the ProwJob ID (if running in Prow) or AWS account ID (if running outside
-	// Prow) and a timestamp. When BUILD_ID is set we use it in place of time.Now() so that multiple kubetest2-kops
-	// invocations within the same CI job (e.g. upgrade tests) resolve to the same bucket name.
-	var suffix string
-	if jobID := os.Getenv("BUILD_ID"); jobID != "" {
-		if len(jobID) > 14 {
-			suffix = jobID[:14]
-		} else {
-			suffix = jobID
-		}
-	} else {
+	// Construct the bucket name based on the ProwJob ID (if running in Prow) or AWS account ID (if
+	// running outside Prow) and a timestamp. When BUILD_ID is set we use it in place of time.Now()
+	// so that multiple kubetest2-kops invocations within the same CI job (e.g. upgrade tests)
+	// resolve to the same bucket name. Use the full build ID because truncating its low-order
+	// digits can make jobs started in the same millisecond collide, allowing one job to delete
+	// another's bucket.
+	suffix := os.Getenv("BUILD_ID")
+	if suffix == "" {
 		callerIdentity, err := c.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 		if err != nil {
 			return "", fmt.Errorf("building AWS STS presigned request: %w", err)
@@ -91,14 +90,12 @@ func (c Client) BucketName(ctx context.Context, bucketType BucketType) (string, 
 	// Only allow lowercase letters, numbers, and hyphens
 	bucket = bucketNameRegex.ReplaceAllString(bucket, "")
 
-	if len(bucket) > 63 {
-		bucket = bucket[:63] // Max length is 63
-	}
-
+	// Names over the 63 character S3 limit fail bucket creation rather than being silently
+	// truncated, which could make distinct jobs collide on one bucket.
 	return bucket, nil
 }
 
-// EnsureS3Bucket creates a new S3 bucket with the given name and public read permissions.
+// EnsureS3Bucket creates an S3 bucket, optionally with public read access.
 func (c Client) EnsureS3Bucket(ctx context.Context, region, bucketName string, publicRead bool) error {
 	bucketName = strings.TrimPrefix(bucketName, "s3://")
 	klog.Infof("Creating bucket %s in region %s", bucketName, region)
@@ -112,14 +109,11 @@ func (c Client) EnsureS3Bucket(ctx context.Context, region, bucketName string, p
 	},
 	)
 	if err != nil {
-		var exists *types.BucketAlreadyExists
-		if errors.As(err, &exists) {
-			klog.Infof("Bucket %s already exists\n", bucketName)
-		} else {
-			klog.Infof("Error creating bucket %s, err: %v\n", bucketName, err)
+		var owned *types.BucketAlreadyOwnedByYou
+		if !errors.As(err, &owned) {
+			return fmt.Errorf("creating bucket %s: %w", bucketName, err)
 		}
-
-		return fmt.Errorf("creating bucket %s: %w", bucketName, err)
+		klog.Infof("Bucket %s already exists in this account", bucketName)
 	}
 
 	// Wait for the bucket to be created
@@ -134,26 +128,21 @@ func (c Client) EnsureS3Bucket(ctx context.Context, region, bucketName string, p
 		return fmt.Errorf("waiting for bucket %s to exist: %w", bucketName, err)
 	}
 
-	klog.Infof("Bucket %s created successfully", bucketName)
+	klog.Infof("Bucket %s is ready", bucketName)
 
 	if publicRead {
-		err = c.setPublicAccessBlock(ctx, bucketName)
-		if err != nil {
+		if err := c.setPublicAccessBlock(ctx, bucketName); err != nil {
 			klog.Errorf("Failed to disable public access block policies on bucket %s, err: %v", bucketName, err)
-
 			return fmt.Errorf("disabling public access block policies for bucket %s: %w", bucketName, err)
 		}
 
 		// Wait for public access block settings to propagate before setting the policy
 		time.Sleep(10 * time.Second)
 
-		err = c.setPublicReadPolicy(ctx, bucketName)
-		if err != nil {
+		if err := c.setPublicReadPolicy(ctx, bucketName); err != nil {
 			klog.Errorf("Failed to set public read policy on bucket %s, err: %v", bucketName, err)
-
 			return fmt.Errorf("setting public read policy for bucket %s: %w", bucketName, err)
 		}
-
 		klog.Infof("Public read policy set on bucket %s", bucketName)
 	}
 
@@ -162,6 +151,15 @@ func (c Client) EnsureS3Bucket(ctx context.Context, region, bucketName string, p
 
 // DeleteS3Bucket deletes a S3 bucket with the given name.
 func (c Client) DeleteS3Bucket(ctx context.Context, bucketName string) error {
+	return c.deleteS3Bucket(ctx, bucketName, false)
+}
+
+// DeleteS3BucketAndContents deletes all objects from an S3 bucket before deleting the bucket.
+func (c Client) DeleteS3BucketAndContents(ctx context.Context, bucketName string) error {
+	return c.deleteS3Bucket(ctx, bucketName, true)
+}
+
+func (c Client) deleteS3Bucket(ctx context.Context, bucketName string, empty bool) error {
 	bucketName = strings.TrimPrefix(bucketName, "s3://")
 
 	// Resolve the bucket's actual region to avoid 301 PermanentRedirect errors.
@@ -169,21 +167,31 @@ func (c Client) DeleteS3Bucket(ctx context.Context, bucketName string) error {
 	// zones, which can differ from the region where the bucket was created.
 	bucketRegion, err := c.getBucketRegion(ctx, bucketName)
 	if err != nil {
+		if isNoSuchBucket(err) {
+			// Teardown may run without creating every bucket it knows about.
+			return nil
+		}
 		klog.Infof("Could not determine region for bucket %s: %v", bucketName, err)
 	}
 
-	regionOpt := func(o *s3.Options) {
-		if bucketRegion != "" {
-			o.Region = bucketRegion
+	client := c.s3Client
+	if bucketRegion != "" {
+		options := c.s3Client.Options()
+		options.Region = bucketRegion
+		client = s3.New(options)
+	}
+
+	if empty {
+		if err := emptyS3Bucket(ctx, client, bucketName); err != nil {
+			return err
 		}
 	}
 
-	_, err = c.s3Client.DeleteBucket(ctx, &s3.DeleteBucketInput{
+	_, err = client.DeleteBucket(ctx, &s3.DeleteBucketInput{
 		Bucket: aws.String(bucketName),
-	}, regionOpt)
+	})
 	if err != nil {
-		var noBucket *types.NoSuchBucket
-		if errors.As(err, &noBucket) {
+		if isNoSuchBucket(err) {
 			klog.Infof("Bucket %s does not exist.", bucketName)
 
 			return nil
@@ -193,7 +201,7 @@ func (c Client) DeleteS3Bucket(ctx context.Context, bucketName string) error {
 		return fmt.Errorf("deleting bucket %s: %w", bucketName, err)
 	}
 
-	err = s3.NewBucketNotExistsWaiter(c.s3Client).Wait(
+	err = s3.NewBucketNotExistsWaiter(client).Wait(
 		ctx, &s3.HeadBucketInput{
 			Bucket: aws.String(bucketName),
 		},
@@ -205,8 +213,51 @@ func (c Client) DeleteS3Bucket(ctx context.Context, bucketName string) error {
 	}
 
 	klog.Infof("Bucket %s deleted", bucketName)
-
 	return nil
+}
+
+func emptyS3Bucket(ctx context.Context, client *s3.Client, bucketName string) error {
+	for {
+		result, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket: aws.String(bucketName),
+		})
+		if err != nil {
+			if isNoSuchBucket(err) {
+				return nil
+			}
+			return fmt.Errorf("listing objects in bucket %s: %w", bucketName, err)
+		}
+
+		if len(result.Contents) == 0 {
+			return nil
+		}
+
+		objects := make([]types.ObjectIdentifier, len(result.Contents))
+		for i, object := range result.Contents {
+			objects[i] = types.ObjectIdentifier{Key: object.Key}
+		}
+		deleteResult, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(bucketName),
+			Delete: &types.Delete{Objects: objects, Quiet: aws.Bool(true)},
+		})
+		if err != nil {
+			return fmt.Errorf("deleting objects from bucket %s: %w", bucketName, err)
+		}
+		if len(deleteResult.Errors) > 0 {
+			objectError := deleteResult.Errors[0]
+			return fmt.Errorf("deleting object %q from bucket %s: %s: %s",
+				aws.ToString(objectError.Key), bucketName, aws.ToString(objectError.Code), aws.ToString(objectError.Message))
+		}
+	}
+}
+
+func isNoSuchBucket(err error) bool {
+	var noBucket *types.NoSuchBucket
+	if errors.As(err, &noBucket) {
+		return true
+	}
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && (apiErr.ErrorCode() == "NoSuchBucket" || apiErr.ErrorCode() == "NotFound")
 }
 
 // getBucketRegion resolves the AWS region where the bucket resides.

--- a/tests/e2e/kubetest2-kops/aws/s3_test.go
+++ b/tests/e2e/kubetest2-kops/aws/s3_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+func TestStagingBucketName(t *testing.T) {
+	t.Setenv("BUILD_ID", "12345678901234567890")
+	name, err := (Client{}).BucketName(context.Background(), BucketTypeStagingStore)
+	if err != nil {
+		t.Fatalf("building bucket name: %v", err)
+	}
+	if expected := "k8s-infra-kops-staging-12345678901234567890"; name != expected {
+		t.Errorf("expected %q, got %q", expected, name)
+	}
+	if len(name) > 63 {
+		t.Errorf("bucket name %q is longer than the 63 character limit", name)
+	}
+}
+
+// Teardown can run without --build, so a missing staging bucket must be a no-op.
+func TestDeleteMissingS3Bucket(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message></Error>`)
+	}))
+	defer server.Close()
+
+	c := Client{s3Client: s3.New(s3.Options{
+		Region:           defaultRegion,
+		BaseEndpoint:     aws.String(server.URL),
+		Credentials:      aws.AnonymousCredentials{},
+		UsePathStyle:     true,
+		RetryMaxAttempts: 1,
+	})}
+
+	if err := c.deleteS3Bucket(context.Background(), "does-not-exist", true); err != nil {
+		t.Errorf("deleting a bucket that does not exist: %v", err)
+	}
+	if len(requests) != 1 || !strings.Contains(requests[0], "location") {
+		t.Errorf("expected the bucket location request only, got %v", requests)
+	}
+}
+
+func TestIsNoSuchBucket(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "typed", err: &types.NoSuchBucket{}, want: true},
+		{name: "generic code", err: &smithy.GenericAPIError{Code: "NoSuchBucket"}, want: true},
+		{name: "generic not found", err: &smithy.GenericAPIError{Code: "NotFound"}, want: true},
+		{name: "other", err: errors.New("other")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNoSuchBucket(tc.err); got != tc.want {
+				t.Errorf("isNoSuchBucket() = %v, expected %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/e2e/kubetest2-kops/builder/build.go
+++ b/tests/e2e/kubetest2-kops/builder/build.go
@@ -46,9 +46,9 @@ type BuildResults struct {
 // Build will build the kops artifacts and publish them to the stage location
 func (b *BuildOptions) Build() (*BuildResults, error) {
 	// We expect to upload to a subdirectory with a version identifier
-	gcsLocation := b.StageLocation
-	if !strings.HasSuffix(gcsLocation, "/") {
-		gcsLocation += "/"
+	stageLocation := b.StageLocation
+	if !strings.HasSuffix(stageLocation, "/") {
+		stageLocation += "/"
 	}
 
 	results := &BuildResults{}
@@ -83,43 +83,47 @@ func (b *BuildOptions) Build() (*BuildResults, error) {
 		return results, nil
 	}
 
-	args := []string{"make", "gcs-publish-ci"}
-	cmd := exec.Command(args[0], args[1:]...)
-	env := []string{
-		fmt.Sprintf("HOME=%v", os.Getenv("HOME")),
-		fmt.Sprintf("PATH=%v", os.Getenv("PATH")),
-		fmt.Sprintf("GCS_LOCATION=%v", gcsLocation),
-		fmt.Sprintf("GOPATH=%v", os.Getenv("GOPATH")),
+	target, publishEnv, err := publishConfig(stageLocation)
+	if err != nil {
+		return nil, err
 	}
-	// We need to "forward" some variables, in particular the variables like "CI" that change the version we use
-	for _, k := range []string{"CI"} {
-		v := os.Getenv(k)
-		if v != "" {
-			env = append(env, fmt.Sprintf("%s=%s", k, v))
+
+	args := []string{"make", target}
+	cmd := exec.Command(args[0], args[1:]...)
+	var env []string
+	if strings.HasPrefix(stageLocation, "s3://") {
+		// The AWS credential chain may use profiles, web identity, or container credentials.
+		env = os.Environ()
+	} else {
+		env = []string{
+			"HOME=" + os.Getenv("HOME"),
+			"PATH=" + os.Getenv("PATH"),
+			"GOPATH=" + os.Getenv("GOPATH"),
+		}
+		if ci := os.Getenv("CI"); ci != "" {
+			env = append(env, "CI="+ci)
 		}
 	}
-	cmd.SetEnv(env...)
+	cmd.SetEnv(append(env, publishEnv...)...)
 	cmd.SetDir(b.KopsRoot)
 	exec.InheritOutput(cmd)
-	klog.Infof("Executing %q (in %v) with env %v", strings.Join(args, " "), b.KopsRoot, env)
+	klog.Infof("Executing %q in %v with stage location %s", strings.Join(args, " "), b.KopsRoot, stageLocation)
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}
 
-	// Get the full path (including subdirectory) that we uploaded to
-	// It is written by gcs-publish-ci to .build/upload/latest-ci.txt
+	// The publish target records the uploaded path in .build/upload/latest-ci.txt.
 	latestPath := filepath.Join(b.KopsRoot, ".build", "upload", "latest-ci.txt")
 	kopsBaseURL, err := os.ReadFile(latestPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %w", latestPath, err)
 	}
-	u, err := url.Parse(strings.TrimSpace(string(kopsBaseURL)))
+	baseURL, err := publishedBaseURL(string(kopsBaseURL))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse url %q from file %q: %w", string(kopsBaseURL), latestPath, err)
+		return nil, fmt.Errorf("reading URL from file %q: %w", latestPath, err)
 	}
-	u.Path = strings.ReplaceAll(u.Path, "//", "/")
 	results = &BuildResults{
-		KopsBaseURL: u.String(),
+		KopsBaseURL: baseURL,
 	}
 
 	// Write some meta files so that other tooling can know e.g. KOPS_BASE_URL
@@ -134,4 +138,31 @@ func (b *BuildOptions) Build() (*BuildResults, error) {
 	klog.Infof("wrote file %q with %q", p, results.KopsBaseURL)
 
 	return results, nil
+}
+
+func publishConfig(stageLocation string) (string, []string, error) {
+	switch {
+	case strings.HasPrefix(stageLocation, "gs://"):
+		return "gcs-publish-ci", []string{"GCS_LOCATION=" + stageLocation}, nil
+	case strings.HasPrefix(stageLocation, "s3://"):
+		// The staging bucket policy already grants public read; object ACLs are rejected
+		// by its public access block settings, so they must not be attempted.
+		return "s3-publish-ci", []string{
+			"UPLOAD_DEST=" + stageLocation,
+			"UPLOAD_ARGS=--private",
+		}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported stage location %q", stageLocation)
+	}
+}
+
+// publishedBaseURL cleans up the location the publish target recorded. s3:// locations are kept
+// as-is so that nodes download the artifacts with their instance profile credentials.
+func publishedBaseURL(value string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return "", fmt.Errorf("parsing URL %q: %w", value, err)
+	}
+	u.Path = strings.ReplaceAll(u.Path, "//", "/")
+	return u.String(), nil
 }

--- a/tests/e2e/kubetest2-kops/builder/build_test.go
+++ b/tests/e2e/kubetest2-kops/builder/build_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPublishConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		location string
+		target   string
+		env      []string
+		wantErr  bool
+	}{
+		{
+			name:     "GCS",
+			location: "gs://bucket/path/",
+			target:   "gcs-publish-ci",
+			env:      []string{"GCS_LOCATION=gs://bucket/path/"},
+		},
+		{
+			name:     "S3",
+			location: "s3://bucket/path/",
+			target:   "s3-publish-ci",
+			env: []string{
+				"UPLOAD_DEST=s3://bucket/path/",
+				"UPLOAD_ARGS=--private",
+			},
+		},
+		{
+			name:     "unsupported",
+			location: "https://example.com/path/",
+			wantErr:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			target, env, err := publishConfig(tc.location)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("building publish config: %v", err)
+			}
+			if target != tc.target {
+				t.Errorf("expected target %q, got %q", tc.target, target)
+			}
+			if !reflect.DeepEqual(env, tc.env) {
+				t.Errorf("expected env %v, got %v", tc.env, env)
+			}
+		})
+	}
+}
+
+func TestPublishedBaseURL(t *testing.T) {
+	for _, tc := range []struct {
+		value    string
+		expected string
+	}{
+		{
+			value:    "https://storage.googleapis.com/bucket/path/version",
+			expected: "https://storage.googleapis.com/bucket/path/version",
+		},
+		{
+			value:    "s3://bucket/path/version",
+			expected: "s3://bucket/path/version",
+		},
+		{
+			// The publish target joins a location that already ends in a slash.
+			value:    "https://storage.googleapis.com/bucket/path//version",
+			expected: "https://storage.googleapis.com/bucket/path/version",
+		},
+	} {
+		actual, err := publishedBaseURL(tc.value)
+		if err != nil {
+			t.Fatalf("converting %q: %v", tc.value, err)
+		}
+		if actual != tc.expected {
+			t.Errorf("expected %q, got %q", tc.expected, actual)
+		}
+	}
+}

--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deployer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -36,7 +37,12 @@ const (
 	defaultGCSPath = "gs://k8s-staging-kops/pulls/%v/pull-%v"
 )
 
-func (d *deployer) Build() error {
+func (d *deployer) Build() (retErr error) {
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, d.deleteStagingStore())
+		}
+	}()
 	if err := d.init(); err != nil {
 		return err
 	}
@@ -48,7 +54,7 @@ func (d *deployer) Build() error {
 		klog.Infof("setting kops base url to %q from build results", results.KopsBaseURL)
 		d.KopsBaseURL = results.KopsBaseURL
 		// In PreTestCmd, we need KOPS_BASE_URL to be set for kops calls
-		os.Setenv("KOPS_BASE_URL", d.maybeGSURL(d.KopsBaseURL))
+		os.Setenv("KOPS_BASE_URL", d.canonicalizeBaseURL(d.KopsBaseURL))
 	}
 
 	if results.KubernetesBaseURL != "" {
@@ -114,6 +120,18 @@ func (d *deployer) verifyBuildFlags() error {
 		if !strings.HasPrefix(d.StageLocation, "gs://") {
 			return errors.New("stage-location must be a gs:// path")
 		}
+	} else if d.CloudProvider == "aws" && !d.BuildOptions.BuildKubernetes &&
+		(os.Getenv("KOPS_STAGING_BUCKET") != "" || os.Getenv("BUILD_ID") != "") {
+		d.StageLocation = d.stagingStore()
+		if !strings.HasPrefix(d.StageLocation, "s3://") {
+			return errors.New("KOPS_STAGING_BUCKET must be an s3:// path for an AWS build")
+		}
+		if os.Getenv("KOPS_STAGING_BUCKET") == "" {
+			klog.Infof("creating staging bucket %s to hold kOps build artifacts", d.StageLocation)
+			if err := d.aws.EnsureS3Bucket(context.Background(), d.region, d.StageLocation, true); err != nil {
+				return err
+			}
+		}
 	} else if d.boskos != nil {
 		d.StageLocation = d.stagingStore()
 		klog.Infof("creating staging bucket %s to hold kops/kubernetes build artifacts", d.StageLocation)
@@ -128,7 +146,11 @@ func (d *deployer) verifyBuildFlags() error {
 		d.StageLocation = stageLocation
 	}
 	if !d.BuildOptions.BuildKubernetes && d.KopsBaseURL == "" && os.Getenv("KOPS_BASE_URL") == "" {
-		d.KopsBaseURL = strings.Replace(d.StageLocation, "gs://", "https://storage.googleapis.com/", 1)
+		if strings.HasPrefix(d.StageLocation, "gs://") {
+			d.KopsBaseURL = strings.Replace(d.StageLocation, "gs://", "https://storage.googleapis.com/", 1)
+		} else {
+			d.KopsBaseURL = d.StageLocation
+		}
 	}
 
 	if d.KopsVersionMarker != "" && !d.BuildOptions.BuildKubernetes {

--- a/tests/e2e/kubetest2-kops/deployer/build_test.go
+++ b/tests/e2e/kubetest2-kops/deployer/build_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/kops/tests/e2e/kubetest2-kops/builder"
+)
+
+func TestVerifyBuildFlagsWithExistingAWSStagingBucket(t *testing.T) {
+	t.Setenv("BUILD_ID", "")
+	t.Setenv("KOPS_STAGING_BUCKET", "s3://existing-staging")
+	d := &deployer{
+		CloudProvider: "aws",
+		BuildOptions:  &builder.BuildOptions{},
+	}
+	if err := d.verifyBuildFlags(); err != nil {
+		t.Fatalf("verifying build flags: %v", err)
+	}
+	if d.StageLocation != "s3://existing-staging" {
+		t.Errorf("unexpected stage location %q", d.StageLocation)
+	}
+	if d.KopsBaseURL != d.StageLocation {
+		t.Errorf("expected KopsBaseURL %q, got %q", d.StageLocation, d.KopsBaseURL)
+	}
+	if d.createStagingStore {
+		t.Error("existing staging bucket must not be deleted during teardown")
+	}
+}
+
+func TestVerifyBuildFlagsRejectsGCSStagingBucketOnAWS(t *testing.T) {
+	t.Setenv("KOPS_STAGING_BUCKET", "gs://existing-staging")
+	d := &deployer{
+		CloudProvider: "aws",
+		BuildOptions:  &builder.BuildOptions{},
+	}
+	err := d.verifyBuildFlags()
+	if err == nil || !strings.Contains(err.Error(), "must be an s3://") {
+		t.Fatalf("expected an S3 staging bucket error, got %v", err)
+	}
+}
+
+func TestVerifyBuildFlagsRejectsS3StageLocation(t *testing.T) {
+	d := &deployer{
+		CloudProvider: "aws",
+		StageLocation: "s3://staging",
+		BuildOptions:  &builder.BuildOptions{},
+	}
+	err := d.verifyBuildFlags()
+	if err == nil || !strings.Contains(err.Error(), "must be a gs:// path") {
+		t.Fatalf("expected a gs:// stage-location error, got %v", err)
+	}
+}
+
+// Without a BUILD_ID, separate kubetest2-kops invocations cannot derive the same staging bucket
+// name, so builds stage to the GCS location as they did before S3 staging existed.
+func TestVerifyBuildFlagsWithoutBuildIDStagesToGCS(t *testing.T) {
+	t.Setenv("BUILD_ID", "")
+	t.Setenv("KOPS_STAGING_BUCKET", "")
+	t.Setenv("KOPS_BASE_URL", "")
+	t.Setenv("JOB_NAME", "pull-kops-e2e-example")
+	t.Setenv("PULL_PULL_SHA", "abcdef1")
+	d := &deployer{
+		CloudProvider: "aws",
+		BuildOptions:  &builder.BuildOptions{},
+	}
+	if err := d.verifyBuildFlags(); err != nil {
+		t.Fatalf("verifying build flags: %v", err)
+	}
+	if expected := "gs://k8s-staging-kops/pulls/pull-kops-e2e-example/pull-abcdef1"; d.StageLocation != expected {
+		t.Errorf("expected stage location %q, got %q", expected, d.StageLocation)
+	}
+	if expected := "https://storage.googleapis.com/k8s-staging-kops/pulls/pull-kops-e2e-example/pull-abcdef1"; d.KopsBaseURL != expected {
+		t.Errorf("expected KopsBaseURL %q, got %q", expected, d.KopsBaseURL)
+	}
+}

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -163,6 +163,12 @@ func (d *deployer) initialize() error {
 		if _, found := os.LookupEnv("KOPS_DISCOVERY_STORE"); !found {
 			d.createDiscoveryStore = true
 		}
+		// --build and --down derive the same ephemeral bucket name from the BUILD_ID, so separate
+		// invocations agree without passing state. Without a BUILD_ID, builds stage to GCS
+		// instead. Caller-provided buckets are never created or deleted.
+		if os.Getenv("KOPS_STAGING_BUCKET") == "" && os.Getenv("BUILD_ID") != "" {
+			d.createStagingStore = true
+		}
 	case "gce":
 		if d.boskos != nil || os.Getenv("KOPS_STATE_STORE") == "" || os.Getenv("KOPS_STAGING_BUCKET") == "" {
 			d.createStateStore = true
@@ -302,9 +308,9 @@ func (d *deployer) env() []string {
 	}
 
 	if d.KopsBaseURL != "" {
-		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.maybeGSURL(d.KopsBaseURL)))
+		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.canonicalizeBaseURL(d.KopsBaseURL)))
 	} else if baseURL := os.Getenv("KOPS_BASE_URL"); baseURL != "" {
-		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.maybeGSURL(baseURL)))
+		vars = append(vars, fmt.Sprintf("KOPS_BASE_URL=%v", d.canonicalizeBaseURL(baseURL)))
 	}
 
 	if kopsBin := d.resolvedKopsBinaryPath(); kopsBin != "" {
@@ -339,15 +345,13 @@ func (d *deployer) env() []string {
 // gcsPublicPrefix is the https form of a GCS bucket, as used for the staged build artifacts.
 const gcsPublicPrefix = "https://storage.googleapis.com/"
 
-// maybeGSURL converts baseURL from the public GCS https form to the gs:// form on GCE, so that
-// nodes download the staged artifacts with their instance service-account credentials. Any other
-// URL, and any other cloud provider, passes through unchanged. Only kops invocations get the gs://
-// form; the scripts that download the kops binary run outside the deployer and keep using https.
-func (d *deployer) maybeGSURL(baseURL string) string {
-	if d.CloudProvider != "gce" || !strings.HasPrefix(baseURL, gcsPublicPrefix) {
-		return baseURL
+// canonicalizeBaseURL converts a public GCS URL to gs:// on GCE so nodes download staged artifacts
+// with their service-account credentials. Other URLs and cloud providers pass through unchanged.
+func (d *deployer) canonicalizeBaseURL(baseURL string) string {
+	if d.CloudProvider == "gce" && strings.HasPrefix(baseURL, gcsPublicPrefix) {
+		return "gs://" + strings.TrimPrefix(baseURL, gcsPublicPrefix)
 	}
-	return "gs://" + strings.TrimPrefix(baseURL, gcsPublicPrefix)
+	return baseURL
 }
 
 // featureFlags returns the kops feature flags to set
@@ -506,6 +510,14 @@ func (d *deployer) stagingStore() string {
 	sb := os.Getenv("KOPS_STAGING_BUCKET")
 	if sb == "" {
 		switch d.CloudProvider {
+		case "aws":
+			ctx := context.Background()
+			bucketName, err := d.aws.BucketName(ctx, aws.BucketTypeStagingStore)
+			if err != nil {
+				klog.Fatalf("Failed to generate bucket name: %v", err)
+				return ""
+			}
+			sb = "s3://" + bucketName
 		case "gce":
 			sb = "gs://" + gce.GCSBucketName(d.GCPProject, "staging")
 		}

--- a/tests/e2e/kubetest2-kops/deployer/common_test.go
+++ b/tests/e2e/kubetest2-kops/deployer/common_test.go
@@ -18,7 +18,7 @@ package deployer
 
 import "testing"
 
-func TestMaybeGSURL(t *testing.T) {
+func TestCanonicalizeBaseURL(t *testing.T) {
 	cases := []struct {
 		name          string
 		cloudProvider string
@@ -38,8 +38,26 @@ func TestMaybeGSURL(t *testing.T) {
 			expected:      "https://storage.googleapis.com/k8s-staging-kops/kops/1.34.0/",
 		},
 		{
+			name:          "aws with S3 staged artifacts",
+			cloudProvider: "aws",
+			baseURL:       "https://example-bucket.s3.us-east-2.amazonaws.com/kops/1.34.0/",
+			expected:      "https://example-bucket.s3.us-east-2.amazonaws.com/kops/1.34.0/",
+		},
+		{
+			name:          "gce with S3 staged artifacts is left alone",
+			cloudProvider: "gce",
+			baseURL:       "https://example-bucket.s3.us-east-2.amazonaws.com/kops/1.34.0/",
+			expected:      "https://example-bucket.s3.us-east-2.amazonaws.com/kops/1.34.0/",
+		},
+		{
 			name:          "gce with a non-GCS url",
 			cloudProvider: "gce",
+			baseURL:       "https://artifacts.k8s.io/binaries/kops/1.34.0/",
+			expected:      "https://artifacts.k8s.io/binaries/kops/1.34.0/",
+		},
+		{
+			name:          "aws with a non-S3 url",
+			cloudProvider: "aws",
 			baseURL:       "https://artifacts.k8s.io/binaries/kops/1.34.0/",
 			expected:      "https://artifacts.k8s.io/binaries/kops/1.34.0/",
 		},
@@ -49,13 +67,19 @@ func TestMaybeGSURL(t *testing.T) {
 			baseURL:       "gs://k8s-staging-kops/kops/1.34.0/",
 			expected:      "gs://k8s-staging-kops/kops/1.34.0/",
 		},
+		{
+			name:          "aws with an already converted url",
+			cloudProvider: "aws",
+			baseURL:       "s3://example-bucket/kops/1.34.0/",
+			expected:      "s3://example-bucket/kops/1.34.0/",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			d := &deployer{CloudProvider: tc.cloudProvider}
-			if actual := d.maybeGSURL(tc.baseURL); actual != tc.expected {
-				t.Errorf("maybeGSURL(%q) = %q, expected %q", tc.baseURL, actual, tc.expected)
+			if actual := d.canonicalizeBaseURL(tc.baseURL); actual != tc.expected {
+				t.Errorf("canonicalizeBaseURL(%q) = %q, expected %q", tc.baseURL, actual, tc.expected)
 			}
 		})
 	}

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -100,6 +100,7 @@ type deployer struct {
 
 	createStateStore     bool
 	createDiscoveryStore bool
+	createStagingStore   bool
 	stateStoreName       string
 	discoveryStoreName   string
 	stagingStoreName     string

--- a/tests/e2e/kubetest2-kops/deployer/down.go
+++ b/tests/e2e/kubetest2-kops/deployer/down.go
@@ -18,6 +18,7 @@ package deployer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -28,7 +29,14 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
+// Down deletes the cluster and its staged artifacts, so scenarios must use them first.
 func (d *deployer) Down() error {
+	return errors.Join(d.down(), d.deleteStagingStore())
+}
+
+// down preserves AWS staged artifacts while Up cleans leaked cluster resources. On GCE, the
+// staging bucket is deleted here together with the state store.
+func (d *deployer) down() error {
 	if err := d.init(); err != nil {
 		return err
 	}
@@ -98,5 +106,16 @@ func (d *deployer) Down() error {
 			return fmt.Errorf("down failed to release boskos project: %s", err)
 		}
 	}
+	return nil
+}
+
+func (d *deployer) deleteStagingStore() error {
+	if !d.createStagingStore {
+		return nil
+	}
+	if err := d.aws.DeleteS3BucketAndContents(context.Background(), d.stagingStore()); err != nil {
+		return err
+	}
+	d.createStagingStore = false
 	return nil
 }

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -50,9 +50,14 @@ const (
 	awsDefaultArmNodeSize         = "c6g.large"
 )
 
-func (d *deployer) Up() error {
+func (d *deployer) Up() (retErr error) {
 	ctx := context.TODO()
 
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, d.deleteStagingStore())
+		}
+	}()
 	if err := d.init(); err != nil {
 		return err
 	}
@@ -70,14 +75,14 @@ func (d *deployer) Up() error {
 
 	// PreTestCmd inherits the process environment rather than d.env().
 	if d.KopsBaseURL != "" {
-		os.Setenv("KOPS_BASE_URL", d.maybeGSURL(d.KopsBaseURL))
+		os.Setenv("KOPS_BASE_URL", d.canonicalizeBaseURL(d.KopsBaseURL))
 	}
 
 	if d.terraform == nil {
 		klog.Info("Cleaning up any leaked resources from previous cluster")
 		// Intentionally ignore errors:
 		// Either the cluster didn't exist or something failed that the next cluster creation will catch
-		_ = d.Down()
+		_ = d.down()
 	}
 
 	switch d.CloudProvider {

--- a/tests/e2e/scenarios/lib/upgrade.sh
+++ b/tests/e2e/scenarios/lib/upgrade.sh
@@ -67,21 +67,32 @@ function kops-upgrade() {
 
     export KOPS_BASE_URL
 
-    echo "Cleaning up any leaked resources from previous cluster"
     # For KOPS_VERSION_B, the value "latest" means build of the tree
     if [[ "${KOPS_VERSION_B}" == "latest" ]]; then
-        kops-acquire-latest
-        KOPS_BASE_URL_B="${KOPS_BASE_URL}"
-        KOPS_B="${KOPS}"
+        # --down deletes staged artifacts, so acquire version B after cleanup. Build its binary
+        # now because cleanup itself uses version B. Periodic jobs only download the binary.
+        if [[ "${JOB_TYPE-}" == "periodic" ]]; then
+            kops-acquire-latest
+            KOPS_B="${KOPS}"
+        else
+            make -C "${REPO_ROOT}" crossbuild-kops-linux-amd64
+            KOPS_B="${REPO_ROOT}/.build/dist/linux/amd64/kops"
+        fi
     else
         KOPS_BASE_URL=$(kops-base-from-marker "${KOPS_VERSION_B}")
-        KOPS_BASE_URL_B="${KOPS_BASE_URL}"
         KOPS_B=$(kops-download-from-base)
     fi
 
+    echo "Cleaning up any leaked resources from previous cluster"
     ${KUBETEST2} \
         --down \
         --kops-binary-path="${KOPS_B}" || echo "kubetest2 down failed"
+
+    if [[ "${KOPS_VERSION_B}" == "latest" ]]; then
+        kops-acquire-latest
+        KOPS_B="${KOPS}"
+    fi
+    KOPS_BASE_URL_B="${KOPS_BASE_URL}"
 
     # First kOps version may be a released version. If so, it is prefixed with v
     if [[ "${KOPS_VERSION_A:0:1}" == "v" ]]; then


### PR DESCRIPTION
The kubetest2-kops deployer stages AWS build artifacts in an ephemeral S3 bucket to exercise the s3:// KOPS_BASE_URL path from kubernetes/kops#18661. The bucket name uses the full BUILD_ID so separate kubetest2 invocations derive the same name without sharing state. The deployer creates the bucket during --build and deletes it during --down or after Build or Up fails. It never manages buckets supplied through KOPS_STAGING_BUCKET. Without BUILD_ID, staging continues to use GCS. Names over S3's 63-character limit fail instead of being truncated, avoiding collisions between jobs.

s3-publish-ci re-exports AWS_REGION because the Makefile unexports it and hack/upload needs it to resolve the AWS CLI region. Uploads use --private because the bucket policy grants public read while its public access block settings reject object ACLs.

upgrade.sh delays acquiring version B artifacts until after kubetest2 --down because teardown deletes staged artifacts. It builds a local version B binary first so cleanup can run before that acquisition.

/cc @rifelpet @ameukam 