### PR TITLE
Automated cherry pick of #18724: nodeup: install kernel-modules-extra on RHEL10-family nodes

### DIFF
--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -579,16 +579,19 @@ func modprobe(module string) error {
 // and used by some components to load its recommended modules.
 // TODO: Move to tasks architecture
 func loadKernelModules(context *model.NodeupModelContext, distribution distributions.Distribution) error {
+	var failed []string
 	if context.NodeupConfig.Networking.Kindnet != nil {
 		err := modprobe("nfnetlink_queue")
 		if err != nil {
 			klog.Warningf("error loading nfnetlink_queue module: %v", err)
+			failed = append(failed, "nfnetlink_queue")
 		}
 	} else {
 		err := modprobe("br_netfilter")
 		if err != nil {
 			// TODO: Return error in 1.11 (too risky for 1.10)
 			klog.Warningf("error loading br_netfilter module: %v", err)
+			failed = append(failed, "br_netfilter")
 		}
 	}
 	if distribution.ForceNftables() {
@@ -603,6 +606,23 @@ func loadKernelModules(context *model.NodeupModelContext, distribution distribut
 		for _, mod := range []string{"nf_tables", "nf_conntrack", "ip_set"} {
 			if err := modprobe(mod); err != nil {
 				klog.Warningf("error loading %s module: %v", mod, err)
+				failed = append(failed, mod)
+			}
+		}
+		// A module that is missing rather than merely unloaded means the image
+		// never got kernel-modules-extra, which is where ip_set and br_netfilter
+		// live alongside nft_compat and the xt_* matches that iptables-nft
+		// autoloads. Without it every iptables-nft rule carrying an xt match
+		// fails and the masquerade and CNI chains are left silently empty.
+		if len(failed) > 0 {
+			if err := installKernelModulesExtra(); err != nil {
+				klog.Warningf("error installing kernel-modules-extra: %v", err)
+			} else {
+				for _, mod := range failed {
+					if err := modprobe(mod); err != nil {
+						klog.Warningf("error loading %s module after installing kernel-modules-extra: %v", mod, err)
+					}
+				}
 			}
 		}
 	} else {
@@ -618,6 +638,32 @@ func loadKernelModules(context *model.NodeupModelContext, distribution distribut
 		}
 	}
 	// TODO: Add to /etc/modules-load.d/ ?
+	return nil
+}
+
+// installKernelModulesExtra installs the kernel-modules-extra package matching the
+// running kernel. The RHEL10 and Rocky10 images drop it from the iptables-nft
+// dependency chain, so nft_compat, the xt_* matches, ip_set and br_netfilter are
+// simply absent from a freshly booted node.
+//
+// The package is pinned to the running kernel release because an unpinned install
+// resolves to the newest build in the repo, whose modules land under a /lib/modules
+// directory we have not booted, leaving the running kernel just as empty.
+//
+// TODO: Move to tasks architecture along with loadKernelModules. It has to happen
+// here for now because the modprobes above run before any task does.
+func installKernelModulesExtra() error {
+	release, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		return fmt.Errorf("error reading kernel release: %w", err)
+	}
+
+	pkg := "kernel-modules-extra-" + strings.TrimSpace(string(release))
+	klog.Infof("Installing %s", pkg)
+	cmd := exec.Command("/usr/bin/dnf", "install", "-y", pkg)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("error installing %s (%v): %s", pkg, err, string(output))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #18724 on release-1.36.

#18724: nodeup: install kernel-modules-extra on RHEL10-family nodes

```release-note
Fixed pod networking on RHEL 10 and Rocky Linux 10 nodes, where the AMIs omit kernel-modules-extra and every iptables-nft rule carrying an xt match was silently dropped.
```

### Why this needs a backport

The RHEL10 and Rocky10 AMIs no longer pull `kernel-modules-extra` through the `iptables-nft` dependency chain, so `nft_compat`, the `xt_*` matches, `ip_set` and `br_netfilter` are absent from a freshly booted node. Every iptables-nft rule carrying an xt match then fails:

```
Warning: Extension MASQUERADE revision 0 not supported, missing kernel module?
iptables v1.8.11 (nf_tables): RULE_APPEND failed (No such file or directory): rule in chain IP-MASQ
```

The kOps masquerade chain and the CNI chains are left silently empty, so pod egress has no SNAT. It surfaces differently per CNI — kubenet loses IMDS/STS access, calico and kube-router fail on `ipset ... Kernel error received: Invalid argument`, flannel exits on the missing `bridge-nf-call-iptables` sysctl — but the cause is the same for all of them, and cilium and kindnet are unaffected because neither touches the compat layer.

EL10 is a supported distro on release-1.36, so without this the clusters are broken for real users, not just in CI. The 26 AWS EL10 grid jobs pinned to kOps 1.35/1.36 are currently red for this reason.

Verified `go build` and `go vet ./upup/pkg/fi/nodeup/...` on this branch after the pick; it applied without conflict.

/sig cluster-lifecycle