### PR TITLE
iam: grant ec2:DescribeSecurityGroups for AWS VPC CNI

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -1581,6 +1581,7 @@ func addAmazonVPCCNIPermissions(p *Policy) {
 		"ec2:DescribeTags",
 		"ec2:DescribeNetworkInterfaces",
 		"ec2:DescribeInstanceTypes",
+		"ec2:DescribeSecurityGroups",
 		"ec2:DescribeSubnets",
 		"ec2:DetachNetworkInterface",
 		"ec2:ModifyNetworkInterfaceAttribute",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -111,6 +111,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -18,6 +18,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
         "ec2:DetachNetworkInterface",

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -18,6 +18,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
         "ec2:DetachNetworkInterface",

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.many-addons.example.com_policy
@@ -18,6 +18,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
         "ec2:DetachNetworkInterface",


### PR DESCRIPTION
Since aws-vpc-cni-k8s v1.22.1, ipamd calls both `ec2:DescribeSubnets` and `ec2:DescribeSecurityGroups` when subnet discovery is enabled, which is the default. Without the permission, subnet discovery fails and the CNI falls back to allocating IPs only from the primary ENI's subnet. Upstream added the permission to its recommended IAM policy in v1.23.0.
See  https://github.com/aws/amazon-vpc-cni-k8s/pull/3709 for more details.

/cc @moshevayner @rifelpet 