### PR TITLE
fix(akamai): normalize volume labels to comply with Akamai Cloud API's length and character restrictions

### DIFF
--- a/upup/pkg/fi/cloudup/linodetasks/volume.go
+++ b/upup/pkg/fi/cloudup/linodetasks/volume.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/linode/linodego/v2"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/truncate"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/linode"
 )
@@ -49,7 +50,8 @@ func (v *Volume) Find(c *fi.CloudupContext) (*Volume, error) {
 	if name == "" {
 		return nil, fmt.Errorf("Volume.Name is required")
 	}
-	listOptions, err := linode.ListOptionsForLabel(name)
+	label := truncate.TruncateString(linode.NormalizeLinodeLabel(name), truncate.TruncateStringOptions{MaxLength: 32})
+	listOptions, err := linode.ListOptionsForLabel(label)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +70,7 @@ func (v *Volume) Find(c *fi.CloudupContext) (*Volume, error) {
 
 	actual := &Volume{
 		ID:        new(matched.ID),
-		Name:      new(matched.Label),
+		Name:      new(name),
 		Lifecycle: v.Lifecycle,
 		Region:    new(matched.Region),
 		SizeGB:    new(matched.Size),
@@ -134,8 +136,9 @@ func (*Volume) RenderLinode(t *linode.APITarget, actual, expected, changes *Volu
 	}
 
 	name := fi.ValueOf(expected.Name)
+	label := truncate.TruncateString(linode.NormalizeLinodeLabel(name), truncate.TruncateStringOptions{MaxLength: 32})
 	created, err := t.Cloud.Client().CreateVolume(context.Background(), linodego.VolumeCreateOptions{
-		Label:  name,
+		Label:  label,
 		Region: fi.ValueOf(expected.Region),
 		Size:   fi.ValueOf(expected.SizeGB),
 		Tags:   expected.Tags,

--- a/upup/pkg/fi/cloudup/linodetasks/volume_test.go
+++ b/upup/pkg/fi/cloudup/linodetasks/volume_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/linode/linodego/v2"
+	"k8s.io/kops/pkg/truncate"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/linode"
 )
@@ -115,6 +116,63 @@ func TestVolumeRenderLinodeCreate(t *testing.T) {
 	}
 	if got, want := fi.ValueOf(expected.ID), 42; got != want {
 		t.Fatalf("expected task ID to be populated from create response: got %d, want %d", got, want)
+	}
+}
+
+func TestVolumeRenderLinodeCreateNormalizesLabel(t *testing.T) {
+	client := &linode.MockLinodeClient{CreateVolumeResponse: &linodego.Volume{ID: 42}}
+	target := linode.NewAPITarget(&linode.MockLinodeCloud{Client_: client})
+	expected := &Volume{
+		Name:   new("d.etcd-main.kops.linode.example.com"),
+		Region: new("us-east"),
+		SizeGB: new(20),
+	}
+
+	if err := (&Volume{}).RenderLinode(target, nil, expected, nil); err != nil {
+		t.Fatalf("RenderLinode returned error: %v", err)
+	}
+	label := client.LastCreateVolumeOpts.Label
+	if len(label) > 32 {
+		t.Fatalf("expected label to fit Linode's length limit: %q", label)
+	}
+	if strings.ContainsAny(label, ".:") {
+		t.Fatalf("expected label to contain only Linode-supported characters: %q", label)
+	}
+	want := truncate.TruncateString(linode.NormalizeLinodeLabel(fi.ValueOf(expected.Name)), truncate.TruncateStringOptions{MaxLength: 32})
+	if label != want {
+		t.Fatalf("unexpected normalized label: %q", label)
+	}
+}
+
+func TestVolumeFindNormalizesLabel(t *testing.T) {
+	name := "d.etcd-main.kops.linode.example.com"
+	label := truncate.TruncateString(linode.NormalizeLinodeLabel(name), truncate.TruncateStringOptions{MaxLength: 32})
+	client := &linode.MockLinodeClient{ListVolumesResponse: []linodego.Volume{{
+		ID:     101,
+		Label:  label,
+		Region: "us-east",
+		Size:   20,
+	}}}
+	ctx := newTestCloudupContext(t, &linode.MockLinodeCloud{Client_: client})
+	task := &Volume{Name: new(name)}
+
+	actual, err := task.Find(ctx)
+	if err != nil {
+		t.Fatalf("Find returned error: %v", err)
+	}
+	if actual == nil {
+		t.Fatalf("expected to find volume")
+	}
+	if got, want := fi.ValueOf(actual.Name), name; got != want {
+		t.Fatalf("unexpected canonical name: got %q, want %q", got, want)
+	}
+
+	expectedListOptions, err := linode.ListOptionsForLabel(label)
+	if err != nil {
+		t.Fatalf("ListOptionsForLabel returned error: %v", err)
+	}
+	if got, want := client.LastListVolumesOpts.Filter, expectedListOptions.Filter; got != want {
+		t.Fatalf("unexpected volume list filter: got %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Right now a relatively longer cluster name such as `kops.linode.example.com` fails with:
```
W0824 13:25:09.744461   64892 executor.go:142] error running task "Volume/d.etcd-main.kops.linode.example.com" (9m58s remaining to succeed): error creating Akamai (Linode) volume "d.etcd-main.kops.linode.example.com": [400] [label] Must only use ascii letters, numbers, underscores, and dashes; [label] Length must be 1-32 characters
```
So adding a logic to limit the label length for volumes by invoking the `NormalizeLinodeLabel` function and truncating the returned result to 32 chars max.

Signed-off-by: Moshe Vayner <moshe@vayner.me>

<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
