### PR TITLE
Do not upload stale images.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,7 +749,7 @@ dev-version-dist-amd64 dev-version-dist-arm64: dev-version-dist-%: version-dist-
 
 .PHONY: dev-upload-linux-amd64 dev-upload-linux-arm64
 dev-upload-linux-amd64 dev-upload-linux-arm64: dev-upload-linux-%: dev-version-dist-%
-	${UPLOAD_CMD} ${UPLOAD}/ ${UPLOAD_DEST}
+	${UPLOAD_CMD} ${UPLOAD}/kops/${VERSION}/ ${UPLOAD_DEST}/kops/${VERSION}
 
 # dev-upload does a faster build and uploads to GCS / S3
 .PHONY: dev-upload


### PR DESCRIPTION
This makes no difference on a clean clone.
However if you have been using the clone on previous releases, then you will likely have some older/stale builds. These old stale builds will then be uploaded to your storage. Fixing this is a minor optimization.
It also prevents you(me) accidentily using an older build because we didn't fix our KOPS_BASE_URL path.