### PR TITLE
tests/e2e: use gs:// base URL only for kops versions supporting it

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/aws"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/gce"
@@ -345,6 +346,14 @@ const gcsPublicPrefix = "https://storage.googleapis.com/"
 // form; the scripts that download the kops binary run outside the deployer and keep using https.
 func (d *deployer) maybeGSURL(baseURL string) string {
 	if d.CloudProvider != "gce" || !strings.HasPrefix(baseURL, gcsPublicPrefix) {
+		return baseURL
+	}
+	// Only kops >= 1.37.0-alpha.1 supports a gs:// base URL. The deployer also tests release
+	// branches, which must keep the https form. The staged artifacts path always ends in the
+	// kops version; if none parses, keep https, which every version can download.
+	segments := strings.Split(strings.TrimRight(baseURL, "/"), "/")
+	version, err := semver.ParseTolerant(segments[len(segments)-1])
+	if err != nil || version.LT(semver.MustParse("1.37.0-alpha.1")) {
 		return baseURL
 	}
 	return "gs://" + strings.TrimPrefix(baseURL, gcsPublicPrefix)

--- a/tests/e2e/kubetest2-kops/deployer/common_test.go
+++ b/tests/e2e/kubetest2-kops/deployer/common_test.go
@@ -26,28 +26,40 @@ func TestMaybeGSURL(t *testing.T) {
 		expected      string
 	}{
 		{
-			name:          "gce staged artifacts",
+			name:          "gce staged artifacts from a CI build",
 			cloudProvider: "gce",
-			baseURL:       "https://storage.googleapis.com/k8s-staging-kops/kops/1.34.0/",
-			expected:      "gs://k8s-staging-kops/kops/1.34.0/",
+			baseURL:       "https://storage.googleapis.com/k8s-staging-kops/kops/releases/1.37.0-alpha.2+v1.37.0-alpha.1-42-gdeadbeef01",
+			expected:      "gs://k8s-staging-kops/kops/releases/1.37.0-alpha.2+v1.37.0-alpha.1-42-gdeadbeef01",
+		},
+		{
+			name:          "gce staged artifacts from a release branch without gs support are left alone",
+			cloudProvider: "gce",
+			baseURL:       "https://storage.googleapis.com/k8s-staging-kops/kops/releases/1.35.3+v1.35.1-39-gc89e13599b",
+			expected:      "https://storage.googleapis.com/k8s-staging-kops/kops/releases/1.35.3+v1.35.1-39-gc89e13599b",
+		},
+		{
+			name:          "gce with no parseable version is left alone",
+			cloudProvider: "gce",
+			baseURL:       "https://storage.googleapis.com/k8s-staging-kops/kops/latest/",
+			expected:      "https://storage.googleapis.com/k8s-staging-kops/kops/latest/",
 		},
 		{
 			name:          "aws staged artifacts are left alone",
 			cloudProvider: "aws",
-			baseURL:       "https://storage.googleapis.com/k8s-staging-kops/kops/1.34.0/",
-			expected:      "https://storage.googleapis.com/k8s-staging-kops/kops/1.34.0/",
+			baseURL:       "https://storage.googleapis.com/k8s-staging-kops/kops/releases/1.37.0-alpha.2+v1.37.0-alpha.1-42-gdeadbeef01",
+			expected:      "https://storage.googleapis.com/k8s-staging-kops/kops/releases/1.37.0-alpha.2+v1.37.0-alpha.1-42-gdeadbeef01",
 		},
 		{
 			name:          "gce with a non-GCS url",
 			cloudProvider: "gce",
-			baseURL:       "https://artifacts.k8s.io/binaries/kops/1.34.0/",
-			expected:      "https://artifacts.k8s.io/binaries/kops/1.34.0/",
+			baseURL:       "https://artifacts.k8s.io/binaries/kops/1.37.0/",
+			expected:      "https://artifacts.k8s.io/binaries/kops/1.37.0/",
 		},
 		{
 			name:          "gce with an already converted url",
 			cloudProvider: "gce",
-			baseURL:       "gs://k8s-staging-kops/kops/1.34.0/",
-			expected:      "gs://k8s-staging-kops/kops/1.34.0/",
+			baseURL:       "gs://k8s-staging-kops/kops/releases/1.37.0-alpha.2+v1.37.0-alpha.1-42-gdeadbeef01",
+			expected:      "gs://k8s-staging-kops/kops/releases/1.37.0-alpha.2+v1.37.0-alpha.1-42-gdeadbeef01",
 		},
 	}
 


### PR DESCRIPTION
Addresses https://github.com/kubernetes/kops/pull/18623#issuecomment-5217146743.

/cc @rifelpet @ameukam 