### PR TITLE
nodeup: install kernel-modules-extra on RHEL10-family nodes

### DIFF
--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -611,16 +611,19 @@ func modprobe(module string) error {
 // and used by some components to load its recommended modules.
 // TODO: Move to tasks architecture
 func loadKernelModules(context *model.NodeupModelContext, distribution distributions.Distribution) error {
+	var failed []string
 	if context.NodeupConfig.Networking.Kindnet != nil {
 		err := modprobe("nfnetlink_queue")
 		if err != nil {
 			klog.Warningf("error loading nfnetlink_queue module: %v", err)
+			failed = append(failed, "nfnetlink_queue")
 		}
 	} else {
 		err := modprobe("br_netfilter")
 		if err != nil {
 			// TODO: Return error in 1.11 (too risky for 1.10)
 			klog.Warningf("error loading br_netfilter module: %v", err)
+			failed = append(failed, "br_netfilter")
 		}
 	}
 	if distribution.ForceNftables() {
@@ -635,6 +638,23 @@ func loadKernelModules(context *model.NodeupModelContext, distribution distribut
 		for _, mod := range []string{"nf_tables", "nf_conntrack", "ip_set"} {
 			if err := modprobe(mod); err != nil {
 				klog.Warningf("error loading %s module: %v", mod, err)
+				failed = append(failed, mod)
+			}
+		}
+		// A module that is missing rather than merely unloaded means the image
+		// never got kernel-modules-extra, which is where ip_set and br_netfilter
+		// live alongside nft_compat and the xt_* matches that iptables-nft
+		// autoloads. Without it every iptables-nft rule carrying an xt match
+		// fails and the masquerade and CNI chains are left silently empty.
+		if len(failed) > 0 {
+			if err := installKernelModulesExtra(); err != nil {
+				klog.Warningf("error installing kernel-modules-extra: %v", err)
+			} else {
+				for _, mod := range failed {
+					if err := modprobe(mod); err != nil {
+						klog.Warningf("error loading %s module after installing kernel-modules-extra: %v", mod, err)
+					}
+				}
 			}
 		}
 	} else {
@@ -650,6 +670,32 @@ func loadKernelModules(context *model.NodeupModelContext, distribution distribut
 		}
 	}
 	// TODO: Add to /etc/modules-load.d/ ?
+	return nil
+}
+
+// installKernelModulesExtra installs the kernel-modules-extra package matching the
+// running kernel. The RHEL10 and Rocky10 images drop it from the iptables-nft
+// dependency chain, so nft_compat, the xt_* matches, ip_set and br_netfilter are
+// simply absent from a freshly booted node.
+//
+// The package is pinned to the running kernel release because an unpinned install
+// resolves to the newest build in the repo, whose modules land under a /lib/modules
+// directory we have not booted, leaving the running kernel just as empty.
+//
+// TODO: Move to tasks architecture along with loadKernelModules. It has to happen
+// here for now because the modprobes above run before any task does.
+func installKernelModulesExtra() error {
+	release, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		return fmt.Errorf("error reading kernel release: %w", err)
+	}
+
+	pkg := "kernel-modules-extra-" + strings.TrimSpace(string(release))
+	klog.Infof("Installing %s", pkg)
+	cmd := exec.Command("/usr/bin/dnf", "install", "-y", pkg)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("error installing %s (%v): %s", pkg, err, string(output))
+	}
 	return nil
 }
 


### PR DESCRIPTION
The RHEL 10 and Rocky 10 images ship no `kernel-modules-extra`, so `nft_compat.ko`, `xt_comment.ko`, `xt_addrtype.ko`, `xt_MASQUERADE.ko`, `ip_set.ko` and `br_netfilter.ko` are not merely unloaded — they are absent from `/lib/modules` entirely. `loadKernelModules` already tries to modprobe them and only warns:

```
W command.go:620] error loading br_netfilter module: modprobe ... failed:
    modprobe: FATAL: Module br_netfilter not found in directory /lib/modules/6.12.0-211.26.1.el10_2.aarch64
W command.go:634] error loading ip_set module: ... Module ip_set not found
```

On an affected node `/proc/modules` has 44 entries and **zero** of the six. Every `iptables` (nft backend) rule using an xt match then fails — `Warning: Extension MASQUERADE revision 0 not supported, missing kernel module?` / `RULE_APPEND failed (No such file or directory)` — including kubelet's own `KUBE-FIREWALL` chain.

That single cause surfaces as four unrelated-looking failures:

| CNI | Proximate failure |
|---|---|
| kubenet | `IP-MASQ` chain created but empty, no POSTROUTING jump, pods lose egress |
| calico | `felix/ipsets.go: ipset v7.11: Kernel error received: Invalid argument` (~9500x) |
| kube-router | `failed to determine if ipset set kube-router-pod-subnets exists: ipset v7.24: Kernel error` |
| flannel | `Failed to check br_netfilter: stat /proc/sys/net/bridge/bridge-nf-call-iptables: no such file` |

This is **AWS-specific in practice**: the GCE EL10 images do load all six (80-84 modules total), which is why `e2e-kops-grid-gce-kubenet-rocky10arm64-k34` is green while its AWS twin has never passed. ~50 grid jobs are affected.

@danwinship called this out on kubernetes/test-infra#36798 back in April: *"You may need to install kernel-modules-extra to get iptables on RHEL10."*

### Approach

Install the package when a modprobe fails, then retry the modules.

Two things worth reviewer attention:

1. **Why it is pinned to `$(uname -r)`.** An unpinned `dnf install kernel-modules-extra` resolves to the newest build in the repo, whose modules land under a `/lib/modules` directory we have not booted — leaving the running kernel just as empty. The release is read from `/proc/sys/kernel/osrelease`.

2. **Why it is not in `PackagesBuilder`.** That is the architecturally correct home, but `loadKernelModules` is called at `command.go:291` and tasks do not run until `context.RunTasks` at `:388`, so a `nodetasks.Package` would install *after* the modprobes. Doing it in place guarantees the ordering. It also sidesteps `Package.Name` being compared against `rpm -q %{NAME}` in `findYum`, which a pinned NVRA name would break. Happy to restructure if reviewers prefer extending the task instead — the function is already flagged `TODO: Move to tasks architecture`.

### Testing

Draft because this is **unverified on a real EL10 node** — it needs an e2e run to confirm dnf resolves the pinned NVRA on both RHEL10 and Rocky10 and that the retried modprobes succeed. Locally: `go build ./upup/...`, `go vet`, gofmt clean, and `go test ./upup/pkg/fi/nodeup/... ./nodeup/... ./util/pkg/distributions/...` all pass, but none of that exercises the new path.

Related: kubernetes/test-infra#37732 removes the Calico eBPF workaround that was added for this same root cause. That PR fixes the GCE half; this one is what the AWS half needs.

/cc @hakman @danwinship

🤖 Generated with [Claude Code](https://claude.com/claude-code)
