### PR TITLE
Automated cherry pick of #18351: gce: allow BGP from nodes to control plane for Calico

### DIFF
--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -147,6 +147,7 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		}
 		if b.NetworkingIsCalico() {
 			t.Allowed = append(t.Allowed, "ipip")
+			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.BGP))
 		}
 		if b.NetworkingIsCilium() {
 			t.Allowed = append(t.Allowed, fmt.Sprintf("udp:%d", wellknownports.VxlanUDP))

--- a/pkg/model/openstackmodel/firewall.go
+++ b/pkg/model/openstackmodel/firewall.go
@@ -518,7 +518,7 @@ func (b *FirewallModelBuilder) addCNIRules(c *fi.CloudupModelBuilderContext, sgM
 	}
 
 	if b.Cluster.Spec.Networking.Calico != nil {
-		tcpPorts = append(tcpPorts, 179)
+		tcpPorts = append(tcpPorts, wellknownports.BGP)
 		protocols = append(protocols, ProtocolIPEncap)
 	}
 

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -20,6 +20,9 @@ const (
 	// KubeAPIServer is the port where kube-apiserver listens.
 	KubeAPIServer = 443
 
+	// BGP is the port used by the BGP routing protocol (Calico node-to-node mesh).
+	BGP = 179
+
 	// NodeupChallenge is the port where nodeup listens for challenges.
 	NodeupChallenge = 3987
 


### PR DESCRIPTION
Cherry pick of #18351 on release-1.35.

#18351: gce: allow BGP from nodes to control plane for Calico

```release-note
Fixed Calico node-to-node BGP on GCE, where the node-to-control-plane firewall rule omitted tcp/179 and some nodes were left without pod routes.
```

### Why this needs a backport

On GCE the `master-to-node` rule allows all protocols, but `node-to-master` is restricted to a named port list which, for Calico, carried `ipip` but **not tcp/179**. Worker→control-plane BGP is dropped by the cloud firewall.

One direction is normally enough for BGP, which is why this does not break every cluster. What makes it fatal is RFC 4271 §6.8 connection collision resolution: when both speakers open at once, the connection opened by the peer with the higher BGP Identifier survives, and Calico derives that identifier from the node IP.

- Worker IP **below** the control plane's → the control plane wins the collision, its allowed inbound connection survives, the session establishes.
- Worker IP **above** → the worker keeps its own firewall-blocked outbound connection and closes the control plane's good inbound one. The session never forms, and no route to that node's pod CIDR is programmed. Because kube-apiserver is hostNetwork, every apiserver→pod path to that node is black-holed while everything via the API load balancer keeps working — so the cluster looks healthy and only webhook, aggregator and pod-proxy tests fail.

### Measured impact

Walking the last 6 builds of all 135 non-EL10 GCE Calico grid periodics (517 builds), comparing the control plane's `proto bird` routes against the node list:

| kops | builds with ≥1 worker IP above the control plane | incomplete mesh |
|---|---|---|
| master | ~63 | 0 (0%) |
| 1.36 | ~16 | 0 (0%) |
| **1.35** | **43** | **42 (98%)** |
| 1.34 | 21 | 20 (95%) |

The trigger arises just as often on the fixed branches (26–36% of builds); it simply stops causing harm. An incomplete mesh never appeared in a passing build (0 of 139 sampled successes) and accounted for 59% of these jobs' failures.

### Conflicts

The AWS and OpenStack hunks of the original commit only swap the literal `179` for the new `wellknownports.BGP` constant. The AWS hunk conflicts with the restructured `GetSecurityGroups` on this branch and has been dropped — `awsmodel` already allows `port=179` for Calico, so there is no functional difference. The GCE fix and the OpenStack constant swap applied cleanly.

`go build ./pkg/...`, `go vet` and `go test ./pkg/model/...` pass. No golden files change.

/sig cluster-lifecycle