### PR TITLE
azure: download nodeup from Blob Storage with curl

### DIFF
--- a/docs/operations/asset-repository.md
+++ b/docs/operations/asset-repository.md
@@ -71,6 +71,20 @@ spec:
     fileRepository: s3://example-bucket/files
 ```
 
+{{ kops_feature_table(kops_added_default='1.37') }}
+
+On Azure, the repository can also be an `azureblob://<account>/<container>/<prefix>` URL.
+Nodes then read it with their system-assigned managed identity, which allows the storage
+account to be private. The managed identities of the instance groups have to be granted
+`Storage Blob Data Reader` on the assets container. Do not grant access to the state-store
+storage account, as that would let nodes read the cluster PKI.
+
+```yaml
+spec:
+  assets:
+    fileRepository: azureblob://exampleaccount/assets/files
+```
+
 ## Copying assets into repositories
 
 {{ kops_feature_table(kops_added_default='1.22') }}
@@ -80,9 +94,11 @@ You can copy assets into their repositories either by running `kops get assets -
 When running `kops get assets --copy`, kOps copies assets into their respective repositories if
 they do not already exist there.
 
-For file assets, kOps only supports copying to a repository that is either an S3 or GCS bucket.
+For file assets, kOps only supports copying to a repository that is an S3 bucket, a GCS bucket,
+or an Azure Blob Storage container.
 An S3 bucket must be configured with a prefix of `s3://` or using the [regional naming conventions of S3](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
 A GCS bucket must be configured with a prefix of `https://storage.googleapis.com/` or `gs://`.
+An Azure Blob Storage container must be configured with a prefix of `azureblob://`.
 
 ## Listing assets
 

