### PR TITLE
Make nodeup resilient to task failures

### DIFF
--- a/upup/pkg/fi/executor.go
+++ b/upup/pkg/fi/executor.go
@@ -136,6 +136,8 @@ func (e *executor[T]) RunTasks(ctx context.Context, taskMap map[string]Task[T]) 
 
 				remaining := time.Second * time.Duration(int(time.Until(ts.deadline).Seconds()))
 				if _, ok := err.(*TryAgainLaterError); ok {
+				var tryAgainLater *TryAgainLaterError
+				if errors.As(err, &tryAgainLater) {
 					klog.V(2).Infof("Task %q not ready: %v", ts.key, err)
 				} else {
 					klog.Warningf("error running task %q (%v remaining to succeed): %v", ts.key, remaining, err)

--- a/upup/pkg/fi/executor.go
+++ b/upup/pkg/fi/executor.go
@@ -159,8 +159,8 @@ func (e *executor[T]) RunTasks(ctx context.Context, taskMap map[string]Task[T]) 
 
 			tryAgainLaterCount := 0
 			for _, err := range errs {
-				var tryAgainLaterError TryAgainLaterError
-				if !errors.Is(err, &tryAgainLaterError) {
+				var tryAgainLater *TryAgainLaterError
+				if errors.As(err, &tryAgainLater) {
 					tryAgainLaterCount++
 				}
 			}

--- a/upup/pkg/fi/executor.go
+++ b/upup/pkg/fi/executor.go
@@ -135,7 +135,6 @@ func (e *executor[T]) RunTasks(ctx context.Context, taskMap map[string]Task[T]) 
 				}
 
 				remaining := time.Second * time.Duration(int(time.Until(ts.deadline).Seconds()))
-				if _, ok := err.(*TryAgainLaterError); ok {
 				var tryAgainLater *TryAgainLaterError
 				if errors.As(err, &tryAgainLater) {
 					klog.V(2).Infof("Task %q not ready: %v", ts.key, err)

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -376,20 +376,23 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 
 	context, err := fi.NewNodeupContext(ctx, target, keyStore, &bootConfig, &nodeupConfig, taskMap)
 	if err != nil {
-		klog.Exitf("error building context: %v", err)
+		return fmt.Errorf("error building context: %w", err)
 	}
 
 	var options fi.RunTasksOptions
 	options.InitDefaults()
 
+	// Return rather than exit, so that the retry loop in cmd/nodeup gets to run:
+	// kops-configuration.service is Type=oneshot, so a bootstrap that exits here is never
+	// retried and the node never joins the cluster.
 	err = context.RunTasks(options)
 	if err != nil {
-		klog.Exitf("error running tasks: %v", err)
+		return fmt.Errorf("error running tasks: %w", err)
 	}
 
 	err = target.Finish(taskMap)
 	if err != nil {
-		klog.Exitf("error closing target: %v", err)
+		return fmt.Errorf("error closing target: %w", err)
 	}
 
 	if nodeupConfig.EnableLifecycleHook {


### PR DESCRIPTION

 Return bootstrap errors instead of exiting the process
 
 
Fixes issue #https://github.com/kubernetes/kubernetes/issues/141447



More context here in this comment - https://github.com/kubernetes/kubernetes/issues/141447#issuecomment-5335642721