### PR TITLE
aws: report the SSH user for Rocky Linux instances

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -478,6 +478,8 @@ func guessSSHUser(image *ec2types.Image) string {
 		return "ubuntu"
 	case awsup.WellKnownAccountFlatcar:
 		return "core"
+	case awsup.WellKnownAccountRockyLinux:
+		return "rocky"
 	}
 
 	name := aws.ToString(image.Name)

--- a/pkg/resources/aws/aws_test.go
+++ b/pkg/resources/aws/aws_test.go
@@ -401,3 +401,43 @@ func TestMatchesElbTags(t *testing.T) {
 		}
 	}
 }
+
+func TestGuessSSHUser(t *testing.T) {
+	cases := []struct {
+		name     string
+		ownerID  string
+		image    string
+		expected string
+	}{
+		{name: "amazon linux 2023", ownerID: awsup.WellKnownAccountAmazonLinux2023, expected: "ec2-user"},
+		{name: "redhat", ownerID: awsup.WellKnownAccountRedhat, expected: "ec2-user"},
+		{name: "debian", ownerID: awsup.WellKnownAccountDebian, expected: "admin"},
+		{name: "ubuntu", ownerID: awsup.WellKnownAccountUbuntu, expected: "ubuntu"},
+		{name: "flatcar", ownerID: awsup.WellKnownAccountFlatcar, expected: "core"},
+		{name: "rocky linux", ownerID: awsup.WellKnownAccountRockyLinux, expected: "rocky"},
+		{
+			name:     "centos is matched on the image name",
+			ownerID:  "123456789012",
+			image:    "CentOS-Stream-ec2-9-20260101.0.x86_64",
+			expected: "centos",
+		},
+		{
+			name:     "an unrecognized image has no known user",
+			ownerID:  "123456789012",
+			image:    "my-custom-image",
+			expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			image := &ec2types.Image{
+				OwnerId: aws.String(tc.ownerID),
+				Name:    aws.String(tc.image),
+			}
+			if actual := guessSSHUser(image); actual != tc.expected {
+				t.Errorf("guessSSHUser(owner=%q, name=%q) = %q, expected %q", tc.ownerID, tc.image, actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`guessSSHUser` (`pkg/resources/aws/aws.go`) maps well-known image owner accounts to their default SSH user, and is what populates `sshUser` for each instance in `kops toolbox dump`. It handles Amazon Linux 2023, RHEL, Debian, Ubuntu, Flatcar and a `centos` name prefix — but never learned about Rocky Linux, so **every Rocky instance dumps an empty `sshUser`**.

kops already recognizes the account everywhere else: `upup/pkg/fi/cloudup/awsup/aws_cloud.go:119` defines `WellKnownAccountRockyLinux`, and `ResolveImageOwnerAlias` maps both `rocky` and `rockylinux` to it. `guessSSHUser` is the only place that was missed.

## Why it matters now

Beyond `toolbox dump` output being wrong for Rocky users today, this blocks work in flight. `kubetest2-kops` is moving toward deriving the SSH user from `kops toolbox dump` instead of taking it from a hardcoded per-distro table in the prow job config (the same direction as the ephemeral SSH keys in #18686). The kops CLI defaults `--ssh-user` to `ubuntu` when it is not supplied, so an empty derived value silently degrades to `ubuntu` — which fails on Rocky.

That would regress the 154 AWS Rocky e2e jobs whose `KUBE_SSH_USER` is currently the correct `rocky` from `aws_distros_ssh_user`. Fixing the guess first keeps the derived value at least as good as the curated one.

## Testing

New `TestGuessSSHUser` covers every owner the function knows about — `ec2-user` for Amazon Linux 2023 and RHEL, `admin` for Debian, `ubuntu` for Ubuntu, `core` for Flatcar, `rocky` for Rocky Linux — plus the `centos` name-prefix branch and the unrecognized-image fallback, so the next addition here is less likely to be forgotten.

`go build ./...`, `go vet` and `go test ./pkg/resources/aws/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)