### PR TITLE
aws: Generate NodePool requirements for instanceRequirements

### DIFF
--- a/docs/operations/karpenter.md
+++ b/docs/operations/karpenter.md
@@ -77,6 +77,34 @@ Supported image selector forms are:
 * `<name>`
 * `<owner>/<name>`
 
+### Instance requirements
+{{ kops_feature_table(kops_added_default='1.37') }}
+
+By default, the generated `NodePool` requires one of the instance types listed in `spec.machineType` and `spec.mixedInstancesPolicy.instances`.
+To let Karpenter choose from any instance type within a capacity range instead, set `spec.mixedInstancesPolicy.instanceRequirements`:
+
+```yaml
+spec:
+  role: Node
+  manager: Karpenter
+  mixedInstancesPolicy:
+    instanceRequirements:
+      cpu:
+        min: "2"
+        max: "16"
+      memory:
+        min: "2Gi"
+        max: "64Gi"
+      excludedInstanceTypes:
+      - m3.*
+      - t3.small
+```
+
+This generates the appropriate `karpenter.k8s.aws/instance-cpu` and `karpenter.k8s.aws/instance-memory` requirements on the `NodePool`.
+`excludedInstanceTypes` entries are mapped to `NotIn` requirements: a `<family>.*` wildcard excludes an instance family, and a bare instance type excludes that type.
+
+When `instanceRequirements` is set, kOps omits the instance type requirement, and `spec.machineType` and `spec.mixedInstancesPolicy.instances` no longer restrict the NodePool.
+
 ## Karpenter-managed InstanceGroups
 {{ kops_feature_table(kops_added_default='1.36') }}
 

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -53,7 +53,7 @@ spec:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: e99c8d21b3acdf2342a854485f596d923694a2027ae8631fed0151f2d4d9c632
+    manifestHash: b6e2db097ea13a340c48d2d9b1da20596d5a402c4f9b96bbfd8dcedbc9fcf87f
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -3212,6 +3212,31 @@ spec:
         operator: In
         values:
         - linux
+      - key: karpenter.k8s.aws/instance-cpu
+        operator: Gte
+        values:
+        - "2"
+      - key: karpenter.k8s.aws/instance-cpu
+        operator: Lte
+        values:
+        - "16"
+      - key: karpenter.k8s.aws/instance-memory
+        operator: Gte
+        values:
+        - "2048"
+      - key: karpenter.k8s.aws/instance-memory
+        operator: Lte
+        values:
+        - "65536"
+      - key: karpenter.k8s.aws/instance-family
+        operator: NotIn
+        values:
+        - c3
+        - m3
+      - key: node.kubernetes.io/instance-type
+        operator: NotIn
+        values:
+        - t2.nano
       - key: karpenter.sh/capacity-type
         operator: In
         values:

--- a/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
@@ -131,6 +131,21 @@ spec:
   image: ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20220404
   role: Node
   maxSize: 20
+  # machineType is set so the generated NodePool demonstrates that instanceRequirements
+  # replaces the instance type requirement rather than being ANDed with it.
+  machineType: t2.medium
+  mixedInstancesPolicy:
+    instanceRequirements:
+      cpu:
+        min: "2"
+        max: "16"
+      memory:
+        min: "2Gi"
+        max: "64Gi"
+      excludedInstanceTypes:
+      - c3.*
+      - m3.*
+      - t2.nano
   subnets:
   - us-test-1a
 

