### PR TITLE
assets: cache file hashes instead of nodeup assets

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -38,6 +38,11 @@ import (
 	"k8s.io/kops/util/pkg/vfs"
 )
 
+// downloadedFileHashes caches hashes read from checksum files, keyed by resolved URL so
+// canonical and mirrored assets do not share entries. Commands can create multiple
+// AssetBuilders, but each builder must still remap and register its own assets.
+var downloadedFileHashes sync.Map // resolved URL -> *hashing.Hash
+
 // ImageDigestResolver looks up the manifest digest for an image, returning it in the form
 // "sha256:...".
 type ImageDigestResolver func(image string) (string, error)
@@ -386,6 +391,11 @@ func (a *AssetBuilder) findHash(file *FileAsset) (*hashing.Hash, error) {
 		return knownHash, nil
 	}
 
+	if cachedHash, found := downloadedFileHashes.Load(u.String()); found {
+		klog.V(8).Infof("using cached hash for %q", u)
+		return cachedHash.(*hashing.Hash), nil
+	}
+
 	klog.V(2).Infof("asset %q is not well-known, downloading hash", file.CanonicalURL)
 
 	// We now prefer sha256 hashes
@@ -418,7 +428,14 @@ func (a *AssetBuilder) findHash(file *FileAsset) (*hashing.Hash, error) {
 					klog.Infof("Hash file was empty %q", hashURL)
 					continue
 				}
