### PR TITLE
digitalocean: delete SSH keys when deleting a cluster

### DIFF
--- a/pkg/resources/digitalocean/resources.go
+++ b/pkg/resources/digitalocean/resources.go
@@ -41,6 +41,7 @@ const (
 	resourceTypeDNSRecord    = "dns-record"
 	resourceTypeLoadBalancer = "loadbalancer"
 	resourceTypeVPC          = "vpc"
+	resourceTypeSSHKey       = "ssh-key"
 )
 
 type listFn func(fi.Cloud, string) ([]*resources.Resource, error)
@@ -60,6 +61,7 @@ func ListResources(cloud do.DOCloud, clusterInfo resources.ClusterInfo) (map[str
 	listFunctions = append(listFunctions,
 		listLoadBalancers,
 		listVPCs,
+		listSSHKeys,
 	)
 
 	for _, fn := range listFunctions {
@@ -380,6 +382,70 @@ func dumpDroplet(op *resources.DumpOperation, r *resources.Resource) error {
 	}
 
 	op.Dump.Instances = append(op.Dump.Instances, i)
+
+	return nil
+}
+
+// listSSHKeys finds the SSH keys kops uploaded for this cluster. DigitalOcean
+// keys are account-scoped, so they are matched by the name kops gives them in
+// pkg/model/names.go: "kubernetes.<cluster name>-<fingerprint>". A cluster that
+// sets spec.sshKeyName reuses a pre-existing key it does not own, and Find in
+// dotasks/sshkey.go leaves that key alone, so this deliberately does not match it.
+func listSSHKeys(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error) {
+	c := cloud.(do.DOCloud)
+	var resourceTrackers []*resources.Resource
+
+	keys, err := c.GetAllSSHKeys()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list ssh keys: %v", err)
+	}
+
+	resourceTrackers = append(resourceTrackers, filterClusterSSHKeys(keys, clusterName)...)
+
+	return resourceTrackers, nil
+}
+
+// filterClusterSSHKeys selects the keys kops named for this cluster. The trailing
+// "-" before the fingerprint matters: without it "foo.k8s.local" would also match
+// the keys of "foo.k8s.local.example.com", and these keys are account-scoped and
+// shared with every other cluster in the account.
+func filterClusterSSHKeys(keys []godo.Key, clusterName string) []*resources.Resource {
+	keyPrefix := "kubernetes." + clusterName + "-"
+
+	var resourceTrackers []*resources.Resource
+	for _, key := range keys {
+		if !strings.HasPrefix(key.Name, keyPrefix) {
+			continue
+		}
+
+		resourceTrackers = append(resourceTrackers, &resources.Resource{
+			Name:    key.Name,
+			ID:      strconv.Itoa(key.ID),
+			Type:    resourceTypeSSHKey,
+			Deleter: deleteSSHKey,
+			Obj:     key,
+		})
+	}
+
+	return resourceTrackers
+}
+
+func deleteSSHKey(cloud fi.Cloud, t *resources.Resource) error {
+	c := cloud.(do.DOCloud)
+
+	id, err := strconv.Atoi(t.ID)
+	if err != nil {
+		return fmt.Errorf("failed to convert ssh key ID %q to int: %s", t.ID, err)
+	}
+
+	klog.V(2).Infof("deleting DO SSH key %q (ID %d)", t.Name, id)
+	response, err := c.KeysService().DeleteByID(context.TODO(), id)
+	if err != nil {
+		if response != nil && response.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("failed to delete ssh key %s (ID %s): %s", t.Name, t.ID, err)
+	}
 
 	return nil
 }

--- a/pkg/resources/digitalocean/resources_test.go
+++ b/pkg/resources/digitalocean/resources_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/digitalocean/godo"
+
+	"k8s.io/kops/pkg/resources"
+)
+
+// DigitalOcean SSH keys are account-scoped, so every cluster in an account sees
+// every other cluster's keys. Matching too loosely here deletes keys belonging to
+// live clusters.
+func TestFilterClusterSSHKeys(t *testing.T) {
+	cases := []struct {
+		name        string
+		clusterName string
+		keys        []godo.Key
+		expected    []string
+	}{
+		{
+			name:        "matches the key kops created for the cluster",
+			clusterName: "cluster.k8s.local",
+			keys: []godo.Key{
+				{ID: 1, Name: "kubernetes.cluster.k8s.local-c4:a8:11:cc:c1:0d:cd:ba:0f:4f:0d:c1:d1:a2:2a:cd"},
+			},
+			expected: []string{"kubernetes.cluster.k8s.local-c4:a8:11:cc:c1:0d:cd:ba:0f:4f:0d:c1:d1:a2:2a:cd"},
+		},
+		{
+			name:        "matches every key the cluster left behind across runs",
+			clusterName: "cluster.k8s.local",
+			keys: []godo.Key{
+				{ID: 1, Name: "kubernetes.cluster.k8s.local-aa:bb"},
+				{ID: 2, Name: "kubernetes.cluster.k8s.local-cc:dd"},
+			},
+			expected: []string{"kubernetes.cluster.k8s.local-aa:bb", "kubernetes.cluster.k8s.local-cc:dd"},
+		},
+		{
+			name:        "ignores another cluster whose name extends this one",
+			clusterName: "cluster.k8s.local",
+			keys: []godo.Key{
+				{ID: 1, Name: "kubernetes.cluster.k8s.local.example.com-aa:bb"},
+			},
+			expected: nil,
+		},
+		{
+			// e2e-kops-do-dns-none vs e2e-kops-do-dns-none-ha, which run concurrently.
+			name:        "ignores a sibling cluster with a suffixed name",
+			clusterName: "e2e-kops-do-dns-none.k8s.local",
+			keys: []godo.Key{
+				{ID: 1, Name: "kubernetes.e2e-kops-do-dns-none-ha.k8s.local-aa:bb"},
+			},
+			expected: nil,
+		},
+		{
+			name:        "ignores an unrelated cluster",
+			clusterName: "cluster.k8s.local",
+			keys: []godo.Key{
+				{ID: 1, Name: "kubernetes.other.k8s.local-aa:bb"},
+			},
+			expected: nil,
+		},
+		{
+			// A user-supplied key via spec.sshKeyName keeps its own name; kops did not
+			// create it and must not delete it.
+			name:        "ignores a key kops did not name",
+			clusterName: "cluster.k8s.local",
+			keys: []godo.Key{
+				{ID: 1, Name: "my-personal-key"},
+				{ID: 2, Name: "cluster.k8s.local"},
+			},
+			expected: nil,
+		},
+		{
+			name:        "ignores the bare cluster name with no fingerprint",
+			clusterName: "cluster.k8s.local",
+			keys: []godo.Key{
+				{ID: 1, Name: "kubernetes.cluster.k8s.local"},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := filterClusterSSHKeys(tc.keys, tc.clusterName)
+
+			if len(actual) != len(tc.expected) {
+				t.Fatalf("matched %d keys, expected %d: %v", len(actual), len(tc.expected), names(actual))
+			}
+			for i, want := range tc.expected {
+				if actual[i].Name != want {
+					t.Errorf("key[%d] = %q, expected %q", i, actual[i].Name, want)
+				}
+				if actual[i].Type != resourceTypeSSHKey {
+					t.Errorf("key[%d] type = %q, expected %q", i, actual[i].Type, resourceTypeSSHKey)
+				}
+				if actual[i].Deleter == nil {
+					t.Errorf("key[%d] has no deleter", i)
+				}
+			}
+		})
+	}
+}
+
+func names(rs []*resources.Resource) []string {
+	var out []string
+	for _, r := range rs {
+		out = append(out, r.Name)
+	}
+	return out
+}

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -73,6 +73,7 @@ type DOCloud interface {
 	GetAllVolumesByRegion() ([]godo.Volume, error)
 	GetVPCUUID(networkCIDR string, vpcName string) (string, error)
 	GetAllVPCs() ([]*godo.VPC, error)
+	GetAllSSHKeys() ([]godo.Key, error)
 }
 
 var readBackoff = wait.Backoff{
@@ -555,6 +556,36 @@ func (c *doCloudImplementation) GetAllLoadBalancers() ([]godo.LoadBalancer, erro
 	}
 
 	return allLoadBalancers, nil
+}
+
+// GetAllSSHKeys returns every SSH key registered on the account. DigitalOcean
+// keys are account-scoped rather than cluster-scoped, so callers must filter by
+// name to find the ones belonging to a cluster.
+func (c *doCloudImplementation) GetAllSSHKeys() ([]godo.Key, error) {
+	allKeys := []godo.Key{}
+
+	opt := &godo.ListOptions{}
+	for {
+		keys, resp, err := c.KeysService().List(context.TODO(), opt)
+		if err != nil {
+			return nil, err
+		}
+
+		allKeys = append(allKeys, keys...)
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		opt.Page = page + 1
+	}
+
+	return allKeys, nil
 }
 
 func (c *doCloudImplementation) GetAllVPCs() ([]*godo.VPC, error) {

--- a/upup/pkg/fi/cloudup/do/mock_do_cloud.go
+++ b/upup/pkg/fi/cloudup/do/mock_do_cloud.go
@@ -143,6 +143,10 @@ func (c *doCloudMockImplementation) GetAllVPCs() ([]*godo.VPC, error) {
 	return nil, nil
 }
 
+func (c *doCloudMockImplementation) GetAllSSHKeys() ([]godo.Key, error) {
+	return nil, nil
+}
+
 func (c *doCloudMockImplementation) VPCsService() godo.VPCsService {
 	return c.Client.VPCs
 }


### PR DESCRIPTION
kops uploads an SSH key to the DigitalOcean account for every cluster (`dotasks/sshkey.go` `createKeypair` → `KeysService().Create`), naming it `kubernetes.<cluster name>-<fingerprint>` per `pkg/model/names.go`. But `pkg/resources/digitalocean/resources.go` only deletes `droplet`, `volume`, `dns-record`, `loadbalancer` and `vpc` — **the SSH key is never removed**.

AWS already cleans up its key pairs (`pkg/resources/aws/aws.go` `DeleteKeypair`, wired in at `ListKeypairs`), and OpenStack has `pkg/resources/openstack/sshkey.go`. DigitalOcean was the gap.

## Why it hasn't bitten yet

Every DO CI job supplies the same SSH key through the `preset-do-ssh` prow preset, so the fingerprint — and therefore the key name — is identical on every run. `SSHKey.Find` matches the existing key and reuses it, and nothing accumulates.

That stops being true as soon as a cluster is created with a per-cluster key. It leaks one key per cluster, and because DigitalOcean scopes SSH keys to the **account** rather than to a cluster, they pile up with nothing identifying what they belonged to.

This is a prerequisite for kubernetes/test-infra#37690, which switches the DO e2e jobs to the ephemeral keys `kubetest2-kops` now generates (kubernetes/kops#18686). That PR is on hold until this ships.

## Matching

Keys are selected on the `kubernetes.<cluster name>-` prefix. Two properties matter, and both are covered by tests:

- **The trailing hyphen is required.** Without it, `foo.k8s.local` would also match keys belonging to `foo.k8s.local.example.com`. The concrete case in CI is `e2e-kops-do-dns-none` and `e2e-kops-do-dns-none-ha`, which run against the same account.
- **A cluster setting `spec.sshKeyName` is left alone.** That key keeps a name kops did not choose, so it does not match the prefix — consistent with `Find` in `dotasks/sshkey.go`, which adopts such a key rather than creating one. Deleting a user's pre-existing key would be considerably worse than leaking one.

Deletion tolerates a 404 so a retried teardown is idempotent.

## Testing

- `TestFilterClusterSSHKeys` covers seven cases: the normal match, several stale keys from repeated runs of one cluster, a longer cluster name that must not match, the `-ha` sibling, an unrelated cluster, a user-named key, and the bare cluster name with no fingerprint.
- `go build ./...`, `go vet`, and `go test ./pkg/resources/... ./upup/pkg/fi/cloudup/do/... ./upup/pkg/fi/cloudup/dotasks/...` all pass.

The listing follows the existing `GetAllVPCs` pagination pattern, and the `DOCloud` mock gains the matching no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)