### PR TITLE
feat(akamai): manage etcd block storage volumes

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
+	"k8s.io/kops/upup/pkg/fi/cloudup/linode"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/upup/pkg/fi/cloudup/scaleway"
 	"k8s.io/kops/upup/pkg/fi/fitasks"
@@ -499,6 +500,10 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 			}
 			config.VolumeNameTag = fmt.Sprintf("%s=%s", hetzner.TagKubernetesInstanceGroup, instanceGroupName)
 
+		case kops.CloudProviderLinode:
+			config.VolumeProvider = "linode"
+			config.VolumeTag, config.VolumeNameTag = linodeVolumeSelectors(b.Cluster.Name, etcdCluster.Name, instanceGroupName)
+
 		case kops.CloudProviderOpenstack:
 			config.VolumeProvider = "openstack"
 
@@ -659,6 +664,15 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 	kubemanifest.MarkPodAsClusterCritical(pod)
 
 	return pod, nil
+}
+
+func linodeVolumeSelectors(clusterName, etcdClusterName, instanceGroupName string) ([]string, string) {
+	volumeTags := []string{
+		fmt.Sprintf("%s:%s", linode.TagKubernetesClusterName, linode.NormalizeLinodeLabel(clusterName)),
+		fmt.Sprintf("%s:%s", linode.TagKubernetesVolumeRole, linode.NormalizeLinodeLabel(etcdClusterName)),
+	}
+	volumeNameTag := fmt.Sprintf("%s:%s", linode.TagKubernetesInstanceGroup, linode.NormalizeLinodeLabel(instanceGroupName))
+	return volumeTags, volumeNameTag
 }
 
 // config defines the flags for etcd-manager

--- a/pkg/model/components/etcdmanager/model_test.go
+++ b/pkg/model/components/etcdmanager/model_test.go
@@ -19,6 +19,7 @@ package etcdmanager
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"k8s.io/kops/pkg/assets"
@@ -166,5 +167,21 @@ func Test_resolveAzureBackupStore(t *testing.T) {
 				t.Errorf("Account: got %q, want %q", gotAccount, tc.wantAccount)
 			}
 		})
+	}
+}
+
+func TestLinodeVolumeSelectors(t *testing.T) {
+	volumeTags, volumeNameTag := linodeVolumeSelectors("example.k8s.local", "main", "control-plane.example.k8s.local")
+
+	wantVolumeTags := []string{
+		"kops.k8s.io/cluster:example-k8s-local",
+		"kops.k8s.io/volume-role:main",
+	}
+	if !reflect.DeepEqual(volumeTags, wantVolumeTags) {
+		t.Fatalf("unexpected volume tags: got %v, want %v", volumeTags, wantVolumeTags)
+	}
+
+	if want := "kops.k8s.io/instance-group:control-plane-example-k8s-local"; volumeNameTag != want {
+		t.Fatalf("unexpected volume name tag: got %q, want %q", volumeNameTag, want)
 	}
 }

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -37,6 +37,8 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/gcetasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetznertasks"
+	"k8s.io/kops/upup/pkg/fi/cloudup/linode"
+	"k8s.io/kops/upup/pkg/fi/cloudup/linodetasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstacktasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/scaleway"
@@ -124,6 +126,9 @@ func (b *MasterVolumeBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				}
 			case kops.CloudProviderScaleway:
 				b.addScalewayVolume(c, name, volumeSize, zone, etcd, m, allMembers)
+
+			case kops.CloudProviderLinode:
+				b.addLinodeVolume(c, name, volumeSize, zone, etcd, m, allMembers)
 
 			case kops.CloudProviderMetal:
 				// Nothing special to do for Metal (yet)
