### PR TITLE
Automated cherry pick of #18701: Update Calico to v3.31.6

### DIFF
--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.25
     manifest: networking.projectcalico.org/k8s-1.25.yaml
-    manifestHash: 719fe2e93fcba2d7170926b15298e735e970becb6ba32e17d053a37a8569f227
+    manifestHash: 85fae26a56219a2c5cee385260af6086e5f7d47b4ab3f6cfea6ea98f0bbc9037
     name: networking.projectcalico.org
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.25_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.25_content
@@ -104,7 +104,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -230,7 +230,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -389,7 +389,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -493,7 +493,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -547,7 +547,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -716,7 +716,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -765,7 +765,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -1645,6 +1645,18 @@ spec:
                   pattern: ^.*
                   x-kubernetes-int-or-string: true
                 type: array
+              logActionRateLimit:
+                description: |-
+                  LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
+                  where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
+                type: string
+              logActionRateLimitBurst:
+                description: LogActionRateLimitBurst sets the rate limit burst of
+                  hitting a Log action when LogActionRateLimit is enabled.
+                maximum: 9999
+                minimum: 0
+                type: integer
               logDebugFilenameRegex:
                 description: |-
                   LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.
@@ -1656,8 +1668,17 @@ spec:
                   none to disable file logging. [Default: /var/log/calico/felix.log]'
                 type: string
               logPrefix:
-                description: 'LogPrefix is the log prefix that Felix uses when rendering
-                  LOG rules. [Default: calico-packet]'
+                description: |-
+                  LogPrefix is the log prefix that Felix uses when rendering LOG rules. It is possible to use the following specifiers
+                  to include extra information in the log prefix.
+                  - %t: Tier name.
+                  - %k: Kind (short names).
+                  - %n: Policy or profile name.
+                  - %p: Policy or profile name (namespace/name for namespaced kinds or just name for non namespaced kinds).
+                  Calico includes ": " characters at the end of the generated log prefix.
+                  Note that iptables shows up to 29 characters for the log prefix and nftables up to 127 characters. Extra characters are truncated.
+                  [Default: calico-packet]
+                pattern: '^([a-zA-Z0-9%: /_-])*$'
                 type: string
               logSeverityFile:
                 description: 'LogSeverityFile is the log severity above which logs
@@ -2036,7 +2057,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2415,7 +2436,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2458,7 +2479,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2528,7 +2549,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2610,7 +2631,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2660,7 +2681,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2710,7 +2731,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2787,7 +2808,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2830,7 +2851,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -3035,7 +3056,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -3406,7 +3427,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -3449,7 +3470,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -3830,7 +3851,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -4083,7 +4104,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -4456,7 +4477,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -7183,7 +7204,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.31.3
+        image: docker.io/calico/node:v3.31.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -7263,7 +7284,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.31.3
+        image: docker.io/calico/cni:v3.31.6
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -7277,7 +7298,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.31.3
+        image: docker.io/calico/node:v3.31.6
         imagePullPolicy: IfNotPresent
         name: ebpf-bootstrap
         securityContext:
@@ -7404,7 +7425,7 @@ spec:
           value: node,loadbalancer
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.31.3
+        image: docker.io/calico/kube-controllers:v3.31.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -91,7 +91,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.25
     manifest: networking.projectcalico.org/k8s-1.25.yaml
-    manifestHash: 8230f9e9b5638dbcb8875e119c3028400a5885a39b1d633f7a2f63903a36e3da
+    manifestHash: 70426f074113d56f2e51a8bcc3de9cd4676ef08eb5f14964fda98bfebb5f5d14
     name: networking.projectcalico.org
     prune:
       kinds:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.25_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.25_content
@@ -103,7 +103,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -229,7 +229,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -388,7 +388,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -492,7 +492,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -546,7 +546,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -715,7 +715,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -764,7 +764,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -1644,6 +1644,18 @@ spec:
                   pattern: ^.*
                   x-kubernetes-int-or-string: true
                 type: array
+              logActionRateLimit:
+                description: |-
+                  LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
+                  where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
+                type: string
+              logActionRateLimitBurst:
+                description: LogActionRateLimitBurst sets the rate limit burst of
+                  hitting a Log action when LogActionRateLimit is enabled.
+                maximum: 9999
+                minimum: 0
+                type: integer
               logDebugFilenameRegex:
                 description: |-
                   LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.
