### PR TITLE
docs: refresh CLI examples and manifests for kOps 1.37

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -81,7 +81,7 @@ spec:
     balanceSimilarNodeGroups: false
     emitPerNodegroupMetrics: false
     awsUseStaticInstanceList: false
-    scaleDownUtilizationThreshold: 0.5
+    scaleDownUtilizationThreshold: "0.5"
     skipNodesWithCustomControllerPods: true
     skipNodesWithLocalStorage: true
     skipNodesWithSystemPods: true

--- a/docs/advanced/download_config.md
+++ b/docs/advanced/download_config.md
@@ -10,26 +10,26 @@ Let us say you create your cluster with the following configuration options:
 export KOPS_STATE_STORE=s3://k8s-us-west
 export CLOUD=aws
 export ZONE="us-west-1a"
-export MASTER_ZONES="us-west-1a"
+export CONTROL_PLANE_ZONES="us-west-1a"
 export NAME=k8s.example.com
-export K8S_VERSION=1.6.4
+export K8S_VERSION=1.36.4
 export NETWORKCIDR="10.240.0.0/16"
-export MASTER_SIZE="m3.large"
-export WORKER_SIZE="m4.large"
+export CONTROL_PLANE_SIZE="m5.large"
+export WORKER_SIZE="m5.large"
 ```
 Next you call the kOps command to create the cluster in your terminal:
 
 ```shell
-kops create cluster $NAME              \
-   --cloud=$CLOUD                      \
-   --zones="$ZONE"                     \
-   --kubernetes-version=$K8S_VERSION   \
-   --master-zones="$MASTER_ZONES"      \
-   --node-count=3                      \
-   --node-size="$WORKER_SIZE"          \
-   --master-size="$MASTER_SIZE"        \
-   --network-cidr=${NETWORKCIDR}       \
-   --dns-zone=ZVO7KL181S5AP            \
+kops create cluster $NAME                             \
+   --cloud=$CLOUD                                     \
+   --zones="$ZONE"                                    \
+   --kubernetes-version=$K8S_VERSION                  \
+   --control-plane-zones="$CONTROL_PLANE_ZONES"       \
+   --control-plane-size="$CONTROL_PLANE_SIZE"         \
+   --node-count=3                                     \
+   --node-size="$WORKER_SIZE"                         \
+   --network-cidr=${NETWORKCIDR}                      \
+   --dns-zone=ZVO7KL181S5AP                           \
    --ssh-public-key=$HOME/.ssh/lab_no_password.pub
 ```
 

--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -37,7 +37,7 @@ metadata:
   name: bastions
 spec:
   associatePublicIp: true
-  image: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404
+  image: ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: t2.micro
   maxSize: 1
   minSize: 1

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -703,7 +703,7 @@ spec:
     - name: GOMEMLIMIT
       value: "2750MiB"
     - name: GOGC
-      value: 50
+      value: "50"
 ```
 
 ## externalDns
@@ -1124,10 +1124,10 @@ spec:
   - before:
     - some_service.service
     requires:
-    - docker.service
+    - containerd.service
     execContainer:
       image: kopeio/nvidia-bootstrap:1.6
-      # these are added as -e to the docker environment
+      # these are set as environment variables in the container
       environment:
         AWS_REGION: eu-west-1
         SOME_VAR: SOME_VALUE
@@ -1300,19 +1300,9 @@ spec:
     manageStorageClasses: false
 ```
 
-## containerRuntime
-{{ kops_feature_table(kops_added_default='1.18', k8s_min='1.11') }}
-
-As of Kubernetes 1.20, the default [container runtime](https://kubernetes.io/docs/setup/production-environment/container-runtimes) is containerd. Previously, the default container runtime was Docker.
-
-Docker can still be used as container runtime with Kubernetes 1.20+,  but be aware that Kubernetes is [deprecating](https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker) support for it and will be removed in Kubernetes 1.22.
-
-```yaml
-spec:
-  containerRuntime: containerd
-```
-
 ## containerd
+
+containerd is the only supported [container runtime](https://kubernetes.io/docs/setup/production-environment/container-runtimes). The `containerRuntime` and `docker` fields were removed: Kubernetes dropped the dockershim in 1.24, and setting `containerRuntime: docker` is now rejected by validation.
 
 ### Configuration
 
@@ -1322,7 +1312,7 @@ Overriding the configuration of containerd has to be done with care as the defau
 ```yaml
 spec:
   containerd:
-    version: 1.4.4
+    version: 2.3.4
     logLevel: info
     configOverride: ""
 ```
@@ -1448,7 +1438,7 @@ spec:
       #!/bin/sh
       cat > /usr/local/share/ca-certificates/mycert.crt <<EOF
       -----BEGIN CERTIFICATE-----
-snip
+      ...snip...
       -----END CERTIFICATE-----
       EOF
       update-ca-certificates
@@ -1530,27 +1520,16 @@ which would end up in a drop-in file on all masters and nodes of the cluster.
 As of Kubernetes 1.20, kOps will default the cgroup driver of the kubelet and the container runtime to use systemd as the default cgroup driver
 as opposed to cgroup fs.
 
-It is important to ensure that the kubelet and the container runtime are using the same cgroup driver. Below are examples showing
-how to set the cgroup driver for kubelet and the container runtime.
+It is important to ensure that the kubelet and the container runtime are using the same cgroup driver.
+containerd follows the kubelet's cgroup driver, so setting `cgroupDriver` on the kubelet is enough;
+there is no separate runtime setting to change.
 
-
-Setting kubelet to use cgroupfs
+Setting kubelet to use cgroupfs:
 ```yaml
 spec:
   kubelet:
     cgroupDriver: cgroupfs
 ```
-
-Setting Docker to use cgroupfs
-```yaml
-spec:
-  docker:
-    execOpt:
-      - native.cgroupdriver=cgroupfs
-```
-
-In the case of containerd, the cgroup-driver is dependent on the cgroup driver of kubelet. To use cgroupfs, just update the
-cgroupDriver of kubelet to use cgroupfs.
 
 ## NTP
 

--- a/docs/contributing/homebrew.md
+++ b/docs/contributing/homebrew.md
@@ -27,7 +27,7 @@ More details on this script are located [here.](https://github.com/Homebrew/brew
 
 Example usage:
 ```bash
