### PR TITLE
test(e2e): deploy cert-manager via the certmanager.io addon

### DIFF
--- a/clusterapi/README.md
+++ b/clusterapi/README.md
@@ -7,19 +7,9 @@ We plug in our own bootstrap provider with the goal of enabling cluster-api node
 *Note*: the name & zone matter, we need to match the values we'll create later in the CAPI resources.
 
 ```
-go run ./cmd/kops create cluster clusterapi.k8s.local --zones us-east4-a
+go run ./cmd/kops create cluster clusterapi.k8s.local --zones us-east4-a --set=cluster.spec.certManager.enabled=true
 go run ./cmd/kops update cluster clusterapi.k8s.local --yes --admin
 go run ./cmd/kops validate cluster --wait=10m
-```
-
-# Install cert-manager
-
-```
-kubectl apply --server-side -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
-
-kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
-kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
-kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook
 ```
 
 # Install CAPI and CAPG

--- a/clusterapi/manifests/cluster-api-provider-gcp/patches/run_on_control_plane.yaml
+++ b/clusterapi/manifests/cluster-api-provider-gcp/patches/run_on_control_plane.yaml
@@ -13,6 +13,3 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists

--- a/clusterapi/manifests/cluster-api-provider-gcp/patches/set_feature_gates.yaml
+++ b/clusterapi/manifests/cluster-api-provider-gcp/patches/set_feature_gates.yaml
@@ -11,7 +11,10 @@ spec:
         - --leader-elect
         #- --feature-gates=GKE=${EXP_CAPG_GKE:=false}
         - --feature-gates=GKE=false
-        - --metrics-bind-addr=localhost:8080
+        #- --diagnostics-address=${CAPG_DIAGNOSTICS_ADDRESS:=:8443}
+        - --diagnostics-address=:8443
+        #- --insecure-diagnostics=${CAPG_INSECURE_DIAGNOSTICS:=false}
+        - --insecure-diagnostics=false
         #- --v=${CAPG_LOGLEVEL:=0}
         - --v=0
         name: manager

--- a/clusterapi/manifests/cluster-api-provider-gcp/patches/set_manager_image.yaml
+++ b/clusterapi/manifests/cluster-api-provider-gcp/patches/set_manager_image.yaml
@@ -7,6 +7,6 @@ spec:
   template:
     spec:
       containers:
-      - image: registry.k8s.io/cluster-api-gcp/cluster-api-gcp-controller:v1.5.0
+      - image: registry.k8s.io/cluster-api-gcp/cluster-api-gcp-controller:v1.10.0
         imagePullPolicy: IfNotPresent
         name: manager

