### PR TITLE
kube-router Daemonset Modernization

### DIFF
--- a/docs/networking/kube-router.md
+++ b/docs/networking/kube-router.md
@@ -33,3 +33,21 @@ spec:
 ```
 
 This only affects the network policy controller; the service proxy and the router controller keep their existing implementations. Upstream considers the nftables backend [experimental](https://github.com/cloudnativelabs/kube-router/blob/master/docs/nftables.md), with no benchmarks against the iptables implementation, so it is not recommended for production clusters yet.
+
+### Restricting externalIPs and loadBalancerIPs
+
+Since v2.8.0 kube-router defaults `--strict-external-ip-validation` to `true`, which makes it drop every `externalIP` and `loadBalancerIP` that falls outside an explicitly configured range. Because an unset range means "accept nothing" rather than "accept everything", kOps leaves strict validation off unless you tell it which CIDRs to trust:
+
+```yaml
+spec:
+  networking:
+    kubeRouter:
+      externalIPRanges:
+      - 192.0.2.0/24
+      loadBalancerIPRanges:
+      - 198.51.100.0/24
+```
+
+Setting either field turns strict validation on, so anything outside the ranges you list stops being programmed into IPVS and stops being advertised over BGP. Leaving both empty keeps the current behavior, where every address is accepted. Both fields take a list of CIDRs, and neither may overlap `spec.networking.serviceClusterIPRange`, since kube-router rejects those at runtime anyway.
+
+Two side effects are worth knowing about. `externalIPRanges` also feeds the network policy controller's firewall rules, which was the flag's original purpose upstream, so it does a little more than filter the service proxy. And `loadBalancerIPRanges` does **not** turn on kube-router's load balancer IPAM - that is gated separately on `--run-loadbalancer`, which kOps does not enable.

--- a/docs/releases/1.37-NOTES.md
+++ b/docs/releases/1.37-NOTES.md
@@ -58,6 +58,10 @@ As part of this removal, the `protokube` component, whose only remaining respons
 
 * kube-router is updated to v2.11.1, and the new `spec.networking.kubeRouter.useNFTablesForNetpol` field makes its network policy controller enforce NetworkPolicies with nftables instead of iptables and ipsets. The nftables backend is experimental upstream and only affects network policy enforcement; the service proxy and router controllers are unchanged.
 
+* The new `spec.networking.kubeRouter.externalIPRanges` and `spec.networking.kubeRouter.loadBalancerIPRanges` fields restrict which CIDRs kube-router accepts Service `externalIPs` and `loadBalancerIPs` from. Setting either one enables kube-router's strict external IP validation, so addresses outside the configured ranges are no longer programmed into IPVS or advertised over BGP. Leaving both unset keeps strict validation disabled and preserves the existing behavior of accepting every address.
+
+* The kube-router DaemonSet now gates its liveness probe behind a startup probe, so clusters where informer sync takes longer than the old ~19 second budget no longer CrashLoopBackOff on startup. It also sets `hostIPC: true`, which kube-router requires for direct server return (DSR) and which kOps was previously missing despite already mounting the container runtime socket.
+
 * Rename all references of "Linode" to "Akamai (Linode)" in the Linode cloud provider code. This includes error messages, log messages, and comments. The Linode API is not changing as of yet. This is purely a cosmetic change to avoid confusion since Linode is part of Akamai and is officially called "Akamai Cloud".
 
 # Breaking changes

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -6100,6 +6100,24 @@ spec:
                     description: KuberouterNetworkingSpec declares that we want Kube-router
                       networking
                     properties:
+                      externalIPRanges:
+                        description: |-
+                          ExternalIPRanges are the CIDRs from which Service externalIPs are accepted.
+                          Setting this or LoadBalancerIPRanges turns on kube-router's strict external
+                          IP validation, which drops any address outside the configured ranges.
+                          Leaving both empty keeps strict validation off.
+                        items:
+                          type: string
+                        type: array
+                      loadBalancerIPRanges:
+                        description: |-
+                          LoadBalancerIPRanges are the CIDRs from which Service loadBalancerIPs are
+                          accepted. Setting this or ExternalIPRanges turns on kube-router's strict
+                          external IP validation, which drops any address outside the configured
+                          ranges. Leaving both empty keeps strict validation off.
+                        items:
+                          type: string
+                        type: array
                       useNFTablesForNetpol:
                         description: |-
                           UseNFTablesForNetpol makes the network policy controller enforce

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -326,6 +326,16 @@ type KuberouterNetworkingSpec struct {
 	// controller; the service proxy and router controllers are unchanged.
 	// Default: false
 	UseNFTablesForNetpol *bool `json:"useNFTablesForNetpol,omitempty"`
+	// ExternalIPRanges are the CIDRs from which Service externalIPs are accepted.
+	// Setting this or LoadBalancerIPRanges turns on kube-router's strict external
+	// IP validation, which drops any address outside the configured ranges.
+	// Leaving both empty keeps strict validation off.
+	ExternalIPRanges []string `json:"externalIPRanges,omitempty"`
+	// LoadBalancerIPRanges are the CIDRs from which Service loadBalancerIPs are
+	// accepted. Setting this or ExternalIPRanges turns on kube-router's strict
+	// external IP validation, which drops any address outside the configured
+	// ranges. Leaving both empty keeps strict validation off.
+	LoadBalancerIPRanges []string `json:"loadBalancerIPRanges,omitempty"`
 }
 
 // RomanaNetworkingSpec declares that we want Romana networking

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -290,6 +290,16 @@ type KuberouterNetworkingSpec struct {
 	// controller; the service proxy and router controllers are unchanged.
 	// Default: false
 	UseNFTablesForNetpol *bool `json:"useNFTablesForNetpol,omitempty"`
+	// ExternalIPRanges are the CIDRs from which Service externalIPs are accepted.
+	// Setting this or LoadBalancerIPRanges turns on kube-router's strict external
+	// IP validation, which drops any address outside the configured ranges.
+	// Leaving both empty keeps strict validation off.
+	ExternalIPRanges []string `json:"externalIPRanges,omitempty"`
+	// LoadBalancerIPRanges are the CIDRs from which Service loadBalancerIPs are
+	// accepted. Setting this or ExternalIPRanges turns on kube-router's strict
+	// external IP validation, which drops any address outside the configured
+	// ranges. Leaving both empty keeps strict validation off.
+	LoadBalancerIPRanges []string `json:"loadBalancerIPRanges,omitempty"`
 }
 
 // RomanaNetworkingSpec declares that we want Romana networking

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -6083,6 +6083,8 @@ func Convert_kops_KubenetNetworkingSpec_To_v1alpha2_KubenetNetworkingSpec(in *ko
 
 func autoConvert_v1alpha2_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(in *KuberouterNetworkingSpec, out *kops.KuberouterNetworkingSpec, s conversion.Scope) error {
 	out.UseNFTablesForNetpol = in.UseNFTablesForNetpol
+	out.ExternalIPRanges = in.ExternalIPRanges
+	out.LoadBalancerIPRanges = in.LoadBalancerIPRanges
 	return nil
 }
 
@@ -6093,6 +6095,8 @@ func Convert_v1alpha2_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(
 
 func autoConvert_kops_KuberouterNetworkingSpec_To_v1alpha2_KuberouterNetworkingSpec(in *kops.KuberouterNetworkingSpec, out *KuberouterNetworkingSpec, s conversion.Scope) error {
 	out.UseNFTablesForNetpol = in.UseNFTablesForNetpol
+	out.ExternalIPRanges = in.ExternalIPRanges
+	out.LoadBalancerIPRanges = in.LoadBalancerIPRanges
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -4559,6 +4559,16 @@ func (in *KuberouterNetworkingSpec) DeepCopyInto(out *KuberouterNetworkingSpec) 
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ExternalIPRanges != nil {
+		in, out := &in.ExternalIPRanges, &out.ExternalIPRanges
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.LoadBalancerIPRanges != nil {
+		in, out := &in.LoadBalancerIPRanges, &out.LoadBalancerIPRanges
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -293,6 +293,16 @@ type KuberouterNetworkingSpec struct {
 	// controller; the service proxy and router controllers are unchanged.
 	// Default: false
 	UseNFTablesForNetpol *bool `json:"useNFTablesForNetpol,omitempty"`
+	// ExternalIPRanges are the CIDRs from which Service externalIPs are accepted.
+	// Setting this or LoadBalancerIPRanges turns on kube-router's strict external
+	// IP validation, which drops any address outside the configured ranges.
+	// Leaving both empty keeps strict validation off.
+	ExternalIPRanges []string `json:"externalIPRanges,omitempty"`
+	// LoadBalancerIPRanges are the CIDRs from which Service loadBalancerIPs are
+	// accepted. Setting this or ExternalIPRanges turns on kube-router's strict
+	// external IP validation, which drops any address outside the configured
+	// ranges. Leaving both empty keeps strict validation off.
+	LoadBalancerIPRanges []string `json:"loadBalancerIPRanges,omitempty"`
 }
 
 // AmazonVPCNetworkingSpec declares that we want Amazon VPC CNI networking

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6517,6 +6517,8 @@ func Convert_kops_KubenetNetworkingSpec_To_v1alpha3_KubenetNetworkingSpec(in *ko
 
 func autoConvert_v1alpha3_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(in *KuberouterNetworkingSpec, out *kops.KuberouterNetworkingSpec, s conversion.Scope) error {
 	out.UseNFTablesForNetpol = in.UseNFTablesForNetpol
+	out.ExternalIPRanges = in.ExternalIPRanges
+	out.LoadBalancerIPRanges = in.LoadBalancerIPRanges
 	return nil
 }
 
@@ -6527,6 +6529,8 @@ func Convert_v1alpha3_KuberouterNetworkingSpec_To_kops_KuberouterNetworkingSpec(
 
 func autoConvert_kops_KuberouterNetworkingSpec_To_v1alpha3_KuberouterNetworkingSpec(in *kops.KuberouterNetworkingSpec, out *KuberouterNetworkingSpec, s conversion.Scope) error {
 	out.UseNFTablesForNetpol = in.UseNFTablesForNetpol
+	out.ExternalIPRanges = in.ExternalIPRanges
+	out.LoadBalancerIPRanges = in.LoadBalancerIPRanges
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -4543,6 +4543,16 @@ func (in *KuberouterNetworkingSpec) DeepCopyInto(out *KuberouterNetworkingSpec) 
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ExternalIPRanges != nil {
+		in, out := &in.ExternalIPRanges, &out.ExternalIPRanges
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.LoadBalancerIPRanges != nil {
+		in, out := &in.LoadBalancerIPRanges, &out.LoadBalancerIPRanges
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1120,7 +1120,6 @@ func validateKubelet(k *kops.KubeletConfigSpec, c *kops.Cluster, kubeletPath *fi
 }
 
 func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *field.Path, strict bool, providerConstraints *cloudProviderConstraints) field.ErrorList {
-	c := &cluster.Spec
 	allErrs := field.ErrorList{}
 
 	var networkCIDRs []*net.IPNet
@@ -1286,13 +1285,7 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 	}
 
 	if v.KubeRouter != nil {
-		if c.KubeProxy != nil && (c.KubeProxy.Enabled == nil || *c.KubeProxy.Enabled) {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Root().Child("spec", "kubeProxy", "enabled"), "kube-router requires kubeProxy to be disabled"))
-		}
-
-		if cluster.Spec.IsIPv6Only() {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kubeRouter"), "kube-router does not support IPv6"))
-		}
+		allErrs = append(allErrs, validateNetworkingKubeRouter(cluster, v.KubeRouter, fldPath.Child("kubeRouter"), serviceClusterIPRange)...)
 	}
 
 	if v.Romana != nil {
@@ -1495,6 +1488,73 @@ func validateNetworkingKindnet(cluster *kops.Cluster, v *kops.KindnetNetworkingS
 			}
 		}
 	}
+	return allErrs
+}
+
+func validateNetworkingKubeRouter(cluster *kops.Cluster, v *kops.KuberouterNetworkingSpec, fldPath *field.Path, serviceClusterIPRange *net.IPNet) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	c := &cluster.Spec
+	if c.KubeProxy != nil && (c.KubeProxy.Enabled == nil || *c.KubeProxy.Enabled) {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Root().Child("spec", "kubeProxy", "enabled"), "kube-router requires kubeProxy to be disabled"))
+	}
+
+	// kube-router itself has supported IPv6 since v2.0.0, but we haven't validated it
+	// against an IPv6-only kOps cluster yet, so the restriction stays for now
+	if c.IsIPv6Only() {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "kube-router does not support IPv6"))
+	}
+
+	allErrs = append(allErrs, validateKubeRouterIPRanges(v.ExternalIPRanges, fldPath.Child("externalIPRanges"), serviceClusterIPRange, c.IsIPv6Only())...)
+	allErrs = append(allErrs, validateKubeRouterIPRanges(v.LoadBalancerIPRanges, fldPath.Child("loadBalancerIPRanges"), serviceClusterIPRange, c.IsIPv6Only())...)
+
+	return allErrs
+}
+
+// validateKubeRouterIPRanges checks the CIDR lists that feed kube-router's strict external IP
+// validation. allowIPv6 tracks the cluster's single stack, so enabling IPv6-only support later
+// widens the family check rather than rewriting it.
+func validateKubeRouterIPRanges(ranges []string, fldPath *field.Path, serviceClusterIPRange *net.IPNet, allowIPv6 bool) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for i, cidr := range ranges {
+		fieldPath := fldPath.Index(i)
+
+		// We hand kube-router the string the user wrote, but net.ParseCIDR quietly folds
+		// IPv4-mapped IPv6 like "::ffff:192.0.2.0/120" into a plain IPv4 network, so
+		// validating the normalized form would tell us nothing about what kube-router
+		// actually receives. Reject the ambiguous spelling instead of forwarding it.
+		if ip, ipNet, err := net.ParseCIDR(cidr); err == nil && strings.Contains(cidr, ":") && ip.To4() != nil {
+			detail := "IPv4-mapped IPv6 ranges are ambiguous, use plain IPv4 notation"
+			if ipNet.IP.To4() != nil {
+				detail = fmt.Sprintf("IPv4-mapped IPv6 ranges are ambiguous (did you mean %q)", ipNet.String())
+			}
+			allErrs = append(allErrs, field.Invalid(fieldPath, cidr, detail))
+			continue
+		}
+
+		parsed, errs := parseCIDR(fieldPath, cidr)
+		allErrs = append(allErrs, errs...)
+		if parsed == nil {
+			continue
+		}
+
+		if isIPv6 := parsed.IP.To4() == nil; isIPv6 != allowIPv6 {
+			rangeFamily, clusterFamily := "IPv4", "IPv6-only"
+			if isIPv6 {
+				rangeFamily, clusterFamily = "IPv6", "IPv4"
+			}
+			allErrs = append(allErrs, field.Forbidden(fieldPath, fmt.Sprintf("%q is an %s range, but this is an %s cluster", cidr, rangeFamily, clusterFamily)))
+			continue
+		}
+
+		// kube-router drops externalIPs that land inside the service CIDR anyway, so failing
+		// here beats silently losing the whole range at runtime
+		if serviceClusterIPRange != nil && subnet.Overlap(parsed, serviceClusterIPRange) {
+			allErrs = append(allErrs, field.Forbidden(fieldPath, fmt.Sprintf("%q must not overlap serviceClusterIPRange %q", cidr, serviceClusterIPRange)))
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -2117,6 +2117,237 @@ func Test_Validate_NriConfig(t *testing.T) {
 	}
 }
 
+func TestValidateNetworkingKubeRouter(t *testing.T) {
+	_, serviceClusterIPRange, err := net.ParseCIDR("100.64.0.0/13")
+	if err != nil {
+		t.Fatalf("parsing serviceClusterIPRange: %v", err)
+	}
+
+	// Detail is asserted on every case, so this doubles as a record of what the user
+	// actually reads back from kops create/replace/update cluster.
+	grid := []struct {
+		Description   string
+		KubeProxy     *kops.KubeProxyConfig
+		NonMasquerade string
+		KubeRouter    kops.KuberouterNetworkingSpec
+		Expected      []*field.Error
+	}{
+		{
+			Description: "no ranges configured",
+			KubeRouter:  kops.KuberouterNetworkingSpec{},
+		},
+		{
+			Description: "valid external and loadBalancer ranges",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges:     []string{"192.0.2.0/24", "203.0.113.0/24"},
+				LoadBalancerIPRanges: []string{"198.51.100.0/24"},
+			},
+		},
+		{
+			Description: "unparseable external range",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges: []string{"not-a-cidr"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeInvalid,
+				Field:  "spec.networking.kubeRouter.externalIPRanges[0]",
+				Detail: "Could not be parsed as a CIDR",
+			}},
+		},
+		{
+			Description: "octet above 255",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges: []string{"192.0.300.0/24"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeInvalid,
+				Field:  "spec.networking.kubeRouter.externalIPRanges[0]",
+				Detail: "Could not be parsed as a CIDR",
+			}},
+		},
+		{
+			Description: "prefix length above 32 on an IPv4 range",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				LoadBalancerIPRanges: []string{"192.0.2.0/64"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeInvalid,
+				Field:  "spec.networking.kubeRouter.loadBalancerIPRanges[0]",
+				Detail: "Could not be parsed as a CIDR",
+			}},
+		},
+		{
+			// net.ParseCIDR folds this into plain 192.0.2.0/24, but we forward the string
+			// verbatim to kube-router, so we reject rather than silently accept it
+			Description: "IPv4-mapped IPv6 range",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges: []string{"::ffff:192.0.2.0/120"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeInvalid,
+				Field:  "spec.networking.kubeRouter.externalIPRanges[0]",
+				Detail: `IPv4-mapped IPv6 ranges are ambiguous (did you mean "192.0.2.0/24")`,
+			}},
+		},
+		{
+			Description: "IPv4-mapped IPv6 range with an IPv6-scale prefix",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges: []string{"::ffff:192.0.2.0/24"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeInvalid,
+				Field:  "spec.networking.kubeRouter.externalIPRanges[0]",
+				Detail: "IPv4-mapped IPv6 ranges are ambiguous, use plain IPv4 notation",
+			}},
+		},
+		{
+			// Genuine IPv6 that merely spells its low bits in dotted quad, so it is a
+			// family mismatch rather than the ambiguous mapped notation above
+			Description: "IPv6 range with an embedded IPv4 suffix",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges: []string{"2001:db8::192.0.2.0/64"},
+			},
+			Expected: []*field.Error{
+				{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "spec.networking.kubeRouter.externalIPRanges[0]",
+					Detail: `Network contains bits outside prefix (did you mean "2001:db8::/64")`,
+				},
+				{
+					Type:   field.ErrorTypeForbidden,
+					Field:  "spec.networking.kubeRouter.externalIPRanges[0]",
+					Detail: `"2001:db8::192.0.2.0/64" is an IPv6 range, but this is an IPv4 cluster`,
+				},
+			},
+		},
+		{
+			Description: "bare IP without a prefix length",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				LoadBalancerIPRanges: []string{"192.0.2.1"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeInvalid,
+				Field:  "spec.networking.kubeRouter.loadBalancerIPRanges[0]",
+				Detail: `Could not be parsed as a CIDR (did you mean "192.0.2.1/32")`,
+			}},
+		},
+		{
+			Description: "host bits set outside the prefix",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges: []string{"192.0.2.1/24"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeInvalid,
+				Field:  "spec.networking.kubeRouter.externalIPRanges[0]",
+				Detail: `Network contains bits outside prefix (did you mean "192.0.2.0/24")`,
+			}},
+		},
+		{
+			Description: "external range overlapping serviceClusterIPRange",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges: []string{"100.64.1.0/24"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeForbidden,
+				Field:  "spec.networking.kubeRouter.externalIPRanges[0]",
+				Detail: `"100.64.1.0/24" must not overlap serviceClusterIPRange "100.64.0.0/13"`,
+			}},
+		},
+		{
+			Description: "loadBalancer range overlapping serviceClusterIPRange",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				LoadBalancerIPRanges: []string{"100.64.0.0/16"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeForbidden,
+				Field:  "spec.networking.kubeRouter.loadBalancerIPRanges[0]",
+				Detail: `"100.64.0.0/16" must not overlap serviceClusterIPRange "100.64.0.0/13"`,
+			}},
+		},
+		{
+			Description: "IPv6 range on an IPv4 cluster",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges: []string{"2001:db8::/64"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeForbidden,
+				Field:  "spec.networking.kubeRouter.externalIPRanges[0]",
+				Detail: `"2001:db8::/64" is an IPv6 range, but this is an IPv4 cluster`,
+			}},
+		},
+		{
+			Description: "only the second range is bad",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges: []string{"192.0.2.0/24", "100.64.2.0/24"},
+			},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeForbidden,
+				Field:  "spec.networking.kubeRouter.externalIPRanges[1]",
+				Detail: `"100.64.2.0/24" must not overlap serviceClusterIPRange "100.64.0.0/13"`,
+			}},
+		},
+		{
+			Description: "kube-proxy left enabled",
+			KubeProxy:   &kops.KubeProxyConfig{Enabled: new(true)},
+			KubeRouter:  kops.KuberouterNetworkingSpec{},
+			// The doubled "spec" is pre-existing: this error anchors at the path root and
+			// then re-adds "spec". Cilium's equivalent check has the same quirk.
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeForbidden,
+				Field:  "spec.spec.kubeProxy.enabled",
+				Detail: "kube-router requires kubeProxy to be disabled",
+			}},
+		},
+		{
+			Description:   "IPv6-only cluster is still rejected",
+			NonMasquerade: "::/0",
+			KubeRouter:    kops.KuberouterNetworkingSpec{},
+			Expected: []*field.Error{{
+				Type:   field.ErrorTypeForbidden,
+				Field:  "spec.networking.kubeRouter",
+				Detail: "kube-router does not support IPv6",
+			}},
+		},
+		{
+			Description:   "IPv4 range on an IPv6-only cluster",
+			NonMasquerade: "::/0",
+			KubeRouter: kops.KuberouterNetworkingSpec{
+				ExternalIPRanges: []string{"192.0.2.0/24"},
+			},
+			Expected: []*field.Error{
+				{
+					Type:   field.ErrorTypeForbidden,
+					Field:  "spec.networking.kubeRouter",
+					Detail: "kube-router does not support IPv6",
+				},
+				{
+					Type:   field.ErrorTypeForbidden,
+					Field:  "spec.networking.kubeRouter.externalIPRanges[0]",
+					Detail: `"192.0.2.0/24" is an IPv4 range, but this is an IPv6-only cluster`,
+				},
+			},
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.Description, func(t *testing.T) {
+			cluster := &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					KubeProxy: g.KubeProxy,
+					Networking: kops.NetworkingSpec{
+						NonMasqueradeCIDR: g.NonMasquerade,
+					},
+				},
+			}
+			// Matches how validateNetworking calls us, which matters because the
+			// kubeProxy error is anchored at the path root rather than at fldPath
+			fldPath := field.NewPath("spec", "networking").Child("kubeRouter")
+			errs := validateNetworkingKubeRouter(cluster, &g.KubeRouter, fldPath, serviceClusterIPRange)
+			testFieldErrors(t, errs, g.Expected)
+		})
+	}
+}
+
 func newLinodeClusterForNetworkingValidation(networking kops.NetworkingSpec) *kops.Cluster {
 	return &kops.Cluster{
 		Spec: kops.ClusterSpec{

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4738,6 +4738,16 @@ func (in *KuberouterNetworkingSpec) DeepCopyInto(out *KuberouterNetworkingSpec) 
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ExternalIPRanges != nil {
+		in, out := &in.ExternalIPRanges, &out.ExternalIPRanges
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.LoadBalancerIPRanges != nil {
+		in, out := &in.LoadBalancerIPRanges, &out.LoadBalancerIPRanges
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -146,6 +146,7 @@ spec:
         - mountPath: /etc/kube-router
           name: kube-router-cfg
       hostNetwork: true
+      hostIPC: true
       hostPID: true
       # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
       dnsPolicy: Default

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -64,7 +64,15 @@ spec:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router:v2.11.1
         args:
-        - --strict-external-ip-validation=false
+        # Strict validation default-denies every externalIP and loadBalancerIP when no ranges are set,
+        # so we only turn it on once the user has given us something to accept
+        - --strict-external-ip-validation={{ if or .Networking.KubeRouter.ExternalIPRanges .Networking.KubeRouter.LoadBalancerIPRanges }}true{{ else }}false{{ end }}
+        {{ if .Networking.KubeRouter.ExternalIPRanges -}}
+        - --service-external-ip-range={{ range $i, $cidr := .Networking.KubeRouter.ExternalIPRanges }}{{ if $i }},{{ end }}{{ $cidr }}{{ end }}
+        {{ end -}}
+        {{ if .Networking.KubeRouter.LoadBalancerIPRanges -}}
+        - --loadbalancer-ip-range={{ range $i, $cidr := .Networking.KubeRouter.LoadBalancerIPRanges }}{{ if $i }},{{ end }}{{ $cidr }}{{ end }}
+        {{ end -}}
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=true

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -1,4 +1,4 @@
-# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v2.1.0/daemonset/kubeadm-kuberouter.yaml
+# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v2.11.1/daemonset/generic-kuberouter-all-features.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,7 +10,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {
@@ -60,7 +60,6 @@ spec:
           level: s0
 {{ end }}
       serviceAccountName: kube-router
-      serviceAccount: kube-router
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router:v2.11.1
@@ -89,12 +88,19 @@ spec:
               fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         resources:
           requests:
             cpu: 250m
@@ -141,6 +147,10 @@ spec:
           name: kube-router-cfg
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - operator: Exists
       volumes:
@@ -156,6 +166,8 @@ spec:
       - name: kubeconfig
         hostPath:
           path: /var/lib/kube-router/kubeconfig
+          # Without an explicit type, kubelet creates a directory here when the kubeconfig is missing
+          type: File
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
@@ -186,7 +198,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - list
       - get
@@ -198,14 +209,6 @@ rules:
     verbs:
       - list
       - get
-      - watch
-  - apiGroups:
-    - extensions
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - "coordination.k8s.io"


### PR DESCRIPTION
@rifelpet / @hakman 

Major changes included in this PR for kube-router:

## DaemonSet Changes

* Update CNI version from `0.3.0` -> `1.0.0`
* Add a startup probe in addition to liveness check to give more time for kube-router to start
* Adds a `linux` specific `nodeSelector` as kube-router is not capable of running on other OSes
* Removes deprecated APIs for `endpoints` and `extensions.networkpolicies`
* Specifies `type: File` for `kubeconfig` mount to prevent the accidental creation of a directory in the event that `kubeconfig` doesn't already exist
* Sets `hostIPC: true` so that users that want to use DSR in kube-router are able to without changing the kube-router deployment

## Configuration Changes

* Added the ability to configure `externalIPRanges` and `loadBalancerIPRanges`
  * These ranges also help ensuring traffic is not blocked when going to these ranges by letting the NetworkPolicyController know about them ahead of time
* When these are set `--strict-external-ip-validation=true` which is a safer default than the current `--strict-external-ip-validation=false` (see https://github.com/cloudnativelabs/kube-router/pull/2079 for more info)
* When neither range is set, it reverts to `--strict-external-ip-validation=false` to preserve existing functionality

I tested this using the same kops harness against my own kops cluster in AWS and all of the changes seemed to slot in fine, so I'm not expecting any errors. I also updated the release notes similar to what I saw @rifelpet do when he originally added the kube-router structure.

Let me know if you want any other changes!