--- a/docs/releases/1.37-NOTES.md
+++ b/docs/releases/1.37-NOTES.md
@@ -34,6 +34,8 @@ As part of this removal, the `protokube` component, whose only remaining respons
 
 * Private cluster asset repositories now support AWS `s3://` URLs in addition to existing GCE `gs://` URLs, both for `KOPS_BASE_URL` (nodeup download) and `spec.assets.fileRepository`. Nodes authenticate with their instance credentials; see the [asset repository documentation](https://kops.sigs.k8s.io/operations/asset-repository/) for the required permissions. The AWS nodeup download requires node images with curl 8.0 or newer.
 
+* Private cluster asset repositories now also support Azure `azureblob://<account>/<container>/<prefix>` URLs, both for `KOPS_BASE_URL` (nodeup download) and `spec.assets.fileRepository`. Nodes authenticate with their system-assigned managed identity, which has to be granted the `Storage Blob Data Reader` role on the assets container; see the [asset repository documentation](https://kops.sigs.k8s.io/operations/asset-repository/) for the details and warnings.
+
 # Breaking changes
 
 * Support for AWS Classic Load Balancer (CLB) for the API has been removed. Clusters with `spec.api.loadBalancer.class: Classic` (or with no explicit `class`, which previously defaulted to Classic) fail validation, and the long-deprecated `kops create cluster --api-loadbalancer-class` flag has been removed. Existing clusters using a CLB must migrate to a Network Load Balancer (NLB) using kOps 1.36 or earlier before upgrading to kOps 1.37, following the [CLB to NLB migration guide](https://github.com/kubernetes/kops/blob/master/permalinks/acm_nlb.md). Attaching instance groups to externally-managed Classic Load Balancers via `spec.externalLoadBalancers[].loadBalancerName` remains supported.

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -806,8 +806,17 @@ func validateFileRepository(s string, fieldPath *field.Path, cloudProvider kops.
 		if cloudProvider != kops.CloudProviderAWS {
 			allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("s3:// fileRepository is only supported on AWS, but the cloud provider is %q", cloudProvider)))
 		}
+	case "azureblob":
+		// Only Azure instances can authenticate to Azure Blob Storage with their managed identity.
+		if cloudProvider != kops.CloudProviderAzure {
+			allErrs = append(allErrs, field.Invalid(fieldPath, s, fmt.Sprintf("azureblob:// fileRepository is only supported on Azure, but the cloud provider is %q", cloudProvider)))
+		}
+		// Without a container, each remapped asset would treat its first path segment as the container.
+		if container, _, _ := strings.Cut(strings.TrimPrefix(u.Path, "/"), "/"); container == "" {
+			allErrs = append(allErrs, field.Invalid(fieldPath, s, "azureblob:// fileRepository must include a container: azureblob://<account>/<container>/<path>"))
+		}
 	default:
-		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must be an http://, https://, gs://, or s3:// URL"))
+		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must be an http://, https://, gs://, s3://, or azureblob:// URL"))
 	}
 	if u.Host == "" {
 		allErrs = append(allErrs, field.Invalid(fieldPath, s, "fileRepository must include a host"))

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -2306,6 +2306,25 @@ func TestValidateFileRepository(t *testing.T) {
 			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
 		},
 		{
+			Input:         "azureblob://exampleaccount/assets/kops",
+			CloudProvider: kops.CloudProviderAzure,
+		},
+		{
+			Input:          "azureblob://exampleaccount/assets/kops",
+			CloudProvider:  kops.CloudProviderGCE,
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
+			Input:          "azureblob://exampleaccount/assets/kops",
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
+			// A container is required so that remapped assets share one container.
+			Input:          "azureblob://exampleaccount",
+			CloudProvider:  kops.CloudProviderAzure,
+			ExpectedErrors: []string{"Invalid value::spec.assets.fileRepository"},
+		},
+		{
 			// Nodes download from GCS with the credentials of their service account.
 			Input:         "gs://example-k8s-assets/kops",
 			CloudProvider: kops.CloudProviderGCE,

--- a/pkg/assets/assetcopy/copyfile.go
+++ b/pkg/assets/assetcopy/copyfile.go
@@ -176,11 +176,11 @@ func writeFile(ctx context.Context, cluster *kops.Cluster, p vfs.Path, data []by
 	return nil
 }
 
-// buildVFSPath returns local paths and memfs://, file://, gs://, and s3:// URLs unchanged.
+// buildVFSPath returns local paths and memfs://, file://, gs://, s3://, and azureblob:// URLs unchanged.
 // It converts recognized S3 or GCS HTTPS URLs to their native VFS form.
 func buildVFSPath(target string) (string, error) {
 	if !strings.Contains(target, "://") || strings.HasPrefix(target, "memfs://") || strings.HasPrefix(target, "file://") ||
-		strings.HasPrefix(target, "gs://") || strings.HasPrefix(target, "s3://") {
+		strings.HasPrefix(target, "gs://") || strings.HasPrefix(target, "s3://") || strings.HasPrefix(target, "azureblob://") {
 		return target, nil
 	}
 

--- a/pkg/assets/assetcopy/copyfile_test.go
+++ b/pkg/assets/assetcopy/copyfile_test.go
@@ -57,6 +57,11 @@ func Test_BuildVFSPath(t *testing.T) {
 			true,
 		},
 		{
+			"azureblob://exampleaccount/assets/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			"azureblob://exampleaccount/assets/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
+			true,
+		},
+		{
 			"https://foo/k8s-for-greeks-kops/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl",
 			"",
 			false,

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -80,6 +80,9 @@ imds-get() {
   curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 \
     -H "X-aws-ec2-metadata-token: $1" "http://169.254.169.254/latest/$2"
 }
+{{- end }}
+
+{{- if or UseGCSDownload UseS3Download UseBlobDownload }}
 
 # Extract a string field from a JSON object. args: json, field
 json-field() {
@@ -107,14 +110,39 @@ download-or-bust() {
   while true; do
     for url in "${urls[@]}"; do
 {{- if UseGCSDownload }}
-      # Use the IP of the metadata server, to not depend on DNS this early in boot
-      local metadata_server="http://169.254.169.254"
-      local token
+      local response token
       echo "== Downloading ${url} =="
-      # Pipe the service account token to curl, to keep it out of the logs
-      if ! token=$(curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 -H 'Metadata-Flavor: Google' "${metadata_server}/computeMetadata/v1/instance/service-accounts/default/token" | grep -o '"access_token" *: *"[^"]*"' | cut -d '"' -f 4); then
+      # Use the IP of the metadata server, to not depend on DNS this early in boot
+      if ! response=$(curl -s -f --noproxy '*' --connect-timeout 2 --max-time 5 -H 'Metadata-Flavor: Google' "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token"); then
         echo "== Failed to get a service account token =="
+      elif ! token=$(json-field "${response}" access_token); then
+        echo "== Failed to parse the service account token =="
+      # Pass the token through stdin so it does not appear in files, logs, or process arguments.
       elif ! echo "Authorization: Bearer ${token}" | curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 -H @- "https://storage.googleapis.com/${url#gs://}"; then
+        echo "== Failed to download ${url} =="
+      elif ! validate-hash "${file}" "${hash}"; then
+        echo "== Failed to validate hash for ${url} =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} with hash ${hash} =="
+        return 0
+      fi
+{{- else if UseBlobDownload }}
+      local rest account response token
+      echo "== Downloading ${url} =="
+      rest="${url#azureblob://}"
+      account="${rest%%/*}"
+      rest="${rest#*/}"
+      # Use the IP of the metadata server, to not depend on DNS this early in boot.
+      # The token request is brokered to Entra ID, so allow more time than for other clouds.
+      if ! response=$(curl -s -f --noproxy '*' --connect-timeout 5 --max-time 30 -H 'Metadata: true' "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F"); then
+        echo "== Failed to get a managed identity token =="
+      elif ! token=$(json-field "${response}" access_token); then
+        echo "== Failed to parse the managed identity token =="
+      # Pass the token through stdin so it does not appear in files, logs, or process arguments.
+      elif ! printf 'Authorization: Bearer %s\nx-ms-version: 2017-11-09\n' "${token}" |
+        curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 -H @- \
+          "https://${account}.blob.core.windows.net/${rest}"; then
         echo "== Failed to download ${url} =="
       elif ! validate-hash "${file}" "${hash}"; then
         echo "== Failed to validate hash for ${url} =="
@@ -267,10 +295,16 @@ func (b *NodeUpScript) nodeUpSource(arch architectures.Architecture) (string, er
 
 	locations := slices.Clone(asset.Locations)
 	for i, location := range locations {
-		if !strings.HasPrefix(location, "s3://") {
+		var escape func(string) (string, error)
+		switch {
+		case strings.HasPrefix(location, "s3://"):
+			escape = escapeS3Location
+		case strings.HasPrefix(location, "azureblob://"):
+			escape = escapeBlobLocation
+		default:
 			continue
 		}
-		escaped, err := escapeS3Location(location)
+		escaped, err := escape(location)
 		if err != nil {
 			return "", fmt.Errorf("escaping nodeup source %q: %w", location, err)
 		}
@@ -291,6 +325,21 @@ func escapeS3Location(location string) (string, error) {
 	return "s3://" + u.Host + httpbinding.EscapePath(u.Path, false), nil
 }
 
+func escapeBlobLocation(location string) (string, error) {
+	u, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("parsing Azure Blob location: %w", err)
+	}
+	container, key, _ := strings.Cut(strings.TrimPrefix(u.Path, "/"), "/")
+	// Reject ports, IPv6 hosts, userinfo, queries, and fragments, which the account-based
+	// blob.core.windows.net URL cannot represent, so they fail here instead of in the boot retry loop.
+	if u.Scheme != "azureblob" || u.Host == "" || u.Hostname() != u.Host || u.User != nil || u.RawQuery != "" || u.Fragment != "" || container == "" || key == "" {
+		return "", fmt.Errorf("invalid Azure Blob location; expected azureblob://<account>/<container>/<key>")
+	}
+
+	return "azureblob://" + u.Host + httpbinding.EscapePath(u.Path, false), nil
+}
+
 func (b *NodeUpScript) Build() (fi.Resource, error) {
 	if b.ProxyEnv == nil {
 		b.ProxyEnv = funcEmptyString
@@ -301,6 +350,14 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 
 	if b.useS3Download() && b.S3Region == "" {
 		return nil, fmt.Errorf("ResolveS3Region must be called before building a nodeup script with an s3:// source")
+	}
+
+	if b.useBlobDownload() {
+		// The script hard-codes the public cloud blob.core.windows.net endpoint suffix.
+		// Azure environment names are case-insensitive; AzureCloud is the CLI name of the public cloud.
+		if azureEnv := os.Getenv("AZURE_ENVIRONMENT"); azureEnv != "" && !strings.EqualFold(azureEnv, "AzurePublicCloud") && !strings.EqualFold(azureEnv, "AzureCloud") {
+			return nil, fmt.Errorf("downloading nodeup from an azureblob:// URL is not supported in Azure environment %q", azureEnv)
+		}
 	}
 
 	functions := template.FuncMap{
@@ -349,9 +406,10 @@ func (b *NodeUpScript) Build() (fi.Resource, error) {
 		"ProxyEnv":             b.ProxyEnv,
 		"EnvironmentVariables": b.EnvironmentVariables,
 
-		"UseGCSDownload": b.useGCSDownload,
-		"UseS3Download":  b.useS3Download,
-		"S3Region":       func() string { return b.S3Region },
+		"UseGCSDownload":  b.useGCSDownload,
+		"UseS3Download":   b.useS3Download,
+		"UseBlobDownload": b.useBlobDownload,
+		"S3Region":        func() string { return b.S3Region },
 	}
 
 	return newTemplateResource("nodeup", nodeUpTemplate, functions, nil)
@@ -382,6 +440,11 @@ func (b *NodeUpScript) firstLocationWithScheme(scheme string) string {
 // S3 downloads require an AWS instance profile.
 func (b *NodeUpScript) useS3Download() bool {
 	return b.CloudProvider == string(kops.CloudProviderAWS) && b.firstLocationWithScheme("s3://") != ""
+}
+
+// Azure Blob downloads require a managed identity on the instance.
+func (b *NodeUpScript) useBlobDownload() bool {
+	return b.CloudProvider == string(kops.CloudProviderAzure) && b.firstLocationWithScheme("azureblob://") != ""
 }
 
 // ResolveS3Region resolves the bucket region because SigV4 requires it but s3:// URLs omit it.

--- a/pkg/model/resources/nodeup_test.go
+++ b/pkg/model/resources/nodeup_test.go
@@ -207,6 +207,152 @@ func Test_S3Download(t *testing.T) {
 	}
 }
 
+func TestEscapeAzureBlobLocation(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		location  string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "plain path",
+			location: "azureblob://exampleaccount/assets/kops/1.37.0/linux/amd64/nodeup",
+			expected: "azureblob://exampleaccount/assets/kops/1.37.0/linux/amd64/nodeup",
+		},
+		{
+			name:     "plus sign",
+			location: "azureblob://exampleaccount/assets/kops/1.37.0+abcdef/linux/amd64/nodeup",
+			expected: "azureblob://exampleaccount/assets/kops/1.37.0%2Babcdef/linux/amd64/nodeup",
+		},
+		{
+			name:     "existing escape",
+			location: "azureblob://exampleaccount/assets/kops/1.37.0%2Babcdef/linux/amd64/nodeup",
+			expected: "azureblob://exampleaccount/assets/kops/1.37.0%2Babcdef/linux/amd64/nodeup",
+		},
+		{
+			name:      "missing account",
+			location:  "azureblob:///assets/kops/nodeup",
+			expectErr: true,
+		},
+		{
+			name:      "missing container",
+			location:  "azureblob://exampleaccount",
+			expectErr: true,
+		},
+		{
+			name:      "missing key",
+			location:  "azureblob://exampleaccount/assets",
+			expectErr: true,
+		},
+		{
+			name:      "invalid escape",
+			location:  "azureblob://exampleaccount/assets/100%/nodeup",
+			expectErr: true,
+		},
+		{
+			name:      "port in host",
+			location:  "azureblob://exampleaccount:443/assets/kops/nodeup",
+			expectErr: true,
+		},
+		{
+			name:      "userinfo",
+			location:  "azureblob://user@exampleaccount/assets/kops/nodeup",
+			expectErr: true,
+		},
+		{
+			name:      "query string",
+			location:  "azureblob://exampleaccount/assets/kops/nodeup?sig=secret",
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := escapeBlobLocation(tc.location)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error escaping %q", tc.location)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("escaping %q: %v", tc.location, err)
+			}
+			if actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func Test_AzureBlobDownload(t *testing.T) {
+	azureBlobMarker := "blob.core.windows.net"
+	standardMarker := "wget --compression=auto"
+
+	for _, tc := range []struct {
+		name            string
+		cloudProvider   string
+		location        string
+		expectedSource  string
+		expectAzureBlob bool
+	}{
+		{
+			name:            "azureblob source",
+			cloudProvider:   "azure",
+			location:        "azureblob://exampleaccount/assets/kops/1.34.0+abcdef/linux/amd64/nodeup",
+			expectedSource:  "NODEUP_URL_AMD64=azureblob://exampleaccount/assets/kops/1.34.0%2Babcdef/linux/amd64/nodeup",
+			expectAzureBlob: true,
+		},
+		{
+			name:            "default https source",
+			cloudProvider:   "azure",
+			location:        "https://artifacts.k8s.io/binaries/kops/1.34.0/linux/amd64/nodeup",
+			expectAzureBlob: false,
+		},
+		{
+			name:            "azureblob source on another cloud provider",
+			cloudProvider:   "hetzner",
+			location:        "azureblob://exampleaccount/assets/kops/1.34.0/linux/amd64/nodeup",
+			expectAzureBlob: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := &NodeUpScript{
+				CloudProvider: tc.cloudProvider,
+				NodeUpAssets:  singleNodeUpAsset(tc.location),
+			}
+			rendered := renderNodeUpScript(t, script)
+			if got := strings.Contains(rendered, azureBlobMarker); got != tc.expectAzureBlob {
+				t.Errorf("authenticated Azure Blob download rendered=%v, expected %v", got, tc.expectAzureBlob)
+			}
+			if tc.expectedSource != "" && !strings.Contains(rendered, tc.expectedSource) {
+				t.Errorf("rendered script does not contain escaped source %q", tc.expectedSource)
+			}
+			if got := strings.Contains(rendered, standardMarker); got != !tc.expectAzureBlob {
+				t.Errorf("standard download commands rendered=%v, expected %v", got, !tc.expectAzureBlob)
+			}
+		})
+	}
+}
+
+func Test_AzureBlobDownloadRequiresPublicCloud(t *testing.T) {
+	script := &NodeUpScript{
+		CloudProvider: "azure",
+		NodeUpAssets:  singleNodeUpAsset("azureblob://exampleaccount/assets/kops/1.34.0/linux/amd64/nodeup"),
+	}
+
+	// Environment names are case-insensitive, and AzureCloud is the CLI name of the public cloud.
+	for _, publicCloud := range []string{"AzurePublicCloud", "azurepubliccloud", "AzureCloud"} {
+		t.Setenv("AZURE_ENVIRONMENT", publicCloud)
+		if _, err := script.Build(); err != nil {
+			t.Errorf("building an azureblob:// nodeup script with AZURE_ENVIRONMENT=%s: %v", publicCloud, err)
+		}
+	}
+
+	t.Setenv("AZURE_ENVIRONMENT", "AzureChinaCloud")
+	if _, err := script.Build(); err == nil {
+		t.Errorf("expected an error building an azureblob:// nodeup script in a non-public cloud")
+	}
+}
+
 func Test_S3DownloadRequiresRegion(t *testing.T) {
 	script := &NodeUpScript{
 		CloudProvider: "aws",

--- a/upup/pkg/fi/assetstore.go
+++ b/upup/pkg/fi/assetstore.go
@@ -201,7 +201,7 @@ func hashFromHTTPHeader(url string) (*hashing.Hash, error) {
 
 // Add an asset into the store, in one of the recognized formats (see Assets in types package)
 func (a *AssetStore) Add(ctx context.Context, id string) error {
-	if strings.HasPrefix(id, "http://") || strings.HasPrefix(id, "https://") || strings.HasPrefix(id, "gs://") || strings.HasPrefix(id, "s3://") {
+	if strings.HasPrefix(id, "http://") || strings.HasPrefix(id, "https://") || strings.HasPrefix(id, "gs://") || strings.HasPrefix(id, "s3://") || strings.HasPrefix(id, "azureblob://") {
 		return a.addURLs(ctx, strings.Split(id, ","), nil)
 	}
 	i := strings.Index(id, "@http://")
@@ -213,6 +213,9 @@ func (a *AssetStore) Add(ctx context.Context, id string) error {
 	}
 	if i == -1 {
 		i = strings.Index(id, "@s3://")
+	}
+	if i == -1 {
+		i = strings.Index(id, "@azureblob://")
 	}
 	if i != -1 {
 		urls := strings.Split(id[i+1:], ",")

--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -135,6 +135,19 @@ func downloadURLToWriter(ctx context.Context, desturl string, dest io.Writer, ha
 		if _, err := s3Path.WriteToWithContext(ctx, writer); err != nil {
 			return nil, fmt.Errorf("error downloading content from %q: %w", desturl, err)
 		}
+	case "azureblob":
+		// vfs authenticates with the ambient Azure credentials, such as the instance managed identity.
+		p, err := vfs.Context.BuildVfsPath(desturl)
+		if err != nil {
+			return nil, fmt.Errorf("building path for %q: %w", desturl, err)
+		}
+		blobPath, ok := p.(*vfs.AzureBlobPath)
+		if !ok {
+			return nil, fmt.Errorf("unexpected path type %T for %q", p, desturl)
+		}
+		if _, err := blobPath.WriteToWithContext(ctx, writer); err != nil {
+			return nil, fmt.Errorf("error downloading content from %q: %w", desturl, err)
+		}
 	default:
 		reader, err := OpenURL(desturl)
 		if err != nil {

--- a/util/pkg/vfs/azureblob.go
+++ b/util/pkg/vfs/azureblob.go
@@ -153,9 +153,14 @@ func (p *AzureBlobPath) ReadFile(ctx context.Context) ([]byte, error) {
 
 // WriteTo writes the content of the blob to the writer.
 func (p *AzureBlobPath) WriteTo(w io.Writer) (int64, error) {
-	klog.V(8).Infof("Writing to: %s", p)
-
 	ctx := context.TODO()
+
+	return p.WriteToWithContext(ctx, w)
+}
+
+// WriteToWithContext writes the content of the blob to the writer, with the given context.
+func (p *AzureBlobPath) WriteToWithContext(ctx context.Context, w io.Writer) (int64, error) {
+	klog.V(8).Infof("Writing to: %s", p)
 
 	b, err := p.ReadFile(ctx)
 	if err != nil {


### PR DESCRIPTION
When `KOPS_BASE_URL` is an `azureblob://<account>/<container>/<key>` URL on an Azure cluster, the bootstrap script downloads nodeup with curl. It requests an OAuth token for the system-assigned managed identity from the instance metadata service and passes the `Authorization` and `x-ms-version` headers to curl through stdin, so the token never reaches disk, process arguments, or console logs.

The download URL hard-codes the public `blob.core.windows.net` endpoint, so validation rejects non-public `AZURE_ENVIRONMENT` values. Source locations are percent-escaped and validated when the script is rendered, so malformed URLs fail during `kops update` rather than in the boot retry loop.

`spec.assets.fileRepository` now accepts an `azureblob://` URL on Azure, so that the node assets can be hosted in the same private container. The URL must include a container, and nodes on other clouds cannot authenticate to Azure Blob Storage, so validation keeps rejecting it there. Nodeup reads these assets through VFS using the managed identity credentials, and `kops get assets --copy` can now also write to an `azureblob://` repository.

Access is not granted automatically: the docs describe granting `Storage Blob Data Reader` on the assets container only, never on the state-store account, which would let nodes read the cluster PKI.