### PR TITLE
refactor: Rename Linode references to Akamai (Linode) across the codebase

### DIFF
--- a/docs/releases/1.37-NOTES.md
+++ b/docs/releases/1.37-NOTES.md
@@ -46,6 +46,8 @@ As part of this removal, the `protokube` component, whose only remaining respons
 
 * etcd-manager now mounts the bundled etcd release images as image volumes on all supported Kubernetes versions. On Kubernetes versions older than 1.36, this is enabled by force-enabling the `ImageVolume` kubelet feature gate on control-plane nodes, now including Kubernetes 1.32. The `kops-utils-cp` utility image, previously used to copy etcd binaries into the etcd-manager pod, is no longer built or published.
 
+* Rename all references of "Linode" to "Akamai (Linode)" in the Linode cloud provider code. This includes error messages, log messages, and comments. The Linode API is not changing as of yet. This is purely a cosmetic change to avoid confusion since Linode is part of Akamai and is officially called "Akamai Cloud".
+
 # Breaking changes
 
 * Support for AWS Classic Load Balancer (CLB) for the API has been removed. Clusters with `spec.api.loadBalancer.class: Classic` (or with no explicit `class`, which previously defaulted to Classic) fail validation, and the long-deprecated `kops create cluster --api-loadbalancer-class` flag has been removed. Existing clusters using a CLB must migrate to a Network Load Balancer (NLB) using kOps 1.36 or earlier before upgrading to kOps 1.37, following the [CLB to NLB migration guide](https://github.com/kubernetes/kops/blob/master/permalinks/acm_nlb.md). Attaching instance groups to externally-managed Classic Load Balancers via `spec.externalLoadBalancers[].loadBalancerName` remains supported.

--- a/nodeup/pkg/model/linode.go
+++ b/nodeup/pkg/model/linode.go
@@ -29,20 +29,20 @@ import (
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 )
 
-// LinodeBuilder writes the Linode-specific configuration
+// LinodeBuilder writes the Akamai (Linode)-specific configuration
 type LinodeBuilder struct {
 	*NodeupModelContext
 }
 
 var _ fi.NodeupModelBuilder = &LinodeBuilder{}
 
-// Build configures Linode-specific node settings including swap disabling.
+// Build configures Akamai (Linode)-specific node settings including swap disabling.
 func (b *LinodeBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.CloudProvider() != kops.CloudProviderLinode {
 		return nil
 	}
 
-	// Linode instances ship with swap enabled. Disable it when MemorySwapBehavior is unset,
+	// Akamai (Linode) instances ship with swap enabled. Disable it when MemorySwapBehavior is unset,
 	// since the default kubelet swap mode (NoSwap) requires swap to be off.
 	if b.NodeupConfig.KubeletConfig.MemorySwapBehavior == "" {
 		if err := b.disableSwap(c); err != nil {

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -204,7 +204,7 @@ type CloudProviderSpec struct {
 	Openstack *OpenstackSpec `json:"openstack,omitempty"`
 	// Scaleway configures the Scaleway cloud provider.
 	Scaleway *ScalewaySpec `json:"scaleway,omitempty"`
-	// Linode configures the Linode (Akamai) cloud provider.
+	// Linode configures the Akamai (Linode) cloud provider.
 	Linode *LinodeSpec `json:"linode,omitempty"`
 }
 
@@ -276,7 +276,7 @@ type HetznerSpec struct{}
 type ScalewaySpec struct {
 }
 
-// LinodeSpec configures the Linode (Akamai) cloud provider.
+// LinodeSpec configures the Akamai (Linode) cloud provider.
 type LinodeSpec struct{}
 
 type KarpenterConfig struct {

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -197,7 +197,7 @@ type CloudProviderSpec struct {
 	Openstack *OpenstackSpec `json:"openstack,omitempty"`
 	// Scaleway configures the Scaleway cloud provider.
 	Scaleway *ScalewaySpec `json:"scaleway,omitempty"`
-	// Linode configures the Linode (Akamai) cloud provider.
+	// Linode configures the Akamai (Linode) cloud provider.
 	Linode *LinodeSpec `json:"linode,omitempty"`
 }
 
@@ -269,7 +269,7 @@ type HetznerSpec struct{}
 type ScalewaySpec struct {
 }
 
-// LinodeSpec configures the Linode (Akamai) cloud provider.
+// LinodeSpec configures the Akamai (Linode) cloud provider.
 type LinodeSpec struct{}
 
 type KarpenterConfig struct {

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1154,9 +1154,9 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 			if networkCIDR != nil && !networkCIDR.IP.IsPrivate() {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("networkCIDR"), v.NetworkCIDR, "networkCIDR must be within a private IP range"))
 			}
-			// verify if networkID is not specified. In case of Linode (Akamai), this is mutually exclusive.
+			// verify if networkID is not specified. In case of Akamai (Linode), this is mutually exclusive.
 			if v.NetworkID != "" {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Child("networkCIDR"), "Linode (Akamai) doesn't support specifying both NetworkID and NetworkCIDR"))
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("networkCIDR"), "Akamai (Linode) doesn't support specifying both NetworkID and NetworkCIDR"))
 			}
 		}
 	}

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -2145,7 +2145,7 @@ func TestValidateNetworkingLinode(t *testing.T) {
 				{
 					Type:   field.ErrorTypeForbidden,
 					Field:  "networking.networkCIDR",
-					Detail: "Linode (Akamai) doesn't support specifying both NetworkID and NetworkCIDR",
+					Detail: "Akamai (Linode) doesn't support specifying both NetworkID and NetworkCIDR",
 				},
 			},
 		},

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -110,7 +110,7 @@ var (
 	ClusterAPI = new("ClusterAPI", Bool(false))
 	// DiscoveryService enables support for OIDC discovery via a hosted service.
 	DiscoveryService = new("DiscoveryService", Bool(false))
-	// Linode toggles the Linode (Akamai) Cloud support.
+	// Linode feature flag toggles Akamai (Linode) Cloud support.
 	Linode = new("Linode", Bool(false))
 )
 

