### PR TITLE
nodeup: order systemd-networkd restarts after package installs

### DIFF
--- a/nodeup/pkg/model/networking/eni_networking.go
+++ b/nodeup/pkg/model/networking/eni_networking.go
@@ -52,9 +52,10 @@ func maskEC2NetUtilsUdevRules(c *fi.NodeupModelBuilderContext, dist distribution
 	}
 
 	c.AddTask(&nodetasks.File{
-		Path:     "/etc/udev/rules.d/99-vpc-policy-routes.rules",
-		Contents: fi.NewStringResource(""),
-		Type:     nodetasks.FileType_File,
+		Path:          "/etc/udev/rules.d/99-vpc-policy-routes.rules",
+		Contents:      fi.NewStringResource(""),
+		Type:          nodetasks.FileType_File,
+		AfterPackages: true,
 		OnChangeExecute: [][]string{
 			// Reload udev rules so the empty mask file takes effect for future ENI attach events.
 			{"udevadm", "control", "--reload-rules"},
@@ -95,6 +96,7 @@ ManageForeignRoutingPolicyRules=no
 		Path:            "/usr/lib/systemd/networkd.conf.d/40-disable-manage-foreign-routes.conf",
 		Contents:        fi.NewStringResource(contents),
 		Type:            nodetasks.FileType_File,
+		AfterPackages:   true,
 		OnChangeExecute: [][]string{{"systemctl", "restart", "systemd-networkd"}},
 	})
 }
@@ -124,6 +126,7 @@ MACAddressPolicy=none
 		Path:            "/etc/systemd/network/99-default.link",
 		Contents:        fi.NewStringResource(contents),
 		Type:            nodetasks.FileType_File,
+		AfterPackages:   true,
 		OnChangeExecute: [][]string{{"systemctl", "restart", "systemd-networkd"}},
 	})
 }
@@ -173,6 +176,7 @@ Unmanaged=yes
 		Path:            "/etc/systemd/network/75-eni-secondary.network",
 		Contents:        fi.NewStringResource(contents),
 		Type:            nodetasks.FileType_File,
+		AfterPackages:   true,
 		OnChangeExecute: [][]string{{"systemctl", "restart", "systemd-networkd"}},
 	})
 	return nil

--- a/upup/pkg/fi/nodeup/nodetasks/file.go
+++ b/upup/pkg/fi/nodeup/nodetasks/file.go
@@ -41,7 +41,11 @@ const (
 )
 
 type File struct {
-	AfterFiles      []string    `json:"afterFiles,omitempty"`
+	AfterFiles []string `json:"afterFiles,omitempty"`
+	// AfterPackages orders this file after every Package task. Set it when
+	// OnChangeExecute restarts the network: nodeup schedules tasks in parallel,
+	// so an unordered restart can land mid apt-get/dnf and fail the package task.
+	AfterPackages   bool        `json:"afterPackages,omitempty"`
 	BeforeServices  []string    `json:"beforeServices,omitempty"`
 	Contents        fi.Resource `json:"contents,omitempty"`
 	Group           *string     `json:"group,omitempty"`
@@ -98,6 +102,18 @@ func (e *File) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
 				if file.Path == f {
 					deps = append(deps, v)
 				}
+			}
+		}
+	}
+
+	// Requires every package to be installed first. For tasks whose
+	// OnChangeExecute restarts the network, nodeup's parallel scheduling
+	// otherwise lets the restart land in the middle of an apt-get or dnf
+	// transaction, which fails the package task and aborts the bootstrap.
+	if e.AfterPackages {
+		for _, v := range tasks {
+			if _, ok := v.(*Package); ok {
+				deps = append(deps, v)
 			}
 		}
 	}

--- a/upup/pkg/fi/nodeup/nodetasks/file_test.go
+++ b/upup/pkg/fi/nodeup/nodetasks/file_test.go
@@ -72,6 +72,18 @@ func TestFileDependencies(t *testing.T) {
 				Type:       FileType_File,
 			},
 		},