-				return hashing.FromString(fields[0])
+				hash, err := hashing.FromString(fields[0])
+				if err != nil {
+					return nil, err
+				}
+
+				downloadedFileHashes.Store(u.String(), hash)
+
+				return hash, nil
 			}
 			if ext == ".sha256" {
 				klog.V(2).Infof("Unable to read new sha256 hash file (is this an older/unsupported kubernetes release?)")

--- a/pkg/assets/builder_test.go
+++ b/pkg/assets/builder_test.go
@@ -18,17 +18,22 @@ package assets
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/testutils/golden"
 	"k8s.io/kops/util/pkg/hashing"
+	"k8s.io/kops/util/pkg/vfs"
 )
 
 func buildAssetBuilder(t *testing.T) *AssetBuilder {
@@ -337,5 +342,133 @@ func TestAssetBuilderConcurrentCollection(t *testing.T) {
 		if prev.Path > curr.Path {
 			t.Fatalf("static files not sorted: %q > %q", prev.Path, curr.Path)
 		}
+	}
+}
+
+func resetDownloadedFileHashes(t *testing.T) {
+	t.Helper()
+
+	downloadedFileHashes.Clear()
+	t.Cleanup(downloadedFileHashes.Clear)
+}
+
+func hashHandler(assetPath string, hash string, requests *atomic.Int64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != assetPath+".sha256" {
+			// The VFS retries 404 and 5xx responses.
+			http.Error(w, "not found", http.StatusForbidden)
+			return
+		}
+		requests.Add(1)
+		fmt.Fprintf(w, "%s  %s\n", hash, path.Base(assetPath))
+	}
+}
+
+func newHashServer(t *testing.T, assetPath string, hash string, requests *atomic.Int64) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(hashHandler(assetPath, hash, requests))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func TestFindHashCachesDownloadedHashesByResolvedURL(t *testing.T) {
+	resetDownloadedFileHashes(t)
+
+	const assetPath = "/binaries/example/linux/amd64/example"
+	const canonicalHash = "2222222222222222222222222222222222222222222222222222222222222222"
+	const mirroredHash = "3333333333333333333333333333333333333333333333333333333333333333"
+
+	var canonicalRequests atomic.Int64
+	canonicalServer := newHashServer(t, assetPath, canonicalHash, &canonicalRequests)
+
+	var mirroredRequests atomic.Int64
+	mirroredServer := newHashServer(t, assetPath, mirroredHash, &mirroredRequests)
+
+	assetURL, err := url.Parse(canonicalServer.URL + assetPath)
+	if err != nil {
+		t.Fatalf("error parsing asset url: %v", err)
+	}
+
+	vfsContext := vfs.NewVFSContext()
+
+	// Each builder registers the asset, but only the first downloads its checksum.
+	for i := 0; i < 3; i++ {
+		builder := NewAssetBuilder(vfsContext, &kops.AssetsSpec{}, false)
+
+		asset, err := builder.RemapFile(assetURL, nil)
+		if err != nil {
+			t.Fatalf("error remapping file with builder %d: %v", i, err)
+		}
+		if actual := asset.SHAValue.Hex(); actual != canonicalHash {
+			t.Errorf("unexpected hash from builder %d: actual %q, expected %q", i, actual, canonicalHash)
+		}
+		if actual := len(builder.FileAssets()); actual != 1 {
+			t.Errorf("expected builder %d to register 1 file asset, got %d", i, actual)
+		}
+	}
+
+	// The mirror must not reuse the canonical URL's cached hash.
+	fileRepository := mirroredServer.URL
+	mirroredBuilder := NewAssetBuilder(vfsContext, &kops.AssetsSpec{FileRepository: &fileRepository}, false)
+	mirroredAsset, err := mirroredBuilder.RemapFile(assetURL, nil)
+	if err != nil {
+		t.Fatalf("error remapping mirrored file: %v", err)
+	}
+	if actual := mirroredAsset.SHAValue.Hex(); actual != mirroredHash {
+		t.Errorf("unexpected mirrored hash: actual %q, expected %q", actual, mirroredHash)
+	}
+
+	if actual := canonicalRequests.Load(); actual != 1 {
+		t.Errorf("expected 1 canonical checksum request, got %d", actual)
+	}
+	if actual := mirroredRequests.Load(); actual != 1 {
+		t.Errorf("expected 1 mirrored checksum request, got %d", actual)
+	}
+}
+
+func TestFindHashDoesNotCacheFailures(t *testing.T) {
+	resetDownloadedFileHashes(t)
+
+	const assetPath = "/binaries/example/linux/amd64/example"
+	const hash = "4444444444444444444444444444444444444444444444444444444444444444"
+
+	var published atomic.Bool
+	var requests atomic.Int64
+	handler := hashHandler(assetPath, hash, &requests)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !published.Load() {
+			// The VFS retries 404 and 5xx responses.
+			http.Error(w, "not found", http.StatusForbidden)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	assetURL, err := url.Parse(server.URL + assetPath)
+	if err != nil {
+		t.Fatalf("error parsing asset url: %v", err)
+	}
+
+	vfsContext := vfs.NewVFSContext()
+	builder := NewAssetBuilder(vfsContext, &kops.AssetsSpec{}, false)
+
+	if _, err := builder.RemapFile(assetURL, nil); err == nil {
+		t.Fatal("expected an error while the checksum file is unavailable")
+	}
+
+	published.Store(true)
+
+	asset, err := builder.RemapFile(assetURL, nil)
+	if err != nil {
+		t.Fatalf("error remapping file after the checksum file was published: %v", err)
+	}
+	if actual := asset.SHAValue.Hex(); actual != hash {
+		t.Errorf("unexpected hash: actual %q, expected %q", actual, hash)
+	}
+	if actual := requests.Load(); actual != 1 {
+		t.Errorf("expected 1 successful checksum request, got %d", actual)
 	}
 }

--- a/pkg/nodemodel/wellknownassets/kopsassets.go
+++ b/pkg/nodemodel/wellknownassets/kopsassets.go
@@ -34,9 +34,6 @@ const (
 
 var kopsBaseURL *url.URL
 
-// nodeUpAsset caches the nodeup binary download url/hash
-var nodeUpAsset map[architectures.Architecture]*assets.MirroredAsset
-
 // BaseURL returns the base url for the distribution of kops - in particular for nodeup & docker images
 func BaseURL() (*url.URL, error) {
 	// returning cached value
@@ -82,17 +79,9 @@ func copyBaseURL(base *url.URL) (*url.URL, error) {
 	return u, nil
 }
 
-// NodeUpAsset returns the asset for where nodeup should be downloaded
+// NodeUpAsset returns nodeup after registering it with assetsBuilder. The result is not cached
+// because its locations depend on the builder's repository mapping. Hashes are cached separately.
 func NodeUpAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Architecture) (*assets.MirroredAsset, error) {
-	if nodeUpAsset == nil {
-		nodeUpAsset = make(map[architectures.Architecture]*assets.MirroredAsset)
-	}
-	if nodeUpAsset[arch] != nil {
-		// Avoid repeated logging
-		klog.V(8).Infof("Using cached nodeup location for %s: %v", arch, nodeUpAsset[arch].Locations)
-		return nodeUpAsset[arch], nil
-	}
-
 	asset, err := KopsFileURL(fmt.Sprintf("linux/%s/nodeup", arch), assetsBuilder)
 	if err != nil {
 		return nil, err
@@ -104,10 +93,9 @@ func NodeUpAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Architec
 			return nil, err
 		}
 	}
-	nodeUpAsset[arch] = assets.BuildMirroredAsset(asset)
 	klog.V(8).Infof("Using default nodeup location for %s: %q", arch, asset.DownloadURL.String())
 
-	return nodeUpAsset[arch], nil
+	return assets.BuildMirroredAsset(asset), nil
 }
 
 // KopsFileURL returns the base url for the distribution of kops - in particular for nodeup & docker images

--- a/pkg/nodemodel/wellknownassets/kopsassets_test.go
+++ b/pkg/nodemodel/wellknownassets/kopsassets_test.go
@@ -18,13 +18,19 @@ package wellknownassets
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	"k8s.io/kops"
+	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/assets"
+	"k8s.io/kops/util/pkg/architectures"
 	"k8s.io/kops/util/pkg/hashing"
+	"k8s.io/kops/util/pkg/vfs"
 )
 
 func TestBaseURL_OverridesVersionFromKopsBaseURL(t *testing.T) {
@@ -128,5 +134,73 @@ func Test_BuildMirroredAsset(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+func TestNodeUpAssetRegistersWithEveryAssetBuilder(t *testing.T) {
+	hashes := map[architectures.Architecture]string{
+		architectures.ArchitectureAmd64: "5555555555555555555555555555555555555555555555555555555555555555",
+		architectures.ArchitectureArm64: "6666666666666666666666666666666666666666666666666666666666666666",
+	}
+
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for arch, hash := range hashes {
+			if r.URL.Path == fmt.Sprintf("/kops/%s/linux/%s/nodeup.sha256", kops.Version, arch) {
+				requests.Add(1)
+				fmt.Fprintf(w, "%s  nodeup\n", hash)
+				return
+			}
+		}
+		// The VFS retries 404 and 5xx responses.
+		http.Error(w, "not found", http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+
+	kopsBaseURL = nil
+	t.Cleanup(func() {
+		kopsBaseURL = nil
+	})
+	// Keep kops.Version unchanged when BaseURL parses KOPS_BASE_URL.
+	t.Setenv("KOPS_BASE_URL", fmt.Sprintf("%s/kops/%s", server.URL, kops.Version))
+
+	vfsContext := vfs.NewVFSContext()
+
+	// Both update and get-assets builders must register nodeup.
+	for _, getAssets := range []bool{false, true} {
+		t.Run(fmt.Sprintf("getAssets=%t", getAssets), func(t *testing.T) {
+			assetBuilder := assets.NewAssetBuilder(vfsContext, &kopsapi.AssetsSpec{}, getAssets)
+
+			for _, arch := range []architectures.Architecture{architectures.ArchitectureAmd64, architectures.ArchitectureArm64} {
+				asset, err := NodeUpAsset(assetBuilder, arch)
+				if err != nil {
+					t.Fatalf("NodeUpAsset(%s) error: %v", arch, err)
+				}
+				expectedLocation := fmt.Sprintf("%s/kops/%s/linux/%s/nodeup", server.URL, kops.Version, arch)
+				if !reflect.DeepEqual(asset.Locations, []string{expectedLocation}) {
+					t.Errorf("unexpected nodeup locations for %s: %v", arch, asset.Locations)
+				}
+				if asset.Hash.Hex() != hashes[arch] {
+					t.Errorf("unexpected nodeup hash for %s: actual %q, expected %q", arch, asset.Hash.Hex(), hashes[arch])
+				}
+			}
+
+			var registered []string
+			for _, fileAsset := range assetBuilder.FileAssets() {
+				registered = append(registered, fileAsset.CanonicalURL.String())
+			}
+			expected := []string{
+				fmt.Sprintf("%s/kops/%s/linux/amd64/nodeup", server.URL, kops.Version),
+				fmt.Sprintf("%s/kops/%s/linux/arm64/nodeup", server.URL, kops.Version),
+			}
+			if !reflect.DeepEqual(registered, expected) {
+				t.Errorf("unexpected registered file assets:\nActual: %v\nExpect: %v", registered, expected)
+			}
+		})
+	}
+
+	// Each architecture's checksum is downloaded once across both builders.
+	if actual := requests.Load(); actual != int64(len(hashes)) {
+		t.Errorf("expected %d checksum requests, got %d", len(hashes), actual)
 	}
 }

--- a/tests/integration/update_cluster/containerd/assets.yaml
+++ b/tests/integration/update_cluster/containerd/assets.yaml
@@ -5,6 +5,12 @@ files:
 - canonical: https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
   download: https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
   sha: 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849
+- canonical: https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/nodeup
+  download: https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/nodeup
+  sha: c86e072f622b91546b7b3f3cb1a0f8a131e48b966ad018a0ac1520ceedf37725
+- canonical: https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/nodeup
+  download: https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/nodeup
+  sha: 64a9a9510538a449e85d05e13e3cd98b80377d68a673447c26821d40f00f0075
 - canonical: https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl
   download: https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl
   sha: 646d58f6d98ee670a71d9cdffbf6625aeea2849d567f214bc43a35f8ccb7bf70

--- a/tests/integration/update_cluster/privatedns1/assets.yaml
+++ b/tests/integration/update_cluster/privatedns1/assets.yaml
@@ -5,6 +5,12 @@ files:
 - canonical: https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
   download: https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.31.7/linux/arm64/ecr-credential-provider-linux-arm64
   sha: 1980e3a038cb16da48a137743b31fb81de6c0b59fa06c206c2bc20ce0a52f849
+- canonical: https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/nodeup
+  download: https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/amd64/nodeup
+  sha: c86e072f622b91546b7b3f3cb1a0f8a131e48b966ad018a0ac1520ceedf37725
+- canonical: https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/nodeup
+  download: https://artifacts.k8s.io/binaries/kops/1.34.0-beta.1/linux/arm64/nodeup
+  sha: 64a9a9510538a449e85d05e13e3cd98b80377d68a673447c26821d40f00f0075
 - canonical: https://dl.k8s.io/release/v1.34.0/bin/linux/amd64/kubectl
   download: https://dl.k8s.io/release/v1.34.0/bin/linux/amd64/kubectl
   sha: cfda68cba5848bc3b6c6135ae2f20ba2c78de20059f68789c090166d6abc3e2c


### PR DESCRIPTION
`NodeUpAsset` cached a complete `MirroredAsset` globally by architecture. The asset contains the repository mapping from the `AssetBuilder` that created it, and `AssetBuilder.RemapFile` is also responsible for registering it. Reusing the cached asset therefore caused later builders to miss nodeup in `FileAssets()` and could carry over another builder's repository mapping.

### What changed

- Remap and register nodeup independently for every `AssetBuilder`.
- Cache successfully downloaded checksum hashes by resolved URL.
- Keep canonical and mirrored URLs in separate cache entries.
- Do not cache failed lookups, so transient failures are retried.

This restores nodeup in `kops get assets` output without repeatedly downloading the same checksum files.

### Test coverage

The tests verify that:

- each builder registers nodeup while sharing downloaded hashes;
- canonical and mirrored URLs do not share hashes;
- failed lookups are retried; and
- integration asset output includes nodeup for both supported architectures.

### Performance

Three alternating `cmd/kops` test runs:

| Variant | Mean | Nodeup checksum lookups |
|---|---:|---:|
| With hash cache | 27.12s | 2 |
| Without hash cache | 35.92s | 236 |

Without hash caching, the suite was 8.80 seconds (32.4%) slower.

/cc @rifelpet @ameukam