### PR TITLE
fix(akamai): Fix Akamai (Linode) Instance tag filter function

### DIFF
--- a/pkg/resources/linode/resources_test.go
+++ b/pkg/resources/linode/resources_test.go
@@ -111,14 +111,10 @@ func TestListResources(t *testing.T) {
 		t.Fatalf("unexpected VPC list filter: got %q, want %q", got, want)
 	}
 
-	expectedInstanceListOptions, err := linode.ListOptionsForTags("kops.k8s.io/cluster:example.k8s.local")
-	if err != nil {
-		t.Fatalf("ListOptionsForTags returned error: %v", err)
-	}
 	if client.LastListInstancesOpts == nil {
 		t.Fatalf("expected instance list options to be recorded")
 	}
-	if got, want := client.LastListInstancesOpts.Filter, expectedInstanceListOptions.Filter; got != want {
+	if got, want := client.LastListInstancesOpts.Filter, `{"+and":[{"tags":{"+contains":"kops.k8s.io/cluster:example.k8s.local"}}]}`; got != want {
 		t.Fatalf("unexpected instance list filter: got %q, want %q", got, want)
 	}
 }

--- a/upup/pkg/fi/cloudup/linode/cloud.go
+++ b/upup/pkg/fi/cloudup/linode/cloud.go
@@ -172,8 +172,11 @@ func ListOptionsForLabel(label string) (*linodego.ListOptions, error) {
 
 // ListOptionsForTags builds Akamai (Linode) list options that filter by an exact tag match.
 func ListOptionsForTags(tags ...string) (*linodego.ListOptions, error) {
-	filter := &linodego.Filter{}
-	filter.AddField(linodego.Eq, "tags", tags)
+	filters := make([]linodego.FilterNode, 0, len(tags))
+	for _, tag := range tags {
+		filters = append(filters, &linodego.Comp{Column: "tags", Operator: linodego.Contains, Value: tag})
+	}
+	filter := linodego.And("", "", filters...)
 	filterJSON, err := filter.MarshalJSON()
 	if err != nil {
 		return nil, fmt.Errorf("error building Akamai (Linode) tag filter: %w", err)

--- a/upup/pkg/fi/cloudup/linode/cloud_test.go
+++ b/upup/pkg/fi/cloudup/linode/cloud_test.go
@@ -25,6 +25,37 @@ import (
 	"k8s.io/kops/pkg/cloudinstances"
 )
 
+func TestListOptionsForTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []string
+		want string
+	}{
+		{
+			name: "single tag",
+			tags: []string{"kops.k8s.io/cluster:example.k8s.local"},
+			want: `{"+and":[{"tags":{"+contains":"kops.k8s.io/cluster:example.k8s.local"}}]}`,
+		},
+		{
+			name: "multiple tags",
+			tags: []string{"kops.k8s.io/cluster:example.k8s.local", "kops.k8s.io/instance-group:control-plane"},
+			want: `{"+and":[{"tags":{"+contains":"kops.k8s.io/cluster:example.k8s.local"}},{"tags":{"+contains":"kops.k8s.io/instance-group:control-plane"}}]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options, err := ListOptionsForTags(test.tags...)
+			if err != nil {
+				t.Fatalf("ListOptionsForTags returned error: %v", err)
+			}
+			if got := options.Filter; got != test.want {
+				t.Fatalf("unexpected filter: got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestCloudDeleteInstance(t *testing.T) {
 	for _, testCase := range []struct {
 		name        string


### PR DESCRIPTION
Use `+contains` predicates for Akamai (Linode) instance tag filters, replacing the rejected tag-array equality filter. Add coverage for single- and multi-tag selectors used by resource discovery and provisioning.

Signed-off-by: Moshe Vayner <moshe@vayner.me>

<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
