### PR TITLE
Round trip Cluster and InstanceGroup across API versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	k8s.io/mount-utils v0.36.3
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/randfill v1.0.0
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -264,7 +265,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
 )
 
 // Newer versions build SRN strings with text/template, which disables linker

--- a/pkg/apis/kops/install/fuzzer_test.go
+++ b/pkg/apis/kops/install/fuzzer_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/randfill"
+)
+
+// The fixups below constrain a fuzzed internal object to values the target API
+// version is able to represent. Every fixup marks a field, or a combination of
+// fields, that does not survive a round trip; see roundtrip_test.go for the
+// catalogue of what is not round trippable and why.
+
+// fixupClusterSpec applies the fixups every API version needs: values that no version
+// round trips, either because a defaulter rewrites them on decode or because the
+// internal type marks the field `json:"-"` and never serializes it at all.
+func fixupClusterSpec(spec *kops.ClusterSpec) {
+	// SetDefaults_ClusterSpec fills these in on decode, so an unset value is never
+	// observable after a round trip.
+	if spec.Networking.Topology == nil {
+		spec.Networking.Topology = &kops.TopologySpec{}
+	}
+	if spec.Networking.Topology.DNS == "" {
+		spec.Networking.Topology.DNS = kops.DNSTypePublic
+	}
+	if spec.Authorization == nil || spec.Authorization.IsEmpty() {
+		spec.Authorization = &kops.AuthorizationSpec{RBAC: &kops.RBACAuthorizationSpec{}}
+	}
+	if spec.Networking.Flannel != nil && spec.Networking.Flannel.Backend == "" {
+		spec.Networking.Flannel.Backend = "udp"
+	}
+
+	// Only one cloud provider can be configured: v1alpha2 stores the choice as a
+	// single string, and validation rejects more than one.
+	keepOneProvider(&spec.CloudProvider)
+}
+
+// keepOneProvider clears all but the first configured cloud provider. v1alpha2
+// stores the choice as a single string, so a spec naming two providers cannot round
+// trip; validation rejects it too.
+func keepOneProvider(spec *kops.CloudProviderSpec) {
+	switch {
+	case spec.AWS != nil:
+		*spec = kops.CloudProviderSpec{AWS: spec.AWS}
+	case spec.Azure != nil:
+		*spec = kops.CloudProviderSpec{Azure: spec.Azure}
+	case spec.DO != nil:
+		*spec = kops.CloudProviderSpec{DO: spec.DO}
+	case spec.GCE != nil:
+		*spec = kops.CloudProviderSpec{GCE: spec.GCE}
+	case spec.Hetzner != nil:
+		*spec = kops.CloudProviderSpec{Hetzner: spec.Hetzner}
+	case spec.Linode != nil:
+		*spec = kops.CloudProviderSpec{Linode: spec.Linode}
+	case spec.Openstack != nil:
+		*spec = kops.CloudProviderSpec{Openstack: spec.Openstack}
+	case spec.Scaleway != nil:
+		*spec = kops.CloudProviderSpec{Scaleway: spec.Scaleway}
+	}
+}
+
+// fixupKubeAPIServer clears the kube-apiserver fields that the internal type
+// marks `json:"-"`.
+func fixupKubeAPIServer(spec *kops.KubeAPIServerConfig) {
+	// The legacy OIDC flags exist only so that v1alpha2 can promote them into
+	// spec.authentication.oidc on read, which is a one-way migration.
+	spec.OIDCClientID = nil
+	spec.OIDCGroupsClaim = nil
+	spec.OIDCGroupsPrefix = nil
+	spec.OIDCIssuerURL = nil
+	spec.OIDCRequiredClaim = nil
+	spec.OIDCUsernameClaim = nil
+	spec.OIDCUsernamePrefix = nil
+}
+
+// commonFuzzerFuncs returns the fuzzer functions shared by every API version.
+func commonFuzzerFuncs() []any {
+	return []any{
+		func(spec *kops.EBSCSIDriverSpec, c randfill.Continue) {
+			c.FillNoCustom(spec)
+			// Enabled is `json:"-"` in the internal type.
+			spec.Enabled = nil
+		},
+		func(sel *corev1.FileKeySelector, c randfill.Continue) {
+			c.FillNoCustom(sel)
+			// corev1 declares Optional as `+default=false`, so defaulter-gen fills it
+			// in on decode.
+			if sel.Optional == nil {
+				sel.Optional = ptr.To(false)
+			}
+		},
+	}
+}
+
+// v1alpha2FuzzerFuncs returns fuzzer functions producing internal objects that
+// v1alpha2 can represent.
+func v1alpha2FuzzerFuncs(_ runtimeserializer.CodecFactory) []any {
+	return append(commonFuzzerFuncs(),
+		func(spec *kops.ClusterSpec, c randfill.Continue) {
+			c.FillNoCustom(spec)
+			fixupClusterSpec(spec)
+
+			// v1alpha2 stashes the AWS and GCE settings it knows about in
+			// spec.cloudConfig, creating the struct when it has something to write, so
+			// a round trip can never observe it unset. This is applied unconditionally
+			// rather than only for the settings that trigger it, which would mean
+			// duplicating the conversion's own stashing rules here.
+			if spec.CloudConfig == nil {
+				spec.CloudConfig = &kops.CloudConfiguration{}
+			}
+
+			// v1alpha2 keeps the OIDC settings in spec.kubeAPIServer, and likewise
+			// creates that struct when it has something to write.
+			if spec.Authentication != nil && spec.Authentication.OIDC != nil && spec.KubeAPIServer == nil {
+				spec.KubeAPIServer = &kops.KubeAPIServerConfig{}
+			}
+
+			// v1alpha2 has no field for the provider binaries location
+			// (kubernetes/kops#18740).
+			if spec.CloudProvider.AWS != nil {
+				spec.CloudProvider.AWS.BinariesLocation = nil
+			}
+			if spec.CloudProvider.GCE != nil {
+				spec.CloudProvider.GCE.BinariesLocation = nil
+			}
+		},
+		func(spec *kops.KubeAPIServerConfig, c randfill.Continue) {
+			c.FillNoCustom(spec)
+			fixupKubeAPIServer(spec)
+		},
+		func(spec *kops.OIDCAuthenticationSpec, c randfill.Continue) {
+			c.FillNoCustom(spec)
+
+			// v1alpha2 flattens the OIDC settings into the kube-apiserver flags, and
+			// only reconstructs spec.authentication.oidc when at least one is set.
+			if spec.ClientID == nil {
+				spec.ClientID = ptr.To(c.String(0))
+			}
+
+			// GroupsClaims is stored comma-joined in a single flag, so an individual
+			// claim may not contain a comma. An empty list joins to "", which splits
+			// back to a single empty claim rather than to an empty list, so normalize
+			// it to unset.
+			for i, claim := range spec.GroupsClaims {
+				spec.GroupsClaims[i] = strings.ReplaceAll(claim, ",", "")
+			}
+			if len(spec.GroupsClaims) == 0 {
+				spec.GroupsClaims = nil
+			}
+
+			// RequiredClaims is stored as a list of "key=value" flags, so a key may
+			// not contain an equals sign. Unlike GroupsClaims it needs no empty-to-nil
+			// normalization: omitempty drops an empty slice, and Semantic.DeepEqual
+			// equates nil with empty, whereas a non-nil *string is not dropped.
+			if spec.RequiredClaims != nil {
+				claims := make(map[string]string, len(spec.RequiredClaims))
+				for k, v := range spec.RequiredClaims {
+					claims[strings.ReplaceAll(k, "=", "")] = v
+				}
+				spec.RequiredClaims = claims
+			}
+		},
+		func(spec *kops.InstanceGroupSpec, c randfill.Continue) {
+			c.FillNoCustom(spec)
+
+			// v1alpha2 flattens RootVolume into individual rootVolume* fields, so an
+			// entirely empty RootVolume decodes back as unset.
+			if spec.RootVolume != nil && *spec.RootVolume == (kops.InstanceRootVolumeSpec{}) {
+				spec.RootVolume = nil
+			}
+		},
+	)
+}
+
+// v1alpha3FuzzerFuncs returns fuzzer functions producing internal objects that
+// v1alpha3 can represent. Everything cleared here is a setting kOps has removed but
+// still carries on the internal type, and which v1alpha3 marks `json:"-"`.
+func v1alpha3FuzzerFuncs(_ runtimeserializer.CodecFactory) []any {
+	return append(commonFuzzerFuncs(),
+		func(spec *kops.ClusterSpec, c randfill.Continue) {
+			c.FillNoCustom(spec)
+			fixupClusterSpec(spec)
+
+			spec.ContainerRuntime = ""
+			spec.Docker = nil
+			spec.NodeAuthorization = nil
+			if spec.IAM != nil {
+				spec.IAM.Legacy = false
+			}
+			spec.Networking.Classic = nil
+			spec.Networking.Romana = nil
+			spec.Networking.LyftVPC = nil
+			if spec.Networking.Calico != nil {
+				spec.Networking.Calico.CrossSubnet = nil
+			}
+			for i := range spec.EtcdClusters {
+				spec.EtcdClusters[i].Provider = ""
+				spec.EtcdClusters[i].LeaderElectionTimeout = nil
+				spec.EtcdClusters[i].HeartbeatInterval = nil
+			}
+		},
+		func(spec *kops.KubeAPIServerConfig, c randfill.Continue) {
+			c.FillNoCustom(spec)
+			fixupKubeAPIServer(spec)
+
+			spec.AllowPrivileged = nil
+			spec.AuthorizationRBACSuperUser = nil
+			spec.BasicAuthFile = ""
+			spec.EtcdCAFile = ""
+			spec.EtcdCertFile = ""
+			spec.EtcdKeyFile = ""
+			spec.EtcdQuorumRead = nil
+			spec.ExperimentalEncryptionProviderConfig = nil
+			spec.KubeletClientCertificate = ""
+			spec.KubeletClientKey = ""
+			spec.ProxyClientCertFile = nil
+			spec.ProxyClientKeyFile = nil
+			spec.RequestheaderClientCAFile = ""
+			spec.TLSCertFile = ""
+			spec.TLSPrivateKeyFile = ""
+		},
+		func(spec *kops.KubeletConfigSpec, c randfill.Continue) {
+			c.FillNoCustom(spec)
+
+			spec.AllowPrivileged = nil
+			spec.APIServers = ""
+			spec.BabysitDaemons = nil
+			spec.ClientCAFile = ""
+			spec.ConfigureCBR0 = nil
+			spec.DockerDisableSharedPID = nil
+			spec.EnableCustomMetrics = nil
+			spec.ExperimentalAllowedUnsafeSysctls = nil
+			spec.HostnameOverride = ""
+			spec.NodeLabels = nil
+			spec.NvidiaGPUs = 0
+			spec.ReconcileCIDR = nil
+			spec.RegisterSchedulable = nil
+			spec.RequireKubeconfig = nil
+		},
+		func(spec *kops.KubeControllerManagerConfig, c randfill.Continue) {
+			c.FillNoCustom(spec)
+
+			spec.RootCAFile = ""
+			spec.ServiceAccountPrivateKeyFile = ""
+		},
+		func(spec *kops.KubeProxyConfig, c randfill.Continue) {
+			c.FillNoCustom(spec)
+
+			spec.BindAddress = ""
+			spec.HostnameOverride = ""
+		},
+	)
+}

