### PR TITLE
tests/e2e: drop the deprecated KOPS_CONTROL_PLANE_SIZE fallback

### DIFF
--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -133,12 +133,6 @@ function kops-up() {
         K8S_VERSION="$(curl -fs -L https://dl.k8s.io/release/stable.txt)"
     fi
 
-    # TODO: Switch scripts to use KOPS_CONTROL_PLANE_COUNT
-    if [[ -n "${KOPS_CONTROL_PLANE_SIZE:-}" ]]; then
-      echo "Recognized (deprecated) KOPS_CONTROL_PLANE_SIZE=${KOPS_CONTROL_PLANE_SIZE}, please set KOPS_CONTROL_PLANE_COUNT instead"
-      KOPS_CONTROL_PLANE_COUNT=${KOPS_CONTROL_PLANE_SIZE}
-    fi
-
     if [[ -z "${ENV_FILE-}" ]]; then
         ENV_FILE="${WORKSPACE}/env"
     fi

--- a/tests/e2e/scenarios/lib/upgrade.sh
+++ b/tests/e2e/scenarios/lib/upgrade.sh
@@ -94,12 +94,6 @@ function kops-upgrade() {
         KOPS="${KOPS_A}"
     fi
 
-    # TODO: Switch scripts to use KOPS_CONTROL_PLANE_COUNT
-    if [[ -n "${KOPS_CONTROL_PLANE_SIZE:-}" ]]; then
-        echo "Recognized (deprecated) KOPS_CONTROL_PLANE_SIZE=${KOPS_CONTROL_PLANE_SIZE}, please set KOPS_CONTROL_PLANE_COUNT instead"
-        KOPS_CONTROL_PLANE_COUNT=${KOPS_CONTROL_PLANE_SIZE}
-    fi
-
     # Note that we use --control-plane-size, even though it is deprecated, because we have to support old versions
     # in the upgrade test.
     ${KUBETEST2} \


### PR DESCRIPTION
`KOPS_CONTROL_PLANE_COUNT` has been the supported name since #15628 (July 2023). Since then `tests/e2e/scenarios/lib/common.sh` and `tests/e2e/scenarios/lib/upgrade.sh` have each carried an identical shim that exists only to warn and reassign:

```bash
# TODO: Switch scripts to use KOPS_CONTROL_PLANE_COUNT
if [[ -n "${KOPS_CONTROL_PLANE_SIZE:-}" ]]; then
    echo "Recognized (deprecated) KOPS_CONTROL_PLANE_SIZE=${KOPS_CONTROL_PLANE_SIZE}, please set KOPS_CONTROL_PLANE_COUNT instead"
    KOPS_CONTROL_PLANE_COUNT=${KOPS_CONTROL_PLANE_SIZE}
fi
```

The only callers were the prow jobs. kubernetes/test-infra#37674 switches all 30 of them to `KOPS_CONTROL_PLANE_COUNT`, which resolves the TODO and makes both shims dead.

The `--control-plane-count` / `--control-plane-size` flags themselves are unchanged, as is the `${KOPS_CONTROL_PLANE_COUNT:-1}` default at each call site. `KOPS_CONTROL_PLANE_SIZE` no longer appears anywhere in the repo after this.

## Ordering — this one is not order-independent

**Hold until kubernetes/test-infra#37674 merges.** Unlike the karpenter pair (#18681 / kubernetes/test-infra#37675), the failure mode here is silent rather than inert: a job that still sets only `KOPS_CONTROL_PLANE_SIZE` falls through to the `:-1` default and creates a **single control plane node instead of three**. The affected jobs are the HA upgrade tests, which would keep passing while no longer testing what they are meant to test.

That also applies to this PR's own presubmits. `pull-kops-aws-upgrade-*` and the `-upgrades-dns-none` presubmits set `KOPS_CONTROL_PLANE_SIZE` today, so until #37674 lands they will exercise this branch with one control plane node. Green presubmits here are not evidence that the ordering is safe.

/hold

## Testing

- `bash -n` on both modified scripts.
- Verified `KOPS_CONTROL_PLANE_SIZE` has zero remaining references repo-wide, and that both `${KOPS_CONTROL_PLANE_COUNT:-1}` call sites are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)