### PR TITLE
aws: validate Karpenter InstanceGroups early

### DIFF
--- a/docs/operations/karpenter.md
+++ b/docs/operations/karpenter.md
@@ -81,7 +81,7 @@ Supported image selector forms are:
 {{ kops_feature_table(kops_added_default='1.37') }}
 
 By default, the generated `NodePool` requires one of the instance types listed in `spec.machineType` and `spec.mixedInstancesPolicy.instances`.
-To let Karpenter choose from any instance type within a capacity range instead, set `spec.mixedInstancesPolicy.instanceRequirements`:
+To let Karpenter choose instance types based on a capacity range, set `spec.mixedInstancesPolicy.instanceRequirements`:
 
 ```yaml
 spec:
@@ -103,7 +103,8 @@ spec:
 This generates the appropriate `karpenter.k8s.aws/instance-cpu` and `karpenter.k8s.aws/instance-memory` requirements on the `NodePool`.
 `excludedInstanceTypes` entries are mapped to `NotIn` requirements: a `<family>.*` wildcard excludes an instance family, and a bare instance type excludes that type.
 
-When `instanceRequirements` is set, kOps omits the instance type requirement, and `spec.machineType` and `spec.mixedInstancesPolicy.instances` no longer restrict the NodePool.
+When `instanceRequirements` is set, neither `spec.machineType` nor `spec.mixedInstancesPolicy.instances` is required.
+If either field is set, its instance types further restrict the generated `NodePool`.
 
 ## Karpenter-managed InstanceGroups
 {{ kops_feature_table(kops_added_default='1.36') }}

--- a/docs/operations/karpenter.md
+++ b/docs/operations/karpenter.md
@@ -106,6 +106,9 @@ This generates the appropriate `karpenter.k8s.aws/instance-cpu` and `karpenter.k
 When `instanceRequirements` is set, neither `spec.machineType` nor `spec.mixedInstancesPolicy.instances` is required.
 If either field is set, its instance types further restrict the generated `NodePool`.
 
