### PR TITLE
Automated cherry pick of #18727: Disable kindnet DNS caching by default

### DIFF
--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: 6bb2eef717e9b77664f55e3029343bb375dba58595c5cbedbff2eaebae108e66
+    manifestHash: 20e995b07e4c5036da40d08b255fe1dae70d673e59c97e14322fa089c67a0888
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -106,7 +106,7 @@ spec:
         - /bin/kindnetd
         - --hostname-override=$(NODE_NAME)
         - --v=2
-        - --dns-caching=true
+        - --dns-caching=false
         - --nat64=false
         - --fastpath-threshold=0
         - --masquerading=false

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -98,7 +98,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: 8eec5430c6c2d0a29696015bc2679de0bf2f2444f6a6f103ac54f03bdb5a4114
+    manifestHash: ec6830ba8c3deba2a70c0bb01bfa094bbd62f6ac80eb673b18d5fe6e937adc00
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -106,7 +106,7 @@ spec:
         - /bin/kindnetd
         - --hostname-override=$(NODE_NAME)
         - --v=2
-        - --dns-caching=true
+        - --dns-caching=false
         - --nat64=false
         - --fastpath-threshold=0
         - --masquerading=true

--- a/upup/models/cloudup/resources/addons/networking.kindnet/k8s-1.32.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kindnet/k8s-1.32.yaml.template
@@ -122,7 +122,7 @@ spec:
         {{ if .Networking.Kindnet.BaselineAdminNetworkPolicies }}
         - --admin-network-policy={{ .Networking.Kindnet.BaselineAdminNetworkPolicies }}
         {{ end }}
-        - --dns-caching={{ WithDefaultBool .Networking.Kindnet.DNSCaching true }}
+        - --dns-caching={{ WithDefaultBool .Networking.Kindnet.DNSCaching false }}
         - --nat64={{ WithDefaultBool .Networking.Kindnet.NAT64 false }}
         - --fastpath-threshold={{ .Networking.Kindnet.FastPathThreshold }}
         {{- if .Networking.Kindnet.Masquerade }}


### PR DESCRIPTION
Cherry pick of #18727 on release-1.35.

#18727: Disable kindnet DNS caching by default

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note

```