--- a/cmd/kops-controller/pkg/server/keystore.go
+++ b/cmd/kops-controller/pkg/server/keystore.go
@@ -119,7 +119,8 @@ func newKeystore(basePath string, cas []string) (*keystore, map[string]string, e
 	for name, keypairID := range keypairIDs {
 		entry, found := keystore.keys[name]
 		if !found {
-			klog.Warningf("keypair %q found in keypair IDs, not found as keypair", name)
+			// keypair-ids.yaml also includes CAs this server is not configured to serve (e.g. the etcd CAs).
+			klog.V(2).Infof("keypair %q found in keypair IDs, not loaded as a served CA", name)
 			continue
 		}
 		primary := &fi.KeysetItem{}

--- a/cmd/kops-controller/pkg/server/node_config.go
+++ b/cmd/kops-controller/pkg/server/node_config.go
@@ -137,11 +137,13 @@ func (s *Server) buildInstanceGroupFromCAPI(ctx context.Context, capiMachine *cl
 
 	// "maxSize": 1, // Should not matter
 	// "minSize": 1, // Should not matter
-	// "image": "", // Should not matter
 	// "machineType": "", // Should not matter
 	// "subnets": // Should not matter
 	ig.Spec.Zones = []string{failureDomain}
 	ig.Spec.Role = "Node" // TODO: Support other roles?
+	// The machine image is chosen by the CAPI infrastructure provider and is not used for
+	// nodeup config generation; the placeholder avoids resolving a default from the channel.
+	ig.Spec.Image = "placeholder-image"
 
 	log.Info("built InstanceGroup from CAPI Machine", "instanceGroup", ig)
 	return ig, nil

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -118,10 +118,9 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	}
 
 	if c.Master == "" {
-		if b.IsMaster {
-			// As a special case, if this is the master, we point kube-proxy to the local IP
-			// This prevents a circular dependency where kube-proxy can't come up until DNS comes up,
-			// which would mean that DNS can't rely on API to come up
+		if b.HasAPIServer {
+			// Use the local API server to avoid a kube-proxy/DNS bootstrap cycle. Dedicated
+			// apiserver nodes also lack an /etc/hosts entry for the API internal name.
 			c.Master = "https://127.0.0.1"
 		} else {
 			c.Master = "https://" + b.APIInternalName()

--- a/pkg/commands/toolbox_enroll.go
+++ b/pkg/commands/toolbox_enroll.go
@@ -588,9 +588,10 @@ func (b *ConfigBuilder) GetFullInstanceGroup(ctx context.Context) (*kops.Instanc
 		return nil, err
 	}
 
+	// The channel only provides optional defaults, and kops-controller may be unable to read it.
 	channel, err := cloudup.ChannelForCluster(clientset.VFSContext(), fullCluster)
 	if err != nil {
-		return nil, fmt.Errorf("getting channel for cluster %q: %w", fullCluster.Name, err)
+		klog.Warningf("getting channel for cluster %q: %v", fullCluster.Name, err)
 	}
 
 	// Build full IG spec to ensure we end up with a valid IG

--- a/pkg/controllers/clusterapi/kopsconfig_controller.go
+++ b/pkg/controllers/clusterapi/kopsconfig_controller.go
@@ -202,6 +202,9 @@ func (r *KopsConfigReconciler) buildBootstrapData(ctx context.Context, cluster *
 	{
 		ig.SetName("placeholder-ig-name") // IG name is not used for nodeup config generation
 		ig.Spec.Role = kops.InstanceGroupRoleNode
+		// The machine image is chosen by the CAPI infrastructure provider and is not used for
+		// nodeup config generation; the placeholder avoids resolving a default from the channel.
+		ig.Spec.Image = "placeholder-image"
 
 		configBuilder.InstanceGroup = ig
 		configBuilder.InstanceGroupName = ig.Name

--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -122,6 +122,30 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		c.AddTask(t)
 	}
 
+	// Ports that nodes (and pods) are allowed to reach on control plane instances.
+	nodeToMasterAllowed := []string{
+		fmt.Sprintf("tcp:%d", wellknownports.KubeAPIServer),
+		fmt.Sprintf("tcp:%d", wellknownports.KubeletAPI),
+		fmt.Sprintf("tcp:%d", wellknownports.KopsControllerPort),
+		// Metrics ports for control plane components, so they can be scraped from nodes.
+		fmt.Sprintf("tcp:%d", wellknownports.KubeControllerManagerMetricsPort),
+		fmt.Sprintf("tcp:%d", wellknownports.KubeSchedulerMetricsPort),
+		fmt.Sprintf("tcp:%d", wellknownports.KubeProxyMetricsPort),
+		fmt.Sprintf("tcp:%d", wellknownports.EtcdMetricsPort),
+		fmt.Sprintf("tcp:%d", wellknownports.EtcdEventsMetricsPort),
+		fmt.Sprintf("tcp:%d", wellknownports.NodeExporterMetricsPort),
+	}
+	if b.NetworkingIsCalico() {
+		nodeToMasterAllowed = append(nodeToMasterAllowed, "ipip")
+		nodeToMasterAllowed = append(nodeToMasterAllowed, fmt.Sprintf("tcp:%d", wellknownports.BGP))
+	}
+	if b.NetworkingIsCilium() {
+		nodeToMasterAllowed = append(nodeToMasterAllowed, fmt.Sprintf("udp:%d", wellknownports.VxlanUDP))
+		if model.UseCiliumEtcd(b.Cluster) {
+			nodeToMasterAllowed = append(nodeToMasterAllowed, fmt.Sprintf("tcp:%d", wellknownports.EtcdCiliumClientPort))
+		}
+	}
+
 	// Allow limited traffic from nodes -> masters
 	{
 		network, err := b.LinkToNetwork()
@@ -134,28 +158,7 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			Network:    network,
 			SourceTags: []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
 			TargetTags: append(b.GCETagsForAPIServerTargets(), b.GCETagForRole("Master")),
-			Allowed: []string{
-				fmt.Sprintf("tcp:%d", wellknownports.KubeAPIServer),
-				fmt.Sprintf("tcp:%d", wellknownports.KubeletAPI),
-				fmt.Sprintf("tcp:%d", wellknownports.KopsControllerPort),
-				// Metrics ports for control plane components, so they can be scraped from nodes.
-				fmt.Sprintf("tcp:%d", wellknownports.KubeControllerManagerMetricsPort),
-				fmt.Sprintf("tcp:%d", wellknownports.KubeSchedulerMetricsPort),
-				fmt.Sprintf("tcp:%d", wellknownports.KubeProxyMetricsPort),
-				fmt.Sprintf("tcp:%d", wellknownports.EtcdMetricsPort),
-				fmt.Sprintf("tcp:%d", wellknownports.EtcdEventsMetricsPort),
-				fmt.Sprintf("tcp:%d", wellknownports.NodeExporterMetricsPort),
-			},
-		}
-		if b.NetworkingIsCalico() {
-			t.Allowed = append(t.Allowed, "ipip")
-			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.BGP))
-		}
-		if b.NetworkingIsCilium() {
-			t.Allowed = append(t.Allowed, fmt.Sprintf("udp:%d", wellknownports.VxlanUDP))
-			if model.UseCiliumEtcd(b.Cluster) {
-				t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.EtcdCiliumClientPort))
-			}
+			Allowed:    nodeToMasterAllowed,
 		}
 		c.AddTask(t)
 	}
@@ -180,6 +183,17 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				SourceRanges: []string{b.Cluster.Spec.Networking.PodCIDR},
 				TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
 				Allowed:      allProtocols,
+			})
+
+			// Source tags cannot match pod-sourced traffic, so without this rule pods cannot
+			// reach pods hosted on control plane nodes. Grant the same restricted access as
+			// nodes so host ports such as etcd stay protected.
+			b.AddFirewallRulesTasks(c, "pod-cidrs-to-master", &gcetasks.FirewallRule{
+				Lifecycle:    b.Lifecycle,
+				Network:      network,
+				SourceRanges: []string{b.Cluster.Spec.Networking.PodCIDR},
+				TargetTags:   append(b.GCETagsForAPIServerTargets(), b.GCETagForRole("Master")),
+				Allowed:      nodeToMasterAllowed,
 			})
 		}
 	}

