### PR TITLE
fix: persist binariesLocation for AWS and GCE in v1alpha2

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -371,6 +371,10 @@ spec:
               cloudConfig:
                 description: CloudConfiguration defines the cloud provider configuration
                 properties:
+                  awsBinariesLocation:
+                    description: AWSBinariesLocation is the location of the AWS cloud
+                      provider binaries.
+                    type: string
                   awsEBSCSIDriver:
                     description: AWSEBSCSIDriver is the config for the AWS EBS CSI
                       driver
@@ -468,6 +472,10 @@ spec:
                       ElbSecurityGroup specifies an existing AWS Security group for the Cloud Controller
                       Manager to assign to each ELB provisioned for a Service, instead of creating
                       one per ELB (AWS only).
+                    type: string
+                  gceBinariesLocation:
+                    description: GCEBinariesLocation is the location of the GCE cloud
+                      provider binaries.
                     type: string
                   gceServiceAccount:
                     description: GCEServiceAccount specifies the service account with

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -998,6 +998,12 @@ type CloudConfiguration struct {
 	// GCEUseStartupScript specifies enables using startup-script instead of user-data metadata.
 	// +k8s:conversion-gen=false
 	GCEUseStartupScript *bool `json:"gceUseStartupScript,omitempty"`
+	// AWSBinariesLocation is the location of the AWS cloud provider binaries.
+	// +k8s:conversion-gen=false
+	AWSBinariesLocation *string `json:"awsBinariesLocation,omitempty"`
+	// GCEBinariesLocation is the location of the GCE cloud provider binaries.
+	// +k8s:conversion-gen=false
+	GCEBinariesLocation *string `json:"gceBinariesLocation,omitempty"`
 	// DisableSecurityGroupIngress disables the Cloud Controller Manager's creation
 	// of an AWS Security Group for each load balancer provisioned for a Service (AWS only).
 	// +k8s:conversion-gen=false

--- a/pkg/apis/kops/v1alpha2/conversion.go
+++ b/pkg/apis/kops/v1alpha2/conversion.go
@@ -208,6 +208,18 @@ func Convert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *kops
 			}
 			out.CloudProvider.GCE.UseStartupScript = in.CloudConfig.GCEUseStartupScript
 		}
+		if in.CloudConfig.AWSBinariesLocation != nil {
+			if out.CloudProvider.AWS == nil {
+				return field.Forbidden(field.NewPath("spec").Child("cloudConfig", "awsBinariesLocation"), "AWS binaries location supports only AWS")
+			}
+			out.CloudProvider.AWS.BinariesLocation = in.CloudConfig.AWSBinariesLocation
+		}
+		if in.CloudConfig.GCEBinariesLocation != nil {
+			if out.CloudProvider.GCE == nil {
+				return field.Forbidden(field.NewPath("spec").Child("cloudConfig", "gceBinariesLocation"), "GCE binaries location supports only GCE")
+			}
+			out.CloudProvider.GCE.BinariesLocation = in.CloudConfig.GCEBinariesLocation
+		}
 		if in.CloudConfig.DisableSecurityGroupIngress != nil {
 			if out.CloudProvider.AWS == nil {
 				return field.Forbidden(field.NewPath("spec").Child("cloudConfig", "disableSecurityGroupIngress"), "disableSecurityGroupIngress supports only AWS")
@@ -477,6 +489,12 @@ func Convert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, out 
 			val := *aws.UseIPBasedNodeNames
 			out.CloudConfig.UseIPBasedNodeNames = &val
 		}
+		if aws.BinariesLocation != nil {
+			if out.CloudConfig == nil {
+				out.CloudConfig = &CloudConfiguration{}
+			}
+			out.CloudConfig.AWSBinariesLocation = aws.BinariesLocation
+		}
 		if aws.EBSCSIDriver != nil {
 			if out.CloudConfig == nil {
 				out.CloudConfig = &CloudConfiguration{}
@@ -586,6 +604,12 @@ func Convert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, out 
 				out.CloudConfig = &CloudConfiguration{}
 			}
 			out.CloudConfig.GCEUseStartupScript = gce.UseStartupScript
+		}
+		if gce.BinariesLocation != nil {
+			if out.CloudConfig == nil {
+				out.CloudConfig = &CloudConfiguration{}
+			}
+			out.CloudConfig.GCEBinariesLocation = gce.BinariesLocation
 		}
 		if gce.PDCSIDriver != nil {
 			if out.CloudConfig == nil {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2315,6 +2315,8 @@ func autoConvert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	// INFO: in.NodeIPFamilies opted out of conversion generation
 	// INFO: in.GCEServiceAccount opted out of conversion generation
 	// INFO: in.GCEUseStartupScript opted out of conversion generation
+	// INFO: in.AWSBinariesLocation opted out of conversion generation
+	// INFO: in.GCEBinariesLocation opted out of conversion generation
 	// INFO: in.DisableSecurityGroupIngress opted out of conversion generation
 	// INFO: in.ElbSecurityGroup opted out of conversion generation
 	// INFO: in.NLBSecurityGroupMode opted out of conversion generation

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -799,6 +799,16 @@ func (in *CloudConfiguration) DeepCopyInto(out *CloudConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AWSBinariesLocation != nil {
+		in, out := &in.AWSBinariesLocation, &out.AWSBinariesLocation
+		*out = new(string)
+		**out = **in
+	}
+	if in.GCEBinariesLocation != nil {
+		in, out := &in.GCEBinariesLocation, &out.GCEBinariesLocation
+		*out = new(string)
+		**out = **in
+	}
 	if in.DisableSecurityGroupIngress != nil {
 		in, out := &in.DisableSecurityGroupIngress, &out.DisableSecurityGroupIngress
 		*out = new(bool)


### PR DESCRIPTION
### What this PR does / why we need it:
Fixes #18736.

`spec.cloudProvider.aws.binariesLocation` and `spec.cloudProvider.gce.binariesLocation` existed in the internal API and `v1alpha3`, but lacked a representation in the `v1alpha2` API. 
Because kOps persists cluster specs to the state store in the `v1alpha2` format, these fields were silently dropped on every write, making them unreachable in standard workflows. 

This PR adds `AWSBinariesLocation` and `GCEBinariesLocation` to the `CloudConfiguration` struct in `pkg/apis/kops/v1alpha2/componentconfig.go` (next to other AWS/GCE-specific settings like `DisableSecurityGroupIngress` and `GCEUseStartupScript`). It also includes the necessary manual conversions in `pkg/apis/kops/v1alpha2/conversion.go` to ensure `BinariesLocation` successfully round-trips to and from the internal `CloudProvider` struct. 

### Which issue(s) this PR fixes:
Fixes #18736

### Special notes for your reviewer:
Ran `make apimachinery` to regenerate conversions and deepcopies.