### PR TITLE
gce: open the etcd events metrics port in the node-to-master firewall

### DIFF
--- a/docs/contributing/ports.md
+++ b/docs/contributing/ports.md
@@ -13,6 +13,7 @@ See also pkg/wellknownports/wellknownports.go
 | 2380 | etcd main peering                        |
 | 2381 | etcd events peering                      |
 | 2382 | etcd cilium peering                      |
+| 2384 | etcd events metrics                      |
 | 3988 | kops controller serving port             |
 | 3989 | node local dns health check              |
 | 3990 | Kube API health check                    |

--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -143,6 +143,7 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				fmt.Sprintf("tcp:%d", wellknownports.KubeSchedulerMetricsPort),
 				fmt.Sprintf("tcp:%d", wellknownports.KubeProxyMetricsPort),
 				fmt.Sprintf("tcp:%d", wellknownports.EtcdMetricsPort),
+				fmt.Sprintf("tcp:%d", wellknownports.EtcdEventsMetricsPort),
 				fmt.Sprintf("tcp:%d", wellknownports.NodeExporterMetricsPort),
 			},
 		}

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -26,6 +26,9 @@ const (
 	// EtcdMetricsPort is used to serve etcd metrics
 	EtcdMetricsPort = 2382
 
+	// EtcdEventsMetricsPort is used to serve etcd metrics for the events etcd
+	EtcdEventsMetricsPort = 2384
+
 	// KopsChannelsHealthCheck is the loopback port the kops-channels static pod serves /readyz on.
 	KopsChannelsHealthCheck = 3986
 

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -412,6 +412,10 @@ resource "google_compute_firewall" "node-to-master-ha-gce-example-com" {
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -332,6 +332,10 @@ resource "google_compute_firewall" "node-to-master-minimal-example-com" {
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -300,6 +300,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -350,6 +350,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -326,6 +326,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-ilb-example-com" 
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }

--- a/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_cilium_etcd/kubernetes.tf
@@ -386,6 +386,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-ilb-cilium-etcd-e
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -326,6 +326,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -308,6 +308,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -330,6 +330,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-plb-example-com" 
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }

--- a/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb_apiserver/kubernetes.tf
@@ -338,6 +338,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-plb-apiserver-exa
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -308,6 +308,10 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-private-example-c
     protocol = "tcp"
   }
   allow {
+    ports    = ["2384"]
+    protocol = "tcp"
+  }
+  allow {
     ports    = ["9100"]
     protocol = "tcp"
   }


### PR DESCRIPTION
open the etcd events metrics port in the node-to-master firewall

xref: https://github.com/kubernetes/kops/pull/18568