--- a/tests/e2e/scenarios/ai-conformance/run-test.sh
+++ b/tests/e2e/scenarios/ai-conformance/run-test.sh
@@ -61,6 +61,7 @@ cp "${KOPS}" "${BIN_DIR}/kops"
 # - NVIDIA driver and runtime are managed by GPU Operator (not kOps)
 # - Cluster Autoscaler: For Cluster Autoscaling of GPU Nodes
 # - Metrics Server: For HPA support
+# - Cert Manager: For AI conformance components that need webhook certificates
 OVERRIDES="${OVERRIDES-} --networking=cilium"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.networking.cilium.gatewayAPI.enabled=true"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.addons[0].manifest=https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml"
@@ -70,6 +71,7 @@ OVERRIDES="${OVERRIDES} --zones=us-east-2a,us-east-2b,us-east-2c"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.clusterAutoscaler.enabled=true"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.metricsServer.enabled=true"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.metricsServer.insecure=true"
+OVERRIDES="${OVERRIDES} --set=cluster.spec.certManager.enabled=true"
 
 kops-up
 
@@ -103,15 +105,6 @@ kubectl get nodes --show-labels
 echo "----------------------------------------------------------------"
 echo "Deploying AI Conformance Components"
 echo "----------------------------------------------------------------"
-
-# cert-manager
-echo "Installing cert-manager..."
-kubectl apply --server-side -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.2/cert-manager.yaml
-
-echo "Waiting for cert-manager to be ready..."
-kubectl rollout status deployment -n cert-manager cert-manager --timeout=5m
-kubectl rollout status deployment -n cert-manager cert-manager-webhook --timeout=5m
-kubectl rollout status deployment -n cert-manager cert-manager-cainjector --timeout=5m
 
 # Setup helm repos for monitoring and NVIDIA components
 helm repo add nvidia https://helm.ngc.nvidia.com/nvidia