@@ -1655,8 +1667,17 @@ spec:
                   none to disable file logging. [Default: /var/log/calico/felix.log]'
                 type: string
               logPrefix:
-                description: 'LogPrefix is the log prefix that Felix uses when rendering
-                  LOG rules. [Default: calico-packet]'
+                description: |-
+                  LogPrefix is the log prefix that Felix uses when rendering LOG rules. It is possible to use the following specifiers
+                  to include extra information in the log prefix.
+                  - %t: Tier name.
+                  - %k: Kind (short names).
+                  - %n: Policy or profile name.
+                  - %p: Policy or profile name (namespace/name for namespaced kinds or just name for non namespaced kinds).
+                  Calico includes ": " characters at the end of the generated log prefix.
+                  Note that iptables shows up to 29 characters for the log prefix and nftables up to 127 characters. Extra characters are truncated.
+                  [Default: calico-packet]
+                pattern: '^([a-zA-Z0-9%: /_-])*$'
                 type: string
               logSeverityFile:
                 description: 'LogSeverityFile is the log severity above which logs
@@ -2035,7 +2056,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2414,7 +2435,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2457,7 +2478,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2527,7 +2548,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2609,7 +2630,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2659,7 +2680,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2709,7 +2730,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2786,7 +2807,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -2829,7 +2850,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -3034,7 +3055,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -3405,7 +3426,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -3448,7 +3469,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -3829,7 +3850,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -4082,7 +4103,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -4455,7 +4476,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     addon.kops.k8s.io/name: networking.projectcalico.org
     app.kubernetes.io/managed-by: kops
@@ -7178,7 +7199,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.31.3
+        image: docker.io/calico/node:v3.31.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -7252,7 +7273,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.31.3
+        image: docker.io/calico/cni:v3.31.6
         imagePullPolicy: IfNotPresent
         name: upgrade-ipam
         securityContext:
@@ -7287,7 +7308,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.31.3
+        image: docker.io/calico/cni:v3.31.6
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -7301,7 +7322,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.31.3
+        image: docker.io/calico/node:v3.31.6
         imagePullPolicy: IfNotPresent
         name: ebpf-bootstrap
         securityContext:
@@ -7431,7 +7452,7 @@ spec:
           value: node,loadbalancer
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.31.3
+        image: docker.io/calico/kube-controllers:v3.31.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.25.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.25.yaml.template
@@ -1,4 +1,4 @@
-# Pulled and modified from: https://raw.githubusercontent.com/projectcalico/calico/v3.31.3/manifests/calico-typha.yaml
+# Pulled and modified from: https://raw.githubusercontent.com/projectcalico/calico/v3.31.6/manifests/calico-typha.yaml
 ---
 {{- if .Networking.Calico.BPFEnabled }}
 # Set these to the IP and port of your API server; In BPF mode, we need to connect directly to the
@@ -135,7 +135,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -256,7 +256,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: bgpfilters.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -410,7 +410,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: bgppeers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -509,7 +509,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: blockaffinities.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -558,7 +558,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: caliconodestatuses.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -722,7 +722,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusterinformations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -766,7 +766,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: felixconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -1653,6 +1653,19 @@ spec:
                     pattern: ^.*
                     x-kubernetes-int-or-string: true
                   type: array
+                logActionRateLimit:
+                  description: |-
+                    LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
+                    where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                  pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
+                  type: string
+                logActionRateLimitBurst:
+                  description:
+                    LogActionRateLimitBurst sets the rate limit burst of
+                    hitting a Log action when LogActionRateLimit is enabled.
+                  maximum: 9999
+                  minimum: 0
+                  type: integer
                 logDebugFilenameRegex:
                   description: |-
                     LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.
@@ -1665,9 +1678,17 @@ spec:
                     none to disable file logging. [Default: /var/log/calico/felix.log]"
                   type: string
                 logPrefix:
-                  description:
-                    "LogPrefix is the log prefix that Felix uses when rendering
-                    LOG rules. [Default: calico-packet]"
+                  description: |-
+                    LogPrefix is the log prefix that Felix uses when rendering LOG rules. It is possible to use the following specifiers
+                    to include extra information in the log prefix.
+                    - %t: Tier name.
+                    - %k: Kind (short names).
+                    - %n: Policy or profile name.
+                    - %p: Policy or profile name (namespace/name for namespaced kinds or just name for non namespaced kinds).
+                    Calico includes ": " characters at the end of the generated log prefix.
+                    Note that iptables shows up to 29 characters for the log prefix and nftables up to 127 characters. Extra characters are truncated.
+                    [Default: calico-packet]
+                  pattern: "^([a-zA-Z0-9%: /_-])*$"
                   type: string
                 logSeverityFile:
                   description:
@@ -2070,7 +2091,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -2444,7 +2465,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: globalnetworksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -2482,7 +2503,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: hostendpoints.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -2547,7 +2568,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: ipamblocks.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -2626,7 +2647,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: ipamconfigs.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -2671,7 +2692,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: ipamhandles.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -2716,7 +2737,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: ippools.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -2788,7 +2809,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: ipreservations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -2826,7 +2847,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: kubecontrollersconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -3026,7 +3047,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: networkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -3392,7 +3413,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: networksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -3430,7 +3451,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: stagedglobalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -3806,7 +3827,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: stagedkubernetesnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -4054,7 +4075,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: stagednetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -4422,7 +4443,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tiers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -7123,7 +7144,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.31.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.31.6" }}
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -7152,7 +7173,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.31.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.31.6" }}
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -7196,7 +7217,7 @@ spec:
         # networking to allow communication with the API Server. Calico-node initialization is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptables mode.
         - name: "ebpf-bootstrap"
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.31.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.31.6" }}
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -7222,7 +7243,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.31.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.31.6" }}
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -7565,7 +7586,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.31.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.31.6" }}
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.
@@ -7659,7 +7680,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.31.3" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.31.6" }}
         imagePullPolicy: IfNotPresent
         name: calico-typha
         ports:


### PR DESCRIPTION
Cherry pick of #18701 on release-1.36, plus the matching `hack/update-expected.sh` regeneration.

#18701: Update Calico to v3.31.6

```release-note
Updated Calico to v3.31.6, fixing a segfault that left Felix unable to program nftables rules on RHEL 10 and Rocky Linux 10 nodes.
```

### Why this needs a backport

Since test-infra #37732 stopped running Calico on EL10 with eBPF, Felix uses the nftables dataplane there. Calico **v3.31.3** cannot: the `nft` binary bundled in `calico/node` segfaults when listing sets, because knftables issued an unscoped `nft list sets/maps` that walks every kernel table and the older in-container `nft` crashes on objects carrying udata — which kube-proxy's nftables mode creates.

```
[WARNING] felix/ipsets.go 350: Failed to resync with dataplane
  error=error listing nftables sets: failed to run nft: signal: segmentation fault (core dumped)
[PANIC]   felix/ipsets.go 369: Failed to update IP sets after multiple retries
```

and on the host:

```
nft[8063]: segfault at 0 ip 0000000000000000 sp 00007ffd25f8aa88 error 14 likely on CPU 1
```

The result is that `nftables-ruleset.log` contains `table ip kube-proxy` but **no `table ip calico` at all** — Felix never writes a rule. BGP is healthy (`Number of node(s) with BGP peering established = 4`); the pod fails readiness with `felix is not ready: readiness probe reporting 503`, so `kops validate` times out.

Upstream: [projectcalico/calico#11750](https://github.com/projectcalico/calico/issues/11750), fixed by PRs #12470, #12714 and #12672, all first shipping in **v3.31.6**.

### Evidence

Across the CI grid, EL10 Calico jobs split cleanly on the Calico version and nothing else:

| kops branch | Calico | EL10 Calico jobs |
|---|---|---|
| master | v3.31.6 | **14 / 14 green** (AWS + GCE) |
| release-1.36 | v3.31.3 | red |
| release-1.35 | v3.31.3 | red |

25 grid jobs are currently held red by this on the two release branches. Same distros, same job config, one variable.

### Contents

Two commits: the cherry-pick itself (one template file), and `hack/update-expected.sh` covering the two Calico integration clusters. The regeneration touches only the four `privatecalico` / `minimal-ipv6-calico` golden files; `go test ./cmd/kops/ -run 'TestPrivateCalico|TestMinimalIPv6Calico'` passes.

/sig cluster-lifecycle