### PR TITLE
Cap the kops-controller bootstrap retry backoff, and verify the e2e upgrade actually rolls

### DIFF
--- a/pkg/kopscontrollerclient/client.go
+++ b/pkg/kopscontrollerclient/client.go
@@ -101,10 +101,15 @@ func (b *Client) Query(ctx context.Context, req any, resp any) error {
 	bootstrapURL := b.BaseURL
 	bootstrapURL.Path = path.Join(bootstrapURL.Path, "/bootstrap")
 
+	// Cap the interval so a control plane that takes a long time to become reachable does not
+	// push the next attempt tens of minutes out. Without a cap, doubling from 1s reaches a 17
+	// minute wait by attempt 11, so a node that has been failing for 17 minutes then sits idle
+	// for another 17 even once kops-controller is serving.
 	backoff := wait.Backoff{
 		Duration: 1 * time.Second,
 		Factor:   2,
 		Jitter:   0.1,
+		Cap:      30 * time.Second,
 		Steps:    100,
 	}
 

--- a/tests/e2e/scenarios/lib/upgrade.sh
+++ b/tests/e2e/scenarios/lib/upgrade.sh
@@ -145,6 +145,19 @@ function kops-upgrade() {
     # Verify kubeconfig-a still works
     kubectl get nodes -owide --kubeconfig="${KUBECONFIG_A}"
 
+    # A cluster that was never rolled still validates, so assert the upgrade actually landed.
+    # A "ci" version was rewritten above into a release-dev URL, so compare on its last segment,
+    # which is the version kubelet reports. Plain versions are unaffected by the strip.
+    local expected_kubelet stale_nodes
+    expected_kubelet="${K8S_VERSION_B##*/}"
+    stale_nodes=$(kubectl get nodes --kubeconfig="${KUBECONFIG_A}" \
+        -o jsonpath="{range .items[?(@.status.nodeInfo.kubeletVersion!='${expected_kubelet}')]}{.metadata.name}{' '}{.status.nodeInfo.kubeletVersion}{'\n'}{end}")
+    if [[ -n "${stale_nodes}" ]]; then
+        >&2 echo "upgrade to ${expected_kubelet} did not reach all nodes:"
+        >&2 echo "${stale_nodes}"
+        exit 1
+    fi
+
     cp "${KOPS_B}" "${WORKSPACE}/kops"
     export PATH="${WORKSPACE}:${PATH}"
 

--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -297,6 +297,17 @@ func (c *VFSContext) readHTTPLocation(httpURL string, httpHeaders map[string]str
 	}
 }
 
+// nextBackoffDuration grows duration by backoff.Factor, clamped to backoff.Cap when one is set.
+// An uncapped backoff with a large Steps count grows without bound, which strands a caller for
+// far longer than the condition it is waiting on takes to become true.
+func nextBackoffDuration(duration time.Duration, backoff wait.Backoff) time.Duration {
+	next := time.Duration(float64(duration) * backoff.Factor)
+	if backoff.Cap > 0 && next > backoff.Cap {
+		return backoff.Cap
+	}
+	return next
+}
+
 // RetryWithBackoff runs until a condition function returns true, or until Steps attempts have been taken
 // As compared to wait.ExponentialBackoff, this function returns the results from the function on the final attempt
 func RetryWithBackoff(backoff wait.Backoff, condition func() (bool, error)) (bool, error) {
@@ -309,7 +320,7 @@ func RetryWithBackoff(backoff wait.Backoff, condition func() (bool, error)) (boo
 				adjusted = wait.Jitter(duration, backoff.Jitter)
 			}
 			time.Sleep(adjusted)
-			duration = time.Duration(float64(duration) * backoff.Factor)
+			duration = nextBackoffDuration(duration, backoff)
 		}
 
 		i++

--- a/util/pkg/vfs/context_test.go
+++ b/util/pkg/vfs/context_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vfs
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestNextBackoffDuration(t *testing.T) {
+	grid := []struct {
+		name     string
+		duration time.Duration
+		backoff  wait.Backoff
+		expected time.Duration
+	}{
+		{
+			name:     "doubles below the cap",
+			duration: 4 * time.Second,
+			backoff:  wait.Backoff{Factor: 2, Cap: 30 * time.Second},
+			expected: 8 * time.Second,
+		},
+		{
+			name:     "clamps at the cap",
+			duration: 16 * time.Second,
+			backoff:  wait.Backoff{Factor: 2, Cap: 30 * time.Second},
+			expected: 30 * time.Second,
+		},
+		{
+			name:     "stays at the cap once reached",
+			duration: 30 * time.Second,
+			backoff:  wait.Backoff{Factor: 2, Cap: 30 * time.Second},
+			expected: 30 * time.Second,
+		},
+		{
+			name:     "grows unbounded when no cap is set",
+			duration: 16 * time.Second,
+			backoff:  wait.Backoff{Factor: 2},
+			expected: 32 * time.Second,
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.name, func(t *testing.T) {
+			actual := nextBackoffDuration(g.duration, g.backoff)
+			if actual != g.expected {
+				t.Errorf("nextBackoffDuration(%v, cap=%v) = %v, want %v", g.duration, g.backoff.Cap, actual, g.expected)
+			}
+		})
+	}
+}
+
+// TestRetryWithBackoffRespectsCap covers the reason the cap exists: an uncapped backoff with a
+// large Steps count pushes later attempts arbitrarily far apart, so a caller that has been
+// failing for a while stops retrying at any useful rate.
+func TestRetryWithBackoffRespectsCap(t *testing.T) {
+	backoff := wait.Backoff{
+		Duration: 1 * time.Millisecond,
+		Factor:   2,
+		Cap:      4 * time.Millisecond,
+		Steps:    8,
+	}
+
+	attempts := 0
+	done, err := RetryWithBackoff(backoff, func() (bool, error) {
+		attempts++
+		return attempts >= 8, nil
+	})
+	if err != nil {
+		t.Fatalf("RetryWithBackoff returned error: %v", err)
+	}
+	if !done {
+		t.Errorf("RetryWithBackoff returned done=false, want true")
+	}
+	if attempts != 8 {
+		t.Errorf("condition called %d times, want 8", attempts)
+	}
+}


### PR DESCRIPTION
Two fixes found while working through the `kops-azure` TestGrid after #18604. Neither is Azure-specific in its fix, though both were surfaced by Azure runs.

## 1. Cap the kops-controller bootstrap retry backoff

`vfs.RetryWithBackoff` never read `wait.Backoff.Cap`, and `pkg/kopscontrollerclient` paired that with `Factor: 2` and `Steps: 100`. The interval doubles without limit, so attempt 11 lands 17 minutes in and attempt 12 at 34 minutes — a node whose control plane is slow to become reachable stops retrying at any useful rate.

Seen on [`e2e-kops-azure-conformance-1-34/2080139096432316416`](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-azure-conformance-1-34/2080139096432316416): the VMSS create stalled ~17.5 minutes, which delayed the role assignments the VMs need in order to read their nodeup config, so every worker spent that window failing with `AuthorizationPermissionMismatch`. kops-controller began serving at 04:21:29, but the first bootstrap request did not arrive until 04:34:25 — 23 seconds *after* cluster validation had already given up — and succeeded on its first try:

```
I0723 04:21:29.707790 server.go:154] kops-controller listening on :3988
I0723 04:34:26.183065 server.go:246] performed successful callback challenge with 10.0.0.7:3987
I0723 04:34:26.649916 server.go:287] bootstrap 51.105.40.77:8980 success
```

All 4 workers were `provisioningState: Succeeded` in Azure but never joined; validation failed on `machine "..." has not yet joined cluster`. Nothing else was wrong — the eventual success proves NSG, NAT gateway, LB rule 3988 and attestation were all fine.

`RetryWithBackoff` now honors `Cap`, and the bootstrap client sets a 30s cap. Every other caller uses between 4 and 20 steps, where the unbounded growth is already bounded in practice, and none of them set `Cap` — so this is the only call site whose behavior changes.

## 2. Assert the A→B upgrade actually rolled the nodes

A cluster that was never rolled validates cleanly, so an upgrade that silently did nothing still reports green.

That is exactly what was happening on `e2e-kops-azure-upgrade-dns-none`, which failed 6 of 17 runs. In all six, both rolling-update phases printed `No rolling-update required` and every node stayed on the old kubelet version — the upgrade never happened. The job only went red because an addon rollout happened to still be in flight when validation ran; had it settled twenty seconds earlier, the run would have passed on an un-upgraded cluster, and some of the eleven "passing" runs may have been exactly that.

The underlying cause was fixed in #18669, so this PR does not re-fix it. It adds the guard that would have caught it in July instead of letting it hide behind an intermittent validation failure for three weeks: every node's kubelet must report `K8S_VERSION_B`.

An earlier revision of this PR also added `--wait 15m` to the `validate cluster` call. That was wrong and has been dropped — as @hakman pointed out in review, the cluster should already be stable at that point, since a rolling update's last action is a full cluster validation (`pkg/instancegroups/instancegroups.go:262`). `e2e-kops-aws-upgrade-dns-none` is 52/52 on the bare `validate cluster`, and waiting would have masked the very regression class this PR is meant to catch.

## Testing

New unit tests in `util/pkg/vfs/context_test.go` cover the cap clamping. `go build ./...` and the affected package tests pass. The scenario change is only exercised by the periodic upgrade jobs.

Draft because I have not run `make ci` / `verify-golangci-lint` locally yet.

```release-note
Fixed an issue where a node could stop retrying kops-controller bootstrap at a useful rate when the control plane was slow to become reachable.
```

/kind bug
/cc @hakman
