### PR TITLE
Avoid client-side throttle bootstrap node lookups

### DIFF
--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	bootstrapapi "k8s.io/kops/clusterapi/bootstrap/kops/api/v1beta1"
@@ -226,7 +227,13 @@ func main() {
 			klog.Fatalf("server verifiers not provided")
 		}
 
-		uncachedClient, err := client.New(mgr.GetConfig(), client.Options{
+		// Every /bootstrap request does one uncached single-key Node GET, and nodes
+		// retry until they join, so offered load scales with node count. Rely on API
+		// priority and fairness.
+		bootstrapConfig := rest.CopyConfig(mgr.GetConfig())
+		bootstrapConfig.QPS = -1
+
+		uncachedClient, err := client.New(bootstrapConfig, client.Options{
 			Scheme: mgr.GetScheme(),
 			Mapper: mgr.GetRESTMapper(),
 		})


### PR DESCRIPTION
The bootstrap server's uncached client shares the controller's client-side rate limit, but its load scales with node count (one uncached Node GET per /bootstrap attempt, retried until the node joins).


It is better if we rely on APIServer  AP&F server side throttling instead of determining the right QPS  which scales with # nodes.

Fixes - https://github.com/kubernetes/kubernetes/issues/141447#issuecomment-5390934836 

Previous attempts to increase QPS :

- https://github.com/kubernetes/kops/pull/15906/changes
- https://github.com/kubernetes/kops/pull/17701/changes