--- a/pkg/apis/kops/install/roundtrip_test.go
+++ b/pkg/apis/kops/install/roundtrip_test.go
@@ -17,7 +17,13 @@ limitations under the License.
 package install
 
 import (
+	// apimachinery's fuzzer.FuzzerFor takes a math/rand (v1) Source, so v1 it is.
 	"math/rand"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
@@ -26,33 +32,136 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kops/pkg/apis/kops"
 )
 
+// testScheme is shared: Install registers several hundred conversion functions per
+// call, and the resulting scheme is read only once registration completes.
+var testScheme = sync.OnceValue(func() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	Install(scheme)
+
+	return scheme
+})
+
+var internalGV = schema.GroupVersion{Group: kops.GroupName, Version: runtime.APIVersionInternal}
+
+// externalVersion pairs an API version with the fuzzer functions describing what it
+// cannot represent.
+type externalVersion struct {
+	version string
+	funcs   fuzzer.FuzzerFuncs
+}
+
+// externalVersions lists every external version and the fuzzer functions describing
+// what it loses. Adding an API version means adding an entry here.
+var externalVersions = []externalVersion{
+	{version: "v1alpha2", funcs: v1alpha2FuzzerFuncs},
+	{version: "v1alpha3", funcs: v1alpha3FuzzerFuncs},
+}
+
+// TestRoundTripTypes fuzzes an internal object, converts it to an external version,
+// serializes it, and checks that reading it back produces the same internal object.
+//
+// Each version is exercised with its own fuzzer functions, because the two versions
+// lose different fields: v1alpha3 drops the settings kOps has removed, while v1alpha2
+// lacks a home for some newer ones and flattens others into legacy kube-apiserver
+// flags. What those functions clear in fuzzer_test.go is the authoritative list of what
+// is silently dropped on write, with the reason recorded on each entry.
 func TestRoundTripTypes(t *testing.T) {
-	var fuzzingFuncs fuzzer.FuzzerFuncs
+	scheme := testScheme()
+	codecFactory := runtimeserializer.NewCodecFactory(scheme)
+	kinds := internalKindNames(t, scheme)
 
-	nonRoundTrippableTypes := make(map[schema.GroupVersionKind]bool)
+	for _, ver := range externalVersions {
+		t.Run(ver.version, func(t *testing.T) {
+			seed := fuzzSeed(t)
+			t.Logf("fuzzing with seed %d; reproduce with KOPS_FUZZ_SEED=%d", seed, seed)
 
-	// TODO: Eliminate this once all types round-trip
-	for _, version := range []string{"v1alpha2", "v1alpha3"} {
-		nonRoundTrippableTypes[schema.GroupVersionKind{Group: "kops.k8s.io", Version: version, Kind: "Cluster"}] = true
-		nonRoundTrippableTypes[schema.GroupVersionKind{Group: "kops.k8s.io", Version: version, Kind: "ClusterList"}] = true
-		nonRoundTrippableTypes[schema.GroupVersionKind{Group: "kops.k8s.io", Version: version, Kind: "InstanceGroup"}] = true
-		nonRoundTrippableTypes[schema.GroupVersionKind{Group: "kops.k8s.io", Version: version, Kind: "InstanceGroupList"}] = true
+			filler := fuzzer.FuzzerFor(
+				fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, ver.funcs),
+				rand.NewSource(seed),
+				codecFactory,
+			)
+
+			skip := skipOtherVersions(ver.version, kinds)
+			for _, kind := range kinds {
+				roundtrip.RoundTripSpecificKindWithoutProtobuf(t, internalGV.WithKind(kind), scheme, codecFactory, filler, skip)
+			}
+		})
+	}
+}
+
+// TestFuzzerFuncsCoverAllVersions fails if an external version reaches the scheme
+// without fuzzer functions describing what it loses. Such a version would otherwise be
+// round tripped under another version's fuzzer, reporting failures against the wrong
+// subtest.
+func TestFuzzerFuncsCoverAllVersions(t *testing.T) {
+	var missing []string
+	for _, gv := range testScheme().PrioritizedVersionsForGroup(kops.GroupName) {
+		if !slices.ContainsFunc(externalVersions, func(v externalVersion) bool { return v.version == gv.Version }) {
+			missing = append(missing, gv.String())
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("no fuzzer funcs registered for %v; add them to externalVersions", missing)
+	}
+}
+
+// fuzzSeed returns the seed to fuzz with. A lossy field combination usually only shows
+// up on a fraction of seeds, so a CI failure is only actionable if the seed it used can
+// be fed back in.
+func fuzzSeed(t *testing.T) int64 {
+	t.Helper()
+
+	s := os.Getenv("KOPS_FUZZ_SEED")
+	if s == "" {
+		return rand.Int63()
 	}
 
-	if len(nonRoundTrippableTypes) == 0 {
-		roundtrip.RoundTripTestForAPIGroup(t, Install, fuzzingFuncs)
-	} else {
-		scheme := runtime.NewScheme()
-		Install(scheme)
-
-		codecFactory := runtimeserializer.NewCodecFactory(scheme)
-		f := fuzzer.FuzzerFor(
-			fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, fuzzingFuncs),
-			rand.NewSource(rand.Int63()),
-			codecFactory,
-		)
-		roundtrip.RoundTripTypesWithoutProtobuf(t, scheme, codecFactory, f, nonRoundTrippableTypes)
+	seed, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		t.Fatalf("parsing KOPS_FUZZ_SEED %q: %v", s, err)
 	}
+
+	return seed
+}
+
+// skipOtherVersions returns the non-round-trippable set covering every external version
+// but keep. roundTripToAllExternalVersions walks every external version of a kind, and
+// each version only round trips under the fuzzer functions written for it.
+func skipOtherVersions(keep string, kinds []string) map[schema.GroupVersionKind]bool {
+	skip := make(map[schema.GroupVersionKind]bool, (len(externalVersions)-1)*len(kinds))
+	for _, ver := range externalVersions {
+		if ver.version == keep {
+			continue
+		}
+		for _, kind := range kinds {
+			skip[schema.GroupVersionKind{Group: kops.GroupName, Version: ver.version, Kind: kind}] = true
+		}
+	}
+
+	return skip
+}
+
+// internalKindNames returns the internal kinds of the kOps API group, so that a newly
+// added type is covered without having to be listed here.
+func internalKindNames(t *testing.T, scheme *runtime.Scheme) []string {
+	t.Helper()
+
+	var kinds []string
+	for kind, goType := range scheme.KnownTypes(internalGV) {
+		// metav1.AddToGroupVersion registers its own types into the group; they are
+		// not ours to round trip.
+		if !strings.HasPrefix(goType.PkgPath(), "k8s.io/kops/") {
+			continue
+		}
+		kinds = append(kinds, kind)
+	}
+	if len(kinds) == 0 {
+		t.Fatalf("no kinds registered for %s", internalGV)
+	}
+	slices.Sort(kinds)
+
+	return kinds
 }