@@ -428,6 +433,23 @@ func (b *MasterVolumeBuilder) addScalewayVolume(c *fi.CloudupModelBuilderContext
 		Zone:      &zone,
 		Tags:      volumeTags,
 		Type:      new(string(instance.VolumeVolumeTypeBSSD)),
+	}
+	c.AddTask(t)
+}
+
+func (b *MasterVolumeBuilder) addLinodeVolume(c *fi.CloudupModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
+	tags := []string{
+		fmt.Sprintf("%s:%s", linode.TagKubernetesClusterName, linode.NormalizeLinodeLabel(b.Cluster.ObjectMeta.Name)),
+		fmt.Sprintf("%s:%s", linode.TagKubernetesInstanceGroup, linode.NormalizeLinodeLabel(fi.ValueOf(m.InstanceGroup))),
+		fmt.Sprintf("%s:%s", linode.TagKubernetesVolumeRole, linode.NormalizeLinodeLabel(etcd.Name)),
+	}
+
+	t := &linodetasks.Volume{
+		Name:      new(name),
+		Lifecycle: b.Lifecycle,
+		SizeGB:    new(int(volumeSize)),
+		Region:    new(zone),
+		Tags:      tags,
 	}
 	c.AddTask(t)
 }

--- a/pkg/resources/linode/resources.go
+++ b/pkg/resources/linode/resources.go
@@ -36,6 +36,7 @@ const (
 	resourceTypeSubnet   = "subnet"
 	resourceTypeSSHKey   = "ssh-key"
 	resourceTypeInstance = "instance"
+	resourceTypeVolume   = "volume"
 )
 
 // parseTrackerIntID parses the tracker's string ID into an integer, which is used for Akamai (Linode) resource IDs.
@@ -55,6 +56,7 @@ func ListResources(cloud cloudlinode.LinodeCloud, clusterInfo resources.ClusterI
 		listVPCs,
 		listSubnets,
 		listInstances,
+		listVolumes,
 		listSSHKeys,
 	}
 
@@ -99,6 +101,38 @@ func listInstances(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resour
 			Blocks:  blocks,
 			Obj:     instance,
 		})
+	}
+
+	return resourceTrackers, nil
+}
+
+// listVolumes lists Akamai (Linode) block storage volumes owned by the cluster.
+func listVolumes(cloud fi.Cloud, clusterInfo resources.ClusterInfo) ([]*resources.Resource, error) {
+	c := cloud.(cloudlinode.LinodeCloud)
+	clusterTag := cloudlinode.NormalizeLinodeLabel(clusterInfo.Name)
+	listOptions, err := cloudlinode.ListOptionsForTags(fmt.Sprintf("%s:%s", cloudlinode.TagKubernetesClusterName, clusterTag))
+	if err != nil {
+		return nil, err
+	}
+
+	volumes, err := c.Client().ListVolumes(context.Background(), listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("error listing Akamai (Linode) volumes: %w", err)
+	}
+
+	resourceTrackers := make([]*resources.Resource, 0, len(volumes))
+	for _, volume := range volumes {
+		resourceTracker := &resources.Resource{
+			Name:    volume.Label,
+			ID:      strconv.Itoa(volume.ID),
+			Type:    resourceTypeVolume,
+			Deleter: deleteVolume,
+			Obj:     volume,
+		}
+		if volume.LinodeID != nil {
+			resourceTracker.Blocked = []string{resourceTypeInstance + ":" + strconv.Itoa(*volume.LinodeID)}
+		}
+		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
 
 	return resourceTrackers, nil
@@ -305,6 +339,24 @@ func deleteInstance(cloud fi.Cloud, tracker *resources.Resource) error {
 			return nil
 		}
 		return fmt.Errorf("error deleting Akamai (Linode) instance %s(%s): %w", tracker.Name, tracker.ID, err)
+	}
+
+	return nil
+}
+
+// deleteVolume deletes an Akamai (Linode) block storage volume.
+func deleteVolume(cloud fi.Cloud, tracker *resources.Resource) error {
+	c := cloud.(cloudlinode.LinodeCloud)
+	volumeID, err := parseTrackerIntID(tracker)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Client().DeleteVolume(context.Background(), volumeID); err != nil {
+		if linodego.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("error deleting Akamai (Linode) volume %s(%s): %w", tracker.Name, tracker.ID, err)
 	}
 
 	return nil

--- a/pkg/resources/linode/resources_test.go
+++ b/pkg/resources/linode/resources_test.go
@@ -129,6 +129,48 @@ func TestListResources_PropagatesErrors(t *testing.T) {
 	}
 }
 