-brew bump-formula-pr kops --version=1.20.2
+brew bump-formula-pr kops --version=1.36.2
 ```
 
 * Update the URL variable to the tar.gz of the new release source code

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -68,7 +68,7 @@ kubetest2 kops \
   --cloud-provider=aws \
   --cluster-name=my.testcluster.com \
   --kops-binary-path=${KOPS_ROOT}/.build/dist/$(go env GOOS)/$(go env GOARCH)/kops \
-  --kubernetes-version=v1.20.2 \
+  --kubernetes-version=v1.36.4 \
   --test=kops \
   -- \
   --test-package-version=v1.20.2 \
@@ -92,7 +92,7 @@ kubetest2 kops \
   --cluster-name=my.testcluster.com \
   --create-args="--networking calico" \
   --kops-binary-path=${KOPS_ROOT}/.build/dist/$(go env GOOS)/$(go env GOARCH)/kops \
-  --kubernetes-version=v1.20.2 \
+  --kubernetes-version=v1.36.4 \
   --test=kops \
   --
   -- \
@@ -104,7 +104,7 @@ kubetest2 kops \
 If you don't specify any additional flags, the kOps deployer Go module will create a kubernetes cluster using the following defaults.
 
 ```shell
-kops create cluster --name my.testcluster.com --admin-access <Client Public IP> --cloud aws --kubernetes-version v1.20.2 --master-count 1 --master-volume-size 48 --node-count 4 --node-volume-size 48 --set cluster.spec.nodePortAccess=0.0.0.0/0 --ssh-public-key /home/ubuntu/.ssh/id_rsa.pub --yes --zones <Random Zone> --master-size c5.large --networking calico
+kops create cluster --name my.testcluster.com --admin-access <Client Public IP> --cloud aws --kubernetes-version v1.36.4 --control-plane-count 1 --control-plane-volume-size 48 --node-count 4 --node-volume-size 48 --set cluster.spec.nodePortAccess=0.0.0.0/0 --ssh-public-key /home/ubuntu/.ssh/id_rsa.pub --yes --zones <Random Zone> --control-plane-size c5.large --networking calico
 ```
 
 For the `--zones` flag, the kOps deployer will select a random zone based on the `--cloud-provider` flag, for `aws` the full list of AWS zones can be found [here](https://github.com/kubernetes/kops/blob/master/tests/e2e/kubetest2-kops/aws/zones.go) and for `gce` the full list of GCE zones can be found [here](https://github.com/kubernetes/kops/blob/master/tests/e2e/kubetest2-kops/gce/zones.go).
@@ -118,7 +118,7 @@ kubetest2 kops \
   --cloud-provider=aws \
   --cluster-name=my.testcluster.com \
   --kops-binary-path=${KOPS_ROOT}/.build/dist/$(go env GOOS)/$(go env GOARCH)/kops \
-  --kubernetes-version=v1.20.2 \
+  --kubernetes-version=v1.36.4 \
   --template-path=my.testcluster.com.yaml \
   --test=kops \
   -- \

--- a/docs/examples/coreos-kops-tests-multimaster.md
+++ b/docs/examples/coreos-kops-tests-multimaster.md
@@ -138,7 +138,7 @@ Let's first create our cluster ensuring a multi-master setup with 3 masters in a
 
 ```bash
 kops create cluster \
---master-zones=us-east-1a,us-east-1b,us-east-1c \
+--control-plane-zones=us-east-1a,us-east-1b,us-east-1c \
 --zones=us-east-1a,us-east-1b,us-east-1c \
 --node-count=2 \
 --image ami-32705b49 \
