### PR TITLE
gce: don't leave routes and LB firewalls behind on cluster deletion

### DIFF
--- a/cloudmock/gce/mockcompute/route.go
+++ b/cloudmock/gce/mockcompute/route.go
@@ -18,6 +18,7 @@ package mockcompute
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	compute "google.golang.org/api/compute/v1"
@@ -48,6 +49,19 @@ func (c *routeClient) All() map[string]interface{} {
 		}
 	}
 	return m
+}
+
+func (c *routeClient) Insert(project string, route *compute.Route) (*compute.Operation, error) {
+	c.Lock()
+	defer c.Unlock()
+	routes, ok := c.routes[project]
+	if !ok {
+		routes = map[string]*compute.Route{}
+		c.routes[project] = routes
+	}
+	route.SelfLink = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/routes/%s", project, route.Name)
+	routes[route.Name] = route
+	return doneOperation(), nil
 }
 
 func (c *routeClient) Delete(project, name string) (*compute.Operation, error) {

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -480,6 +480,10 @@ func (d *clusterDiscoveryGCE) listForwardingRules() ([]*resources.Resource, erro
 			resourceTracker.Blocks = append(resourceTracker.Blocks, typeAddress+":"+gce.LastComponent(fr.IPAddress))
 		}
 
+		if fr.BackendService != "" {
+			resourceTracker.Blocks = append(resourceTracker.Blocks, typeBackendService+":"+gce.LastComponent(fr.BackendService))
+		}
+
 		klog.V(4).Infof("Found resource: %s", fr.SelfLink)
 		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}
@@ -629,7 +633,10 @@ nextFirewallRule:
 				// l4 level healthchecks
 
 				healthCheckName := gce.LastComponent(healthCheckLink)
-				if !strings.HasPrefix(healthCheckName, "k8s-") || !strings.Contains(healthCheckLink, "/httpHealthChecks/") {
+				// The health check is named k8s-<clusterid>-node when it is the health check shared
+				// by all services, but is named for the load balancer itself when the service sets
+				// externalTrafficPolicy: Local.
+				if (!strings.HasPrefix(healthCheckName, "k8s-") && healthCheckName != forwardingRuleName) || !strings.Contains(healthCheckLink, "/httpHealthChecks/") {
 					klog.Warningf("found non-k8s healthcheck %q in targetPool %q, assuming firewallRule %q is not a k8s rule", healthCheckLink, targetPoolName, firewallRule.Name)
 					continue nextFirewallRule
 				}
@@ -658,8 +665,10 @@ nextFirewallRule:
 			resourceTrackers = append(resourceTrackers, k8sResources...)
 		}
 