+Karpenter NodePools can include both GPU and non-GPU instance types.
+When using kOps-managed NVIDIA support, use a dedicated GPU-only InstanceGroup because kOps applies GPU labels and taints to the entire NodePool.
+
 ## Karpenter-managed InstanceGroups
 {{ kops_feature_table(kops_added_default='1.36') }}
 

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -292,30 +292,60 @@ func awsValidateInstanceInterruptionBehavior(fieldPath *field.Path, ig *kops.Ins
 func awsValidateMixedInstancesPolicy(path *field.Path, spec *kops.MixedInstancesPolicySpec, ig *kops.InstanceGroup, cloud awsup.AWSCloud) field.ErrorList {
 	var errs field.ErrorList
 
-	mainMachineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(ig.Spec.MachineType))
-	if err != nil {
-		errs = append(errs, field.Invalid(field.NewPath("spec", "machineType"), ig.Spec.MachineType, fmt.Sprintf("machine type specified is invalid: %q", ig.Spec.MachineType)))
-		return errs
-	}
-
-	hasGPU := mainMachineTypeInfo.GPU
-
-	// @step: check the instance types are valid
-	for i, instanceTypes := range spec.Instances {
-		fld := path.Child("instances").Index(i)
-		errs = append(errs, awsValidateInstanceTypeAndImage(path.Child("instances").Index(i), path.Child("image"), instanceTypes, ig.Spec.Image, cloud)...)
-
-		for _, instanceType := range strings.Split(instanceTypes, ",") {
-			machineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(instanceType))
-			if err != nil {
-				errs = append(errs, field.Invalid(field.NewPath("spec", "machineType"), ig.Spec.MachineType, fmt.Sprintf("machine type specified is invalid: %q", ig.Spec.MachineType)))
-				return errs
+	if ig.Spec.Manager == kops.InstanceManagerKarpenter {
+		if spec.InstanceRequirements == nil {
+			var hasGPU *bool
+			if ig.Spec.MachineType != "" {
+				mainMachineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(ig.Spec.MachineType))
+				if err != nil {
+					errs = append(errs, field.Invalid(field.NewPath("spec", "machineType"), ig.Spec.MachineType, fmt.Sprintf("machine type specified is invalid: %q", ig.Spec.MachineType)))
+					return errs
+				}
+				hasGPU = &mainMachineTypeInfo.GPU
 			}
-			if machineTypeInfo.GPU != hasGPU {
-				errs = append(errs, field.Forbidden(fld, "Cannot mix GPU and non-GPU machine types in the same Instance Group"))
+
+			for i, instanceTypes := range spec.Instances {
+				fld := path.Child("instances").Index(i)
+				errs = append(errs, awsValidateInstanceTypeAndImage(fld, path.Child("image"), instanceTypes, ig.Spec.Image, cloud)...)
+
+				if hasGPU != nil {
+					for _, instanceType := range strings.Split(instanceTypes, ",") {
+						machineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(instanceType))
+						if err != nil {
+							continue
+						}
+						if machineTypeInfo.GPU != *hasGPU {
+							errs = append(errs, field.Forbidden(fld, "Cannot mix GPU and non-GPU machine types in the same Instance Group"))
+						}
+					}
+				}
 			}
 		}
+	} else {
+		mainMachineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(ig.Spec.MachineType))
+		if err != nil {
+			errs = append(errs, field.Invalid(field.NewPath("spec", "machineType"), ig.Spec.MachineType, fmt.Sprintf("machine type specified is invalid: %q", ig.Spec.MachineType)))
+			return errs
+		}
 
+		hasGPU := mainMachineTypeInfo.GPU
+
+		// @step: check the instance types are valid
+		for i, instanceTypes := range spec.Instances {
+			fld := path.Child("instances").Index(i)
+			errs = append(errs, awsValidateInstanceTypeAndImage(path.Child("instances").Index(i), path.Child("image"), instanceTypes, ig.Spec.Image, cloud)...)
+
+			for _, instanceType := range strings.Split(instanceTypes, ",") {
+				machineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(instanceType))
+				if err != nil {
+					errs = append(errs, field.Invalid(field.NewPath("spec", "machineType"), ig.Spec.MachineType, fmt.Sprintf("machine type specified is invalid: %q", ig.Spec.MachineType)))
+					return errs
+				}
+				if machineTypeInfo.GPU != hasGPU {
+					errs = append(errs, field.Forbidden(fld, "Cannot mix GPU and non-GPU machine types in the same Instance Group"))
+				}
+			}
+		}
 	}
 
 	if spec.OnDemandBase != nil {

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -293,30 +293,9 @@ func awsValidateMixedInstancesPolicy(path *field.Path, spec *kops.MixedInstances
 	var errs field.ErrorList
 
 	if ig.Spec.Manager == kops.InstanceManagerKarpenter {
-		var hasGPU *bool
-		validateGPU := func(fld *field.Path, instanceTypes string) {
-			for _, instanceType := range strings.Split(instanceTypes, ",") {
-				instanceType = strings.TrimSpace(instanceType)
-				if instanceType == "" {
-					continue
-				}
-				machineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(instanceType))
-				if err != nil {
-					continue
-				}
-				if hasGPU == nil {
-					hasGPU = new(machineTypeInfo.GPU)
-				} else if machineTypeInfo.GPU != *hasGPU {
-					errs = append(errs, field.Forbidden(fld, "Cannot mix GPU and non-GPU machine types in the same Instance Group"))
-				}
-			}
-		}
-		validateGPU(field.NewPath("spec", "machineType"), ig.Spec.MachineType)
-
 		for i, instanceTypes := range spec.Instances {
 			fld := path.Child("instances").Index(i)
 			errs = append(errs, awsValidateInstanceTypeAndImage(fld, path.Child("image"), instanceTypes, ig.Spec.Image, cloud)...)
-			validateGPU(fld, instanceTypes)
 		}
 	} else {
 		mainMachineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(ig.Spec.MachineType))

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -293,33 +293,30 @@ func awsValidateMixedInstancesPolicy(path *field.Path, spec *kops.MixedInstances
 	var errs field.ErrorList
 
 	if ig.Spec.Manager == kops.InstanceManagerKarpenter {
-		if spec.InstanceRequirements == nil {
-			var hasGPU *bool
-			if ig.Spec.MachineType != "" {
-				mainMachineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(ig.Spec.MachineType))
+		var hasGPU *bool
+		validateGPU := func(fld *field.Path, instanceTypes string) {
+			for _, instanceType := range strings.Split(instanceTypes, ",") {
+				instanceType = strings.TrimSpace(instanceType)
+				if instanceType == "" {
+					continue
+				}
+				machineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(instanceType))
 				if err != nil {
-					errs = append(errs, field.Invalid(field.NewPath("spec", "machineType"), ig.Spec.MachineType, fmt.Sprintf("machine type specified is invalid: %q", ig.Spec.MachineType)))
-					return errs
+					continue
 				}
-				hasGPU = &mainMachineTypeInfo.GPU
-			}
-
-			for i, instanceTypes := range spec.Instances {
-				fld := path.Child("instances").Index(i)
-				errs = append(errs, awsValidateInstanceTypeAndImage(fld, path.Child("image"), instanceTypes, ig.Spec.Image, cloud)...)
-
-				if hasGPU != nil {
-					for _, instanceType := range strings.Split(instanceTypes, ",") {
-						machineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(instanceType))
-						if err != nil {
-							continue
-						}
-						if machineTypeInfo.GPU != *hasGPU {
-							errs = append(errs, field.Forbidden(fld, "Cannot mix GPU and non-GPU machine types in the same Instance Group"))
-						}
-					}
+				if hasGPU == nil {
+					hasGPU = new(machineTypeInfo.GPU)
+				} else if machineTypeInfo.GPU != *hasGPU {
+					errs = append(errs, field.Forbidden(fld, "Cannot mix GPU and non-GPU machine types in the same Instance Group"))
 				}
 			}
+		}
+		validateGPU(field.NewPath("spec", "machineType"), ig.Spec.MachineType)
+
+		for i, instanceTypes := range spec.Instances {
+			fld := path.Child("instances").Index(i)
+			errs = append(errs, awsValidateInstanceTypeAndImage(fld, path.Child("image"), instanceTypes, ig.Spec.Image, cloud)...)
+			validateGPU(fld, instanceTypes)
 		}
 	} else {
 		mainMachineTypeInfo, err := awsup.GetMachineTypeInfo(cloud, ec2types.InstanceType(ig.Spec.MachineType))

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -407,13 +407,12 @@ func TestKarpenterMixedInstancesPolicyValidation(t *testing.T) {
 			},
 		},
 		{
-			desc:        "GPU and non-GPU instance list",
+			desc:        "heterogeneous instance list with machine type",
 			machineType: "g4dn.xlarge",
 			spec: &kops.MixedInstancesPolicySpec{
 				Instances:            []string{"m5.large"},
 				InstanceRequirements: &kops.InstanceRequirementsSpec{},
 			},
-			expected: []string{"Forbidden::spec.mixedInstancesPolicy.instances[0]"},
 		},
 		{
 			desc: "instance requirements do not suppress instance validation",
@@ -431,12 +430,11 @@ func TestKarpenterMixedInstancesPolicyValidation(t *testing.T) {
 			},
 		},
 		{
-			desc: "GPU and non-GPU instance list without machine type",
+			desc: "heterogeneous instance list without machine type",
 			spec: &kops.MixedInstancesPolicySpec{
 				Instances:            []string{"g4dn.xlarge", "m5.large"},
 				InstanceRequirements: &kops.InstanceRequirementsSpec{},
 			},
-			expected: []string{"Forbidden::spec.mixedInstancesPolicy.instances[1]"},
 		},
 	}
 

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -30,6 +31,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops/pkg/apis/kops"
 )
