### PR TITLE
kube-dns: use policy/v1 for PodDisruptionBudget

### DIFF
--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -337,7 +337,7 @@ subjects:
 
 ---
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: kube-dns


### PR DESCRIPTION
policy/v1beta1 was removed in Kubernetes 1.25, so the kube-dns PDB manifest could not apply on any supported cluster version.

/cc @rifelpet @ameukam 