-		// find the objects if this is a Kubernetes node health check
-		if strings.HasPrefix(firewallRule.Name, "k8s-") && strings.HasSuffix(firewallRule.Name, "-node-http-hc") {
+		// find the objects if this is a Kubernetes health check.  The rule is named
+		// k8s-<clusterid>-node-http-hc for the health check shared by all services, and
+		// k8s-<loadbalancer>-http-hc for a service with externalTrafficPolicy: Local.
+		if strings.HasPrefix(firewallRule.Name, "k8s-") && strings.HasSuffix(firewallRule.Name, "-http-hc") {
 			// TODO: Check port matches http health check (always 10256?)
 			// TODO: Check description - looks like '{"kubernetes.io/cluster-id":"cb2e931dec561053"}'
 
@@ -723,9 +732,13 @@ func (d *clusterDiscoveryGCE) listRoutes(ctx context.Context, resourceMap map[st
 	var resourceTrackers []*resources.Resource
 
 	instancesToDelete := make(map[string]*resources.Resource)
+	migsToDelete := make(map[string]*resources.Resource)
 	for _, resource := range resourceMap {
-		if resource.Type == typeInstance {
+		switch resource.Type {
+		case typeInstance:
 			instancesToDelete[resource.ID] = resource
+		case typeInstanceGroupManager:
+			migsToDelete[resource.ID] = resource
 		}
 	}
 
@@ -772,9 +785,13 @@ func (d *clusterDiscoveryGCE) listRoutes(ctx context.Context, resourceMap map[st
 			}
 
 			// To avoid race conditions where the control-plane re-adds the routes, we delete routes
-			// only after we have deleted all the instances.
+			// only after we have deleted all the instances, and the managed instance groups that
+			// would otherwise recreate a control-plane instance.
 			for _, instance := range instancesToDelete {
 				resourceTracker.Blocked = append(resourceTracker.Blocked, typeInstance+":"+instance.ID)
+			}
+			for _, mig := range migsToDelete {
+				resourceTracker.Blocked = append(resourceTracker.Blocked, typeInstanceGroupManager+":"+mig.ID)
 			}
 
 			klog.V(4).Infof("Found resource: %s", r.SelfLink)
@@ -1091,7 +1108,7 @@ func (d *clusterDiscoveryGCE) listBackendServices() ([]*resources.Resource, erro
 	var bs []*resources.Resource
 	for _, svc := range svcs {
 		if containsOnlyListedIGMs(svc, igms) {
-			bs = append(bs, &resources.Resource{
+			resourceTracker := &resources.Resource{
 				Name: svc.Name,
 				ID:   svc.Name,
 				Type: typeBackendService,
@@ -1107,7 +1124,23 @@ func (d *clusterDiscoveryGCE) listBackendServices() ([]*resources.Resource, erro
 					return c.WaitForOp(op)
 				},
 				Obj: svc,
-			})
+			}
+
+			for _, hc := range svc.HealthChecks {
+				resourceTracker.Blocks = append(resourceTracker.Blocks, typeHealthcheck+":"+gce.LastComponent(hc))
+			}
+
+			// GCE refuses to delete an InstanceGroupManager while a BackendService still refers to
+			// its instance group; deleting them in the other order costs a full retry interval.
+			for _, be := range svc.Backends {
+				for _, igm := range igms {
+					if igm.Type == typeInstanceGroupManager && strings.HasSuffix(be.Group, "/"+igm.Name) {
+						resourceTracker.Blocks = append(resourceTracker.Blocks, typeInstanceGroupManager+":"+igm.ID)
+					}
+				}
+			}
+
+			bs = append(bs, resourceTracker)
 		}
 	}
 

--- a/pkg/resources/gce/gce_test.go
+++ b/pkg/resources/gce/gce_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package gce
 
 import (
+	"context"
+	"reflect"
+	"sort"
 	"testing"
 
 	compute "google.golang.org/api/compute/v1"
+	gcemock "k8s.io/kops/cloudmock/gce"
 	"k8s.io/kops/pkg/resources"
 )
 
@@ -174,5 +178,164 @@ func TestContainsOnlyListedIGMs(t *testing.T) {
 				t.Fatalf("containsOnlyListedIGMs() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// routeInserter is implemented by the mock compute client; the production RouteClient
+// does not create routes, so tests assert to this interface to seed them.
+type routeInserter interface {
+	Insert(project string, route *compute.Route) (*compute.Operation, error)
+}
+
+func trackerKeys(trackers []*resources.Resource) []string {
+	var keys []string
+	for _, t := range trackers {
+		keys = append(keys, t.Type+":"+t.ID)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestListFirewallRulesLoadBalancer verifies that we find all the resources of a Service
+// LoadBalancer with externalTrafficPolicy: Local, whose health check is named for the load
+// balancer rather than the cluster.
+func TestListFirewallRulesLoadBalancer(t *testing.T) {
+	ctx := context.TODO()
+
+	const (
+		project     = "testproject"
+		region      = "us-test1"
+		clusterName = "cluster.example.com"
+		lbName      = "a1b2c3d4e5f67890a1b2c3d4e5f67890"
+	)
+
+	c := gcemock.InstallMockGCECloud(region, project)
+
+	network := "https://www.googleapis.com/compute/v1/projects/" + project + "/global/networks/cluster-example-com"
+	nodeTags := []string{"cluster-example-com-k8s-io-role-node"}
+
+	for _, firewall := range []*compute.Firewall{
+		{Name: "k8s-fw-" + lbName, Network: network, TargetTags: nodeTags},
+		{Name: "k8s-" + lbName + "-http-hc", Network: network, TargetTags: nodeTags},
+		{Name: "k8s-fw-ffffffffffffffffffffffffffffffff", Network: network, TargetTags: []string{"other-example-com-k8s-io-role-node"}},
+	} {
+		if _, err := c.Compute().Firewalls().Insert(project, firewall); err != nil {
+			t.Fatalf("error creating firewall %q: %v", firewall.Name, err)
+		}
+	}
+
+	if _, err := c.Compute().ForwardingRules().Insert(ctx, project, region, &compute.ForwardingRule{
+		Name:   lbName,
+		Target: "https://www.googleapis.com/compute/v1/projects/" + project + "/regions/" + region + "/targetPools/" + lbName,
+	}); err != nil {
+		t.Fatalf("error creating forwarding rule: %v", err)
+	}
+
+	if _, err := c.Compute().TargetPools().Insert(project, region, &compute.TargetPool{
+		Name:         lbName,
+		HealthChecks: []string{"https://www.googleapis.com/compute/v1/projects/" + project + "/global/httpHealthChecks/" + lbName},
+	}); err != nil {
+		t.Fatalf("error creating target pool: %v", err)
+	}
+
+	if _, err := c.Compute().HTTPHealthChecks().Insert(project, &compute.HttpHealthCheck{Name: lbName}); err != nil {
+		t.Fatalf("error creating http health check: %v", err)
+	}
+
+	d := &clusterDiscoveryGCE{
+		cloud:       c,
+		gceCloud:    c,
+		clusterName: clusterName,
+	}
+
+	trackers, err := d.listFirewallRules()
+	if err != nil {
+		t.Fatalf("error listing firewall rules: %v", err)
+	}
+
+	want := []string{
+		"FirewallRule:k8s-" + lbName + "-http-hc",
+		"FirewallRule:k8s-fw-" + lbName,
+		"ForwardingRule:" + lbName,
+		"HTTP HealthCheck:" + lbName,
+		"TargetPool:" + lbName,
+	}
+	sort.Strings(want)
+	if got := trackerKeys(trackers); !reflect.DeepEqual(got, want) {
+		t.Errorf("listFirewallRules() got %v, want %v", got, want)
+	}
+}
+
+// TestListRoutesBlockedOnInstanceGroupManagers verifies that we delete routes only after the
+// managed instance groups, which would otherwise recreate a control-plane instance that
+// recreates the routes.
+func TestListRoutesBlockedOnInstanceGroupManagers(t *testing.T) {
+	ctx := context.TODO()
+
+	const (
+		project     = "testproject"
+		region      = "us-test1"
+		zone        = "us-test1-a"
+		clusterName = "cluster.example.com"
+	)
+
+	c := gcemock.InstallMockGCECloud(region, project)
+
+	routes, ok := c.Compute().Routes().(routeInserter)
+	if !ok {
+		t.Fatalf("mock route client does not implement Insert")
+	}
+	for _, route := range []*compute.Route{
+		{
+			Name:            "cluster-example-com-51a343e2-c285-4e73-b933-18a6ea44c3e4",
+			NextHopInstance: "https://www.googleapis.com/compute/v1/projects/" + project + "/zones/" + zone + "/instances/nodes-abcd",
+		},
+		{
+			Name:            "other-example-com-51a343e2-c285-4e73-b933-18a6ea44c3e4",
+			NextHopInstance: "https://www.googleapis.com/compute/v1/projects/" + project + "/zones/" + zone + "/instances/nodes-abcd",
+		},
+	} {
+		if _, err := routes.Insert(project, route); err != nil {
+			t.Fatalf("error creating route %q: %v", route.Name, err)
+		}
+	}
+
+	resourceMap := map[string]*resources.Resource{
+		"Instance:" + zone + "/nodes-abcd": {
+			Name: "nodes-abcd",
+			ID:   zone + "/nodes-abcd",
+			Type: typeInstance,
+		},
+		"InstanceGroupManager:" + zone + "/a-nodes-" + zone: {
+			Name: "a-nodes-" + zone,
+			ID:   zone + "/a-nodes-" + zone,
+			Type: typeInstanceGroupManager,
+		},
+	}
+
+	d := &clusterDiscoveryGCE{
+		cloud:       c,
+		gceCloud:    c,
+		clusterName: clusterName,
+	}
+
+	trackers, err := d.listRoutes(ctx, resourceMap)
+	if err != nil {
+		t.Fatalf("error listing routes: %v", err)
+	}
+
+	want := []string{"Route:cluster-example-com-51a343e2-c285-4e73-b933-18a6ea44c3e4"}
+	if got := trackerKeys(trackers); !reflect.DeepEqual(got, want) {
+		t.Fatalf("listRoutes() got %v, want %v", got, want)
+	}
+
+	wantBlocked := []string{
+		"Instance:" + zone + "/nodes-abcd",
+		"InstanceGroupManager:" + zone + "/a-nodes-" + zone,
+	}
+	got := append([]string{}, trackers[0].Blocked...)
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, wantBlocked) {
+		t.Errorf("route Blocked got %v, want %v", got, wantBlocked)
 	}
 }


### PR DESCRIPTION
Two distinct bugs that leave a resource behind in the cluster's network, so `kops delete cluster` retries the network deletion until it gives up (`wait time exceeded during resources deletion`).

Found by classifying every fatal teardown in the last 4 builds of all 909 GCE periodics (2,881 builds, 21 fatal teardowns): 14 were leaked routes, 6 were leaked load balancer firewalls, and 1 was GCE zonal slowness (`WaitForOp` timing out), which this PR does not address.

### Routes are recreated after we delete them (14 of 21)

In all 14 the blocking route **was** listed and deleted successfully, and the network deletion then failed on that same route name for the rest of the hour:

```
Instance:us-central1-a/control-plane-us-central1-a-f6v0                  ok   03:04
Route:e2e-…-kube-431765d1-c8e5-435b-b029-1b90a8d7236a                    ok   03:05
InstanceGroupManager:…/a-control-plane-…  error … 'is already being used by' …/backendServices/api-…   03:06
InstanceGroupManager:…/a-control-plane-…                                 ok   03:07
E0820 03:08:33 … network … 'is already being used by' …/global/routes/e2e-…-kube-431765d1-…
… every 60s until 04:02 → Error: wait time exceeded during resources deletion
```

`listRoutes` delays route deletion until every instance is gone, but not until every MIG is gone, and instances are deliberately not blocked on their MIG. GCE refuses to delete the control-plane MIG while the `api-` BackendService still refers to its instance group, so the MIG outlives its instance, recreates a control-plane (the etcd disks are still there, since their deletion is blocked by the instance that was just deleted), and its route controller recreates the routes. `DeleteResources` works from the resource list collected up front and never re-lists, so the recreated route is invisible and the network is blocked permanently.

This also explains why the failures skew 5.4x towards arm64 (17 of 21) with no CNI correlation: instance deletion operations there take 2m+, which is exactly the window the MIG needs to boot a replacement.

Blocking route deletion on the MIGs as well means there is no control plane left to recreate them.

### LoadBalancer firewalls are never listed when externalTrafficPolicy is Local (6 of 21)

Unlike the routes, these were never listed and never deleted - they are in the project before teardown starts and we walk past them. 4 builds were blocked by `k8s-<loadbalancer>-http-hc` and 2 by `k8s-fw-<loadbalancer>`, both from a Service left behind by an e2e spec.

- We only matched the health check firewall shared by all services (`k8s-<clusterid>-node-http-hc`), never the per-service `k8s-<loadbalancer>-http-hc`. Nothing else models that object. The target tags are already verified to be the cluster's before this point, so relaxing the suffix is enough.
- We required the target pool's health check to be named `k8s-*`. With `externalTrafficPolicy: Local` it is named for the load balancer instead (`aff5f97a7265f4864af344d7be217ed1`), so the `continue nextFirewallRule` threw away the whole set of resources we had already assembled for that load balancer - firewall, forwarding rule, target pool and health check. The warning is visible in the logs of the affected builds:

```
W0826 10:03:07 gce.go:633] found non-k8s healthcheck ".../httpHealthChecks/a2e4db661bbac4ce29959b154ee25009"
    in targetPool ... assuming firewallRule "k8s-fw-..." is not a k8s rule
```

### Ordering

The last commit hunk models the ForwardingRule -> BackendService -> {HealthCheck, MIG} dependencies that GCE enforces but we did not, so those deletions no longer fail once and wait a full `--interval` (60s in CI) before being retried.

### Testing

Two tests over the mock GCE cloud, both of which fail without the corresponding fix: one asserts that every resource of an `externalTrafficPolicy: Local` load balancer is listed (and that another cluster's is not), the other that a route is blocked on both its instance and the MIGs. The mock route client gained an `Insert` so routes can be seeded; the production `RouteClient` interface is unchanged.

Verification in CI needs to be by classification rather than by pass rate - this is 0.73% of builds, so a green run proves nothing on its own.