--- a/upup/pkg/fi/cloudup/template_functions_karpenter.go
+++ b/upup/pkg/fi/cloudup/template_functions_karpenter.go
@@ -18,12 +18,15 @@ package cloudup
 
 import (
 	"fmt"
+	"math"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kops/pkg/apis/kops"
 	kopsutil "k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/model/awsmodel"
@@ -40,6 +43,12 @@ const (
 	karpenterNodePoolAPIGroup  = "karpenter.sh"
 	karpenterNodePoolLabel     = "karpenter.sh/nodepool"
 	karpenterCapacityTypeLabel = "karpenter.sh/capacity-type"
+
+	karpenterOSLabel             = "kubernetes.io/os"
+	karpenterInstanceTypeLabel   = "node.kubernetes.io/instance-type"
+	karpenterInstanceCPULabel    = "karpenter.k8s.aws/instance-cpu"
+	karpenterInstanceMemoryLabel = "karpenter.k8s.aws/instance-memory"
+	karpenterInstanceFamilyLabel = "karpenter.k8s.aws/instance-family"
 )
 
 type karpenterObjectMeta struct {
@@ -400,9 +409,14 @@ func (tf *TemplateFunctions) buildKarpenterNodePool(ig *kops.InstanceGroup) (*ka
 	}
 	labels = karpenterNodePoolTemplateLabels(labels)
 
+	requirements, err := tf.karpenterRequirements(ig)
+	if err != nil {
+		return nil, fmt.Errorf("building requirements for %q: %w", ig.Name, err)
+	}
+
 	template := karpenterNodeClaimTemplate{
 		Spec: karpenterNodeClaimSpec{
-			Requirements: tf.karpenterRequirements(ig),
+			Requirements: requirements,
 			NodeClassRef: karpenterNodeClassRef{
 				Group: karpenterAWSAPIGroup,
 				Kind:  "EC2NodeClass",
@@ -496,19 +510,29 @@ func (tf *TemplateFunctions) karpenterAssociatePublicIP(ig *kops.InstanceGroup) 
 	}
 }
 
-func (tf *TemplateFunctions) karpenterRequirements(ig *kops.InstanceGroup) []karpenterRequirement {
+func (tf *TemplateFunctions) karpenterRequirements(ig *kops.InstanceGroup) ([]karpenterRequirement, error) {
 	requirements := []karpenterRequirement{
 		{
-			Key:      "kubernetes.io/os",
+			Key:      karpenterOSLabel,
 			Operator: "In",
 			Values:   []string{"linux"},
 		},
 	}
 
-	instanceTypes := karpenterInstanceTypes(ig)
-	if len(instanceTypes) != 0 {
+	var instanceRequirements *kops.InstanceRequirementsSpec
+	if ig.Spec.MixedInstancesPolicy != nil {
+		instanceRequirements = ig.Spec.MixedInstancesPolicy.InstanceRequirements
+	}
+
+	if instanceRequirements != nil {
+		converted, err := karpenterInstanceRequirements(instanceRequirements)
+		if err != nil {
+			return nil, err
+		}
+		requirements = append(requirements, converted...)
+	} else if instanceTypes := karpenterInstanceTypes(ig); len(instanceTypes) != 0 {
 		requirements = append(requirements, karpenterRequirement{
-			Key:      "node.kubernetes.io/instance-type",
+			Key:      karpenterInstanceTypeLabel,
 			Operator: "In",
 			Values:   instanceTypes,
 		})
@@ -520,7 +544,128 @@ func (tf *TemplateFunctions) karpenterRequirements(ig *kops.InstanceGroup) []kar
 		Values:   karpenterCapacityTypes(ig),
 	})
 
-	return requirements
+	return requirements, nil
+}
+
+func karpenterInstanceRequirements(spec *kops.InstanceRequirementsSpec) ([]karpenterRequirement, error) {
+	var requirements []karpenterRequirement
+
+	// Karpenter's Gt/Lt/Gte/Lte operators take exactly one value, interpreted as an integer.
+	addBound := func(key string, quantity *resource.Quantity, operator string, toValue func(*resource.Quantity) (int64, error)) error {
+		if quantity == nil {
+			return nil
+		}
+		value, err := toValue(quantity)
+		if err != nil {
+			return fmt.Errorf("%s: %w", key, err)
+		}
+		requirements = append(requirements, karpenterRequirement{
+			Key:      key,
+			Operator: operator,
+			Values:   []string{strconv.FormatInt(value, 10)},
+		})
+		return nil
+	}
+
+	if cpu := spec.CPU; cpu != nil {
+		if err := addBound(karpenterInstanceCPULabel, cpu.Min, "Gte", quantityToCount); err != nil {
+			return nil, err
+		}
+		if err := addBound(karpenterInstanceCPULabel, cpu.Max, "Lte", quantityToCount); err != nil {
+			return nil, err
+		}
+	}
+
+	if memory := spec.Memory; memory != nil {
+		// Round the lower bound up and the upper bound down, so the generated envelope
+		// never admits an instance outside the requested range.
+		if err := addBound(karpenterInstanceMemoryLabel, memory.Min, "Gte", quantityToMiBRoundUp); err != nil {
+			return nil, err
+		}
+		if err := addBound(karpenterInstanceMemoryLabel, memory.Max, "Lte", quantityToMiBRoundDown); err != nil {
+			return nil, err
+		}
+	}
+
+	excluded, err := karpenterExcludedTypeRequirements(spec.ExcludedInstanceTypes)
+	if err != nil {
+		return nil, err
+	}
+	return append(requirements, excluded...), nil
+}
+
+// karpenterExcludedInstanceFamily matches the "<family>.*" wildcard form of
+// excludedInstanceTypes, which maps to an instance family rather than an instance type.
+var karpenterExcludedInstanceFamily = regexp.MustCompile(`^([a-z0-9][a-z0-9-]*)\.\*$`)
+
+func karpenterExcludedTypeRequirements(excluded []string) ([]karpenterRequirement, error) {
+	var families, instanceTypes []string
+	for _, entry := range excluded {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if match := karpenterExcludedInstanceFamily.FindStringSubmatch(entry); match != nil {
+			families = append(families, match[1])
+			continue
+		}
+		if strings.Contains(entry, "*") {
+			return nil, fmt.Errorf("excludedInstanceTypes entry %q is not supported for Karpenter; only an instance type or a %q family wildcard can be expressed as a NodePool requirement", entry, "<family>.*")
+		}
+		instanceTypes = append(instanceTypes, entry)
+	}
+
+	var requirements []karpenterRequirement
+	if len(families) != 0 {
+		sort.Strings(families)
+		requirements = append(requirements, karpenterRequirement{
+			Key:      karpenterInstanceFamilyLabel,
+			Operator: "NotIn",
+			Values:   families,
+		})
+	}
+	if len(instanceTypes) != 0 {
+		sort.Strings(instanceTypes)
+		requirements = append(requirements, karpenterRequirement{
+			Key:      karpenterInstanceTypeLabel,
+			Operator: "NotIn",
+			Values:   instanceTypes,
+		})
+	}
+	return requirements, nil
+}
+
+// quantityToCount converts a Quantity to a whole count, for labels such as instance-cpu.
+func quantityToCount(quantity *resource.Quantity) (int64, error) {
+	value, ok := quantity.AsInt64()
+	if !ok {
+		return 0, fmt.Errorf("value %q is not a whole number", quantity.String())
+	}
+	return checkKarpenterBound(quantity, value)
+}
+
+// quantityToMiBRoundUp and quantityToMiBRoundDown convert a Quantity to MiB, the unit of
+// the karpenter.k8s.aws/instance-memory label. Note this differs from the ASG path, which
+// scales by 10^6 into a field AWS defines as MiB; see kubernetes/kops#15305.
+func quantityToMiBRoundUp(quantity *resource.Quantity) (int64, error) {
+	bytes := quantity.Value()
+	return checkKarpenterBound(quantity, (bytes+mib-1)/mib)
+}
+
+func quantityToMiBRoundDown(quantity *resource.Quantity) (int64, error) {
+	return checkKarpenterBound(quantity, quantity.Value()/mib)
+}
+
+const mib = 1024 * 1024
+
+func checkKarpenterBound(quantity *resource.Quantity, value int64) (int64, error) {
+	if value < 0 {
+		return 0, fmt.Errorf("value %q must not be negative", quantity.String())
+	}
+	if value > math.MaxInt32 {
+		return 0, fmt.Errorf("value %q is too large", quantity.String())
+	}
+	return value, nil
 }
 
 func karpenterInstanceTypes(ig *kops.InstanceGroup) []string {

--- a/upup/pkg/fi/cloudup/template_functions_karpenter_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_karpenter_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 )
@@ -229,6 +230,192 @@ func TestKarpenterCapacityTypes(t *testing.T) {
 			actual := karpenterCapacityTypes(g.ig)
 			if !reflect.DeepEqual(actual, g.expected) {
 				t.Errorf("expected %#v, got %#v", g.expected, actual)
+			}
+		})
+	}
+}
+
+func TestKarpenterRequirements(t *testing.T) {
+	osRequirement := karpenterRequirement{Key: "kubernetes.io/os", Operator: "In", Values: []string{"linux"}}
+	onDemand := karpenterRequirement{Key: "karpenter.sh/capacity-type", Operator: "In", Values: []string{"on-demand"}}
+	quantity := func(s string) *resource.Quantity {
+		q := resource.MustParse(s)
+		return &q
+	}
+
+	grid := []struct {
+		desc        string
+		spec        kops.InstanceGroupSpec
+		expected    []karpenterRequirement
+		expectError bool
+	}{
+		{
+			// Regression guard: without instanceRequirements the output must not move.
+			desc: "no instanceRequirements keeps the instance type list",
+			spec: kops.InstanceGroupSpec{MachineType: "t3.medium"},
+			expected: []karpenterRequirement{
+				osRequirement,
+				{Key: "node.kubernetes.io/instance-type", Operator: "In", Values: []string{"t3.medium"}},
+				onDemand,
+			},
+		},
+		{
+			desc: "cpu bounds",
+			spec: kops.InstanceGroupSpec{
+				MachineType: "t3.medium",
+				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
+					InstanceRequirements: &kops.InstanceRequirementsSpec{
+						CPU: &kops.MinMaxSpec{Min: quantity("2"), Max: quantity("16")},
+					},
+				},
+			},
+			expected: []karpenterRequirement{
+				osRequirement,
+				{Key: "karpenter.k8s.aws/instance-cpu", Operator: "Gte", Values: []string{"2"}},
+				{Key: "karpenter.k8s.aws/instance-cpu", Operator: "Lte", Values: []string{"16"}},
+				onDemand,
+			},
+		},
+		{
+			desc: "memory bounds",
+			spec: kops.InstanceGroupSpec{
+				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
+					InstanceRequirements: &kops.InstanceRequirementsSpec{
+						Memory: &kops.MinMaxSpec{Min: quantity("2Gi"), Max: quantity("64Gi")},
+					},
+				},
+			},
+			expected: []karpenterRequirement{
+				osRequirement,
+				{Key: "karpenter.k8s.aws/instance-memory", Operator: "Gte", Values: []string{"2048"}},
+				{Key: "karpenter.k8s.aws/instance-memory", Operator: "Lte", Values: []string{"65536"}},
+				onDemand,
+			},
+		},
+		{
+			// instanceRequirements describes a capacity envelope, so an instance type
+			// requirement would defeat it by pinning the pool to spec.machineType.
+			desc: "instanceRequirements suppress the instance type list",
+			spec: kops.InstanceGroupSpec{
+				MachineType: "t3.medium",
+				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
+					Instances: []string{"m6i.large"},
+					InstanceRequirements: &kops.InstanceRequirementsSpec{
+						CPU: &kops.MinMaxSpec{Min: quantity("2")},
+					},
+				},
+			},
+			expected: []karpenterRequirement{
+				osRequirement,
+				{Key: "karpenter.k8s.aws/instance-cpu", Operator: "Gte", Values: []string{"2"}},
+				onDemand,
+			},
+		},
+		{
+			desc: "excluded instance types and families",
+			spec: kops.InstanceGroupSpec{
+				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
+					InstanceRequirements: &kops.InstanceRequirementsSpec{
+						ExcludedInstanceTypes: []string{"m3.*", "t2.nano", "c3.*", "t2.micro"},
+					},
+				},
+			},
+			expected: []karpenterRequirement{
+				osRequirement,
+				{Key: "karpenter.k8s.aws/instance-family", Operator: "NotIn", Values: []string{"c3", "m3"}},
+				{Key: "node.kubernetes.io/instance-type", Operator: "NotIn", Values: []string{"t2.micro", "t2.nano"}},
+				onDemand,
+			},
+		},
+		{
+			desc: "unsupported wildcard is rejected",
+			spec: kops.InstanceGroupSpec{
+				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
+					InstanceRequirements: &kops.InstanceRequirementsSpec{
+						ExcludedInstanceTypes: []string{"m5.*large"},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			desc: "negative quantity is rejected",
+			spec: kops.InstanceGroupSpec{
+				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
+					InstanceRequirements: &kops.InstanceRequirementsSpec{
+						CPU: &kops.MinMaxSpec{Min: quantity("-1")},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			desc: "overflowing quantity is rejected",
+			spec: kops.InstanceGroupSpec{
+				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
+					InstanceRequirements: &kops.InstanceRequirementsSpec{
+						CPU: &kops.MinMaxSpec{Max: quantity("5000000000")},
+					},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	tf := &TemplateFunctions{}
+	for _, g := range grid {
+		t.Run(g.desc, func(t *testing.T) {
+			actual, err := tf.karpenterRequirements(&kops.InstanceGroup{Spec: g.spec})
+			if g.expectError {
+				if err == nil {
+					t.Fatalf("expected an error, got %#v", actual)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(g.expected, actual); diff != "" {
+				t.Errorf("unexpected requirements, diff=%v", diff)
+			}
+		})
+	}
+}
+
+func TestKarpenterQuantityConversion(t *testing.T) {
+	grid := []struct {
+		desc        string
+		quantity    string
+		convert     func(*resource.Quantity) (int64, error)
+		expected    int64
+		expectError bool
+	}{
+		{desc: "cpu whole number", quantity: "4", convert: quantityToCount, expected: 4},
+		{desc: "cpu fractional is rejected", quantity: "500m", convert: quantityToCount, expectError: true},
+		// Binary suffixes are exact; decimal ones are not, so the rounding direction matters.
+		{desc: "2Gi rounds to 2048", quantity: "2Gi", convert: quantityToMiBRoundUp, expected: 2048},
+		{desc: "2G rounds up to 1908", quantity: "2G", convert: quantityToMiBRoundUp, expected: 1908},
+		{desc: "2G rounds down to 1907", quantity: "2G", convert: quantityToMiBRoundDown, expected: 1907},
+		{desc: "64Gi rounds to 65536", quantity: "64Gi", convert: quantityToMiBRoundDown, expected: 65536},
+		{desc: "1000Mi is exact", quantity: "1000Mi", convert: quantityToMiBRoundUp, expected: 1000},
+		{desc: "negative memory is rejected", quantity: "-1Gi", convert: quantityToMiBRoundUp, expectError: true},
+	}
+
+	for _, g := range grid {
+		t.Run(g.desc, func(t *testing.T) {
+			q := resource.MustParse(g.quantity)
+			actual, err := g.convert(&q)
+			if g.expectError {
+				if err == nil {
+					t.Fatalf("expected an error, got %d", actual)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != g.expected {
+				t.Errorf("expected %d, got %d", g.expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
Updates the Karpenter addon to support `mixedInstancesPolicy.instanceRequirements` specified in instance groups because, really, who wants to maintain a massive list of instance types in `mixedInstancesPolicy.instances`? 🙃 