+func TestListResourcesListsVolumes(t *testing.T) {
+	instanceID := 1001
+	client := &linode.MockLinodeClient{
+		ListVolumesResponse: []linodego.Volume{
+			{
+				ID:       1101,
+				Label:    "example-k8s-local-etcd-main",
+				LinodeID: &instanceID,
+				Tags:     []string{"kops.k8s.io/cluster:example-k8s-local"},
+			},
+		},
+	}
+	cloud := &linode.MockLinodeCloud{Client_: client, Region_: "us-east"}
+
+	resourceMap, err := ListResources(cloud, resources.ClusterInfo{Name: "example.k8s.local"})
+	if err != nil {
+		t.Fatalf("ListResources returned error: %v", err)
+	}
+
+	tracker := resourceMap["volume:1101"]
+	if tracker == nil {
+		t.Fatalf("missing volume:1101")
+	}
+	if got, want := tracker.Name, "example-k8s-local-etcd-main"; got != want {
+		t.Fatalf("unexpected volume name: got %q, want %q", got, want)
+	}
+	if got, want := tracker.Blocked, []string{"instance:1001"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected volume dependencies: got %v, want %v", got, want)
+	}
+
+	wantOptions, err := linode.ListOptionsForTags("kops.k8s.io/cluster:example-k8s-local")
+	if err != nil {
+		t.Fatalf("ListOptionsForTags returned error: %v", err)
+	}
+	if client.LastListVolumesOpts == nil {
+		t.Fatalf("expected volume list options to be recorded")
+	}
+	if got, want := client.LastListVolumesOpts.Filter, wantOptions.Filter; got != want {
+		t.Fatalf("unexpected volume list filter: got %q, want %q", got, want)
+	}
+}
+
 func TestDeleteVPC(t *testing.T) {
 	client := &linode.MockLinodeClient{}
 	cloud := &linode.MockLinodeCloud{Client_: client}
@@ -223,6 +265,30 @@ func TestDeleteInstance(t *testing.T) {
 			}
 			if !reflect.DeepEqual(client.DeletedInstanceIDs, testCase.wantDeleted) {
 				t.Fatalf("unexpected deleted instance IDs: got %v, want %v", client.DeletedInstanceIDs, testCase.wantDeleted)
+			}
+		})
+	}
+}
+
+func TestDeleteVolume(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		deleteError error
+		wantDeleted []int
+	}{
+		{name: "success", wantDeleted: []int{1101}},
+		{name: "not found", deleteError: &linodego.Error{Code: 404, Message: "not found"}, wantDeleted: []int{1101}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := &linode.MockLinodeClient{DeleteVolumeError: testCase.deleteError}
+			cloud := &linode.MockLinodeCloud{Client_: client}
+
+			tracker := &resources.Resource{Name: "example-k8s-local-etcd-main", ID: "1101", Type: resourceTypeVolume}
+			if err := deleteVolume(cloud, tracker); err != nil {
+				t.Fatalf("deleteVolume returned error: %v", err)
+			}
+			if !reflect.DeepEqual(client.DeletedVolumeIDs, testCase.wantDeleted) {
+				t.Fatalf("unexpected deleted volume IDs: got %v, want %v", client.DeletedVolumeIDs, testCase.wantDeleted)
 			}
 		})
 	}

--- a/upup/pkg/fi/cloudup/linode/cloud.go
+++ b/upup/pkg/fi/cloudup/linode/cloud.go
@@ -38,6 +38,7 @@ const (
 	TagKubernetesInstanceRole     = "kops.k8s.io/instance-role"
 	TagKubernetesClusterName      = "kops.k8s.io/cluster"
 	TagKubernetesInstanceUserData = "kops.k8s.io/instance-userdata"
+	TagKubernetesVolumeRole       = "kops.k8s.io/volume-role"
 )
 
 // LinodeClient is the subset of the Akamai (Linode) API client used by the Akamai (Linode) cloudup tasks.
