### PR TITLE
Fix flaky concurrent rolling-update tests

### DIFF
--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -1074,6 +1074,10 @@ type concurrentTest struct {
 	validationChan          chan bool
 	terminationChan         chan bool
 	detached                map[string]bool
+	// wakers tracks the delayThenWakeValidation goroutines so the test does not
+	// finish while one is still live. A t.Error from a goroutine that outlives
+	// its test panics the whole test binary rather than failing the test.
+	wakers sync.WaitGroup
 }
 
 func (c *concurrentTest) Validate(ctx context.Context) (*validation.ValidationCluster, error) {
@@ -1156,6 +1160,7 @@ func (c *concurrentTest) TerminateInstances(ctx context.Context, input *ec2.Term
 				c.t.Error("timed out reading from terminationChan")
 			}
 			c.mutex.Lock()
+			c.wakers.Add(1)
 			go c.delayThenWakeValidation()
 		case 5, 3:
 			assert.Equal(c.t, terminationRequestsLeft+1, c.previousValidation, "previous validation")
@@ -1167,6 +1172,7 @@ func (c *concurrentTest) TerminateInstances(ctx context.Context, input *ec2.Term
 const postTerminationValidationDelay = 100 * time.Millisecond // NodeInterval plus some
 
 func (c *concurrentTest) delayThenWakeValidation() {
+	defer c.wakers.Done()
 	time.Sleep(postTerminationValidationDelay)
 	select {
 	case c.validationChan <- true:
@@ -1176,6 +1182,7 @@ func (c *concurrentTest) delayThenWakeValidation() {
 }
 
 func (c *concurrentTest) AssertComplete() {
+	c.wakers.Wait()
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	assert.Equal(c.t, 0, c.previousValidation, "last validation")
@@ -1187,9 +1194,17 @@ func newConcurrentTest(t *testing.T, cloud *awsup.MockAWSCloud, numSurge int, al
 		t:                       t,
 		surge:                   numSurge,
 		terminationRequestsLeft: 6,
-		validationChan:          make(chan bool),
-		terminationChan:         make(chan bool),
-		detached:                map[string]bool{},
+		// Buffered: these channels are a wake-up mechanism between the Validate
+		// and TerminateInstances mocks, which do not arrive in a fixed order. On
+		// an unbuffered channel a non-blocking send lands in the default branch
+		// unless the peer is already parked in its receive, so whichever mock got
+		// there first would report a spurious "channel is full" and the other
+		// would then time out. With room for one token the handoff works in
+		// either order, and the default branch still catches a genuine
+		// double-signal.
+		validationChan:  make(chan bool, 1),
+		terminationChan: make(chan bool, 1),
+		detached:        map[string]bool{},
 	}
 	if numSurge == 0 && allNeedUpdate {
 		test.terminationRequestsLeft = 7

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -1186,6 +1186,8 @@ func (c *concurrentTest) AssertComplete() {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	assert.Equal(c.t, 0, c.previousValidation, "last validation")
+	assert.Empty(c.t, c.terminationChan, "unconsumed termination token")
+	assert.Empty(c.t, c.validationChan, "unconsumed validation token")
 }
 
 func newConcurrentTest(t *testing.T, cloud *awsup.MockAWSCloud, numSurge int, allNeedUpdate bool) *concurrentTest {
@@ -1206,6 +1208,7 @@ func newConcurrentTest(t *testing.T, cloud *awsup.MockAWSCloud, numSurge int, al
 		terminationChan: make(chan bool, 1),
 		detached:        map[string]bool{},
 	}
+	t.Cleanup(test.wakers.Wait)
 	if numSurge == 0 && allNeedUpdate {
 		test.terminationRequestsLeft = 7
 	}


### PR DESCRIPTION
`TestRollingUpdateMaxSurgeAllNeedUpdate` failed on an unrelated PR ([run 32421320715, build-linux-arm64](https://github.com/kubernetes/kops/actions/runs/32421320715/job/96593766598)) and took the whole `pkg/instancegroups` test binary down with it:

```
rollingupdate_test.go:1116: terminationChan is full
rollingupdate_test.go:1156: timed out reading from terminationChan
rollingupdate_test.go:1122: timed out reading from validationChan
--- FAIL: TestRollingUpdateMaxSurgeAllNeedUpdate (1.22s)
panic: Fail in goroutine after TestRollingUpdateMaxSurgeAllNeedUpdate has completed
```

Two separate defects in the `concurrentTest` harness.

### 1. The handoff depends on which mock arrives first

`Validate` and `TerminateInstances` rendezvous over `validationChan` and `terminationChan`, both created with `make(chan bool)` — **unbuffered** — and signalled with a non-blocking send whose default branch reports `"... is full"`.

On an unbuffered channel a non-blocking send succeeds only if the peer is *already parked* in its receive. The two mocks are driven by different goroutines and do not arrive in a fixed order, so whenever the sender got there first it fell into `default` and reported a channel full that was actually empty. The peer then sat in its receive until the one-second timeout. That is exactly the three-line sequence above.

Demonstrating the semantics in isolation:

```go
func trySend(ch chan bool) string {
    select {
    case ch <- true:
        return "sent"
    default:
        return "reported \"channel is full\""
    }
}
```
```
unbuffered, no receiver parked:   reported "channel is full"
buffered(1), no receiver parked:  sent
buffered(1), token still pending: reported "channel is full"
```

Giving each channel room for one token makes the handoff work in either order while keeping the assertion honest: `default` still fires on a genuine double-signal, and the one-second timeouts still catch a peer that never arrives. The `previousValidation` assertions that actually enforce the documented interleaving are untouched.

### 2. A `t.Error` outliving its test panics the binary

`delayThenWakeValidation` runs in a goroutine that sleeps 100ms and then calls `c.t.Error` if its send fails. Once defect 1 derailed the sequence, the test finished while that goroutine was still asleep, and `t.Error` from a goroutine that outlives its test panics rather than failing:

```
panic: Fail in goroutine after TestRollingUpdateMaxSurgeAllNeedUpdate has completed
    k8s.io/kops/pkg/instancegroups.(*concurrentTest).delayThenWakeValidation
        pkg/instancegroups/rollingupdate_test.go:1174
```

Because it panics, the remaining tests in the package never run — one flaky test takes out the whole binary. Tracking those goroutines in a `sync.WaitGroup` and joining them in `AssertComplete` (called by all six tests that use the harness) keeps a failure a failure.

### Testing

- `go test ./pkg/instancegroups/ -count=20` — clean
- `go test ./pkg/instancegroups/ -race -count=8` — clean
- `go vet`, gofmt clean

I was **not able to reproduce the original flake locally** — 40 runs, plus 30 at `-cpu=1`, plus 25 under saturating CPU load, all passed. It is rare: the last 40 master CI runs are green and master failures are months apart. So the case here rests on the channel semantics above rather than on a before/after reproduction, and defect 2 is worth fixing on its own merits regardless.

Found while investigating CI on #18725; entirely unrelated to that change, hence a separate PR. `pkg/instancegroups` does not depend on either package #18725 touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