--- a/pkg/apis/kops/v1alpha2/conversion.go
+++ b/pkg/apis/kops/v1alpha2/conversion.go
@@ -109,29 +109,35 @@ func Convert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *kops
 			kube.OIDCRequiredClaim != nil ||
 			kube.OIDCUsernameClaim != nil ||
 			kube.OIDCUsernamePrefix != nil {
-			if out.Authentication == nil {
-				out.Authentication = &kops.AuthenticationSpec{}
+			// Build the settings before publishing them. The generated conversion
+			// copies the OIDC pointer straight across, so out.Authentication.OIDC can
+			// still be the caller's struct; writing into it would mutate the input,
+			// and returning an error partway would leave it half rewritten.
+			oidc := &kops.OIDCAuthenticationSpec{
+				ClientID:       kube.OIDCClientID,
+				GroupsPrefix:   kube.OIDCGroupsPrefix,
+				IssuerURL:      kube.OIDCIssuerURL,
+				UsernameClaim:  kube.OIDCUsernameClaim,
+				UsernamePrefix: kube.OIDCUsernamePrefix,
 			}
-			if out.Authentication.OIDC == nil {
-				out.Authentication.OIDC = &kops.OIDCAuthenticationSpec{}
-			}
-
-			oidc := out.Authentication.OIDC
-			oidc.ClientID = kube.OIDCClientID
 			if kube.OIDCGroupsClaim != nil {
 				oidc.GroupsClaims = strings.Split(*kube.OIDCGroupsClaim, ",")
 			}
-			oidc.GroupsPrefix = kube.OIDCGroupsPrefix
-			oidc.IssuerURL = kube.OIDCIssuerURL
 			if kube.OIDCRequiredClaim != nil {
 				oidc.RequiredClaims = make(map[string]string, len(kube.OIDCRequiredClaim))
-				for _, claim := range kube.OIDCRequiredClaim {
-					split := strings.SplitN(claim, "=", 2)
-					oidc.RequiredClaims[split[0]] = split[1]
+				for i, claim := range kube.OIDCRequiredClaim {
+					key, value, found := strings.Cut(claim, "=")
+					if !found {
+						return field.Invalid(field.NewPath("spec", "kubeAPIServer", "oidcRequiredClaim").Index(i), claim, `must be of the form "key=value"`)
+					}
+					oidc.RequiredClaims[key] = value
 				}
 			}
-			oidc.UsernameClaim = kube.OIDCUsernameClaim
-			oidc.UsernamePrefix = kube.OIDCUsernamePrefix
+
+			if out.Authentication == nil {
+				out.Authentication = &kops.AuthenticationSpec{}
+			}
+			out.Authentication.OIDC = oidc
 		}
 	}
 	if in.LegacyNetworking != nil {

--- a/pkg/apis/kops/v1alpha2/conversion_test.go
+++ b/pkg/apis/kops/v1alpha2/conversion_test.go
@@ -1,0 +1,487 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2_test
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/install"
+	"k8s.io/kops/pkg/apis/kops/v1alpha2"
+	"k8s.io/utils/ptr"
+)
+
+// The conversions between the internal type and v1alpha2 are hand written, and the
+// round trip test in pkg/apis/kops/install cannot cover the cases where they are
+// deliberately lossy or where they rename a value. Those are pinned here instead.
+
+// testScheme is shared: Install registers several hundred conversion functions per
+// call, and the resulting scheme is read only once registration completes.
+var testScheme = sync.OnceValue(func() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	install.Install(scheme)
+
+	return scheme
+})
+
+func toV1alpha2(t *testing.T, spec kops.ClusterSpec) *v1alpha2.ClusterSpec {
+	t.Helper()
+
+	out := &v1alpha2.Cluster{}
+	if err := testScheme().Convert(&kops.Cluster{Spec: spec}, out, nil); err != nil {
+		t.Fatalf("converting to v1alpha2: %v", err)
+	}
+
+	return &out.Spec
+}
+
+// toInternal converts a v1alpha2 spec back to the internal type. It drops
+// spec.authentication.oidc, which v1alpha2 declares `json:"-"` and types as the internal
+// *kops.OIDCAuthenticationSpec, so a real decode never carries one; the generated
+// conversion copies that pointer straight across, which would otherwise hand the
+// assertion back the very object the test passed in. The AuthenticationSpec is copied
+// rather than modified in place, because the by-value spec still shares that pointer
+// with the caller.
+func toInternal(t *testing.T, spec v1alpha2.ClusterSpec) *kops.ClusterSpec {
+	t.Helper()
+
+	if spec.Authentication != nil {
+		auth := *spec.Authentication
+		auth.OIDC = nil
+		spec.Authentication = &auth
+	}
+
+	out := &kops.Cluster{}
+	if err := testScheme().Convert(&v1alpha2.Cluster{Spec: spec}, out, nil); err != nil {
+		t.Fatalf("converting to internal: %v", err)
+	}
+
+	return &out.Spec
+}
+
+// TestConvertInvertedBooleans covers the fields v1alpha2 spells as the negation of
+// the internal field.
+func TestConvertInvertedBooleans(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("enabled=%v", enabled), func(t *testing.T) {
+			internal := kops.ClusterSpec{
+				Networking: kops.NetworkingSpec{
+					TagSubnets: ptr.To(enabled),
+					Canal:      &kops.CanalNetworkingSpec{FlanneldIptablesForwardRules: ptr.To(enabled)},
+					Cilium: &kops.CiliumNetworkingSpec{
+						InstallIptablesRules: ptr.To(enabled),
+						Masquerade:           ptr.To(enabled),
+					},
+				},
+				Hooks: []kops.HookSpec{{Enabled: ptr.To(enabled)}},
+			}
+
+			external := toV1alpha2(t, internal)
+			if external.LegacyNetworking == nil {
+				t.Fatal("networking was not populated")
+			}
+			if external.LegacyNetworking.Canal == nil || external.LegacyNetworking.Cilium == nil {
+				t.Fatalf("canal and cilium were not populated: %#v", external.LegacyNetworking)
+			}
+
+			want := ptr.To(!enabled)
+			for _, tc := range []struct {
+				name string
+				got  *bool
+			}{
+				{"tagSubnets", external.TagSubnets},
+				{"canal.flanneldIptablesForwardRules", external.LegacyNetworking.Canal.FlanneldIptablesForwardRules},
+				{"cilium.installIptablesRules", external.LegacyNetworking.Cilium.InstallIptablesRules},
+				{"cilium.masquerade", external.LegacyNetworking.Cilium.Masquerade},
+			} {
+				if diff := cmp.Diff(want, tc.got); diff != "" {
+					t.Errorf("%s (-want +got):\n%s", tc.name, diff)
+				}
+			}
+			if diff := cmp.Diff([]v1alpha2.HookSpec{{Enabled: want}}, external.Hooks); diff != "" {
+				t.Errorf("hooks (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestConvertControlPlaneNaming covers the places where v1alpha2 still says "master".
+func TestConvertControlPlaneNaming(t *testing.T) {
+	internal := kops.ClusterSpec{
+		AdditionalPolicies: map[string]string{"control-plane": "cp-policy", "node": "node-policy"},
+		ExternalPolicies:   map[string][]string{"control-plane": {"cp-arn"}, "node": {"node-arn"}},
+		Hooks:              []kops.HookSpec{{Roles: []kops.InstanceGroupRole{kops.InstanceGroupRoleControlPlane, kops.InstanceGroupRoleNode}}},
+	}
+
+	external := toV1alpha2(t, internal)
+	if diff := cmp.Diff(map[string]string{"master": "cp-policy", "node": "node-policy"}, external.AdditionalPolicies); diff != "" {
+		t.Errorf("toV1alpha2(%v).AdditionalPolicies (-want +got):\n%s", internal.AdditionalPolicies, diff)
+	}
+	if diff := cmp.Diff(map[string][]string{"master": {"cp-arn"}, "node": {"node-arn"}}, external.ExternalPolicies); diff != "" {
+		t.Errorf("toV1alpha2(%v).ExternalPolicies (-want +got):\n%s", internal.ExternalPolicies, diff)
+	}
+	if diff := cmp.Diff([]v1alpha2.HookSpec{{Roles: []v1alpha2.InstanceGroupRole{"Master", "Node"}}}, external.Hooks); diff != "" {
+		t.Errorf("toV1alpha2(%v).Hooks (-want +got):\n%s", internal.Hooks, diff)
+	}
+
+	back := toInternal(t, *external)
+	if diff := cmp.Diff(internal.AdditionalPolicies, back.AdditionalPolicies); diff != "" {
+		t.Errorf("additionalPolicies round trip (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(internal.ExternalPolicies, back.ExternalPolicies); diff != "" {
+		t.Errorf("externalPolicies round trip (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(internal.Hooks, back.Hooks); diff != "" {
+		t.Errorf("hooks round trip (-want +got):\n%s", diff)
+	}
+}
+
+// TestConvertInstanceGroupRootVolume covers the flattening of spec.rootVolume into the
+// individual v1alpha2 rootVolume* fields.
+func TestConvertInstanceGroupRootVolume(t *testing.T) {
+	internal := &kops.InstanceGroup{
+		Spec: kops.InstanceGroupSpec{
+			Role: kops.InstanceGroupRoleControlPlane,
+			RootVolume: &kops.InstanceRootVolumeSpec{
+				Size:          ptr.To(int32(64)),
+				Type:          ptr.To("gp3"),
+				IOPS:          ptr.To(int32(3000)),
+				Throughput:    ptr.To(int32(125)),
+				Optimization:  ptr.To(true),
+				Encryption:    ptr.To(true),
+				EncryptionKey: ptr.To("alias/kops"),
+			},
+		},
+	}
+
+	external := &v1alpha2.InstanceGroup{}
+	if err := testScheme().Convert(internal, external, nil); err != nil {
+		t.Fatalf("converting to v1alpha2: %v", err)
+	}
+
+	// Drop spec.rootVolume for the same reason toInternal drops
+	// spec.authentication.oidc: v1alpha2 declares it `json:"-"` and types it as the
+	// internal struct, so a real decode never carries one and the generated pointer copy
+	// would otherwise let the round trip below pass through the alias rather than
+	// through the flattened rootVolume* fields.
+	external.Spec.RootVolume = nil
+
+	// Compare the whole spec: a round trip alone cannot catch a symmetric error such as
+	// writing IOPS into rootVolumeThroughput and reading it back from there.
+	want := v1alpha2.InstanceGroupSpec{
+		Role:                    "Master",
+		RootVolumeSize:          ptr.To(int32(64)),
+		RootVolumeType:          ptr.To("gp3"),
+		RootVolumeIOPS:          ptr.To(int32(3000)),
+		RootVolumeThroughput:    ptr.To(int32(125)),
+		RootVolumeOptimization:  ptr.To(true),
+		RootVolumeEncryption:    ptr.To(true),
+		RootVolumeEncryptionKey: ptr.To("alias/kops"),
+	}
+	if diff := cmp.Diff(want, external.Spec); diff != "" {
+		t.Errorf("Convert(%+v) to v1alpha2 (-want +got):\n%s", internal.Spec, diff)
+	}
+
+	back := &kops.InstanceGroup{}
+	if err := testScheme().Convert(external, back, nil); err != nil {
+		t.Fatalf("converting to internal: %v", err)
+	}
+	if diff := cmp.Diff(internal.Spec, back.Spec); diff != "" {
+		t.Errorf("Convert(%+v) to internal (-want +got):\n%s", external.Spec, diff)
+	}
+}
+
+// TestConvertOIDC covers the promotion of the legacy kube-apiserver OIDC flags into
+// spec.authentication.oidc. wantExternal pins the v1alpha2 encoding itself, which is the
+// backward compatibility contract every stored cluster spec depends on: a symmetric
+// change to the separators or the loss of the sort would round trip fine while
+// reinterpreting every spec already on disk.
+func TestConvertOIDC(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		in           kops.OIDCAuthenticationSpec
+		wantExternal v1alpha2.KubeAPIServerConfig
+		want         kops.OIDCAuthenticationSpec
+	}{
+		{
+			name: "round trips",
+			in: kops.OIDCAuthenticationSpec{
+				ClientID:       ptr.To("kubernetes"),
+				IssuerURL:      ptr.To("https://example.com"),
+				GroupsClaims:   []string{"groups", "roles"},
+				RequiredClaims: map[string]string{"hd": "example.com", "aud": "kops"},
+			},
+			wantExternal: v1alpha2.KubeAPIServerConfig{
+				OIDCClientID:  ptr.To("kubernetes"),
+				OIDCIssuerURL: ptr.To("https://example.com"),
+				// Comma joined, and sorted so that ranging the map stays deterministic.
+				OIDCGroupsClaim:   ptr.To("groups,roles"),
+				OIDCRequiredClaim: []string{"aud=kops", "hd=example.com"},
+			},
+			want: kops.OIDCAuthenticationSpec{
+				ClientID:       ptr.To("kubernetes"),
+				IssuerURL:      ptr.To("https://example.com"),
+				GroupsClaims:   []string{"groups", "roles"},
+				RequiredClaims: map[string]string{"hd": "example.com", "aud": "kops"},
+			},
+		},
+		{
+			// This documents a known defect, not desired behaviour: groupsClaims is
+			// stored comma joined in a single flag, so a claim containing a comma comes
+			// back as two claims.
+			name: "a groups claim containing a comma is split in two",
+			in: kops.OIDCAuthenticationSpec{
+				ClientID:     ptr.To("kubernetes"),
+				GroupsClaims: []string{"a,b"},
+			},
+			wantExternal: v1alpha2.KubeAPIServerConfig{
+				OIDCClientID:    ptr.To("kubernetes"),
+				OIDCGroupsClaim: ptr.To("a,b"),
+			},
+			want: kops.OIDCAuthenticationSpec{
+				ClientID:     ptr.To("kubernetes"),
+				GroupsClaims: []string{"a", "b"},
+			},
+		},
+		{
+			// Likewise a known defect: requiredClaims is stored as a list of
+			// "key=value" flags, so an equals sign in a key moves into the value.
+			name: "a required claim key containing an equals sign moves into the value",
+			in: kops.OIDCAuthenticationSpec{
+				ClientID:       ptr.To("kubernetes"),
+				RequiredClaims: map[string]string{"a=b": "c"},
+			},
+			wantExternal: v1alpha2.KubeAPIServerConfig{
+				OIDCClientID:      ptr.To("kubernetes"),
+				OIDCRequiredClaim: []string{"a=b=c"},
+			},
+			want: kops.OIDCAuthenticationSpec{
+				ClientID:       ptr.To("kubernetes"),
+				RequiredClaims: map[string]string{"a": "b=c"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oidc := tc.in.DeepCopy()
+			external := toV1alpha2(t, kops.ClusterSpec{Authentication: &kops.AuthenticationSpec{OIDC: oidc}})
+			if external.KubeAPIServer == nil {
+				t.Fatal("expected the OIDC settings to be written to spec.kubeAPIServer")
+			}
+			if diff := cmp.Diff(tc.wantExternal, *external.KubeAPIServer); diff != "" {
+				t.Errorf("toV1alpha2(oidc=%+v).KubeAPIServer (-want +got):\n%s", tc.in, diff)
+			}
+
+			back := toInternal(t, *external)
+			if back.Authentication == nil || back.Authentication.OIDC == nil {
+				t.Fatal("expected spec.authentication.oidc to be reconstructed")
+			}
+			if diff := cmp.Diff(tc.want, *back.Authentication.OIDC); diff != "" {
+				t.Errorf("oidc round trip (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestConvertOIDCFlagsWinOverInMemorySpec pins the precedence when both OIDC sources are
+// populated. This is only reachable in memory, because v1alpha2 declares
+// spec.authentication.oidc as `json:"-"`.
+func TestConvertOIDCFlagsWinOverInMemorySpec(t *testing.T) {
+	external := &v1alpha2.Cluster{
+		Spec: v1alpha2.ClusterSpec{
+			Authentication: &v1alpha2.AuthenticationSpec{
+				OIDC: &kops.OIDCAuthenticationSpec{ClientID: ptr.To("in-memory")},
+			},
+			KubeAPIServer: &v1alpha2.KubeAPIServerConfig{OIDCClientID: ptr.To("from-flags")},
+		},
+	}
+
+	out := &kops.Cluster{}
+	if err := testScheme().Convert(external, out, nil); err != nil {
+		t.Fatalf("converting to internal: %v", err)
+	}
+	if out.Spec.Authentication == nil || out.Spec.Authentication.OIDC == nil {
+		t.Fatal("expected spec.authentication.oidc to be populated")
+	}
+	if diff := cmp.Diff(ptr.To("from-flags"), out.Spec.Authentication.OIDC.ClientID); diff != "" {
+		t.Errorf("authentication.oidc.clientID (-want +got):\n%s", diff)
+	}
+}
+
+// TestConvertOIDCRequiredClaimWithoutValue covers a malformed oidcRequiredClaim entry,
+// which used to panic the conversion.
+func TestConvertOIDCRequiredClaimWithoutValue(t *testing.T) {
+	external := &v1alpha2.Cluster{
+		Spec: v1alpha2.ClusterSpec{
+			KubeAPIServer: &v1alpha2.KubeAPIServerConfig{OIDCRequiredClaim: []string{"hd=example.com", "novalue"}},
+		},
+	}
+
+	err := testScheme().Convert(external, &kops.Cluster{}, nil)
+
+	var fieldErr *field.Error
+	if !errors.As(err, &fieldErr) {
+		t.Fatalf("error = %v (%T); want a *field.Error", err, err)
+	}
+	if got, want := fieldErr.Type, field.ErrorTypeInvalid; got != want {
+		t.Errorf("error type = %v; want %v", got, want)
+	}
+	if got, want := fieldErr.Field, "spec.kubeAPIServer.oidcRequiredClaim[1]"; got != want {
+		t.Errorf("error field = %q; want %q", got, want)
+	}
+	if got, want := fieldErr.BadValue, "novalue"; got != want {
+		t.Errorf("error value = %v; want %q", got, want)
+	}
+}
+
+// TestConvertCloudProvider covers the single "cloudProvider" string that v1alpha2 uses
+// in place of spec.cloudProvider, and the settings it stashes in spec.cloudConfig.
+func TestConvertCloudProvider(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		in            kops.CloudProviderSpec
+		wantLegacy    string
+		checkExternal func(*testing.T, *v1alpha2.ClusterSpec)
+	}{
+		{
+			name:       "aws settings move to cloudConfig",
+			in:         kops.CloudProviderSpec{AWS: &kops.AWSSpec{ElbSecurityGroup: ptr.To("sg-1")}},
+			wantLegacy: "aws",
+			checkExternal: func(t *testing.T, spec *v1alpha2.ClusterSpec) {
+				if spec.CloudConfig == nil {
+					t.Fatal("cloudConfig was not populated")
+				}
+				if diff := cmp.Diff(ptr.To("sg-1"), spec.CloudConfig.ElbSecurityGroup); diff != "" {
+					t.Errorf("cloudConfig.elbSecurityGroup (-want +got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name:       "gce project moves to spec.project",
+			in:         kops.CloudProviderSpec{GCE: &kops.GCESpec{Project: "my-project"}},
+			wantLegacy: "gce",
+			checkExternal: func(t *testing.T, spec *v1alpha2.ClusterSpec) {
+				if got, want := spec.Project, "my-project"; got != want {
+					t.Errorf("project = %q; want %q", got, want)
+				}
+			},
+		},
+		{
+			name:       "openstack settings move to cloudConfig",
+			in:         kops.CloudProviderSpec{Openstack: &kops.OpenstackSpec{Router: &kops.OpenstackRouter{ExternalNetwork: ptr.To("public")}}},
+			wantLegacy: "openstack",
+			checkExternal: func(t *testing.T, spec *v1alpha2.ClusterSpec) {
+				if spec.CloudConfig == nil || spec.CloudConfig.Openstack == nil || spec.CloudConfig.Openstack.Router == nil {
+					t.Fatalf("cloudConfig.openstack.router was not populated: %#v", spec.CloudConfig)
+				}
+				if diff := cmp.Diff(ptr.To("public"), spec.CloudConfig.Openstack.Router.ExternalNetwork); diff != "" {
+					t.Errorf("cloudConfig.openstack.router.externalNetwork (-want +got):\n%s", diff)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			internal := kops.ClusterSpec{CloudProvider: tc.in}
+
+			external := toV1alpha2(t, internal)
+			if got := external.LegacyCloudProvider; got != tc.wantLegacy {
+				t.Errorf("cloudProvider = %q; want %q", got, tc.wantLegacy)
+			}
+			tc.checkExternal(t, external)
+
+			back := toInternal(t, *external)
+			if diff := cmp.Diff(tc.in, back.CloudProvider); diff != "" {
+				t.Errorf("cloudProvider round trip (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestConvertCloudConfigRejectsMismatchedProvider covers the settings that v1alpha2
+// stores in the provider agnostic spec.cloudConfig but that only one provider accepts.
+func TestConvertCloudConfigRejectsMismatchedProvider(t *testing.T) {
+	external := &v1alpha2.Cluster{
+		Spec: v1alpha2.ClusterSpec{
+			LegacyCloudProvider: "gce",
+			CloudConfig:         &v1alpha2.CloudConfiguration{ElbSecurityGroup: ptr.To("sg-1")},
+		},
+	}
+
+	err := testScheme().Convert(external, &kops.Cluster{}, nil)
+
+	var fieldErr *field.Error
+	if !errors.As(err, &fieldErr) {
+		t.Fatalf("error = %v (%T); want a *field.Error", err, err)
+	}
+	if got, want := fieldErr.Type, field.ErrorTypeForbidden; got != want {
+		t.Errorf("error type = %v; want %v", got, want)
+	}
+	if got, want := fieldErr.Field, "spec.cloudConfig.elbSecurityGroup"; got != want {
+		t.Errorf("error field = %q; want %q", got, want)
+	}
+}
+
+// TestConvertExternalDNSDisable covers spec.externalDNS.disable, which v1alpha3 spells
+// as a "none" provider.
+func TestConvertExternalDNSDisable(t *testing.T) {
+	internal := toInternal(t, v1alpha2.ClusterSpec{ExternalDNS: &v1alpha2.ExternalDNSConfig{Disable: true}})
+	if internal.ExternalDNS == nil {
+		t.Fatal("expected spec.externalDNS to be populated")
+	}
+	if got, want := internal.ExternalDNS.Provider, kops.ExternalDNSProviderNone; got != want {
+		t.Errorf("externalDNS.provider = %q; want %q", got, want)
+	}
+
+	external := toV1alpha2(t, *internal)
+	if external.ExternalDNS == nil {
+		t.Fatal("expected spec.externalDNS to be populated")
+	}
+	if !external.ExternalDNS.Disable {
+		t.Error("externalDNS.disable = false; want true")
+	}
+	if got := external.ExternalDNS.Provider; got != "" {
+		t.Errorf("externalDNS.provider = %q; want it to be cleared", got)
+	}
+}
+
+// TestConvertTopologyDNS covers spec.topology.dns, which v1alpha2 nests one level deeper.
+func TestConvertTopologyDNS(t *testing.T) {
+	internal := kops.ClusterSpec{
+		Networking: kops.NetworkingSpec{Topology: &kops.TopologySpec{DNS: kops.DNSTypePrivate}},
+	}
+
+	external := toV1alpha2(t, internal)
+	if external.Topology == nil || external.Topology.LegacyDNS == nil {
+		t.Fatal("expected topology.dns to be set")
+	}
+	if got, want := external.Topology.LegacyDNS.Type, v1alpha2.DNSType(kops.DNSTypePrivate); got != want {
+		t.Errorf("topology.dns.type = %q; want %q", got, want)
+	}
+
+	back := toInternal(t, *external)
+	if back.Networking.Topology == nil {
+		t.Fatal("expected topology to be set")
+	}
+	if got, want := back.Networking.Topology.DNS, kops.DNSTypePrivate; got != want {
+		t.Errorf("topology.dns = %q; want %q", got, want)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`TestRoundTripTypes` excluded `Cluster`, `ClusterList`, `InstanceGroup` and
`InstanceGroupList` for both API versions, so its real coverage was `Host`, `Keyset`
and `SSHCredential` — none of which have hand-written conversions. Every field that
v1alpha2 renames, flattens or inverts was untested by round trip, and there were no
conversion unit tests either.

There is also no codegen signal to fall back on: neither generated conversion file
contains a `WARNING: ... requires manual conversion`. v1alpha2 uses 131
`+k8s:conversion-gen=false` opt-outs, and it has no `AWSSpec`/`GCESpec` types at all —
those internal fields are reachable only through the manual code — so a field added to
either gets no warning and no test.

This PR enables the round trip for `Cluster` and `InstanceGroup`, fuzzing each version
with its own functions because the two versions lose different fields. What those
functions clear is the catalogue of settings that are silently dropped on write, with
the reason recorded on each entry. Kinds are discovered from the scheme so a new type
is covered without being listed, and a new API version that arrives without fuzzer
functions now fails loudly rather than being round tripped under another version's.

It also adds unit tests pinning the manual v1alpha2 conversions the fuzzer has to
exclude: the inverted booleans, the `control-plane`/`master` renaming, the `rootVolume`
flattening, the OIDC promotion, and the `cloudProvider` string.

Along the way it fixes a crash. A v1alpha2 spec whose
`spec.kubeAPIServer.oidcRequiredClaim` held an entry without an `=` panicked the
conversion with `index out of range [1] with length 1`, reachable from user YAML. That
is now a `field.Invalid` naming the offending index.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Two findings are reported rather than fixed here, because both would change behaviour
for existing clusters and deserve their own discussion:

- **`spec.authentication.oidc` is lossy through v1alpha2.** v1alpha2 has no field for
  it, so the settings are flattened into the kube-apiserver OIDC flags: `groupsClaims`
  comma-joined, `requiredClaims` as `key=value`. A claim containing the separator is
  silently corrupted — `{"a=b": "c"}` reads back as `{"a": "b=c"}`, and `["a,b"]`
  becomes `["a", "b"]`. Since the state store is still written as v1alpha2
  (`vfsclientset.StoreVersion`), every write/read cycle re-applies it. Related: an
  empty `groupsClaims` list becomes `[""]`, and duplicate `oidcRequiredClaim` keys
  collapse silently. The two corruption cases are pinned as tests here, labelled as
  known defects rather than desired behaviour, so a fix shows up as a deliberate change.

- **`spec.cloudProvider.{aws,gce}.binariesLocation` has no v1alpha2 representation** and
  is dropped on write. #18740 already fixes this; the fuzzer fixup for it is commented
  to be removed when that merges.

For context on what v1alpha3 drops: it marks 44 removed settings `json:"-"`. Those are
safe — each is either rejected by validation (`apiServers`, `configureCbr0`,
`nodeAuthorization`, `crossSubnet`, ...), or recomputed every run by
`pkg/model/components` and `nodeup/pkg/model` and carried to nodes via the
internal-typed nodeup config, which never goes through v1alpha2/v1alpha3.

The round trip has been run at 1200 iterations per version per kind. To reproduce a
fuzz failure, the seed is logged and can be fed back with `KOPS_FUZZ_SEED=<n>`.