@@ -149,7 +149,7 @@ A few things to note here:
 
 - The environment variable ${NAME} was previously exported with our cluster name: coreosbasedkopscluster.k8s.local.
 - For true HA at the master level, we need to pick a region with at least 3 availability zones. For this practical exercise, we are using "us-east-1" AWS region which contains 5 availability zones (az's for short): us-east-1a, us-east-1b, us-east-1c, us-east-1d and us-east-1e.
-- The "--master-zones=us-east-1a,us-east-1b,us-east-1c" KOPS argument will actually enforce that we want 3 masters here. "--node-count=2" only applies to the worker nodes (not the masters).
+- The "--control-plane-zones=us-east-1a,us-east-1b,us-east-1c" KOPS argument will actually enforce that we want 3 masters here. "--node-count=2" only applies to the worker nodes (not the masters).
 - The "--image ami-32705b49" KOPS argument will enforce the usage or our desired image: CoreOS Stable 1409.8.0. You can use here any of the aforementioned formats: "ami-32705b49" or "595879546273/CoreOS-stable-1409.8.0-hvm". KOPS will understand both ways to indicate the AMI we want to use here.
 
 With those points clarified, let's deploy our cluster:
@@ -192,7 +192,7 @@ Before continuing, let's note something interesting here: Can you see your maste
 If you don't want KOPS to auto-select the instance type, you can use the following arguments in order to enforce the instance types for both masters and nodes:
 
 - Specify the node size: --node-size=m4.large
-- Specify the master size: --master-size=m4.large
+- Specify the master size: --control-plane-size=m4.large
 
 But, before doing that, always ensure the instance types are available on your desired AZ.
 

--- a/docs/examples/kops-test-route53-subdomain.md
+++ b/docs/examples/kops-test-route53-subdomain.md
@@ -268,11 +268,11 @@ Let's first create our cluster ensuring a multi-master setup with 3 masters in a
 ```bash
 kops create cluster \
 --cloud=aws \
---master-zones=us-east-1a,us-east-1b,us-east-1c \
+--control-plane-zones=us-east-1a,us-east-1b,us-east-1c \
 --zones=us-east-1a,us-east-1b,us-east-1c \
 --node-count=2 \
 --node-size=t2.micro \
---master-size=t2.micro \
+--control-plane-size=t2.micro \
 ${NAME}
 ```
 
@@ -281,8 +281,8 @@ A few things to note here:
 - The environment variable ${NAME} was previously exported with our cluster name: mycluster01.kopsclustertest.example.org.
 - "--cloud=aws": As kOps grows and begin to support more clouds, we need to tell the command to use the specific cloud we want for our deployment. In this case: amazon web services (aws).
 - For true HA at the master level, we need to pick a region with at least 3 availability zones. For this practical exercise, we are using "us-east-1" AWS region which contains 5 availability zones (az's for short): us-east-1a, us-east-1b, us-east-1c, us-east-1d and us-east-1e.
-- The "--master-zones=us-east-1a,us-east-1b,us-east-1c" KOPS argument will actually enforce that we want 3 masters here. "--node-count=2" only applies to the worker nodes (not the masters).
-- We are including the arguments "--node-size" and "master-size" to specify the "instance types" for both our masters and worker nodes.
+- The "--control-plane-zones=us-east-1a,us-east-1b,us-east-1c" KOPS argument will actually enforce that we want 3 masters here. "--node-count=2" only applies to the worker nodes (not the masters).
+- We are including the arguments "--node-size" and "--control-plane-size" to specify the "instance types" for both our masters and worker nodes.
 - Because we are just doing a simple LAB, we are using "t2.micro" machines. Please DON'T USE t2.micro on real production systems. Start with "t2.medium" as a minimum realistic/workable machine type.
 
 With those points clarified, let's deploy our cluster:
@@ -693,7 +693,7 @@ metadata:
     kops.k8s.io/cluster: mycluster01.kopsclustertest.example.org
   name: nodes
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: t2.micro
   maxSize: 2
   minSize: 2
@@ -714,7 +714,7 @@ metadata:
     kops.k8s.io/cluster: mycluster01.kopsclustertest.example.org
   name: nodes
 spec:
-  image: kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-07-28
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: t2.micro
   maxSize: 3
   minSize: 3
@@ -787,7 +787,7 @@ You can see how your cluster scaled up to 3 nodes.
 **SCALING RECOMMENDATIONS:**
 
 - Always think ahead. If you want to ensure to have the capability to scale-up to all available zones in the region, ensure to add them to the "--zones=" argument when using the "kops create cluster" command. Example: --zones=us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1e. That will make things simpler later.
-- For the masters, always consider "odd" numbers starting from 3. Like many other cluster, odd numbers starting from "3" are the proper way to create a fully redundant multi-master solution. In the specific case of "kOps", you add masters by adding zones to the "--master-zones" argument on "kops create command".
+- For the masters, always consider "odd" numbers starting from 3. Like many other cluster, odd numbers starting from "3" are the proper way to create a fully redundant multi-master solution. In the specific case of "kOps", you add masters by adding zones to the "--control-plane-zones" argument on "kops create command".
 
 ## DELETING OUR CLUSTER AND CHECKING OUR DNS SUBDOMAIN:
 

--- a/docs/examples/kops-tests-private-net-bastion-host.md
+++ b/docs/examples/kops-tests-private-net-bastion-host.md
@@ -58,13 +58,13 @@ Let's first create our cluster ensuring a multi-master setup with 3 masters in a
 ```bash
 kops create cluster \
 --cloud=aws \
---master-zones=us-east-1a,us-east-1b,us-east-1c \
+--control-plane-zones=us-east-1a,us-east-1b,us-east-1c \
 --zones=us-east-1a,us-east-1b,us-east-1c \
 --node-count=2 \
 --topology private \
 --networking kindnet \
 --node-size=t3.micro \
---master-size=t3.micro \
+--control-plane-size=t3.micro \
 ${NAME}
 ```
 
@@ -73,9 +73,9 @@ A few things to note here:
 - The environment variable ${NAME} was previously exported with our cluster name: privatekopscluster.k8s.local.
 - "--cloud=aws": As kOps grows and begin to support more clouds, we need to tell the command to use the specific cloud we want for our deployment. In this case: amazon web services (aws).
 - For true HA (high availability) at the master level, we need to pick a region with 3 availability zones. For this practical exercise, we are using "us-east-1" AWS region which contains 5 availability zones (az's for short): us-east-1a, us-east-1b, us-east-1c, us-east-1d and us-east-1e. We used "us-east-1a,us-east-1b,us-east-1c" for our masters.
-- The "--master-zones=us-east-1a,us-east-1b,us-east-1c" KOPS argument will actually enforce we want 3 masters here. "--node-count=2" only applies to the worker nodes (not the masters). Again, real "HA" on Kubernetes control plane requires 3 masters.
+- The "--control-plane-zones=us-east-1a,us-east-1b,us-east-1c" KOPS argument will actually enforce we want 3 masters here. "--node-count=2" only applies to the worker nodes (not the masters). Again, real "HA" on Kubernetes control plane requires 3 masters.
 - The "--topology private" argument will ensure that all our instances will have private IP's and no public IP's from amazon.
-- We are including the arguments "--node-size" and "master-size" to specify the "instance types" for both our masters and worker nodes.
+- We are including the arguments "--node-size" and "--control-plane-size" to specify the "instance types" for both our masters and worker nodes.
 - Because we are just doing a simple LAB, we are using "t3.micro" machines. Please DON'T USE t3.micro on real production systems. Start with "t3.medium" as a minimum realistic/workable machine type.
 - And finally, the "--networking kindnet" argument. With the private networking model, we need to tell kOps which networking subsystem to use. More information about kOps supported networking models can be obtained from the [KOPS Kubernetes Networking Documentation](../networking.md). For this exercise we'll use "kindnet".
 
@@ -148,7 +148,7 @@ kind: InstanceGroup
 metadata:
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: t3.micro
   maxSize: 1
   minSize: 1
@@ -327,7 +327,7 @@ metadata:
     kops.k8s.io/cluster: privatekopscluster.k8s.local
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: t3.micro
   maxSize: 3
   minSize: 3

--- a/docs/getting_started/digitalocean.md
+++ b/docs/getting_started/digitalocean.md
@@ -68,7 +68,7 @@ Ensure the master-count is odd-numbered. A load balancer is created dynamically 
 
 ```bash
 # debian (the default) + flannel overlay cluster in tor1 with 3 master setup and a public load balancer.
-kops create cluster --cloud=digitalocean --name=dev5.k8s.local --networking=cilium --api-loadbalancer-type=public --master-count=3 --zones=tor1 --dns none --ssh-public-key=~/.ssh/id_rsa.pub --yes
+kops create cluster --cloud=digitalocean --name=dev5.k8s.local --networking=cilium --api-loadbalancer-type=public --control-plane-count=3 --zones=tor1 --dns none --ssh-public-key=~/.ssh/id_rsa.pub --yes
 
 # to delete a cluster - this will also delete the load balancer associated with the cluster.
 kops delete cluster dev5.k8s.local --yes

--- a/docs/getting_started/gce.md
+++ b/docs/getting_started/gce.md
@@ -87,7 +87,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: 1.7.2
+  kubernetesVersion: 1.36.4
   masterPublicName: api.simple.k8s.local
   networking:
     kubenet: {}
@@ -214,9 +214,9 @@ Example of creating a high availability multi-zonal cluster, with both the contr
 
 ```
 kops create cluster \
---master-zones=us-central1-a,us-central1-b,us-central1-c \
+--control-plane-zones=us-central1-a,us-central1-b,us-central1-c \
 --zones=us-central1-a,us-central1-b,us-central1-c \
---node-count=2
+--node-count=2 \
 ${CLUSTER_NAME}
 ```
 

--- a/docs/getting_started/spot-ocean.md
+++ b/docs/getting_started/spot-ocean.md
@@ -140,21 +140,22 @@ To create a new instance group and have more control over the configuration, a c
 apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
+  name: ocean-nodes
   labels:
     kops.k8s.io/cluster: "example"
     spotinst.io/spot-percentage: "90"
-  spec:
-    image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
-    instanceMetadata:
-      httpPutResponseHopLimit: 1
-      httpTokens: required
-    machineType: m5.large
-    #define the max and min numbers of instances in the group
-    maxSize: 3
-    minSize: 1
-    role: Node
-    subnets:
-      - us-west-2b
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+  instanceMetadata:
+    httpPutResponseHopLimit: 1
+    httpTokens: required
+  machineType: m5.large
+  #define the max and min numbers of instances in the group
+  maxSize: 3
+  minSize: 1
+  role: Node
+  subnets:
+    - us-west-2b
 ```
 
 ## InstanceGroup Metadata Labels

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -12,8 +12,7 @@ kOps will add `kops.k8s.io/gpu="1"` as node selector as well as the following ta
 
 ```yaml
   taints:
-  - effect: NoSchedule
-    key: nvidia.com/gpu
+  - nvidia.com/gpu:NoSchedule
 ```
 
 The taint will prevent you from accidentially scheduling workloads on GPU Nodes.
@@ -40,7 +39,7 @@ metadata:
     kops.k8s.io/cluster: <cluster name>
   name: gpu-nodes
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   nodeLabels:
     kops.k8s.io/instancegroup: gpu-nodes
   machineType: g4dn.xlarge
@@ -63,7 +62,7 @@ metadata:
     kops.k8s.io/cluster: <cluster name>
   name: gpu-nodes
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   nodeLabels:
     kops.k8s.io/instancegroup: gpu-nodes
   machineType: g4dn.xlarge

--- a/docs/iam_roles.md
+++ b/docs/iam_roles.md
@@ -118,9 +118,11 @@ spec:
   networkCIDR: 10.100.0.0/16
   networkID: vpc-a80734c1
   nonMasqueradeCIDR: 100.64.0.0/10
-  zones:
+  subnets:
   - cidr: 10.100.32.0/19
     name: eu-central-1a
+    type: Public
+    zone: eu-central-1a
   additionalPolicies:
     node: |
       [

--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -205,7 +205,7 @@ Instance groups with a mixedInstancesPolicy can be generated with the `kops tool
 The instance-selector accepts user supplied resource parameters like vcpus, memory, and much more to dynamically select instance types that match your criteria.
 
 ```bash
-kops toolbox instance-selector --vcpus 4 --flexible --usage-class spot --instance-group-name spotgroup
+kops toolbox instance-selector spotgroup --vcpus 4 --flexible --usage-class spot
 ```
 
 ```yaml
@@ -216,7 +216,7 @@ metadata:
     kops.k8s.io/cluster: spot.k8s.local
   name: spotgroup
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: c3.xlarge
   maxSize: 15
   minSize: 2

--- a/docs/manifests_and_customizing_via_api.md
+++ b/docs/manifests_and_customizing_via_api.md
@@ -37,15 +37,15 @@ export NAME=k8s.example.com
 export KOPS_STATE_STORE=s3://example-state-store
 kops create cluster $NAME \
     --zones "us-east-2a,us-east-2b,us-east-2c" \
-    --master-zones "us-east-2a,us-east-2b,us-east-2c" \
+    --control-plane-zones "us-east-2a,us-east-2b,us-east-2c" \
     --networking calico \
     --topology private \
     --bastion \
     --node-count 3 \
-    --node-size m4.xlarge \
-    --kubernetes-version v1.6.6 \
-    --master-size m4.large \
-    --vpc vpc-6335dd1a \
+    --node-size m5.xlarge \
+    --kubernetes-version v1.36.4 \
+    --control-plane-size m5.large \
+    --network-id vpc-6335dd1a \
     --dry-run \
     -o yaml > $NAME.yaml
 ```
@@ -64,70 +64,202 @@ metadata:
 spec:
   api:
     loadBalancer:
+      class: Network
       type: Public
   authorization:
-    alwaysAllow: {}
+    rbac: {}
   channel: stable
   cloudProvider: aws
   configBase: s3://example-state-store/k8s.example.com
   etcdClusters:
-  - etcdMembers:
-    - instanceGroup: master-us-east-2d
+  - cpuRequest: 200m
+    etcdMembers:
+    - encryptedVolume: true
+      instanceGroup: control-plane-us-east-2a
       name: a
-    - instanceGroup: master-us-east-2b
+    - encryptedVolume: true
+      instanceGroup: control-plane-us-east-2b
       name: b
-    - instanceGroup: master-us-east-2c
+    - encryptedVolume: true
+      instanceGroup: control-plane-us-east-2c
       name: c
+    manager:
+      backupRetentionDays: 90
+    memoryRequest: 100Mi
     name: main
-  - etcdMembers:
-    - instanceGroup: master-us-east-2d
+  - cpuRequest: 100m
+    etcdMembers:
+    - encryptedVolume: true
+      instanceGroup: control-plane-us-east-2a
       name: a
-    - instanceGroup: master-us-east-2b
+    - encryptedVolume: true
+      instanceGroup: control-plane-us-east-2b
       name: b
-    - instanceGroup: master-us-east-2c
+    - encryptedVolume: true
+      instanceGroup: control-plane-us-east-2c
       name: c
+    manager:
+      backupRetentionDays: 90
+    memoryRequest: 100Mi
     name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: 1.6.6
-  masterPublicName: api.k8s.example.com
+  - ::/0
+  kubernetesVersion: v1.36.4
   networkCIDR: 172.20.0.0/16
-  networkID: vpc-6335dd1a
   networking:
     calico: {}
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
   - 0.0.0.0/0
+  - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
-    name: us-east-2d
+  - cidr: 172.20.64.0/18
+    name: us-east-2a
     type: Private
-    zone: us-east-2d
-  - cidr: 172.20.64.0/19
+    zone: us-east-2a
+  - cidr: 172.20.128.0/18
     name: us-east-2b
     type: Private
     zone: us-east-2b
-  - cidr: 172.20.96.0/19
+  - cidr: 172.20.192.0/18
     name: us-east-2c
     type: Private
     zone: us-east-2c
-  - cidr: 172.20.0.0/22
-    name: utility-us-east-2d
+  - cidr: 172.20.0.0/21
+    name: utility-us-east-2a
     type: Utility
-    zone: us-east-2d
-  - cidr: 172.20.4.0/22
+    zone: us-east-2a
+  - cidr: 172.20.8.0/21
     name: utility-us-east-2b
     type: Utility
     zone: us-east-2b
-  - cidr: 172.20.8.0/22
+  - cidr: 172.20.16.0/21
     name: utility-us-east-2c
     type: Utility
     zone: us-east-2c
   topology:
-    bastion:
-      bastionPublicName: bastion.k8s.example.com
     dns:
-      type: Public
+      type: None
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: k8s.example.com
+  name: control-plane-us-east-2a
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+  machineType: m5.large
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-east-2a
+  role: Master
+  subnets:
+  - us-east-2a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: k8s.example.com
+  name: control-plane-us-east-2b
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+  machineType: m5.large
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-east-2b
+  role: Master
+  subnets:
+  - us-east-2b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: k8s.example.com
+  name: control-plane-us-east-2c
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+  machineType: m5.large
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: control-plane-us-east-2c
+  role: Master
+  subnets:
+  - us-east-2c
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: k8s.example.com
+  name: nodes-us-east-2a
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+  machineType: m5.xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-east-2a
+  role: Node
+  subnets:
+  - us-east-2a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: k8s.example.com
+  name: nodes-us-east-2b
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+  machineType: m5.xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-east-2b
+  role: Node
+  subnets:
+  - us-east-2b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: k8s.example.com
+  name: nodes-us-east-2c
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+  machineType: m5.xlarge
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-east-2c
+  role: Node
+  subnets:
+  - us-east-2c
 
 ---
 
@@ -138,87 +270,15 @@ metadata:
     kops.k8s.io/cluster: k8s.example.com
   name: bastions
 spec:
-  image: kope.io/k8s-1.6-debian-jessie-amd64-hvm-ebs-2017-05-02
-  machineType: t2.micro
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+  machineType: t3.micro
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
-  - utility-us-east-2d
-  - utility-us-east-2b
-  - utility-us-east-2c
-
-
----
-
-apiVersion: kops.k8s.io/v1alpha2
-kind: InstanceGroup
-metadata:
-  labels:
-    kops.k8s.io/cluster: k8s.example.com
-  name: master-us-east-2d
-spec:
-  image: kope.io/k8s-1.6-debian-jessie-amd64-hvm-ebs-2017-05-02
-  machineType: m4.large
-  maxSize: 1
-  minSize: 1
-  role: Master
-  subnets:
-  - us-east-2d
-
-
----
-
-apiVersion: kops.k8s.io/v1alpha2
-kind: InstanceGroup
-metadata:
-  labels:
-    kops.k8s.io/cluster: k8s.example.com
-  name: master-us-east-2b
-spec:
-  image: kope.io/k8s-1.6-debian-jessie-amd64-hvm-ebs-2017-05-02
-  machineType: m4.large
-  maxSize: 1
-  minSize: 1
-  role: Master
-  subnets:
-  - us-east-2b
-
-
----
-
-apiVersion: kops.k8s.io/v1alpha2
-kind: InstanceGroup
-metadata:
-  labels:
-    kops.k8s.io/cluster: k8s.example.com
-  name: master-us-east-2c
-spec:
-  image: kope.io/k8s-1.6-debian-jessie-amd64-hvm-ebs-2017-05-02
-  machineType: m4.large
-  maxSize: 1
-  minSize: 1
-  role: Master
-  subnets:
-  - us-east-2c
-
-
----
-
-apiVersion: kops.k8s.io/v1alpha2
-kind: InstanceGroup
-metadata:
-  labels:
-    kops.k8s.io/cluster: k8s.example.com
-  name: nodes
-spec:
-  image: kope.io/k8s-1.6-debian-jessie-amd64-hvm-ebs-2017-05-02
-  machineType: m4.xlarge
-  maxSize: 3
-  minSize: 3
-  role: Node
-  subnets:
-  - us-east-2d
+  - us-east-2a
   - us-east-2b
   - us-east-2c
 ```
@@ -240,8 +300,8 @@ spec:
   cloudLabels:
     team: example
     project: ion
-  image: kope.io/k8s-1.6-debian-jessie-amd64-hvm-ebs-2017-05-02
-  machineType: m4.10xlarge
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+  machineType: m5.12xlarge
   maxSize: 42
   minSize: 42
   maxPrice: "0.35"
@@ -250,7 +310,7 @@ spec:
   - us-east-2c
 ```
 
-This configuration will create an autoscale group that will include 42 m4.10xlarge nodes running as spot instances with custom labels.
+This configuration will create an autoscale group that will include 42 m5.12xlarge nodes running as spot instances with custom labels.
 
 To create the cluster execute:
 

--- a/docs/networking/calico.md
+++ b/docs/networking/calico.md
@@ -81,7 +81,7 @@ When cross-subnet mode is enabled in kOps 1.19+, it is equivalent to either:
   networking:
     calico:
       awsSrcDstCheck: Disable
-      IPIPMode: CrossSubnet
+      ipipMode: CrossSubnet
 ```
 or
 ```yaml

--- a/docs/networking/kube-router.md
+++ b/docs/networking/kube-router.md
@@ -28,7 +28,7 @@ By default, kube-router enforces `NetworkPolicy` objects with iptables and ipset
 ```yaml
 spec:
   networking:
-    kubeRouter:
+    kuberouter:
       useNFTablesForNetpol: true
 ```
 

--- a/docs/operations/cluster_template.md
+++ b/docs/operations/cluster_template.md
@@ -38,7 +38,7 @@ The file passed as `--values` must contain the variables referenced in the templ
 ```yaml
 # File values.yaml
 clusterName: eu1
-kubernetesVersion: 1.7.1
+kubernetesVersion: 1.36.4
 dnsZone: k8s.example.com
 awsRegion: eu-west-1
 ```

--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -1,6 +1,6 @@
 # Images
 
-As of Kubernetes 1.27 the default images used by kOps are the **[official Ubuntu 22.04](#ubuntu-2204-jammy)** images.
+As of Kubernetes 1.32 the default images used by kOps are the **[official Ubuntu 24.04](#ubuntu-2404-noble)** images.
 
 You can choose a different image for an instance group by editing it with `kops edit ig nodes`.
 
@@ -13,9 +13,9 @@ For AWS, you should set the `image` field in one of the following formats:
 
 ```yaml
 image: ami-00579fbb15b954340
-image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200423
-image: ubuntu/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200423
-image: ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id
+image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+image: ubuntu/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
+image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
 ```
 
 ## Security Updates
@@ -42,7 +42,7 @@ The following table provides the support status for various distros with regards
 | CoreOS                                  |          1.6 |    1.9 |       1.17 |    1.18 |
 | Debian 8                                |            - |    1.5 |       1.17 |    1.18 |
 | Debian 9                                |          1.8 |   1.10 |       1.21 |    1.23 |
-| [Debian 10](#debian-10-buster)          |         1.13 |   1.17 |       1.35 |    1.36 |
+| Debian 10                               |         1.13 |   1.17 |       1.35 |    1.36 |
 | [Debian 11](#debian-11-bullseye)        |       1.21.1 |      - |          - |       - |
 | [Debian 12](#debian-12-bookworm)        |       1.26.3 |      - |          - |       - |
 | [Debian 13](#debian-13-trixie)          |         1.34 |      - |          - |       - |
@@ -57,7 +57,7 @@ The following table provides the support status for various distros with regards
 | [Rocky 10](#rocky-10)                   |         1.35 |      - |          - |       - |
 | Ubuntu 16.04                            |          1.5 |   1.10 |       1.17 |    1.20 |
 | Ubuntu 18.04                            |         1.10 |   1.16 |       1.26 |    1.28 |
-| [Ubuntu 20.04](#ubuntu-2004-focal)      |       1.16.2 |   1.18 |       1.35 |    1.36 |
+| Ubuntu 20.04                            |       1.16.2 |   1.18 |       1.35 |    1.36 |
 | [Ubuntu 22.04](#ubuntu-2204-jammy)      |         1.23 |   1.24 |          - |       - |
 | [Ubuntu 24.04](#ubuntu-2404-noble)      |         1.29 |   1.31 |          - |       - |
 | [Ubuntu 26.04](#ubuntu-2604-resolute)   |         1.36 |      - |          - |       - |
@@ -75,42 +75,6 @@ aws ec2 describe-images --region us-east-1 --output table \
   --filters "Name=owner-alias,Values=amazon" \
   --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
   --filters "Name=name,Values=al2023-ami-2*-kernel-6.1-*"
-```
-
-### Debian 10 (Buster)
-
-Debian 10 is based on Kernel version **4.19** which fixes some of the bugs present in Debian 9 and effects are less visible.
-
-One notable change is the addition of `iptables` NFT, which is by default. This is not yet supported by most CNI plugins and seems to be [slower](https://youtu.be/KHMnC3kj3Js?t=771) than the legacy version. It is recommended to switch to `iptables` legacy by using the following script in `additionalUserData` for each instance group:
-
-```yaml
-additionalUserData:
-  - name: busterfix.sh
-    type: text/x-shellscript
-    content: |
-      #!/bin/sh
-      update-alternatives --set iptables /usr/sbin/iptables-legacy
-      update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-      update-alternatives --set arptables /usr/sbin/arptables-legacy
-      update-alternatives --set ebtables /usr/sbin/ebtables-legacy
-```
-
-Available images can be listed using:
-
-```bash
-# Amazon Web Services (AWS)
-aws ec2 describe-images --region us-east-1 --output table \
-  --owners 136693071363 \
-  --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
-  --filters "Name=name,Values=debian-10-*-*"
-
-# Google Cloud Platform (GCP)
-gcloud compute images list --filter debian-10-buster- \
-  --project debian-cloud
-
-# Microsoft Azure
-az vm image list --all --output table \
-  --publisher Debian --offer debian-10 --sku 10-gen2
 ```
 
 ### Debian 11 (Bullseye)
@@ -295,28 +259,6 @@ aws ec2 describe-images --region us-east-1 --output table \
 gcloud compute images list --filter rocky-linux-10-optimized-gcp-v \
   --project rocky-linux-cloud
 
-```
-
-### Ubuntu 20.04 (Focal)
-
-Ubuntu 20.04 is based on Kernel version **5.4** which fixes all the known major Kernel bugs.
-
-Available images can be listed using:
-
-```bash
-# Amazon Web Services (AWS)
-aws ec2 describe-images --region us-east-1 --output table \
-  --owners 099720109477 \
-  --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
-  --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*-*"
-
-# Google Cloud Platform (GCP)
-gcloud compute images list --filter ubuntu-2004-focal-v \
-  --project ubuntu-os-cloud
-
-# Microsoft Azure
-az vm image list --all --output table \
-  --publisher Canonical --offer 0001-com-ubuntu-server-focal --sku 20_04-lts-gen2
 ```
 
 ### Ubuntu 22.04 (Jammy)

--- a/docs/operations/rolling-update.md
+++ b/docs/operations/rolling-update.md
@@ -67,7 +67,7 @@ Rolling update will then terminate the instance. Unless the instance had been de
 this will cause the cloud provider to create a new instance with the current specification.
 
 Rolling update then waits for 15 seconds to allow the Kubernetes APIserver to notice the termination.
-The amount of time to wait may be changed with the `--bastion-interval`, `--master-interval`, and/or
+The amount of time to wait may be changed with the `--bastion-interval`, `--control-plane-interval`, and/or
 `--node-interval` flags.
 
 Unless the `--cloudonly` flag was given, rolling update then waits until the cluster validates

--- a/docs/operations/scaling.md
+++ b/docs/operations/scaling.md
@@ -19,7 +19,7 @@ metadata:
     kops.k8s.io/cluster: <cluster name>
   name: apiserver-eu-central-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: t3.small
   maxSize: 3
   minSize: 3

--- a/docs/tutorial/upgrading-kubernetes.md
+++ b/docs/tutorial/upgrading-kubernetes.md
@@ -89,7 +89,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: 1.17.2
+  kubernetesVersion: 1.36.2
   masterPublicName: api.simple.k8s.local
   networking:
     kubenet: {}
@@ -106,7 +106,7 @@ spec:
       type: Public
 ```
 
-Edit `kubernetesVersion`, changing it to `1.17.7` for example.
+Edit `kubernetesVersion`, changing it to `1.36.4` for example.
 
 
 Apply the changes to the cloud infrastructure using `kops update cluster` and `kops update cluster --yes`:
@@ -117,7 +117,7 @@ Will create resources:
   	Network             	name:default id:default
   	Tags                	[simple-k8s-local-k8s-io-role-master]
   	Preemptible         	false
-  	BootDiskImage       	cos-cloud/cos-stable-57-9202-64-0
+  	BootDiskImage       	ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   	BootDiskSizeGB      	64
   	BootDiskType        	pd-standard
   	CanIPForward        	true
@@ -129,7 +129,7 @@ Will create resources:
   	Network             	name:default id:default
   	Tags                	[simple-k8s-local-k8s-io-role-node]
   	Preemptible         	false
-  	BootDiskImage       	debian-cloud/debian-9-stretch-v20170918
+  	BootDiskImage       	ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   	BootDiskSizeGB      	128
   	BootDiskType        	pd-standard
   	CanIPForward        	true
@@ -159,10 +159,10 @@ Restart the instances with `kops rolling-update cluster --yes`.
 ```
 > kubectl get nodes -owide
 NAME                        STATUS    AGE       VERSION   EXTERNAL-IP     OS-IMAGE                             KERNEL-VERSION
-master-us-central1-a-8fcc   Ready     26m       v1.17.7   35.194.56.129   Container-Optimized OS from Google   4.4.35+
-nodes-9cml                  Ready     16m       v1.17.7   35.193.12.73    Ubuntu 16.04.3 LTS                   4.10.0-35-generic
-nodes-km98                  Ready     10m       v1.17.7   35.194.25.144   Ubuntu 16.04.3 LTS                   4.10.0-35-generic
-nodes-wbb2                  Ready     2m        v1.17.7   35.188.177.16   Ubuntu 16.04.3 LTS                   4.10.0-35-generic
+master-us-central1-a-8fcc   Ready     26m       v1.36.4   35.194.56.129   Ubuntu 24.04.3 LTS                   6.8.0-51-generic
+nodes-9cml                  Ready     16m       v1.36.4   35.193.12.73    Ubuntu 24.04.3 LTS                   6.8.0-51-generic
+nodes-km98                  Ready     10m       v1.36.4   35.194.25.144   Ubuntu 24.04.3 LTS                   6.8.0-51-generic
+nodes-wbb2                  Ready     2m        v1.36.4   35.188.177.16   Ubuntu 24.04.3 LTS                   6.8.0-51-generic
 ```
 
 <!-- TODO: Do we drain, validate and then restart -->

--- a/docs/tutorial/working-with-instancegroups.md
+++ b/docs/tutorial/working-with-instancegroups.md
@@ -88,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: simple.k8s.local
   name: nodes-us-central1-a
 spec:
-  image: cos-cloud/cos-stable-57-9202-64-0
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260615
   machineType: n1-standard-2
   maxSize: 2
   minSize: 2
@@ -140,20 +140,20 @@ nodes-us-central1-a-z2cz    Ready     1s       v1.7.2
 
 That was a fairly simple change, because we didn't have to reboot the nodes. Most changes though do
 require rolling your instances - this is actually a deliberate design decision, in that we are aiming
-for immutable nodes.  An example is changing your image.  We're using `cos-stable`, which is Google's
-Container OS.  Let's try Debian Stretch instead.
+for immutable nodes.  An example is changing your image.  We're using Ubuntu 24.04, which is the kOps
+default on GCE.  Let's try Debian 12 instead.
 
 If you run `gcloud compute images list` to list the images available to you in GCE, you should see
-a debian-9 image:
+a debian-12 image:
 
 ```
 > gcloud compute images list
 ...
-debian-9-stretch-v20170918                        debian-cloud             debian-9                              READY
+debian-12-bookworm-v20260610                      debian-cloud             debian-12                             READY
 ...
 ```
 
-So now we'll do the same `kops edit ig nodes`, except this time change the image to `debian-cloud/debian-9-stretch-v20170918`:
+So now we'll do the same `kops edit ig nodes`, except this time change the image to `debian-cloud/debian-12-bookworm-v20260610`:
 
 Now `kops update cluster` will show that you're going to create a new [GCE Instance Template](https://cloud.google.com/compute/docs/reference/latest/instanceTemplates),
 and that the Managed Instance Group is going to use it:
@@ -164,7 +164,7 @@ Will create resources:
   	Network             	name:default id:default
   	Tags                	[simple-k8s-local-k8s-io-role-node]
   	Preemptible         	false
-  	BootDiskImage       	debian-cloud/debian-9-stretch-v20170918
+  	BootDiskImage       	debian-cloud/debian-12-bookworm-v20260610
   	BootDiskSizeGB      	128
   	BootDiskType        	pd-standard
   	CanIPForward        	true
@@ -177,7 +177,7 @@ Will modify resources:
   	InstanceTemplate    	 id:nodes-us-central1-a-simple-k8s-local-1507043948 -> name:nodes-us-central1-a-simple-k8s-local
 ```
 
-Note that the `BootDiskImage` is indeed set to the debian 9 image you requested.
+Note that the `BootDiskImage` is indeed set to the debian 12 image you requested.
 
 `kops update cluster --yes` will now apply the change, but if you were to run `kubectl get nodes` you would see
 that the instances had not yet been reconfigured. There's a hint at the bottom:
@@ -203,7 +203,7 @@ An example spec looks like this:
 metadata:
   name: nodes-us-west-2a
 spec:
-  image: ssm:/aws/service/canonical/ubuntu/server/18.04/stable/current/amd64/hvm/ebs-gp2/ami-id
+  image: ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
   machineType: t3.medium
   maxSize: 1
   minSize: 1
@@ -304,7 +304,7 @@ metadata:
 spec:
   cloudLabels:
     role: compute
-  image: coreos.com/CoreOS-stable-1855.4.0-hvm
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: m4.large
   ...
   volumes:
@@ -332,7 +332,7 @@ metadata:
 spec:
   cloudLabels:
     role: compute
-  image: coreos.com/CoreOS-stable-1855.4.0-hvm
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: m4.large
   ...
   volumeMounts:
@@ -359,7 +359,7 @@ metadata:
 spec:
   cloudLabels:
     role: compute
-  image: coreos.com/CoreOS-stable-1855.4.0-hvm
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: c5d.large
   ...
   volumeMounts:
@@ -451,7 +451,7 @@ metadata:
 spec:
   cloudLabels:
     role: compute
-  image: coreos.com/CoreOS-stable-1911.4.0-hvm
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714
   machineType: m4.large
   maxSize: 50
   minSize: 10
@@ -516,7 +516,7 @@ So the procedure is:
 
 ## Adding Taints or Labels to an Instance Group
 
-If you're running Kubernetes 1.6.0 or later, you can also control taints in the InstanceGroup.
+You can also control taints in the InstanceGroup.
 The taints property takes a list of strings. The following example would add two taints to an IG,
 using the same `edit` -> `update` -> `rolling-update` process as above.
 
@@ -526,7 +526,7 @@ Additionally, `nodeLabels` can be added to an IG in order to take advantage of P
 metadata:
   name: nodes-us-east-1a
 spec:
-  machineType: m3.medium
+  machineType: m5.large
   maxSize: 3
   minSize: 3
   role: Node
@@ -537,19 +537,19 @@ spec:
     spot: "false"
 ```
 
-## Resizing the master
+## Resizing the control plane
 
 (This procedure should be pretty familiar by now!)
 
-Your master instance group will probably be called `master-us-west-1c` or something similar.
+Your control plane instance group will probably be called `control-plane-us-west-1c` or something similar.
 
-`kops edit ig master-us-west-1c`
+`kops edit ig control-plane-us-west-1c`
 
 Add or set the machineType:
 
 ```YAML
 spec:
-  machineType: m3.large
+  machineType: m5.xlarge
 ```
 
 * Preview changes: `kops update cluster <clustername>`


### PR DESCRIPTION
Every YAML example under `docs/` was strict-decoded through the kOps API scheme, and every documented `kops` command was checked against the 1.37 flag set. That surfaced a number of examples that current kOps would reject outright.

### Examples that would be rejected today

* `networking.kubeRouter` and `calico.IPIPMode` do not match the JSON tags in the API types — they are `kuberouter` and `ipipMode`.
* `clusterAutoscaler.scaleDownUtilizationThreshold` and a `kubeAPIServer` env value were unquoted numbers, but both fields are strings.
* An InstanceGroup in the Spot Ocean docs had its `spec` nested under `metadata`.
* `iam_roles.md` used the long-removed `zones` field instead of `subnets`.
* The GPU taint was shown as a Kubernetes taint object, but the kOps `taints` field takes strings; the value kOps actually sets is `nvidia.com/gpu:NoSchedule`.
* A missing line continuation split the GCE `kops create cluster` command.

### Renamed flags

`--master-zones`, `--master-size`, `--master-count`, `--master-volume-size` and `--master-interval` moved to `--control-plane-*`, and `--vpc` is now `--network-id`. `kops toolbox instance-selector` takes the instance group name as a positional argument.

### Removed features

Dropped the `containerRuntime` and `spec.docker` sections — validation now rejects `containerRuntime: docker` outright, and `docker.service` in the hooks example became `containerd.service`.

### Stale versions and images

Kubernetes 1.36.4 (latest recommended in `channels/stable`), containerd 2.3.4, and Ubuntu 24.04 in place of focal, CoreOS, `kope.io` and debian-9 references. The exported manifest in `manifests_and_customizing_via_api.md` was regenerated with `kops create cluster --dry-run -o yaml` rather than hand-edited.

### Worth a look during review

* **`images.md`** — I removed the "Ubuntu 20.04 (Focal)" and "Debian 10 (Buster)" sections. Both were removed in kOps 1.36 and were the only removed distros still listed under "Supported Distros". This leaves a dead fragment in an old release note (the page still resolves, just not the anchor). Happy to drop this hunk if you'd rather keep them.
* **`coreos-kops-tests-multimaster.md`** — only the flags were fixed. The doc is an end-to-end CoreOS tutorial and CoreOS was removed in kOps 1.18, so the AMI IDs and `coreos.com` URLs are all dead. It probably wants deleting or rewriting against a supported distro, which felt out of scope here.

Examples stay on the `v1alpha2` apiVersion, which is what kOps writes today.

59 YAML blocks still do not strict-decode; each was checked by hand and they are intentional `...` elisions, Go templates in `cluster_template.md`, non-kOps manifests, and shell transcripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwhWXUuoWwsv9WSzGAkanj