@@ -60,7 +61,8 @@ type LinodeClient interface {
 	ListInterfaces(ctx context.Context, instanceID int, opts *linodego.ListOptions) ([]linodego.LinodeInterface, error)
 	CreateVolume(ctx context.Context, opts linodego.VolumeCreateOptions) (*linodego.Volume, error)
 	ListVolumes(ctx context.Context, opts *linodego.ListOptions) ([]linodego.Volume, error)
-	// TODO(moshevayner): Add DeleteVolume and UpdateVolume/ResizeVolume methods to support volume deletion, update and resizing.
+	DeleteVolume(ctx context.Context, volumeID int) error
+	ResizeVolume(ctx context.Context, volumeID int, opts linodego.VolumeResizeOptions) error
 }
 
 // LinodeCloud exposes Akamai (Linode) cloud APIs used by kOps.

--- a/upup/pkg/fi/cloudup/linode/mock_linode_cloud.go
+++ b/upup/pkg/fi/cloudup/linode/mock_linode_cloud.go
@@ -177,6 +177,15 @@ type MockLinodeClient struct {
 	CreateVolumeError    error
 	CreateVolumeCalls    int
 	LastCreateVolumeOpts linodego.VolumeCreateOptions
+
+	DeleteVolumeError error
+	DeleteVolumeCalls int
+	DeletedVolumeIDs  []int
+
+	ResizeVolumeError    error
+	ResizeVolumeCalls    int
+	ResizedVolumeIDs     []int
+	LastResizeVolumeOpts linodego.VolumeResizeOptions
 }
 
 var _ LinodeClient = &MockLinodeClient{}
@@ -366,4 +375,17 @@ func (c *MockLinodeClient) ListVolumes(ctx context.Context, opts *linodego.ListO
 		return nil, c.ListVolumesError
 	}
 	return c.ListVolumesResponse, nil
+}
+
+func (c *MockLinodeClient) DeleteVolume(ctx context.Context, volumeID int) error {
+	c.DeleteVolumeCalls++
+	c.DeletedVolumeIDs = append(c.DeletedVolumeIDs, volumeID)
+	return c.DeleteVolumeError
+}
+
+func (c *MockLinodeClient) ResizeVolume(ctx context.Context, volumeID int, opts linodego.VolumeResizeOptions) error {
+	c.ResizeVolumeCalls++
+	c.ResizedVolumeIDs = append(c.ResizedVolumeIDs, volumeID)
+	c.LastResizeVolumeOpts = opts
+	return c.ResizeVolumeError
 }