--- a/pkg/model/components/linodecloudcontrollermanager.go
+++ b/pkg/model/components/linodecloudcontrollermanager.go
@@ -21,14 +21,14 @@ import (
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
 
-// LinodeCloudControllerManagerOptionsBuilder adds options for the Linode (Akamai) cloud controller manager to the model.
+// LinodeCloudControllerManagerOptionsBuilder adds options for the Akamai (Linode) cloud controller manager to the model.
 type LinodeCloudControllerManagerOptionsBuilder struct {
 	*OptionsContext
 }
 
 var _ loader.ClusterOptionsBuilder = &LinodeCloudControllerManagerOptionsBuilder{}
 
-// BuildOptions generates the configurations used for the Linode (Akamai) cloud controller manager manifest
+// BuildOptions generates the configurations used for the Akamai (Linode) cloud controller manager manifest
 func (b *LinodeCloudControllerManagerOptionsBuilder) BuildOptions(cluster *kops.Cluster) error {
 	clusterSpec := &cluster.Spec
 
@@ -53,7 +53,7 @@ func (b *LinodeCloudControllerManagerOptionsBuilder) BuildOptions(cluster *kops.
 	eccm.ConfigureCloudRoutes = new(false)
 
 	if eccm.Image == "" {
-		// Using the official Linode (Akamai) CCM image
+		// Using the official Akamai (Linode) CCM image
 		// https://github.com/linode/linode-cloud-controller-manager
 		eccm.Image = "linode/linode-cloud-controller-manager:v0.9.5"
 	}

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -185,7 +185,7 @@ func (b *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 		case kops.CloudProviderGCE:
 			// TODO: Do nothing for now while we figure out how to address GCE label length limit of 63
 		case kops.CloudProviderLinode:
-			// Akamai Cloud (Linode) tags have a 50 character limit
+			// Akamai (Linode) Cloud tags have a 50 character limit
 			// Only store the critical kops.k8s.io/instancegroup label
 			// Role labels will be derived from the instance role tag by the identifier
 			if k == linode.TagKubernetesInstanceGroup {

--- a/pkg/model/linodemodel/OWNERS
+++ b/pkg/model/linodemodel/OWNERS
@@ -1,3 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 labels:
+- area/provider/akamai
 - area/provider/linode

--- a/pkg/model/linodemodel/context.go
+++ b/pkg/model/linodemodel/context.go
@@ -18,7 +18,7 @@ package linodemodel
 
 import "k8s.io/kops/pkg/model"
 
-// LinodeModelContext holds shared model context for Linode (Akamai) builders.
+// LinodeModelContext holds shared model context for Akamai (Linode) builders.
 type LinodeModelContext struct {
 	*model.KopsModelContext
 }

--- a/pkg/model/linodemodel/instances.go
+++ b/pkg/model/linodemodel/instances.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/linodetasks"
 )
 
-// InstanceModelBuilder configures the Linode (Akamai) instances (aka Linodes) for the cluster.
+// InstanceModelBuilder configures the Akamai (Linode) instances (aka Linodes) for the cluster.
 type InstanceModelBuilder struct {
 	*LinodeModelContext
 	Lifecycle              fi.Lifecycle

--- a/pkg/model/linodemodel/network.go
+++ b/pkg/model/linodemodel/network.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/linodetasks"
 )
 
-// NetworkModelBuilder configures the Linode (Akamai) VPC for the cluster.
+// NetworkModelBuilder configures the Akamai (Linode) VPC for the cluster.
 type NetworkModelBuilder struct {
 	*LinodeModelContext
 	Lifecycle fi.Lifecycle

--- a/pkg/model/linodemodel/sshkey.go
+++ b/pkg/model/linodemodel/sshkey.go
@@ -27,7 +27,7 @@ import (
 
 const maxLinodeSSHKeyNameLength = 64
 
-// SSHKeyModelBuilder configures profile SSH key resources for Linode (Akamai).
+// SSHKeyModelBuilder configures profile SSH key resources for Akamai (Linode).
 type SSHKeyModelBuilder struct {
 	*LinodeModelContext
 	Lifecycle fi.Lifecycle
@@ -42,11 +42,11 @@ func (b *SSHKeyModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 
 	name, err := b.SSHKeyName()
 	if err != nil {
-		return fmt.Errorf("error building Linode (Akamai) SSH key task: %w", err)
+		return fmt.Errorf("error building Akamai (Linode) SSH key task: %w", err)
 	}
 	name = linode.NormalizeLinodeLabel(name)
 
-	// Linode (Akamai) SSH key labels have a maximum length of 64 characters. If the generated name exceeds this length, we truncate it and trim any trailing hyphens or underscores.
+	// Akamai (Linode) SSH key labels have a maximum length of 64 characters. If the generated name exceeds this length, we truncate it and trim any trailing hyphens or underscores.
 	if len(name) > maxLinodeSSHKeyNameLength {
 		name = strings.Trim(name[:maxLinodeSSHKeyNameLength], "-_")
 	}

--- a/pkg/nodeidentity/linode/OWNERS
+++ b/pkg/nodeidentity/linode/OWNERS
@@ -2,4 +2,5 @@
 
 labels:
 
+- area/provider/akamai
 - area/provider/linode

--- a/pkg/nodeidentity/linode/identify.go
+++ b/pkg/nodeidentity/linode/identify.go
@@ -43,14 +43,14 @@ type linodeClient interface {
 	GetInstance(ctx context.Context, linodeID int) (*linodego.Instance, error)
 }
 
-// nodeIdentifier identifies a node from Linode (Akamai).
+// nodeIdentifier identifies a node from Akamai (Linode).
 type nodeIdentifier struct {
 	client       linodeClient
 	cache        expirationcache.Store
 	cacheEnabled bool
 }
 
-// New creates and returns a nodeidentity.Identifier for Nodes running on Linode (Akamai).
+// New creates and returns a nodeidentity.Identifier for Nodes running on Akamai (Linode).
 func New(cacheNodeidentityInfo bool) (nodeidentity.Identifier, error) {
 	accessToken := os.Getenv("LINODE_TOKEN")
 	if accessToken == "" {
@@ -71,7 +71,7 @@ func New(cacheNodeidentityInfo bool) (nodeidentity.Identifier, error) {
 	}, nil
 }
 
-// IdentifyNode queries Linode (Akamai) for the node identity information.
+// IdentifyNode queries Akamai (Linode) for the node identity information.
 func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*nodeidentity.Info, error) {
 	providerID := node.Spec.ProviderID
 	if providerID == "" {
@@ -95,10 +95,10 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 
 	instance, err := i.client.GetInstance(ctx, instanceNumericID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get info for Linode (Akamai) instance %q: %w", instanceID, err)
+		return nil, fmt.Errorf("failed to get info for Akamai (Linode) instance %q: %w", instanceID, err)
 	}
 	if instance == nil {
-		return nil, fmt.Errorf("failed to get info for Linode (Akamai) instance %q: empty response", instanceID)
+		return nil, fmt.Errorf("failed to get info for Akamai (Linode) instance %q: empty response", instanceID)
 	}
 
 	if !isExpectedInstanceStatus(instance.Status) {
@@ -156,7 +156,7 @@ func isExpectedInstanceStatus(status linodego.InstanceStatus) bool {
 	}
 }
 
-// buildLabelsFromTags converts Linode instance tags into Kubernetes node labels.
+// buildLabelsFromTags converts Akamai (Linode) instance tags into Kubernetes node labels.
 // It handles role tags (kops.k8s.io/instance-role) and direct label tags (kops.k8s.io/* and node-role.kubernetes.io/*).
 func buildLabelsFromTags(tags []string) map[string]string {
 	labels := map[string]string{}
@@ -177,7 +177,7 @@ func buildLabelsFromTags(tags []string) map[string]string {
 			case kops.InstanceGroupRoleAPIServer:
 				labels[nodelabels.RoleLabelAPIServer16] = ""
 			default:
-				klog.Warningf("Unknown node role %q for Linode (Akamai) instance", value)
+				klog.Warningf("Unknown node role %q for Akamai (Linode) instance", value)
 			}
 			continue
 		}

--- a/pkg/resources/linode/OWNERS
+++ b/pkg/resources/linode/OWNERS
@@ -1,3 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 labels:
+- area/provider/akamai
 - area/provider/linode

--- a/pkg/resources/linode/resources.go
+++ b/pkg/resources/linode/resources.go
@@ -38,16 +38,16 @@ const (
 	resourceTypeInstance = "instance"
 )
 
-// parseTrackerIntID parses the tracker's string ID into an integer, which is used for Linode (Akamai) resource IDs.
+// parseTrackerIntID parses the tracker's string ID into an integer, which is used for Akamai (Linode) resource IDs.
 func parseTrackerIntID(tracker *resources.Resource) (int, error) {
 	id, err := strconv.Atoi(tracker.ID)
 	if err != nil {
-		return 0, fmt.Errorf("error parsing Linode (Akamai) %s ID %q: %w", tracker.Type, tracker.ID, err)
+		return 0, fmt.Errorf("error parsing Akamai (Linode) %s ID %q: %w", tracker.Type, tracker.ID, err)
 	}
 	return id, nil
 }
 
-// ListResources collects Linode (Akamai) cloud resources owned by the cluster.
+// ListResources collects Akamai (Linode) cloud resources owned by the cluster.
 func ListResources(cloud cloudlinode.LinodeCloud, clusterInfo resources.ClusterInfo) (map[string]*resources.Resource, error) {
 	resourceTrackers := make(map[string]*resources.Resource)
 
@@ -71,7 +71,7 @@ func ListResources(cloud cloudlinode.LinodeCloud, clusterInfo resources.ClusterI
 	return resourceTrackers, nil
 }
 
-// listInstances lists Linode (Akamai) instances owned by the cluster.
+// listInstances lists Akamai (Linode) instances owned by the cluster.
 func listInstances(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resources.Resource, error) {
 	c := cloud.(cloudlinode.LinodeCloud)
 	listOptions, err := cloudlinode.ListOptionsForTags(fmt.Sprintf("%s:%s", cloudlinode.TagKubernetesClusterName, clusterInfo.Name))
@@ -81,7 +81,7 @@ func listInstances(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resour
 
 	instances, err := c.Client().ListInstances(context.Background(), listOptions)
 	if err != nil {
-		return nil, fmt.Errorf("error listing Linode (Akamai) instances: %w", err)
+		return nil, fmt.Errorf("error listing Akamai (Linode) instances: %w", err)
 	}
 
 	var resourceTrackers []*resources.Resource
@@ -107,7 +107,7 @@ func listInstances(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resour
 func instanceSubnetBlocks(cloud cloudlinode.LinodeCloud, instance linodego.Instance) ([]string, error) {
 	interfaces, err := cloud.Client().ListInterfaces(context.Background(), instance.ID, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error listing Linode (Akamai) interfaces for instance %s(%d): %w", instance.Label, instance.ID, err)
+		return nil, fmt.Errorf("error listing Akamai (Linode) interfaces for instance %s(%d): %w", instance.Label, instance.ID, err)
 	}
 
 	blockSet := make(map[string]struct{})
@@ -127,7 +127,7 @@ func instanceSubnetBlocks(cloud cloudlinode.LinodeCloud, instance linodego.Insta
 	return blocks, nil
 }
 
-// findClusterVPCs finds Linode (Akamai) VPCs with the cluster's deterministic VPC label.
+// findClusterVPCs finds Akamai (Linode) VPCs with the cluster's deterministic VPC label.
 func findClusterVPCs(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]linodego.VPC, error) {
 	c := cloud.(cloudlinode.LinodeCloud)
 	vpcLabel := cloudlinode.NormalizeLinodeLabel(clusterInfo.Name)
@@ -138,7 +138,7 @@ func findClusterVPCs(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]linod
 
 	vpcs, err := c.Client().ListVPCs(context.Background(), listOptions)
 	if err != nil {
-		return nil, fmt.Errorf("error listing Linode (Akamai) VPCs: %w", err)
+		return nil, fmt.Errorf("error listing Akamai (Linode) VPCs: %w", err)
 	}
 
 	region := c.Region()
@@ -158,12 +158,12 @@ func findClusterVPCs(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]linod
 	return clusterVPCs, nil
 }
 
-// listSSHKeys lists Linode (Akamai) SSH keys that were generated for the cluster.
+// listSSHKeys lists Akamai (Linode) SSH keys that were generated for the cluster.
 func listSSHKeys(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resources.Resource, error) {
 	c := cloud.(cloudlinode.LinodeCloud)
 	keys, err := c.Client().ListSSHKeys(context.Background(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("error listing Linode (Akamai) SSH keys: %w", err)
+		return nil, fmt.Errorf("error listing Akamai (Linode) SSH keys: %w", err)
 	}
 
 	keyLabelPrefix := cloudlinode.NormalizeLinodeLabel("kubernetes."+clusterInfo.Name) + "-"
@@ -185,7 +185,7 @@ func listSSHKeys(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resource
 	return resourceTrackers, nil
 }
 
-// listVPCs lists Linode (Akamai) VPC resources owned by the cluster.
+// listVPCs lists Akamai (Linode) VPC resources owned by the cluster.
 func listVPCs(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resources.Resource, error) {
 	vpcs, err := findClusterVPCs(cloud, clusterInfo)
 	if err != nil {
@@ -206,7 +206,7 @@ func listVPCs(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resources.R
 	return resourceTrackers, nil
 }
 
-// listSubnets lists Linode (Akamai) VPC subnets attached to the cluster's managed VPC.
+// listSubnets lists Akamai (Linode) VPC subnets attached to the cluster's managed VPC.
 func listSubnets(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resources.Resource, error) {
 	c := cloud.(cloudlinode.LinodeCloud)
 	vpcs, err := findClusterVPCs(cloud, clusterInfo)
@@ -218,7 +218,7 @@ func listSubnets(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resource
 	for _, vpc := range vpcs {
 		subnets, err := c.Client().ListVPCSubnets(context.Background(), vpc.ID, nil)
 		if err != nil {
-			return nil, fmt.Errorf("error listing Linode (Akamai) VPC subnets for VPC %s(%d): %w", vpc.Label, vpc.ID, err)
+			return nil, fmt.Errorf("error listing Akamai (Linode) VPC subnets for VPC %s(%d): %w", vpc.Label, vpc.ID, err)
 		}
 
 		for _, subnet := range subnets {
@@ -238,7 +238,7 @@ func listSubnets(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resource
 	return resourceTrackers, nil
 }
 
-// deleteSSHKey deletes a Linode (Akamai) SSH key.
+// deleteSSHKey deletes an Akamai (Linode) SSH key.
 func deleteSSHKey(cloud fi.Cloud, tracker *resources.Resource) error {
 	c := cloud.(cloudlinode.LinodeCloud)
 	keyID, err := parseTrackerIntID(tracker)
@@ -250,13 +250,13 @@ func deleteSSHKey(cloud fi.Cloud, tracker *resources.Resource) error {
 		if linodego.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("error deleting Linode (Akamai) SSH key %s(%s): %w", tracker.Name, tracker.ID, err)
+		return fmt.Errorf("error deleting Akamai (Linode) SSH key %s(%s): %w", tracker.Name, tracker.ID, err)
 	}
 
 	return nil
 }
 
-// deleteVPC deletes a Linode (Akamai) VPC.
+// deleteVPC deletes an Akamai (Linode) VPC.
 func deleteVPC(cloud fi.Cloud, tracker *resources.Resource) error {
 	c := cloud.(cloudlinode.LinodeCloud)
 	vpcID, err := parseTrackerIntID(tracker)
@@ -268,13 +268,13 @@ func deleteVPC(cloud fi.Cloud, tracker *resources.Resource) error {
 		if linodego.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("error deleting Linode (Akamai) VPC %s(%s): %w", tracker.Name, tracker.ID, err)
+		return fmt.Errorf("error deleting Akamai (Linode) VPC %s(%s): %w", tracker.Name, tracker.ID, err)
 	}
 
 	return nil
 }
 
-// deleteSubnet deletes a Linode (Akamai) VPC subnet.
+// deleteSubnet deletes an Akamai (Linode) VPC subnet.
 func deleteSubnet(vpcID int, cloud fi.Cloud, tracker *resources.Resource) error {
 	c := cloud.(cloudlinode.LinodeCloud)
 	subnetID, err := parseTrackerIntID(tracker)
@@ -286,13 +286,13 @@ func deleteSubnet(vpcID int, cloud fi.Cloud, tracker *resources.Resource) error 
 		if linodego.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("error deleting Linode (Akamai) subnet %s(%s): %w", tracker.Name, tracker.ID, err)
+		return fmt.Errorf("error deleting Akamai (Linode) subnet %s(%s): %w", tracker.Name, tracker.ID, err)
 	}
 
 	return nil
 }
 
-// deleteInstance deletes a Linode (Akamai) instance.
+// deleteInstance deletes an Akamai (Linode) instance.
 func deleteInstance(cloud fi.Cloud, tracker *resources.Resource) error {
 	c := cloud.(cloudlinode.LinodeCloud)
 	instanceID, err := parseTrackerIntID(tracker)
@@ -304,7 +304,7 @@ func deleteInstance(cloud fi.Cloud, tracker *resources.Resource) error {
 		if linodego.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("error deleting Linode (Akamai) instance %s(%s): %w", tracker.Name, tracker.ID, err)
+		return fmt.Errorf("error deleting Akamai (Linode) instance %s(%s): %w", tracker.Name, tracker.ID, err)
 	}
 
 	return nil

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -502,7 +502,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 	case kops.CloudProviderLinode:
 		{
 			if !featureflag.Linode.Enabled() {
-				return nil, fmt.Errorf("Linode (Akamai) support is currently alpha, and is feature-gated. Please export KOPS_FEATURE_FLAGS=Linode")
+				return nil, fmt.Errorf("Akamai (Linode) support is currently alpha, and is feature-gated. Please export KOPS_FEATURE_FLAGS=Linode")
 			}
 		}
 

--- a/upup/pkg/fi/cloudup/linode/OWNERS
+++ b/upup/pkg/fi/cloudup/linode/OWNERS
@@ -1,3 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 labels:
+- area/provider/akamai
 - area/provider/linode

--- a/upup/pkg/fi/cloudup/linode/api_target.go
+++ b/upup/pkg/fi/cloudup/linode/api_target.go
@@ -18,14 +18,14 @@ package linode
 
 import "k8s.io/kops/upup/pkg/fi"
 
-// APITarget runs cloudup tasks directly against Linode (Akamai) APIs.
+// APITarget runs cloudup tasks directly against Akamai (Linode) APIs.
 type APITarget struct {
 	Cloud LinodeCloud
 }
 
 var _ fi.CloudupTarget = &APITarget{}
 
-// NewAPITarget builds a Linode (Akamai) target implementation.
+// NewAPITarget builds an Akamai (Linode) target implementation.
 func NewAPITarget(cloud LinodeCloud) *APITarget {
 	return &APITarget{Cloud: cloud}
 }

--- a/upup/pkg/fi/cloudup/linode/cloud.go
+++ b/upup/pkg/fi/cloudup/linode/cloud.go
@@ -40,7 +40,7 @@ const (
 	TagKubernetesInstanceUserData = "kops.k8s.io/instance-userdata"
 )
 
-// LinodeClient is the subset of the Linode API client used by the Linode cloudup tasks.
+// LinodeClient is the subset of the Akamai (Linode) API client used by the Akamai (Linode) cloudup tasks.
 type LinodeClient interface {
 	ListVPCs(ctx context.Context, opts *linodego.ListOptions) ([]linodego.VPC, error)
 	CreateVPC(ctx context.Context, opts linodego.VPCCreateOptions) (*linodego.VPC, error)
@@ -60,7 +60,7 @@ type LinodeClient interface {
 	ListInterfaces(ctx context.Context, instanceID int, opts *linodego.ListOptions) ([]linodego.LinodeInterface, error)
 }
 
-// LinodeCloud exposes Linode (Akamai) cloud APIs used by kOps.
+// LinodeCloud exposes Akamai (Linode) cloud APIs used by kOps.
 type LinodeCloud interface {
 	fi.Cloud
 	Client() LinodeClient
@@ -107,7 +107,7 @@ func (c *Cloud) ProviderID() kops.CloudProviderID {
 }
 
 func (c *Cloud) DNS() (dnsprovider.Interface, error) {
-	return nil, fmt.Errorf("DNS is not yet implemented for Linode (Akamai)")
+	return nil, fmt.Errorf("DNS is not yet implemented for Akamai (Linode)")
 }
 
 func (c *Cloud) FindVPCInfo(id string) (*fi.VPCInfo, error) {
@@ -117,14 +117,14 @@ func (c *Cloud) FindVPCInfo(id string) (*fi.VPCInfo, error) {
 func (c *Cloud) DeleteInstance(instance *cloudinstances.CloudInstance) error {
 	instanceID, err := strconv.Atoi(instance.ID)
 	if err != nil {
-		return fmt.Errorf("error parsing Linode (Akamai) instance ID %q: %w", instance.ID, err)
+		return fmt.Errorf("error parsing Akamai (Linode) instance ID %q: %w", instance.ID, err)
 	}
 
 	if err := c.client.DeleteInstance(context.Background(), instanceID); err != nil {
 		if linodego.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("error deleting Linode (Akamai) instance %q: %w", instance.ID, err)
+		return fmt.Errorf("error deleting Akamai (Linode) instance %q: %w", instance.ID, err)
 	}
 
 	return nil
@@ -135,11 +135,11 @@ func (c *Cloud) DeregisterInstance(instance *cloudinstances.CloudInstance) error
 }
 
 func (c *Cloud) DeleteGroup(group *cloudinstances.CloudInstanceGroup) error {
-	return fmt.Errorf("instance group deletion is not yet implemented for Linode (Akamai)")
+	return fmt.Errorf("instance group deletion is not yet implemented for Akamai (Linode)")
 }
 
 func (c *Cloud) DetachInstance(instance *cloudinstances.CloudInstance) error {
-	return fmt.Errorf("instance detach is not yet implemented for Linode (Akamai)")
+	return fmt.Errorf("instance detach is not yet implemented for Akamai (Linode)")
 }
 
 func (c *Cloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
@@ -158,25 +158,25 @@ func (c *Cloud) GetApiIngressStatus(cluster *kops.Cluster) ([]fi.ApiIngressStatu
 	return nil, nil
 }
 
-// ListOptionsForLabel builds Linode (Akamai) list options that filter by an exact label match.
+// ListOptionsForLabel builds Akamai (Linode) list options that filter by an exact label match.
 func ListOptionsForLabel(label string) (*linodego.ListOptions, error) {
 	filter := &linodego.Filter{}
 	filter.AddField(linodego.Eq, "label", label)
 	filterJSON, err := filter.MarshalJSON()
 	if err != nil {
-		return nil, fmt.Errorf("error building Linode (Akamai) label filter: %w", err)
+		return nil, fmt.Errorf("error building Akamai (Linode) label filter: %w", err)
 	}
 
 	return &linodego.ListOptions{Filter: string(filterJSON)}, nil
 }
 
-// ListOptionsForTags builds Linode (Akamai) list options that filter by an exact tag match.
+// ListOptionsForTags builds Akamai (Linode) list options that filter by an exact tag match.
 func ListOptionsForTags(tags ...string) (*linodego.ListOptions, error) {
 	filter := &linodego.Filter{}
 	filter.AddField(linodego.Eq, "tags", tags)
 	filterJSON, err := filter.MarshalJSON()
 	if err != nil {
-		return nil, fmt.Errorf("error building Linode (Akamai) tag filter: %w", err)
+		return nil, fmt.Errorf("error building Akamai (Linode) tag filter: %w", err)
 	}
 
 	return &linodego.ListOptions{
@@ -185,7 +185,7 @@ func ListOptionsForTags(tags ...string) (*linodego.ListOptions, error) {
 	}, nil
 }
 
-// NormalizeLinodeLabel returns a normalized label for Linode (Akamai) resources
+// NormalizeLinodeLabel returns a normalized label for Akamai (Linode) resources
 func NormalizeLinodeLabel(name string) string {
 	name = invalidLinodeLabelChars.ReplaceAllString(name, "-")
 	name = strings.Trim(name, "-_")

--- a/upup/pkg/fi/cloudup/linode/cloud_test.go
+++ b/upup/pkg/fi/cloudup/linode/cloud_test.go
@@ -34,7 +34,7 @@ func TestCloudDeleteInstance(t *testing.T) {
 		wantDeleted []int
 	}{
 		{name: "success", id: "101", wantDeleted: []int{101}},
-		{name: "invalid id", id: "not-an-int", wantError: "error parsing Linode (Akamai) instance ID"},
+		{name: "invalid id", id: "not-an-int", wantError: "error parsing Akamai (Linode) instance ID"},
 		{name: "not found", id: "101", deleteError: &linodego.Error{Code: 404, Message: "not found"}, wantDeleted: []int{101}},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/upup/pkg/fi/cloudup/linode/linodemetadata/authenticator.go
+++ b/upup/pkg/fi/cloudup/linode/linodemetadata/authenticator.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package linodemetadata provides the node-local (metadata-service based)
-// parts of the Linode support, kept separate so that nodeup does not link the
+// parts of the Akamai (Linode) support, kept separate so that nodeup does not link the
 // full cloud provider implementation.
 package linodemetadata
 
@@ -44,7 +44,7 @@ type linodeAuthenticator struct {
 var _ bootstrap.Authenticator = (*linodeAuthenticator)(nil)
 
 // NewLinodeAuthenticator returns a bootstrap.Authenticator that can create
-// authentication tokens for Linode instances by querying the Linode metadata
+// authentication tokens for Akamai (Linode) instances by querying the Akamai (Linode) metadata
 // service for the instance ID and returning it prefixed with "x-linode-instance-id".
 func NewLinodeAuthenticator() (bootstrap.Authenticator, error) {
 	return &linodeAuthenticator{
@@ -53,24 +53,24 @@ func NewLinodeAuthenticator() (bootstrap.Authenticator, error) {
 	}, nil
 }
 
-// CreateToken queries the Linode (Akamai) metadata service for the instance ID and returns
+// CreateToken queries the Akamai (Linode) metadata service for the instance ID and returns
 // it prefixed with "x-linode-instance-id ".
 func (a *linodeAuthenticator) CreateToken(body []byte) (string, error) {
 	instanceID, err := getLinodeMetadataValue(context.TODO(), a.client, a.metadataBaseURL, "id")
 	if err != nil {
-		return "", fmt.Errorf("unable to fetch Linode (Akamai) instance id: %w", err)
+		return "", fmt.Errorf("unable to fetch Akamai (Linode) instance id: %w", err)
 	}
 
 	return LinodeAuthenticationTokenPrefix + instanceID, nil
 }
 
-// GetMetadataValue fetches the given field from the Linode instance metadata service
+// GetMetadataValue fetches the given field from the Akamai (Linode) instance metadata service
 // using the standard metadata endpoint and default HTTP client.
 func GetMetadataValue(ctx context.Context, key string) (string, error) {
 	return getLinodeMetadataValue(ctx, http.DefaultClient, linodeMetadataBaseURL, key)
 }
 
-// getLinodeMetadataValue queries the Linode (Akamai) metadata service for the given key
+// getLinodeMetadataValue queries the Akamai (Linode) metadata service for the given key
 // and returns the value as a string.
 func getLinodeMetadataValue(ctx context.Context, client *http.Client, metadataBaseURL, key string) (string, error) {
 	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodPut, metadataBaseURL+"/v1/token", nil)
@@ -122,12 +122,12 @@ func getLinodeMetadataValue(ctx context.Context, client *http.Client, metadataBa
 
 	value := parseLinodeMetadataValue(string(instanceBytes), key)
 	if value == "" {
-		return "", fmt.Errorf("instance %s from Linode (Akamai) metadata was empty", key)
+		return "", fmt.Errorf("instance %s from Akamai (Linode) metadata was empty", key)
 	}
 	return value, nil
 }
 
-// parseLinodeMetadataValue parses the Linode (Akamai) metadata response for the given key
+// parseLinodeMetadataValue parses the Akamai (Linode) metadata response for the given key
 // and returns the value as a string.
 func parseLinodeMetadataValue(metadata string, key string) string {
 	prefix := key + ":"

--- a/upup/pkg/fi/cloudup/linode/verifier.go
+++ b/upup/pkg/fi/cloudup/linode/verifier.go
@@ -43,7 +43,7 @@ type linodeVerifier struct {
 
 var _ bootstrap.Verifier = (*linodeVerifier)(nil)
 
-// NewLinodeVerifier returns a bootstrap.Verifier that can verify Linode (Akamai) instance tokens using the LINODE_TOKEN environment variable.
+// NewLinodeVerifier returns a bootstrap.Verifier that can verify Akamai (Linode) instance tokens using the LINODE_TOKEN environment variable.
 func NewLinodeVerifier(opt *LinodeVerifierOptions) (bootstrap.Verifier, error) {
 	accessToken := os.Getenv("LINODE_TOKEN")
 	if accessToken == "" {
@@ -60,7 +60,7 @@ func NewLinodeVerifier(opt *LinodeVerifierOptions) (bootstrap.Verifier, error) {
 	return &linodeVerifier{client: &client}, nil
 }
 
-// VerifyToken verifies that the given token corresponds to a valid Linode (Akamai) instance.
+// VerifyToken verifies that the given token corresponds to a valid Akamai (Linode) instance.
 func (v *linodeVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request, token string, body []byte) (*bootstrap.VerifyResult, error) {
 	if !strings.HasPrefix(token, linodemetadata.LinodeAuthenticationTokenPrefix) {
 		return nil, bootstrap.ErrNotThisVerifier
@@ -74,10 +74,10 @@ func (v *linodeVerifier) VerifyToken(ctx context.Context, rawRequest *http.Reque
 
 	instance, err := v.client.GetInstance(ctx, instanceID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get info for Linode (Akamai) instance %q: %w", instanceIDString, err)
+		return nil, fmt.Errorf("failed to get info for Akamai (Linode) instance %q: %w", instanceIDString, err)
 	}
 	if instance == nil {
-		return nil, fmt.Errorf("failed to get info for Linode (Akamai) instance %q: empty response", instanceIDString)
+		return nil, fmt.Errorf("failed to get info for Akamai (Linode) instance %q: empty response", instanceIDString)
 	}
 
 	addresses, challengeEndpoints := gatherIPv4Addresses(instance.IPv4)
@@ -116,7 +116,7 @@ func gatherIPv4Addresses(ips []net.IP) ([]string, []string) {
 	return addresses, challengeEndpoints
 }
 
-// instanceGroupNameFromTags returns the instance group name from the given list of Linode (Akamai) tags.
+// instanceGroupNameFromTags returns the instance group name from the given list of Akamai (Linode) tags.
 func instanceGroupNameFromTags(tags []string) string {
 	for _, tag := range tags {
 		if after, ok := strings.CutPrefix(tag, TagKubernetesInstanceGroup+":"); ok {

--- a/upup/pkg/fi/cloudup/linodetasks/OWNERS
+++ b/upup/pkg/fi/cloudup/linodetasks/OWNERS
@@ -1,3 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 labels:
+- area/provider/akamai
 - area/provider/linode

--- a/upup/pkg/fi/cloudup/linodetasks/instance.go
+++ b/upup/pkg/fi/cloudup/linodetasks/instance.go
@@ -125,7 +125,7 @@ func (i *Instance) Find(c *fi.CloudupContext) (*Instance, error) {
 		}
 		interfaces, err := cloud.Client().ListInterfaces(c.Context(), instance.ID, nil)
 		if err != nil {
-			return nil, fmt.Errorf("error listing Linode (Akamai) interfaces for instance %q: %w", instance.Label, err)
+			return nil, fmt.Errorf("error listing Akamai (Linode) interfaces for instance %q: %w", instance.Label, err)
 		}
 		if !hasExpectedInterfaces(interfaces, fi.ValueOf(i.Subnet.ID), fi.ValueOf(i.RequirePublicInterface)) {
 			needsUpdate = append(needsUpdate, instance.Label)
@@ -225,7 +225,7 @@ func (i *Instance) RenderLinode(t *linode.APITarget, actual, expected, changes *
 	for range toCreate {
 		label, err := buildLinodeInstanceLabel(fi.ValueOf(expected.Name))
 		if err != nil {
-			return fmt.Errorf("error generating Linode (Akamai) instance label for group %q: %w", fi.ValueOf(expected.Name), err)
+			return fmt.Errorf("error generating Akamai (Linode) instance label for group %q: %w", fi.ValueOf(expected.Name), err)
 		}
 		_, err = t.Cloud.Client().CreateInstance(context.Background(), linodego.InstanceCreateOptions{
 			Region:              expected.Region,
@@ -239,7 +239,7 @@ func (i *Instance) RenderLinode(t *linode.APITarget, actual, expected, changes *
 			LinodeInterfaces:    interfaces,
 		})
 		if err != nil {
-			return fmt.Errorf("error creating Linode (Akamai) instance for group %q: %w", fi.ValueOf(expected.Name), err)
+			return fmt.Errorf("error creating Akamai (Linode) instance for group %q: %w", fi.ValueOf(expected.Name), err)
 		}
 	}
 
@@ -259,7 +259,7 @@ func generateUserDataHash(userData string) string {
 }
 
 // resolveAuthorizedKeys resolves the authorized keys for the instance.
-// It checks if the key has a public key directly provided or if it needs to be looked up by name in Linode (Akamai).
+// It checks if the key has a public key directly provided or if it needs to be looked up by name in Akamai (Linode).
 func resolveAuthorizedKeys(client linode.LinodeClient, keys []*SSHKey) ([]string, error) {
 	var authorizedKeys []string
 	var keysByName map[string]string
@@ -280,7 +280,7 @@ func resolveAuthorizedKeys(client linode.LinodeClient, keys []*SSHKey) ([]string
 		if keysByName == nil {
 			listedKeys, err := client.ListSSHKeys(context.TODO(), nil)
 			if err != nil {
-				return nil, fmt.Errorf("error listing Linode (Akamai) SSH keys: %w", err)
+				return nil, fmt.Errorf("error listing Akamai (Linode) SSH keys: %w", err)
 			}
 			keysByName = make(map[string]string, len(listedKeys))
 			for _, listedKey := range listedKeys {
@@ -290,7 +290,7 @@ func resolveAuthorizedKeys(client linode.LinodeClient, keys []*SSHKey) ([]string
 
 		publicKey, found := keysByName[fi.ValueOf(key.Name)]
 		if !found {
-			return nil, fmt.Errorf("SSH key %q not found in Linode (Akamai)", fi.ValueOf(key.Name))
+			return nil, fmt.Errorf("SSH key %q not found in Akamai (Linode)", fi.ValueOf(key.Name))
 		}
 		authorizedKeys = append(authorizedKeys, strings.TrimSpace(publicKey))
 	}
@@ -298,7 +298,7 @@ func resolveAuthorizedKeys(client linode.LinodeClient, keys []*SSHKey) ([]string
 	return authorizedKeys, nil
 }
 
-// buildLinodeInterfaces builds the Linode (Akamai) interfaces for the instance based on the subnet ID and whether a public interface is required.
+// buildLinodeInterfaces builds the Akamai (Linode) interfaces for the instance based on the subnet ID and whether a public interface is required.
 func buildLinodeInterfaces(subnetID int, requirePublicInterface bool) []linodego.LinodeInterfaceCreateOptions {
 	var interfaces []linodego.LinodeInterfaceCreateOptions
 	if requirePublicInterface {
@@ -313,7 +313,7 @@ func buildLinodeInterfaces(subnetID int, requirePublicInterface bool) []linodego
 	return interfaces
 }
 
-// buildLinodeInstanceLabel generates a unique label for the Linode (Akamai) instance by appending a random suffix to the provided name.
+// buildLinodeInstanceLabel generates a unique label for the Akamai (Linode) instance by appending a random suffix to the provided name.
 // It ensures that the final label does not exceed 64 characters and trims any trailing hyphens, underscores, or periods.
 func buildLinodeInstanceLabel(name string) (string, error) {
 	var randomSuffix [8]byte
@@ -331,7 +331,7 @@ func buildLinodeInstanceLabel(name string) (string, error) {
 	return name + suffix, nil
 }
 
-// hasExpectedInterfaces checks if the Linode (Akamai) instance has the expected network interfaces.
+// hasExpectedInterfaces checks if the Akamai (Linode) instance has the expected network interfaces.
 // It verifies that there is exactly one VPC interface with the matching subnet ID and checks for the presence of a public interface if required.
 func hasExpectedInterfaces(interfaces []linodego.LinodeInterface, subnetID int, requirePublicInterface bool) bool {
 	publicCount := 0
@@ -361,7 +361,7 @@ func hasExpectedInterfaces(interfaces []linodego.LinodeInterface, subnetID int, 
 	return publicCount == 0
 }
 
-// hasAllTags checks if all expected tags are present in the actual tags of the Linode (Akamai) instance.
+// hasAllTags checks if all expected tags are present in the actual tags of the Akamai (Linode) instance.
 func hasAllTags(actual, expected []string) bool {
 	for _, tag := range expected {
 		if !slices.Contains(actual, tag) {

--- a/upup/pkg/fi/cloudup/linodetasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/linodetasks/sshkey.go
@@ -51,7 +51,7 @@ func (s *SSHKey) Find(c *fi.CloudupContext) (*SSHKey, error) {
 
 	keys, err := cloud.Client().ListSSHKeys(c.Context(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("error listing Linode (Akamai) SSH keys: %w", err)
+		return nil, fmt.Errorf("error listing Akamai (Linode) SSH keys: %w", err)
 	}
 
 	var matched *linodego.SSHKey
@@ -84,7 +84,7 @@ func (s *SSHKey) Find(c *fi.CloudupContext) (*SSHKey, error) {
 		}
 
 		if strings.TrimSpace(expectedPublicKey) != strings.TrimSpace(matched.SSHKey) {
-			return nil, fmt.Errorf("found SSH key %q in Linode (Akamai), but public key data did not match", name)
+			return nil, fmt.Errorf("found SSH key %q in Akamai (Linode), but public key data did not match", name)
 		}
 
 		// Avoid spurious changes.
@@ -145,11 +145,11 @@ func (*SSHKey) RenderLinode(t *linode.APITarget, actual, expected, changes *SSHK
 		SSHKey: strings.TrimSpace(publicKey),
 	})
 	if err != nil {
-		return fmt.Errorf("error creating Linode (Akamai) SSH key %q: %w", name, err)
+		return fmt.Errorf("error creating Akamai (Linode) SSH key %q: %w", name, err)
 	}
 
 	expected.ID = new(created.ID)
-	klog.V(2).Infof("Created Linode (Akamai) SSH key %q (id=%d)", created.Label, created.ID)
+	klog.V(2).Infof("Created Akamai (Linode) SSH key %q (id=%d)", created.Label, created.ID)
 
 	return nil
 }

--- a/upup/pkg/fi/cloudup/linodetasks/sshkey_test.go
+++ b/upup/pkg/fi/cloudup/linodetasks/sshkey_test.go
@@ -106,7 +106,7 @@ func TestSSHKeyFindListError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected list error")
 	}
-	if !strings.Contains(err.Error(), "error listing Linode (Akamai) SSH keys") {
+	if !strings.Contains(err.Error(), "error listing Akamai (Linode) SSH keys") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/upup/pkg/fi/cloudup/linodetasks/subnet.go
+++ b/upup/pkg/fi/cloudup/linodetasks/subnet.go
@@ -65,7 +65,7 @@ func (v *Subnet) Find(c *fi.CloudupContext) (*Subnet, error) {
 
 	subnets, err := cloud.Client().ListVPCSubnets(c.Context(), fi.ValueOf(v.VPC.ID), nil)
 	if err != nil {
-		return nil, fmt.Errorf("error listing Linode (Akamai) VPC Subnets: %w", err)
+		return nil, fmt.Errorf("error listing Akamai (Linode) VPC Subnets: %w", err)
 	}
 
 	var foundByName *linodego.VPCSubnet
@@ -76,7 +76,7 @@ func (v *Subnet) Find(c *fi.CloudupContext) (*Subnet, error) {
 		candidate := &subnets[i]
 		if candidate.Label == name {
 			if foundByName != nil {
-				return nil, fmt.Errorf("found multiple Linode (Akamai) VPC Subnets named %q", name)
+				return nil, fmt.Errorf("found multiple Akamai (Linode) VPC Subnets named %q", name)
 			}
 			foundByName = candidate
 		}
@@ -146,7 +146,7 @@ func (_ *Subnet) RenderLinode(t *linode.APITarget, actual, expected, changes *Su
 			fi.ValueOf(expected.VPC.ID),
 		)
 		if err != nil {
-			return fmt.Errorf("error creating Linode (Akamai) Subnet %q: %w", fi.ValueOf(expected.Name), err)
+			return fmt.Errorf("error creating Akamai (Linode) Subnet %q: %w", fi.ValueOf(expected.Name), err)
 		}
 		expected.ID = new(subnet.ID)
 		return nil
@@ -161,7 +161,7 @@ func (_ *Subnet) RenderLinode(t *linode.APITarget, actual, expected, changes *Su
 		Label: fi.ValueOf(expected.Name),
 	})
 	if err != nil {
-		return fmt.Errorf("error updating Linode (Akamai) Subnet %q: %w", fi.ValueOf(expected.Name), err)
+		return fmt.Errorf("error updating Akamai (Linode) Subnet %q: %w", fi.ValueOf(expected.Name), err)
 	}
 	expected.ID = new(subnet.ID)
 

--- a/upup/pkg/fi/cloudup/linodetasks/subnet_test.go
+++ b/upup/pkg/fi/cloudup/linodetasks/subnet_test.go
@@ -202,7 +202,7 @@ func TestSubnetFindDuplicateName(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected duplicate name error")
 	}
-	if !strings.Contains(err.Error(), "found multiple Linode (Akamai) VPC Subnets named") {
+	if !strings.Contains(err.Error(), "found multiple Akamai (Linode) VPC Subnets named") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -216,7 +216,7 @@ func TestSubnetFindListError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected list error")
 	}
-	if !strings.Contains(err.Error(), "error listing Linode (Akamai) VPC Subnets") {
+	if !strings.Contains(err.Error(), "error listing Akamai (Linode) VPC Subnets") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/upup/pkg/fi/cloudup/linodetasks/vpc.go
+++ b/upup/pkg/fi/cloudup/linodetasks/vpc.go
@@ -56,7 +56,7 @@ func (v *VPC) Find(c *fi.CloudupContext) (*VPC, error) {
 
 	vpcs, err := cloud.Client().ListVPCs(c.Context(), listOptions)
 	if err != nil {
-		return nil, fmt.Errorf("error listing Linode (Akamai) VPCs: %w", err)
+		return nil, fmt.Errorf("error listing Akamai (Linode) VPCs: %w", err)
 	}
 
 	var found *linodego.VPC
@@ -70,7 +70,7 @@ func (v *VPC) Find(c *fi.CloudupContext) (*VPC, error) {
 			continue
 		}
 		if found != nil {
-			return nil, fmt.Errorf("found multiple Linode (Akamai) VPCs named %q", name)
+			return nil, fmt.Errorf("found multiple Akamai (Linode) VPCs named %q", name)
 		}
 		found = candidate
 	}
@@ -123,7 +123,7 @@ func (_ *VPC) RenderLinode(t *linode.APITarget, actual, expected, changes *VPC) 
 			Region:      fi.ValueOf(expected.Region),
 		})
 		if err != nil {
-			return fmt.Errorf("error creating Linode (Akamai) VPC %q: %w", fi.ValueOf(expected.Name), err)
+			return fmt.Errorf("error creating Akamai (Linode) VPC %q: %w", fi.ValueOf(expected.Name), err)
 		}
 		expected.ID = new(vpc.ID)
 		return nil
@@ -139,7 +139,7 @@ func (_ *VPC) RenderLinode(t *linode.APITarget, actual, expected, changes *VPC) 
 		Description: fi.ValueOf(expected.Description),
 	})
 	if err != nil {
-		return fmt.Errorf("error updating Linode (Akamai) VPC %q: %w", fi.ValueOf(expected.Name), err)
+		return fmt.Errorf("error updating Akamai (Linode) VPC %q: %w", fi.ValueOf(expected.Name), err)
 	}
 	expected.ID = new(vpc.ID)
 

--- a/upup/pkg/fi/cloudup/linodetasks/vpc_test.go
+++ b/upup/pkg/fi/cloudup/linodetasks/vpc_test.go
@@ -112,7 +112,7 @@ func TestVPCFindListError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected list error")
 	}
-	if !strings.Contains(err.Error(), "error listing Linode (Akamai) VPCs") {
+	if !strings.Contains(err.Error(), "error listing Akamai (Linode) VPCs") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -131,7 +131,7 @@ func TestVPCFindDuplicateName(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected duplicate name error")
 	}
-	if !strings.Contains(err.Error(), "found multiple Linode (Akamai) VPCs named") {
+	if !strings.Contains(err.Error(), "found multiple Akamai (Linode) VPCs named") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -791,7 +791,7 @@ func setupZones(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.Stri
 			return nil, fmt.Errorf("linode cloud provider currently supports one region only")
 		}
 
-		// For Linode (Akamai) we pass regions via --zones.
+		// For Akamai (Linode) we pass regions via --zones.
 		region := opt.Zones[0]
 		subnet := model.FindSubnet(cluster, region)
 

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -216,12 +216,12 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 			}
 		}
 		if region == "" {
-			return nil, fmt.Errorf("on Linode (Akamai), subnets must include Regions")
+			return nil, fmt.Errorf("on Akamai (Linode), subnets must include Regions")
 		}
 
 		linodeCloud, err := linode.NewCloud(region)
 		if err != nil {
-			return nil, fmt.Errorf("error initializing Linode (Akamai) cloud: %w", err)
+			return nil, fmt.Errorf("error initializing Akamai (Linode) cloud: %w", err)
 		}
 
 		cloud = linodeCloud

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -544,7 +544,7 @@ func evaluateHostnameOverride(cloudProvider api.CloudProviderID, useIPBasedNodeN
 			return "", fmt.Errorf("error reading hostname from Linode metadata: %v", err)
 		}
 
-		// Linode cloud-init does not set the OS hostname.
+		// Akamai (Linode) cloud-init does not set the OS hostname.
 		// Set it here so the OS hostname matches the kubelet hostname override.
 		if err := os.WriteFile("/etc/hostname", []byte(label+"\n"), 0o644); err != nil { //nolint:gosec // /etc/hostname is conventionally world-readable system configuration.
 			klog.Warningf("Failed to write /etc/hostname: %v", err)

--- a/util/pkg/env/standard.go
+++ b/util/pkg/env/standard.go
@@ -85,7 +85,7 @@ func BuildSystemComponentEnvVars(spec *kops.ClusterSpec) EnvVars {
 	// Hetzner Cloud related values.
 	vars.addEnvVariableIfExist("HCLOUD_TOKEN")
 
-	// Linode (Akamai) related values.
+	// Akamai (Linode) related values.
 	vars.addEnvVariableIfExist("LINODE_TOKEN")
 
 	// Scaleway related values.

--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -419,7 +419,7 @@ func (c *VFSContext) buildLinodePath(p string) (*S3Path, error) {
 		o.BaseEndpoint = aws.String(endpoint)
 		o.UsePathStyle = true
 		o.DisableLogOutputChecksumValidationSkipped = true
-		// Linode (Akamai) requires checksum-when-required behavior
+		// Akamai (Linode) requires checksum-when-required behavior
 		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 		o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired
 	})

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -651,7 +651,7 @@ func (p *S3Path) IsBucketPublic(ctx context.Context) (bool, error) {
 
 func (p *S3Path) IsPublic() (bool, error) {
 	if p.scheme == "linode" {
-		// Linode (Akamai) does not implement GetObjectAcl. In that case we conservatively treat the object as non-public and continue.
+		// Akamai (Linode) does not implement GetObjectAcl. In that case we conservatively treat the object as non-public and continue.
 		return false, nil
 	}
 	ctx := context.TODO()


### PR DESCRIPTION
- Updated error messages and comments to reflect the correct naming convention for Linode as Akamai (Linode).
- Modified the OWNERS files to include the new area label for Akamai.
- Adjusted function comments and documentation to clarify the relationship between Akamai and Linode.
- Ensured consistency in naming throughout the linode package and related tasks, including API interactions, instance management, and metadata handling.

Signed-off-by: Moshe Vayner <moshe@vayner.me>

<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