+		{
+			name: "afterPackages",
+			parent: &Package{
+				Name: "iptables",
+			},
+			child: &File{
+				AfterPackages: true,
+				Path:          childFileName,
+				Contents:      fi.NewStringResource("I depend on every package"),
+				Type:          FileType_File,
+			},
+		},
 	}
 
 	for _, g := range grid {


### PR DESCRIPTION
Four File tasks in `nodeup/pkg/model/networking/eni_networking.go` restart systemd-networkd from `OnChangeExecute`. nodeup schedules tasks in parallel, so nothing stops those restarts from landing in the middle of an `apt-get` transaction.

### The race is live today

From [`e2e-kops-grid-cilium-eni-deb12-k35` build 2088708922297815040](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-cilium-eni-deb12-k35/2088708922297815040) (Aug 15), [`journal.log`](https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-grid-cilium-eni-deb12-k35/2088708922297815040/artifacts/52.199.201.128/journal.log) — package installs and networkd restarts fully interleaved inside ~180ms:

```
19:35:41.868318 nodeup: Executing task "Package/chrony"
19:35:41.880414 systemd[1]: Stopping systemd-networkd.service
19:35:41.880949 nodeup: Executing task "Package/unattended-upgrades"
19:35:41.883946 nodeup: Executing task "Package/libapparmor1"
19:35:41.905244 systemd[1]: Starting systemd-networkd.service
19:35:41.924383 nodeup: Executing task "Package/util-linux"
19:35:41.953505 systemd[1]: Starting systemd-networkd.service
19:35:41.960845 nodeup: Running command apt-get update          <-- 7ms after a restart
19:35:41.977303 nodeup: Executing task "Package/iptables"
19:35:42.029294 systemd[1]: Starting systemd-networkd.service   <-- 68ms into apt-get update
```

That node won the race. When it loses, the failure is:

```
E: Unable to locate package iptables
F command.go:387] error running tasks: deadline exceeded executing task Package/iptables
```

with `apt-get update` at 09:10:58.384 and `Stopping systemd-networkd` at 09:10:58.565 — 181ms apart. Two Debian 12 nodes show the same sub-100ms co-timing followed by 16-18 minutes of nodeup silence.

Note the **three** restarts in that trace. On a Debian 12 cilium-eni node exactly three of the four tasks apply (`maskEC2NetUtilsUdevRules` is AL2023-only), which is why this fixes all four rather than only `disableManageForeignRoutes`. `setMACAddressPolicyNone` and `markSecondaryENIsUnmanaged` carry the identical hazard.

### The fix

Add an `AfterPackages` field to the `File` task, mirroring the existing `AfterFiles`, making the file depend on every `Package` task. `Package.GetDependencies` only ever depends on `AptSource` and other `Package` tasks, so a `File -> Package` edge cannot introduce a cycle.

### Why not the alternatives

- **Dropping the restart.** `ManageForeignRoutes=no` lives in `networkd.conf`, which systemd-networkd reads only at startup. networkd is already running by the time nodeup lands the drop-in, so without a restart the setting would not take effect on the boot that installs it, and networkd could still clobber CNI routes — the exact bug the file exists to prevent.
- **`networkctl reload`.** Reloads `.network`/`.netdev` files, not `networkd.conf`, so it has the same problem for `disableManageForeignRoutes`.
- **Restarting *before* packages instead of after.** Also closes the window, but ordering after is the safer edge (no cycle risk) and correctness is unaffected: CNI does not add routes until kubelet starts pods, long after nodeup finishes.

### Exposure

`disableManageForeignRoutes` is called unconditionally for cilium (`networking/cilium.go:61`) and amazon-vpc (`amazon-vpc-routed-eni.go:38`). Its guard was `(Ubuntu >= 22.04) || AmazonLinux2023` in v1.35.1 and gained `(Debian >= 12)` in v1.36.1 via `62aab309c7`, which is what widened the exposure.

### Testing

Added an `afterPackages` case to the existing `TestFileDependencies` table. I checked it is not vacuous — with the flag off it fails with `found unexpected dependencies for child: File: "/dependent" []`, and passes with it on.

`go build ./...`, `go vet`, gofmt clean, and `./upup/pkg/fi/nodeup/... ./nodeup/...` all pass.

**Not verified on a live node.** The race is timing-dependent and low-rate, so a green e2e run does not prove much either way — I scanned the latest build of 491 cilium/amazonvpc grid jobs on affected distros and none of the 28 currently-failing ones are failing on this signature right now. The evidence that it is real is the interleaving above plus the captured failures.

/cc @hakman

🤖 Generated with [Claude Code](https://claude.com/claude-code)