--- a/tests/e2e/scenarios/clusterapi/run-test.sh
+++ b/tests/e2e/scenarios/clusterapi/run-test.sh
@@ -31,6 +31,7 @@ ZONES=us-east4-a # Currently the zone name gets encoded in the machinedeployment
 
 OVERRIDES="${OVERRIDES-} --node-count=2" # We need at least 2 nodes for CoreDNS to validate
 OVERRIDES="${OVERRIDES} --gce-service-account=default" # Use default service account because boskos permissions are limited
+OVERRIDES="${OVERRIDES} --set=cluster.spec.certManager.enabled=true" # cert-manager is a prerequisite of cluster-api
 
 # Create kOps cluster
 source "${REPO_ROOT}/tests/e2e/scenarios/lib/common.sh"
@@ -55,13 +56,6 @@ kubectl apply --server-side -f "${REPO_ROOT}/clusterapi/examples/kopscontroller.
 
 # Bounce kops-controller in case it went into backoff before the CRDs were installed
 kubectl delete pod -n kube-system -l k8s-app=kops-controller
-
-# Install cert-manager
-kubectl apply --server-side -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
-
-kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
-kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
-kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook
 
 # Install cluster-api core and cluster-api-provider-gcp
 kubectl apply --server-side -k "${REPO_ROOT}/clusterapi/manifests/cluster-api"

--- a/tests/e2e/scenarios/splitkcp/run-test.sh
+++ b/tests/e2e/scenarios/splitkcp/run-test.sh
@@ -89,10 +89,7 @@ kubectl get gcpmachine -A -owide
 
 # CAPI currently creates some firewall rules that otherwise are not cleaned up, and block kops cluster cleanup
 function cleanup_capi_leaks() {
-  gcloud compute firewall-rules delete allow-clusterapi-k8s-local-cluster --quiet || true
-  gcloud compute firewall-rules delete allow-clusterapi-k8s-local-healthchecks --quiet || true
-
-  #gcloud compute networks subnets delete us-east4-clusterapi-k8s-local --region us-east4 --quiet
-  #gcloud compute networks delete clusterapi-k8s-local --quiet
+  gcloud compute firewall-rules delete allow-splitkcp-k8s-local-cluster --quiet || true
+  gcloud compute firewall-rules delete allow-splitkcp-k8s-local-healthchecks --quiet || true
 }
 cleanup_capi_leaks

--- a/tests/e2e/scenarios/splitkcp/run-test.sh
+++ b/tests/e2e/scenarios/splitkcp/run-test.sh
@@ -37,6 +37,7 @@ OVERRIDES="${OVERRIDES} --node-size=e2-standard-2" #
 OVERRIDES="${OVERRIDES} --api-server-size=e2-standard-2" #
 OVERRIDES="${OVERRIDES} --control-plane-size=e2-standard-4" #
 OVERRIDES="${OVERRIDES} --gce-service-account=default" # Use default service account because boskos permissions are limited
+OVERRIDES="${OVERRIDES} --set=cluster.spec.certManager.enabled=true" # cert-manager is a prerequisite of cluster-api
 
 # Create kOps cluster
 source "${REPO_ROOT}/tests/e2e/scenarios/lib/common.sh"
@@ -61,13 +62,6 @@ kubectl apply --server-side -f "${REPO_ROOT}/clusterapi/examples/kopscontroller.
 
 # Bounce kops-controller in case it went into backoff before the CRDs were installed
 kubectl delete pod -n kube-system -l k8s-app=kops-controller
-
-# Install cert-manager
-kubectl apply --server-side -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
-
-kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
-kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
-kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook
 
 # Install cluster-api core and cluster-api-provider-gcp
 kubectl apply --server-side -k "${REPO_ROOT}/clusterapi/manifests/cluster-api"


### PR DESCRIPTION
The `clusterapi`, `splitkcp` and `ai-conformance` scenarios each installed cert-manager from their own pinned upstream release URL, with two different versions across the three scripts. This enables the bundled `certmanager.io` addon in the cluster spec instead, so there is a single cert-manager definition in the tree and version bumps happen only in the addon.

The explicit readiness waits are removed: the addon pods run with the `system-cluster-critical` priority class, so cluster validation during `kops-up` already waits for them to be ready.

The clusterapi README is updated to match. The discovery dev task keeps its upstream install, as it targets clusters not managed by kOps.

/cc @rifelpet @ameukam 