### PR TITLE
tests/e2e: keep cilium externalTrafficPolicy skips through k8s 1.38

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -86,11 +86,11 @@ func (t *Tester) setSkipRegexFlag() error {
 		// https://github.com/kubernetes/kubernetes/blob/418ae605ec1b788d43bff7ac44af66d8b669b833/test/e2e/network/networking.go#L135
 		skipRegex += "|should.check.kube-proxy.urls"
 
-		if k8sVersion.Minor < 38 {
+		if k8sVersion.Minor < 39 {
 			// Cilium SNATs the client source IP to a pod IP instead of preserving it, so it fails the
 			// externalTrafficPolicy=Local for type=NodePort test. This test passes on every other CNI,
 			// so it stays gated to Cilium.
-			// < 38 so we look at this again
+			// < 39 so we look at this again
 			skipRegex += "|Services.should.support.externalTrafficPolicy.Local.for.type.NodePort"
 		}
 	} else if networking.KubeRouter != nil {
@@ -108,8 +108,8 @@ func (t *Tester) setSkipRegexFlag() error {
 	// vxlan.calico on Azure) and the masquerade rewrites the source to the node's tunnel address.
 	// Calico preserves the source IP only on AWS, where kOps disables the source/dest check and
 	// routes pod traffic natively. amazon-vpc and kindnet preserve it and keep running the test.
-	// < 38 so we look at this again
-	if k8sVersion.Minor < 38 &&
+	// < 39 so we look at this again
+	if k8sVersion.Minor < 39 &&
 		(networking.Cilium != nil || networking.Flannel != nil || networking.KubeRouter != nil ||
 			(networking.Calico != nil && (cluster.Spec.LegacyCloudProvider == "gce" || cluster.Spec.LegacyCloudProvider == "azure"))) {
 		skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"


### PR DESCRIPTION
Both `Services should support externalTrafficPolicy=Local for type=NodePort` and `Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes` were gated to `k8sVersion.Minor < 38` with a note to look at them again once k8s 1.38 CI builds existed.

`ci/latest.txt` is now `v1.38.0-alpha.0`, so I checked the jobs that actually reach the computed skip regex at 1.38 (8 of the 31 `ci/latest.txt` jobs — the rest pass their own `--skip-regex`, which makes `setSkipRegexFlag` return early):

| Job | Cloud / CNI | Both tests |
|---|---|---|
| `e2e-kops-aws-cni-cilium-k8s-ci` | aws / cilium | **fail**, 5/5 builds |
| `e2e-kops-gce-cni-cilium-k8s-ci` | gce / cilium | **fail**, 5/5 builds |
| `e2e-kops-aws-k8s-master` | aws / calico | pass, 12/12 builds |
| `e2e-kops-gce-latest` | gce / kubenet | pass, 12/12 builds |
| `pull-kops-e2e-k8s-ci`, `pull-kops-e2e-k8s-ci-ha` | aws / calico | ginkgo-skipped (`[Conformance]` focus) |
| `pull-kops-e2e-k8s-gce-ci` | gce / cilium | no recent non-aborted build |
| `pull-kops-e2e-k8s-gce-kindnet-hyperdisk` | gce / kindnet | no recent non-aborted build |

The failures are the same SNAT symptom the existing comments describe, not something new:

```
[FAILED] Source IP 100.96.2.147 is not the client IP
[FAILED] expected client IP to be preserved
```

`100.96.0.0/11` is the pod CIDR in both jobs. These two tests are the **only** failures in the latest build of each cilium job, so this should turn both green.

Since calico on AWS and kubenet on GCE still pass on 1.38, the CNI/cloud conditions are left alone — only the version gates move to `< 39`.

While I was in here I also re-checked the other version-gated patterns that are already live on 1.38 and left them as-is:
- `[Burstable|Guaranteed] QoS pod` (`< 35`): ginkgo-skipped in every 1.38 job.
- `Pod InPlace Resize Container` (`< 35`): passing (24/24 specs per build); one flake in 12 builds of `e2e-kops-gce-latest`, not the runc `cpu.weight` regression.
- `Services should function for service endpoints using hostNetwork` (`< 37`): passing, and no RHEL-family distro reaches the computed regex at 1.38.