--- a/upup/pkg/fi/cloudup/linodetasks/volume.go
+++ b/upup/pkg/fi/cloudup/linodetasks/volume.go
@@ -94,9 +94,10 @@ func (_ *Volume) CheckChanges(actual, expected, changes *Volume) error {
 		if changes.Region != nil {
 			return fi.CannotChangeField("Region")
 		}
-		// TODO(moshevayner): Add support for resizing a volume.
 		if changes.SizeGB != nil {
-			return fi.CannotChangeField("SizeGB")
+			if fi.ValueOf(expected.SizeGB) < fi.ValueOf(actual.SizeGB) {
+				return fmt.Errorf("SizeGB cannot be decreased")
+			}
 		}
 		if changes.Tags != nil {
 			return fi.CannotChangeField("Tags")
@@ -121,6 +122,14 @@ func (_ *Volume) CheckChanges(actual, expected, changes *Volume) error {
 
 func (*Volume) RenderLinode(t *linode.APITarget, actual, expected, changes *Volume) error {
 	if actual != nil {
+		expected.ID = actual.ID
+		if changes.SizeGB == nil {
+			return nil
+		}
+		if err := t.Cloud.Client().ResizeVolume(context.Background(), fi.ValueOf(actual.ID), linodego.VolumeResizeOptions{Size: fi.ValueOf(expected.SizeGB)}); err != nil {
+			return fmt.Errorf("error resizing Akamai (Linode) volume %q: %w", fi.ValueOf(actual.Name), err)
+		}
+		klog.V(2).Infof("Resized Akamai (Linode) volume %q (id=%d) to %d GB", fi.ValueOf(actual.Name), fi.ValueOf(actual.ID), fi.ValueOf(expected.SizeGB))
 		return nil
 	}
 

--- a/upup/pkg/fi/cloudup/linodetasks/volume_test.go
+++ b/upup/pkg/fi/cloudup/linodetasks/volume_test.go
@@ -118,6 +118,46 @@ func TestVolumeRenderLinodeCreate(t *testing.T) {
 	}
 }
 
+func TestVolumeRenderLinodeResize(t *testing.T) {
+	client := &linode.MockLinodeClient{}
+	target := linode.NewAPITarget(&linode.MockLinodeCloud{Client_: client})
+	actual := &Volume{ID: new(42), Name: new("example-k8s-local-etcd-main"), SizeGB: new(20)}
+	expected := &Volume{SizeGB: new(30)}
+	changes := &Volume{SizeGB: expected.SizeGB}
+
+	if err := (&Volume{}).RenderLinode(target, actual, expected, changes); err != nil {
+		t.Fatalf("RenderLinode returned error: %v", err)
+	}
+	if got, want := client.ResizeVolumeCalls, 1; got != want {
+		t.Fatalf("unexpected resize calls: got %d, want %d", got, want)
+	}
+	if got, want := client.ResizedVolumeIDs, []int{42}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected resized volume IDs: got %v, want %v", got, want)
+	}
+	if got, want := client.LastResizeVolumeOpts.Size, 30; got != want {
+		t.Fatalf("unexpected resize size: got %d, want %d", got, want)
+	}
+	if got, want := fi.ValueOf(expected.ID), 42; got != want {
+		t.Fatalf("expected task ID to stay populated after resize: got %d, want %d", got, want)
+	}
+}
+
+func TestVolumeRenderLinodeResizeError(t *testing.T) {
+	client := &linode.MockLinodeClient{ResizeVolumeError: errors.New("resize API down")}
+	target := linode.NewAPITarget(&linode.MockLinodeCloud{Client_: client})
+	actual := &Volume{ID: new(42), Name: new("example-k8s-local-etcd-main"), SizeGB: new(20)}
+	expected := &Volume{SizeGB: new(30)}
+	changes := &Volume{SizeGB: expected.SizeGB}
+
+	err := (&Volume{}).RenderLinode(target, actual, expected, changes)
+	if err == nil {
+		t.Fatalf("expected resize error")
+	}
+	if !strings.Contains(err.Error(), "resize API down") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestVolumeCheckChangesRejectsUnsupportedChanges(t *testing.T) {
 	actual := &Volume{
 		ID:     new(42),
@@ -133,11 +173,6 @@ func TestVolumeCheckChangesRejectsUnsupportedChanges(t *testing.T) {
 		changes  *Volume
 	}{
 		{
-			name:     "size",
-			expected: &Volume{SizeGB: new(30)},
-			changes:  &Volume{SizeGB: new(30)},
-		},
-		{
 			name:     "tags",
 			expected: &Volume{Tags: []string{"kops.k8s.io/cluster:other.k8s.local"}},
 			changes:  &Volume{Tags: []string{"kops.k8s.io/cluster:other.k8s.local"}},
@@ -148,6 +183,20 @@ func TestVolumeCheckChangesRejectsUnsupportedChanges(t *testing.T) {
 				t.Fatalf("expected %s change to be rejected", testCase.name)
 			}
 		})
+	}
+}
+
+func TestVolumeCheckChangesRejectsSizeDecrease(t *testing.T) {
+	actual := &Volume{SizeGB: new(20)}
+	expected := &Volume{SizeGB: new(10)}
+	changes := &Volume{SizeGB: expected.SizeGB}
+
+	err := (&Volume{}).CheckChanges(actual, expected, changes)
+	if err == nil {
+		t.Fatalf("expected size decrease to be rejected")
+	}
+	if !strings.Contains(err.Error(), "SizeGB cannot be decreased") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION

Signed-off-by: Moshe Vayner <moshe@vayner.me>

<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:
Create Akamai (Linode) volume tasks for etcd members and configure etcd-manager volume selectors and Object Storage checksum settings.

Support growth-only volume resizing. Discover and delete cluster-tagged volumes during resource cleanup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