+
+type emptyInstanceTypeRejectingCloud struct {
+	awsup.AWSCloud
+}
+
+func (c *emptyInstanceTypeRejectingCloud) DescribeInstanceType(instanceType string) (*ec2types.InstanceTypeInfo, error) {
+	if instanceType == "" {
+		return nil, errors.New("instance type is empty")
+	}
+	return c.AWSCloud.DescribeInstanceType(instanceType)
+}
 
 func TestAWSValidateEBSCSIDriver(t *testing.T) {
 	grid := []struct {
@@ -357,6 +369,67 @@ func TestMixedInstancePolicies(t *testing.T) {
 		errs := awsValidateInstanceGroup(ig, cloud)
 
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
+	}
+}
+
+func TestKarpenterMixedInstancesPolicyValidation(t *testing.T) {
+	baseCloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
+	mockEC2 := &mockec2.MockEC2{}
+	baseCloud.MockEC2 = mockEC2
+	mockEC2.Images = append(mockEC2.Images, &ec2types.Image{
+		ImageId:      aws.String("ami-073c8c0760395aab8"),
+		Architecture: ec2types.ArchitectureValuesX8664,
+	})
+	cloud := &emptyInstanceTypeRejectingCloud{AWSCloud: baseCloud}
+
+	grid := []struct {
+		desc        string
+		machineType string
+		spec        *kops.MixedInstancesPolicySpec
+		expected    []string
+	}{
+		{
+			desc: "instance requirements",
+			spec: &kops.MixedInstancesPolicySpec{
+				InstanceRequirements: &kops.InstanceRequirementsSpec{},
+			},
+		},
+		{
+			desc: "capacity types",
+			spec: &kops.MixedInstancesPolicySpec{
+				OnDemandAboveBase: new(int64(50)),
+			},
+		},
+		{
+			desc: "instance list",
+			spec: &kops.MixedInstancesPolicySpec{
+				Instances: []string{"m5.large"},
+			},
+		},
+		{
+			desc:        "GPU and non-GPU instance list",
+			machineType: "g4dn.xlarge",
+			spec: &kops.MixedInstancesPolicySpec{
+				Instances: []string{"m5.large"},
+			},
+			expected: []string{"Forbidden::spec.mixedInstancesPolicy.instances[0]"},
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.desc, func(t *testing.T) {
+			ig := &kops.InstanceGroup{
+				Spec: kops.InstanceGroupSpec{
+					Manager:              kops.InstanceManagerKarpenter,
+					Image:                "ami-073c8c0760395aab8",
+					MachineType:          g.machineType,
+					MixedInstancesPolicy: g.spec,
+				},
+			}
+
+			errs := awsValidateInstanceGroup(ig, cloud)
+			testErrors(t, g.desc, errs, g.expected)
+		})
 	}
 }
 

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -410,9 +410,33 @@ func TestKarpenterMixedInstancesPolicyValidation(t *testing.T) {
 			desc:        "GPU and non-GPU instance list",
 			machineType: "g4dn.xlarge",
 			spec: &kops.MixedInstancesPolicySpec{
-				Instances: []string{"m5.large"},
+				Instances:            []string{"m5.large"},
+				InstanceRequirements: &kops.InstanceRequirementsSpec{},
 			},
 			expected: []string{"Forbidden::spec.mixedInstancesPolicy.instances[0]"},
+		},
+		{
+			desc: "instance requirements do not suppress instance validation",
+			spec: &kops.MixedInstancesPolicySpec{
+				Instances:            []string{"t2.invalidType"},
+				InstanceRequirements: &kops.InstanceRequirementsSpec{},
+			},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instances[0]"},
+		},
+		{
+			desc:        "comma-separated machine types",
+			machineType: "m5.large,m5.xlarge",
+			spec: &kops.MixedInstancesPolicySpec{
+				InstanceRequirements: &kops.InstanceRequirementsSpec{},
+			},
+		},
+		{
+			desc: "GPU and non-GPU instance list without machine type",
+			spec: &kops.MixedInstancesPolicySpec{
+				Instances:            []string{"g4dn.xlarge", "m5.large"},
+				InstanceRequirements: &kops.InstanceRequirementsSpec{},
+			},
+			expected: []string{"Forbidden::spec.mixedInstancesPolicy.instances[1]"},
 		},
 	}
 

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -18,12 +18,16 @@ package validation
 
 import (
 	"fmt"
+	"math"
+	"regexp"
 	"strings"
 
 	"k8s.io/kops/pkg/nodeidentity/aws"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"k8s.io/apimachinery/pkg/api/resource"
+	contentvalidation "k8s.io/apimachinery/pkg/api/validate/content"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -330,6 +334,9 @@ func validateKarpenterInstanceGroup(g *kops.InstanceGroup, cluster *kops.Cluster
 	if cluster.GetCloudProvider() != kops.CloudProviderAWS {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "manager"), "Karpenter InstanceGroups are only supported on AWS"))
 	}
+	if cluster.Spec.Karpenter == nil || !cluster.Spec.Karpenter.Enabled {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "manager"), "Karpenter InstanceGroups require cluster.spec.karpenter.enabled"))
+	}
 	if !g.Spec.Role.HasNode() {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "role"), "Karpenter InstanceGroups must have role Node"))
 	}
@@ -338,7 +345,117 @@ func validateKarpenterInstanceGroup(g *kops.InstanceGroup, cluster *kops.Cluster
 	}
 	allErrs = append(allErrs, validateKarpenterAMISelectorImage(g.Spec.Image, field.NewPath("spec", "image"))...)
 	allErrs = append(allErrs, validateKarpenterStaticCapacity(g, cluster)...)
+	allErrs = append(allErrs, validateKarpenterInstanceRequirements(g)...)
 	return allErrs
