### PR TITLE
tests/e2e: honor KOPS_EXTRA_FLAGS in the karpenter scenario

### DIFF
--- a/tests/e2e/scenarios/karpenter/run-test.sh
+++ b/tests/e2e/scenarios/karpenter/run-test.sh
@@ -35,6 +35,7 @@ CREATE_ARGS="${CREATE_ARGS} --control-plane-size=c6g.large"
 CREATE_ARGS="${CREATE_ARGS} --node-count=4"
 CREATE_ARGS="${CREATE_ARGS} --node-size=m6g.large"
 CREATE_ARGS="${CREATE_ARGS} --set=cluster.spec.karpenter.featureGates=StaticCapacity=true"
+CREATE_ARGS="${CREATE_ARGS} ${KOPS_EXTRA_FLAGS:-}"
 
 K8S_VERSION="${K8S_VERSION:-$(curl -s -L https://dl.k8s.io/release/stable.txt)}"
 


### PR DESCRIPTION
`tests/e2e/scenarios/karpenter/run-test.sh` builds `CREATE_ARGS` entirely from hardcoded values and never reads any flags supplied by the prow job. That makes the two IPv6 variants of this scenario a no-op:

- `e2e-kops-aws-ipv6-karpenter` (periodic, on the `kops-ipv6` dashboard)
- `pull-kops-e2e-aws-ipv6-karpenter` (presubmit)

Both set `OVERRIDES="--ipv6 --topology=private --bastion"` in their job config, but nothing in this scenario reads `OVERRIDES` — the only script that does is `splitkcp/run-test.sh`, which sets its own value locally. So both jobs have been creating plain IPv4 karpenter clusters, identical to the non-ipv6 jobs, presumably since they were added.

This appends `KOPS_EXTRA_FLAGS` to `CREATE_ARGS`, which is the variable `build_jobs.py` already populates from a scenario job's `extra_flags` and which `upgrade-ab/run-test.sh` already consumes. Appending last means a job can also override one of the defaults above it.

The companion test-infra PR, kubernetes/test-infra#37675, switches those two jobs from `OVERRIDES` to `extra_flags` (which `build_jobs.py` renders as `KOPS_EXTRA_FLAGS`). Until it merges the jobs keep behaving exactly as they do today, so the two can land in either order.

## Testing

Verified the expansion is correct in both states:

```
unset  -> [--networking cilium ]
set    -> [--networking cilium --ipv6 --topology=private --bastion]
```

The scenario is exercised by `pull-kops-e2e-aws-karpenter` and `pull-kops-e2e-aws-ipv6-karpenter`. Worth noting the ipv6 presubmit will be doing real work for the first time once the test-infra side lands, so it may surface pre-existing IPv6+karpenter issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
