### PR TITLE
dump: capture Calico BGP session state from each node

### DIFF
--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -250,6 +250,8 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 
 		dumper := dump.NewLogDumper(bastionAddress, sshConfig, keyRing, options.Dir, options.NodeDumpTimeout)
 
+		dumper.SetDumpBGP(cluster.Spec.Networking.Calico != nil)
+
 		// Karpenter nodes never get the cluster SSH key pair (their EC2NodeClass has no key-name
 		// field). When Karpenter is enabled, grant short-lived access via EC2 Instance Connect
 		// before connecting, using the public key matching --private-key. A no-op without the agent.

--- a/docs/e2e-failure-troubleshooting.md
+++ b/docs/e2e-failure-troubleshooting.md
@@ -137,6 +137,10 @@ Each build directory contains the following hierarchy:
         ├── ip-rules.log       # ip rule list
         ├── ip-link.log        # ip -s link
         ├── netstat.log        # ss -s (socket statistics)
+        ├── bgp-protocols.log  # birdcl show protocols all (Calico only)
+        ├── bird.cfg           # confd-generated BIRD config (Calico only)
+        ├── bgp-sockets.log    # TCP sockets on port 179 (Calico only)
+        ├── bgp-conntrack.log  # conntrack entries for port 179 (Calico only)
         │
         │   # System state:
         ├── etchosts           # /etc/hosts

--- a/pkg/dump/dumper.go
+++ b/pkg/dump/dumper.go
@@ -51,6 +51,9 @@ type logDumper struct {
 	files        []string
 	podSelectors []string
 
+	// dumpBGP enables the Calico BIRD captures, which are meaningless on other CNIs.
+	dumpBGP bool
+
 	// sshAccessGranter grants short-lived SSH access to a node before connecting. On AWS it uses
 	// EC2 Instance Connect so Karpenter nodes, lacking the cluster SSH key pair, are reachable.
 	sshAccessGranter SSHAccessGranter
@@ -119,6 +122,11 @@ func NewLogDumper(bastionAddress string, sshConfig *ssh.ClientConfig, keyRing ag
 // SetSSHAccessGranter registers a hook to grant SSH access to a node before connecting.
 func (d *logDumper) SetSSHAccessGranter(granter SSHAccessGranter) {
 	d.sshAccessGranter = granter
+}
+
+// SetDumpBGP enables capturing Calico BIRD session state from each node.
+func (d *logDumper) SetDumpBGP(enabled bool) {
+	d.dumpBGP = enabled
 }
 
 // grantSSHAccess best-effort grants SSH access before connecting. Failures are non-fatal: some
@@ -419,6 +427,36 @@ func (n *logDumperNode) dump(ctx context.Context) []error {
 	}
 	if err := n.shellToFile(ctx, "ss -s", filepath.Join(n.dir, "netstat.log")); err != nil {
 		errors = append(errors, err)
+	}
+
+	if n.dumper.dumpBGP {
+		// calico-node is hostNetwork, so the sockets and conntrack entries are visible
+		// from the host, but birdcl and the confd-generated config only exist inside
+		// the container -- hence the hop into bird's mount namespace. Without "show
+		// protocols all" there is no record of why a session failed to establish:
+		// BIRD reports a stuck peer only in its own state, and the calico-node pod log
+		// is collected with kubectl logs and routinely truncated past the point where
+		// the session was set up. The pgrep guard still matters here: Calico in VXLAN
+		// mode runs no BIRD at all.
+		const inBirdNS = `pid=$(pgrep -x bird 2>/dev/null | head -1); if [ -n "$pid" ]; then sudo nsenter -t "$pid" -m -- `
+		if err := n.shellToFile(ctx, inBirdNS+"birdcl -s /var/run/calico/bird.ctl show protocols all; fi", filepath.Join(n.dir, "bgp-protocols.log")); err != nil {
+			errors = append(errors, err)
+		}
+		if err := n.shellToFile(ctx, inBirdNS+"cat /etc/calico/confd/config/bird.cfg; fi", filepath.Join(n.dir, "bird.cfg")); err != nil {
+			errors = append(errors, err)
+		}
+		if err := n.shellToFile(ctx, "sudo ss -tanp state all '( sport = :179 or dport = :179 )'", filepath.Join(n.dir, "bgp-sockets.log")); err != nil {
+			errors = append(errors, err)
+		}
+		// The conntrack CLI is absent from most node images, so fall back to the kernel
+		// table, which is populated whenever kube-proxy is running. It cannot be guarded
+		// with a test: /proc/net/nf_conntrack is 0440 root:root and this shell is not
+		// root, so only the privileged read itself can tell us whether it is there.
+		const conntrack179 = `if command -v conntrack &> /dev/null; then sudo conntrack -L -p tcp --dport 179; ` +
+			`else sudo grep -E 'sport=179|dport=179' /proc/net/nf_conntrack 2>/dev/null || true; fi`
+		if err := n.shellToFile(ctx, conntrack179, filepath.Join(n.dir, "bgp-conntrack.log")); err != nil {
+			errors = append(errors, err)
+		}
 	}
 
 	// Capture any file logs where the files exist


### PR DESCRIPTION
Adds four per-node captures to `kops toolbox dump` so that a failed Calico BGP session leaves evidence behind.

```release-note
NONE
```

### Why

Triaging the GCE Calico grid failures, the recurring dead end is that the artifacts record the *symptom* and nothing else. The control plane's `ip-routes.log` is missing a `proto bird` route for one peer, and there is no way to tell a SYN that was never sent from one that never arrived.

I walked the last 6 builds of all 135 non-EL10 GCE Calico grid periodics (517 builds, 173 failures). An incomplete BGP mesh shows up in **69 of 117** analysable failures and in **0 of 139** successful builds, so it is sufficient for failure rather than merely correlated, and it accounts for ~59% of these jobs' failures. What none of those 69 builds can tell me is *why* the session never came up.

The calico-node pod log is not a workaround. It is collected with `kubectl logs` and routinely truncated past the point where the session was set up — in one sampled build the isolated worker's log began 19 minutes after the control plane's, so BIRD's startup and peer state had already scrolled away.

### What it collects

| File | Command |
|---|---|
| `bgp-protocols.log` | `birdcl show protocols all` — per-peer state and last error |
| `bird.cfg` | the confd-generated peer list |
| `bgp-sockets.log` | TCP sockets on port 179 |
| `bgp-conntrack.log` | conntrack entries for port 179 |

`bgp-protocols.log` is the one that matters: BIRD keeps the reason a peer is stuck in its own state and reports it nowhere else.

### Notes on the implementation

- calico-node is hostNetwork, so the sockets and conntrack entries are visible from the host. `birdcl` and the confd config are not — they only exist inside the container, and `/etc/calico/confd` is not a hostPath — hence the hop into bird's mount namespace. `crictl` was not an option since kops only installs it when `containerd.installCriCtl` is set.
- Gated on the cluster running Calico, set by the caller from the cluster spec, the same way the Karpenter SSH hook already is.
- The runtime `pgrep` guard is kept in addition to that gate, because Calico in VXLAN mode runs no BIRD at all; the commands then write empty files rather than failing.
- `pgrep -x` matches the process name only, so it cannot match the dump command's own cmdline the way `pgrep -f` would.

/sig cluster-lifecycle