+}
+
+func validateKarpenterInstanceRequirements(g *kops.InstanceGroup) field.ErrorList {
+	if g.Spec.MixedInstancesPolicy == nil || g.Spec.MixedInstancesPolicy.InstanceRequirements == nil {
+		return nil
+	}
+
+	requirements := g.Spec.MixedInstancesPolicy.InstanceRequirements
+	requirementsPath := field.NewPath("spec", "mixedInstancesPolicy", "instanceRequirements")
+	var allErrs field.ErrorList
+
+	if requirements.CPU != nil {
+		minValue, errs := validateKarpenterCPURequirement(requirements.CPU.Min, requirementsPath.Child("cpu", "min"))
+		allErrs = append(allErrs, errs...)
+		maxValue, errs := validateKarpenterCPURequirement(requirements.CPU.Max, requirementsPath.Child("cpu", "max"))
+		allErrs = append(allErrs, errs...)
+		allErrs = append(allErrs, validateKarpenterRequirementRange(minValue, maxValue, requirements.CPU.Max, requirementsPath.Child("cpu", "max"))...)
+	}
+
+	if requirements.Memory != nil {
+		minValue, errs := validateKarpenterMemoryRequirement(requirements.Memory.Min, requirementsPath.Child("memory", "min"), true)
+		allErrs = append(allErrs, errs...)
+		maxValue, errs := validateKarpenterMemoryRequirement(requirements.Memory.Max, requirementsPath.Child("memory", "max"), false)
+		allErrs = append(allErrs, errs...)
+		allErrs = append(allErrs, validateKarpenterRequirementRange(minValue, maxValue, requirements.Memory.Max, requirementsPath.Child("memory", "max"))...)
+	}
+
+	for i, configuredEntry := range requirements.ExcludedInstanceTypes {
+		entryPath := requirementsPath.Child("excludedInstanceTypes").Index(i)
+		entry := strings.TrimSpace(configuredEntry)
+		if entry == "" {
+			allErrs = append(allErrs, field.Invalid(entryPath, configuredEntry, "must not be empty"))
+			continue
+		}
+
+		value := entry
+		if match := karpenterExcludedInstanceFamily.FindStringSubmatch(entry); match != nil {
+			value = match[1]
+		} else if strings.Contains(entry, "*") {
+			allErrs = append(allErrs, field.Invalid(
+				entryPath,
+				configuredEntry,
+				"only an instance type or a \"<family>.*\" family wildcard can be expressed as a NodePool requirement",
+			))
+			continue
+		}
+		for _, msg := range contentvalidation.IsLabelValue(value) {
+			allErrs = append(allErrs, field.Invalid(entryPath, configuredEntry, msg))
+		}
+	}
+	return allErrs
+}
+
+var karpenterExcludedInstanceFamily = regexp.MustCompile(`^([a-z0-9][a-z0-9-]*)\.\*$`)
+
+func validateKarpenterCPURequirement(quantity *resource.Quantity, fldPath *field.Path) (*int64, field.ErrorList) {
+	if quantity == nil {
+		return nil, nil
+	}
+	if quantity.Sign() < 0 {
+		return nil, field.ErrorList{field.Invalid(fldPath, quantity, "must not be negative")}
+	}
+	value, ok := quantity.AsInt64()
+	if !ok {
+		return nil, field.ErrorList{field.Invalid(fldPath, quantity, "must be a whole number")}
+	}
+	if value > math.MaxInt32 {
+		return nil, field.ErrorList{field.Invalid(fldPath, quantity, "is too large")}
+	}
+	return &value, nil
+}
+
+func validateKarpenterMemoryRequirement(quantity *resource.Quantity, fldPath *field.Path, roundUp bool) (*int64, field.ErrorList) {
+	if quantity == nil {
+		return nil, nil
+	}
+	if quantity.Sign() < 0 {
+		return nil, field.ErrorList{field.Invalid(fldPath, quantity, "must not be negative")}
+	}
+
+	const mib = int64(1024 * 1024)
+	maxBytes := int64(math.MaxInt32) * mib
+	if !roundUp {
+		maxBytes += mib - 1
+	}
+	maxQuantity := resource.NewQuantity(maxBytes, resource.DecimalSI)
+	if quantity.Cmp(*maxQuantity) > 0 {
+		return nil, field.ErrorList{field.Invalid(fldPath, quantity, "is too large")}
+	}
+
+	bytes := quantity.Value()
+	value := bytes / mib
+	if roundUp && bytes%mib != 0 {
+		value++
+	}
+	return &value, nil
+}
+
+func validateKarpenterRequirementRange(minValue, maxValue *int64, maxQuantity *resource.Quantity, maxPath *field.Path) field.ErrorList {
+	if maxValue == nil {
+		return nil
+	}
+	if *maxValue == 0 {
+		return field.ErrorList{field.Invalid(maxPath, maxQuantity, "must resolve to a positive value")}
+	}
+	if minValue != nil && *minValue > *maxValue {
+		return field.ErrorList{field.Invalid(maxPath, maxQuantity, "must be greater than or equal to min")}
+	}
+	return nil
 }
 
 func validateKarpenterStaticCapacity(g *kops.InstanceGroup, cluster *kops.Cluster) field.ErrorList {

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package validation
 
 import (
+	"strings"
 	"testing"
 
 	"k8s.io/kops/pkg/nodeidentity/aws"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kops/pkg/apis/kops"
@@ -264,6 +266,7 @@ func TestCrossValidateKarpenterInstanceGroup(t *testing.T) {
 			CloudProvider: kops.CloudProviderSpec{
 				AWS: &kops.AWSSpec{},
 			},
+			Karpenter: &kops.KarpenterConfig{Enabled: true},
 		},
 	}
 	gceCluster := &kops.Cluster{
@@ -271,6 +274,7 @@ func TestCrossValidateKarpenterInstanceGroup(t *testing.T) {
 			CloudProvider: kops.CloudProviderSpec{
 				GCE: &kops.GCESpec{},
 			},
+			Karpenter: &kops.KarpenterConfig{Enabled: true},
 		},
 	}
 
@@ -318,6 +322,17 @@ func TestCrossValidateKarpenterInstanceGroup(t *testing.T) {
 			role:     kops.InstanceGroupRoleAPIServer,
 			image:    "ami-0123456789abcdef0",
 			expected: []string{"Forbidden::spec.role"},
+		},
+		{
+			desc: "addon disabled",
+			cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					CloudProvider: kops.CloudProviderSpec{AWS: &kops.AWSSpec{}},
+				},
+			},
+			role:     kops.InstanceGroupRoleNode,
+			image:    "ami-0123456789abcdef0",
+			expected: []string{"Forbidden::spec.manager"},
 		},
 		{
 			desc:     "url image",
@@ -466,6 +481,138 @@ func TestValidateKarpenterStaticCapacity(t *testing.T) {
 					Image:   "my-image",
 					MinSize: g.minSize,
 					MaxSize: g.maxSize,
+				},
+			}
+
+			errs := CrossValidateInstanceGroup(ig, cluster, nil, true)
+			testErrors(t, g.desc, errs, g.expected)
+		})
+	}
+}
+
+func TestValidateKarpenterInstanceRequirements(t *testing.T) {
+	quantity := func(s string) *resource.Quantity {
+		q := resource.MustParse(s)
+		return &q
+	}
+
+	grid := []struct {
+		desc                  string
+		cpu                   *kops.MinMaxSpec
+		memory                *kops.MinMaxSpec
+		excludedInstanceTypes []string
+		expected              []string
+	}{
+		{
+			desc:                  "valid requirements",
+			cpu:                   &kops.MinMaxSpec{Min: quantity("2"), Max: quantity("16")},
+			memory:                &kops.MinMaxSpec{Min: quantity("1"), Max: quantity("64Gi")},
+			excludedInstanceTypes: []string{"m3.*", "t2.nano"},
+		},
+		{
+			desc:     "fractional cpu",
+			cpu:      &kops.MinMaxSpec{Min: quantity("500m")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.cpu.min"},
+		},
+		{
+			desc:     "negative cpu",
+			cpu:      &kops.MinMaxSpec{Max: quantity("-1")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.cpu.max"},
+		},
+		{
+			desc:     "cpu exceeds Karpenter range",
+			cpu:      &kops.MinMaxSpec{Max: quantity("5000000000")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.cpu.max"},
+		},
+		{
+			desc:     "cpu maximum is zero",
+			cpu:      &kops.MinMaxSpec{Max: quantity("0")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.cpu.max"},
+		},
+		{
+			desc:     "cpu minimum exceeds maximum",
+			cpu:      &kops.MinMaxSpec{Min: quantity("4"), Max: quantity("2")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.cpu.max"},
+		},
+		{
+			desc:     "negative minimum",
+			memory:   &kops.MinMaxSpec{Min: quantity("-1")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.memory.min"},
+		},
+		{
+			desc:     "negative maximum",
+			memory:   &kops.MinMaxSpec{Max: quantity("-1")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.memory.max"},
+		},
+		{
+			desc:     "memory minimum exceeds Karpenter range",
+			memory:   &kops.MinMaxSpec{Min: quantity("2147483648Mi")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.memory.min"},
+		},
+		{
+			desc:     "memory maximum exceeds Karpenter range",
+			memory:   &kops.MinMaxSpec{Max: quantity("2147483648Mi")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.memory.max"},
+		},
+		{
+			desc:     "memory overflow",
+			memory:   &kops.MinMaxSpec{Max: quantity("1e30")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.memory.max"},
+		},
+		{
+			desc:     "memory maximum rounds to zero",
+			memory:   &kops.MinMaxSpec{Max: quantity("1")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.memory.max"},
+		},
+		{
+			desc:     "memory range inverted by rounding",
+			memory:   &kops.MinMaxSpec{Min: quantity("2G"), Max: quantity("2G")},
+			expected: []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.memory.max"},
+		},
+		{
+			desc:                  "unsupported excluded instance wildcard",
+			excludedInstanceTypes: []string{"m5.*large"},
+			expected:              []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.excludedInstanceTypes[0]"},
+		},
+		{
+			desc:                  "comma-separated excluded instance types",
+			excludedInstanceTypes: []string{"m5.large,c5.large"},
+			expected:              []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.excludedInstanceTypes[0]"},
+		},
+		{
+			desc:                  "excluded instance type with slash",
+			excludedInstanceTypes: []string{"not/an-instance-type"},
+			expected:              []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.excludedInstanceTypes[0]"},
+		},
+		{
+			desc:                  "overlong excluded instance family",
+			excludedInstanceTypes: []string{strings.Repeat("a", 64) + ".*"},
+			expected:              []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.excludedInstanceTypes[0]"},
+		},
+		{
+			desc:                  "empty excluded instance type",
+			excludedInstanceTypes: []string{" "},
+			expected:              []string{"Invalid value::spec.mixedInstancesPolicy.instanceRequirements.excludedInstanceTypes[0]"},
+		},
+	}
+
+	cluster := &kops.Cluster{
+		Spec: kops.ClusterSpec{
+			CloudProvider: kops.CloudProviderSpec{
+				AWS: &kops.AWSSpec{},
+			},
+			Karpenter: &kops.KarpenterConfig{Enabled: true},
+		},
+	}
+	for _, g := range grid {
+		t.Run(g.desc, func(t *testing.T) {
+			ig := createMinimalInstanceGroup()
+			ig.Spec.Manager = kops.InstanceManagerKarpenter
+			ig.Spec.MixedInstancesPolicy = &kops.MixedInstancesPolicySpec{
+				InstanceRequirements: &kops.InstanceRequirementsSpec{
+					CPU:                   g.cpu,
+					Memory:                g.memory,
+					ExcludedInstanceTypes: g.excludedInstanceTypes,
 				},
 			}
 

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -53,7 +53,7 @@ spec:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: b6e2db097ea13a340c48d2d9b1da20596d5a402c4f9b96bbfd8dcedbc9fcf87f
+    manifestHash: 36d11e7c340786eece11f12c35a5f4c8f7764cc2f84f6cc51b81a43967c2c4c2
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -3212,6 +3212,10 @@ spec:
         operator: In
         values:
         - linux
+      - key: node.kubernetes.io/instance-type
+        operator: In
+        values:
+        - t2.medium
       - key: karpenter.k8s.aws/instance-cpu
         operator: Gte
         values:

--- a/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
@@ -132,7 +132,7 @@ spec:
   role: Node
   maxSize: 20
   # machineType is set so the generated NodePool demonstrates that instanceRequirements
-  # replaces the instance type requirement rather than being ANDed with it.
+  # is combined with the instance type requirement.
   machineType: t2.medium
   mixedInstancesPolicy:
     instanceRequirements:
@@ -148,4 +148,3 @@ spec:
       - t2.nano
   subnets:
   - us-test-1a
-

--- a/upup/pkg/fi/cloudup/template_functions_karpenter.go
+++ b/upup/pkg/fi/cloudup/template_functions_karpenter.go
@@ -518,14 +518,15 @@ func (tf *TemplateFunctions) karpenterRequirements(ig *kops.InstanceGroup) []kar
 		instanceRequirements = ig.Spec.MixedInstancesPolicy.InstanceRequirements
 	}
 
-	if instanceRequirements != nil {
-		requirements = append(requirements, karpenterInstanceRequirements(instanceRequirements)...)
-	} else if instanceTypes := karpenterInstanceTypes(ig); len(instanceTypes) != 0 {
+	if instanceTypes := karpenterInstanceTypes(ig); len(instanceTypes) != 0 {
 		requirements = append(requirements, karpenterRequirement{
 			Key:      karpenterInstanceTypeLabel,
 			Operator: "In",
 			Values:   instanceTypes,
 		})
+	}
+	if instanceRequirements != nil {
+		requirements = append(requirements, karpenterInstanceRequirements(instanceRequirements)...)
 	}
 
 	requirements = append(requirements, karpenterRequirement{

--- a/upup/pkg/fi/cloudup/template_functions_karpenter.go
+++ b/upup/pkg/fi/cloudup/template_functions_karpenter.go
@@ -18,7 +18,6 @@ package cloudup
 
 import (
 	"fmt"
-	"math"
 	"regexp"
 	"sort"
 	"strconv"
@@ -409,14 +408,9 @@ func (tf *TemplateFunctions) buildKarpenterNodePool(ig *kops.InstanceGroup) (*ka
 	}
 	labels = karpenterNodePoolTemplateLabels(labels)
 
-	requirements, err := tf.karpenterRequirements(ig)
-	if err != nil {
-		return nil, fmt.Errorf("building requirements for %q: %w", ig.Name, err)
-	}
-
 	template := karpenterNodeClaimTemplate{
 		Spec: karpenterNodeClaimSpec{
-			Requirements: requirements,
+			Requirements: tf.karpenterRequirements(ig),
 			NodeClassRef: karpenterNodeClassRef{
 				Group: karpenterAWSAPIGroup,
 				Kind:  "EC2NodeClass",
@@ -510,7 +504,7 @@ func (tf *TemplateFunctions) karpenterAssociatePublicIP(ig *kops.InstanceGroup) 
 	}
 }
 
-func (tf *TemplateFunctions) karpenterRequirements(ig *kops.InstanceGroup) ([]karpenterRequirement, error) {
+func (tf *TemplateFunctions) karpenterRequirements(ig *kops.InstanceGroup) []karpenterRequirement {
 	requirements := []karpenterRequirement{
 		{
 			Key:      karpenterOSLabel,
@@ -525,11 +519,7 @@ func (tf *TemplateFunctions) karpenterRequirements(ig *kops.InstanceGroup) ([]ka
 	}
 
 	if instanceRequirements != nil {
-		converted, err := karpenterInstanceRequirements(instanceRequirements)
-		if err != nil {
-			return nil, err
-		}
-		requirements = append(requirements, converted...)
+		requirements = append(requirements, karpenterInstanceRequirements(instanceRequirements)...)
 	} else if instanceTypes := karpenterInstanceTypes(ig); len(instanceTypes) != 0 {
 		requirements = append(requirements, karpenterRequirement{
 			Key:      karpenterInstanceTypeLabel,
@@ -544,61 +534,44 @@ func (tf *TemplateFunctions) karpenterRequirements(ig *kops.InstanceGroup) ([]ka
 		Values:   karpenterCapacityTypes(ig),
 	})
 
-	return requirements, nil
+	return requirements
 }
 
-func karpenterInstanceRequirements(spec *kops.InstanceRequirementsSpec) ([]karpenterRequirement, error) {
+func karpenterInstanceRequirements(spec *kops.InstanceRequirementsSpec) []karpenterRequirement {
 	var requirements []karpenterRequirement
 
 	// Karpenter's Gt/Lt/Gte/Lte operators take exactly one value, interpreted as an integer.
-	addBound := func(key string, quantity *resource.Quantity, operator string, toValue func(*resource.Quantity) (int64, error)) error {
+	addBound := func(key string, quantity *resource.Quantity, operator string, toValue func(*resource.Quantity) int64) {
 		if quantity == nil {
-			return nil
-		}
-		value, err := toValue(quantity)
-		if err != nil {
-			return fmt.Errorf("%s: %w", key, err)
+			return
 		}
 		requirements = append(requirements, karpenterRequirement{
 			Key:      key,
 			Operator: operator,
-			Values:   []string{strconv.FormatInt(value, 10)},
+			Values:   []string{strconv.FormatInt(toValue(quantity), 10)},
 		})
-		return nil
 	}
 
 	if cpu := spec.CPU; cpu != nil {
-		if err := addBound(karpenterInstanceCPULabel, cpu.Min, "Gte", quantityToCount); err != nil {
-			return nil, err
-		}
-		if err := addBound(karpenterInstanceCPULabel, cpu.Max, "Lte", quantityToCount); err != nil {
-			return nil, err
-		}
+		addBound(karpenterInstanceCPULabel, cpu.Min, "Gte", quantityToCount)
+		addBound(karpenterInstanceCPULabel, cpu.Max, "Lte", quantityToCount)
 	}
 
 	if memory := spec.Memory; memory != nil {
 		// Round the lower bound up and the upper bound down, so the generated envelope
 		// never admits an instance outside the requested range.
-		if err := addBound(karpenterInstanceMemoryLabel, memory.Min, "Gte", quantityToMiBRoundUp); err != nil {
-			return nil, err
-		}
-		if err := addBound(karpenterInstanceMemoryLabel, memory.Max, "Lte", quantityToMiBRoundDown); err != nil {
-			return nil, err
-		}
+		addBound(karpenterInstanceMemoryLabel, memory.Min, "Gte", quantityToMiBRoundUp)
+		addBound(karpenterInstanceMemoryLabel, memory.Max, "Lte", quantityToMiBRoundDown)
 	}
 
-	excluded, err := karpenterExcludedTypeRequirements(spec.ExcludedInstanceTypes)
-	if err != nil {
-		return nil, err
-	}
-	return append(requirements, excluded...), nil
+	return append(requirements, karpenterExcludedTypeRequirements(spec.ExcludedInstanceTypes)...)
 }
 
 // karpenterExcludedInstanceFamily matches the "<family>.*" wildcard form of
 // excludedInstanceTypes, which maps to an instance family rather than an instance type.
 var karpenterExcludedInstanceFamily = regexp.MustCompile(`^([a-z0-9][a-z0-9-]*)\.\*$`)
 
-func karpenterExcludedTypeRequirements(excluded []string) ([]karpenterRequirement, error) {
+func karpenterExcludedTypeRequirements(excluded []string) []karpenterRequirement {
 	var families, instanceTypes []string
 	for _, entry := range excluded {
 		entry = strings.TrimSpace(entry)
@@ -608,9 +581,6 @@ func karpenterExcludedTypeRequirements(excluded []string) ([]karpenterRequiremen
 		if match := karpenterExcludedInstanceFamily.FindStringSubmatch(entry); match != nil {
 			families = append(families, match[1])
 			continue
-		}
-		if strings.Contains(entry, "*") {
-			return nil, fmt.Errorf("excludedInstanceTypes entry %q is not supported for Karpenter; only an instance type or a %q family wildcard can be expressed as a NodePool requirement", entry, "<family>.*")
 		}
 		instanceTypes = append(instanceTypes, entry)
 	}
@@ -632,40 +602,30 @@ func karpenterExcludedTypeRequirements(excluded []string) ([]karpenterRequiremen
 			Values:   instanceTypes,
 		})
 	}
-	return requirements, nil
+	return requirements
 }
 
 // quantityToCount converts a Quantity to a whole count, for labels such as instance-cpu.
-func quantityToCount(quantity *resource.Quantity) (int64, error) {
-	value, ok := quantity.AsInt64()
-	if !ok {
-		return 0, fmt.Errorf("value %q is not a whole number", quantity.String())
-	}
-	return checkKarpenterBound(quantity, value)
-}
-
-// quantityToMiBRoundUp and quantityToMiBRoundDown convert a Quantity to MiB, the unit of
-// the karpenter.k8s.aws/instance-memory label. Note this differs from the ASG path, which
-// scales by 10^6 into a field AWS defines as MiB; see kubernetes/kops#15305.
-func quantityToMiBRoundUp(quantity *resource.Quantity) (int64, error) {
-	bytes := quantity.Value()
-	return checkKarpenterBound(quantity, (bytes+mib-1)/mib)
-}
-
-func quantityToMiBRoundDown(quantity *resource.Quantity) (int64, error) {
-	return checkKarpenterBound(quantity, quantity.Value()/mib)
+func quantityToCount(quantity *resource.Quantity) int64 {
+	return quantity.Value()
 }
 
 const mib = 1024 * 1024
 
-func checkKarpenterBound(quantity *resource.Quantity, value int64) (int64, error) {
-	if value < 0 {
-		return 0, fmt.Errorf("value %q must not be negative", quantity.String())
+// quantityToMiBRoundUp and quantityToMiBRoundDown convert a Quantity to MiB, the unit of
+// the karpenter.k8s.aws/instance-memory label. Note this differs from the ASG path, which
+// scales by 10^6 into a field AWS defines as MiB; see kubernetes/kops#15305.
+func quantityToMiBRoundUp(quantity *resource.Quantity) int64 {
+	bytes := quantity.Value()
+	value := bytes / mib
+	if bytes%mib != 0 {
+		value++
 	}
-	if value > math.MaxInt32 {
-		return 0, fmt.Errorf("value %q is too large", quantity.String())
-	}
-	return value, nil
+	return value
+}
+
+func quantityToMiBRoundDown(quantity *resource.Quantity) int64 {
+	return quantity.Value() / mib
 }
 
 func karpenterInstanceTypes(ig *kops.InstanceGroup) []string {

--- a/upup/pkg/fi/cloudup/template_functions_karpenter_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_karpenter_test.go
@@ -244,10 +244,9 @@ func TestKarpenterRequirements(t *testing.T) {
 	}
 
 	grid := []struct {
-		desc        string
-		spec        kops.InstanceGroupSpec
-		expected    []karpenterRequirement
-		expectError bool
+		desc     string
+		spec     kops.InstanceGroupSpec
+		expected []karpenterRequirement
 	}{
 		{
 			// Regression guard: without instanceRequirements the output must not move.
@@ -327,54 +326,12 @@ func TestKarpenterRequirements(t *testing.T) {
 				onDemand,
 			},
 		},
-		{
-			desc: "unsupported wildcard is rejected",
-			spec: kops.InstanceGroupSpec{
-				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
-					InstanceRequirements: &kops.InstanceRequirementsSpec{
-						ExcludedInstanceTypes: []string{"m5.*large"},
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			desc: "negative quantity is rejected",
-			spec: kops.InstanceGroupSpec{
-				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
-					InstanceRequirements: &kops.InstanceRequirementsSpec{
-						CPU: &kops.MinMaxSpec{Min: quantity("-1")},
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			desc: "overflowing quantity is rejected",
-			spec: kops.InstanceGroupSpec{
-				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
-					InstanceRequirements: &kops.InstanceRequirementsSpec{
-						CPU: &kops.MinMaxSpec{Max: quantity("5000000000")},
-					},
-				},
-			},
-			expectError: true,
-		},
 	}
 
 	tf := &TemplateFunctions{}
 	for _, g := range grid {
 		t.Run(g.desc, func(t *testing.T) {
-			actual, err := tf.karpenterRequirements(&kops.InstanceGroup{Spec: g.spec})
-			if g.expectError {
-				if err == nil {
-					t.Fatalf("expected an error, got %#v", actual)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			actual := tf.karpenterRequirements(&kops.InstanceGroup{Spec: g.spec})
 			if diff := cmp.Diff(g.expected, actual); diff != "" {
 				t.Errorf("unexpected requirements, diff=%v", diff)
 			}
@@ -384,36 +341,24 @@ func TestKarpenterRequirements(t *testing.T) {
 
 func TestKarpenterQuantityConversion(t *testing.T) {
 	grid := []struct {
-		desc        string
-		quantity    string
-		convert     func(*resource.Quantity) (int64, error)
-		expected    int64
-		expectError bool
+		desc     string
+		quantity string
+		convert  func(*resource.Quantity) int64
+		expected int64
 	}{
 		{desc: "cpu whole number", quantity: "4", convert: quantityToCount, expected: 4},
-		{desc: "cpu fractional is rejected", quantity: "500m", convert: quantityToCount, expectError: true},
 		// Binary suffixes are exact; decimal ones are not, so the rounding direction matters.
 		{desc: "2Gi rounds to 2048", quantity: "2Gi", convert: quantityToMiBRoundUp, expected: 2048},
 		{desc: "2G rounds up to 1908", quantity: "2G", convert: quantityToMiBRoundUp, expected: 1908},
 		{desc: "2G rounds down to 1907", quantity: "2G", convert: quantityToMiBRoundDown, expected: 1907},
 		{desc: "64Gi rounds to 65536", quantity: "64Gi", convert: quantityToMiBRoundDown, expected: 65536},
 		{desc: "1000Mi is exact", quantity: "1000Mi", convert: quantityToMiBRoundUp, expected: 1000},
-		{desc: "negative memory is rejected", quantity: "-1Gi", convert: quantityToMiBRoundUp, expectError: true},
 	}
 
 	for _, g := range grid {
 		t.Run(g.desc, func(t *testing.T) {
 			q := resource.MustParse(g.quantity)
-			actual, err := g.convert(&q)
-			if g.expectError {
-				if err == nil {
-					t.Fatalf("expected an error, got %d", actual)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			actual := g.convert(&q)
 			if actual != g.expected {
 				t.Errorf("expected %d, got %d", g.expected, actual)
 			}

--- a/upup/pkg/fi/cloudup/template_functions_karpenter_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_karpenter_test.go
@@ -270,6 +270,7 @@ func TestKarpenterRequirements(t *testing.T) {
 			},
 			expected: []karpenterRequirement{
 				osRequirement,
+				{Key: "node.kubernetes.io/instance-type", Operator: "In", Values: []string{"t3.medium"}},
 				{Key: "karpenter.k8s.aws/instance-cpu", Operator: "Gte", Values: []string{"2"}},
 				{Key: "karpenter.k8s.aws/instance-cpu", Operator: "Lte", Values: []string{"16"}},
 				onDemand,
@@ -292,9 +293,7 @@ func TestKarpenterRequirements(t *testing.T) {
 			},
 		},
 		{
-			// instanceRequirements describes a capacity envelope, so an instance type
-			// requirement would defeat it by pinning the pool to spec.machineType.
-			desc: "instanceRequirements suppress the instance type list",
+			desc: "instanceRequirements combine with the instance type list",
 			spec: kops.InstanceGroupSpec{
 				MachineType: "t3.medium",
 				MixedInstancesPolicy: &kops.MixedInstancesPolicySpec{
@@ -306,6 +305,7 @@ func TestKarpenterRequirements(t *testing.T) {
 			},
 			expected: []karpenterRequirement{
 				osRequirement,
+				{Key: "node.kubernetes.io/instance-type", Operator: "In", Values: []string{"m6i.large", "t3.medium"}},
 				{Key: "karpenter.k8s.aws/instance-cpu", Operator: "Gte", Values: []string{"2"}},
 				onDemand,
 			},


### PR DESCRIPTION
Follow-up to #18676.

Validate Karpenter InstanceGroup configuration before addon rendering:

- allow mixed instance policies without `machineType`
- combine `machineType` and `mixedInstancesPolicy.instances` with `instanceRequirements` when supplied
- validate CPU and memory bounds, ranges, and overflow
- validate excluded-instance wildcard and label-value syntax
- require the Karpenter addon to be enabled
- preserve instance architecture validation while allowing heterogeneous Karpenter pools
- simplify NodePool rendering to trust validated input

Invalid configurations now produce field-specific validation errors instead of render-time failures or unusable NodePools.

/cc @rifelpet @ameukam @danports