### PR TITLE
do: set providerID on nodes and update CCM to v0.1.69

### DIFF
--- a/docs/releases/1.37-NOTES.md
+++ b/docs/releases/1.37-NOTES.md
@@ -106,6 +106,7 @@ Gossip DNS was the only remaining purpose of `protokube`. kOps no longer builds,
 | GCP | PD CSI driver | v1.26.0 |
 | Azure | cloud-controller-manager and cloud-node-manager | v1.36.5 |
 | Azure | azuredisk CSI driver | v1.34.5 |
+| DigitalOcean | cloud-controller-manager | v0.1.69 |
 | DigitalOcean | CSI driver | v4.18.0 |
 | Hetzner | cloud-controller-manager | v1.36.0 |
 | Hetzner | CSI driver | v2.22.2 |
@@ -113,7 +114,9 @@ Gossip DNS was the only remaining purpose of `protokube`. kOps no longer builds,
 
   kOps applies the addon changes during `kops update cluster`. The `ecr-credential-provider` binary is part of the node image, so nodes install it when they are replaced.
 
-* The DigitalOcean cloud controller manager stays on v0.1.45. kOps names DigitalOcean nodes after their private IP and does not set a `providerID`, so the cloud-node-controller must resolve a node by name. v0.1.45 matches a droplet by name or by any of its addresses. Later releases moved to the `InstancesV2` interface, which requires a `providerID`, and the name lookup that v0.1.62 restored queries the DigitalOcean API for droplets whose name equals the node name, which never matches an IP-named node. On those releases, nodes keep the `node.cloudprovider.kubernetes.io/uninitialized` taint and the cluster does not validate. kOps must set a `providerID` on DigitalOcean nodes before this component can move forward.
+* On DigitalOcean, kOps now sets a `providerID` on nodes. The cloud controller manager needs it from v0.1.58 on, because those releases resolve a node through the `InstancesV2` interface. The field is immutable, so only nodes created after this change carry it. Nodes already in the cluster keep the `providerID` that v0.1.45 recorded for them, so both kinds work with the version that kOps now deploys.
+
+* On DigitalOcean, the cloud controller manager now creates a network load balancer for a new `LoadBalancer` Service that carries no `service.beta.kubernetes.io/do-loadbalancer-type` annotation. Earlier versions created a regional load balancer. A network load balancer passes traffic through and forwards TCP and UDP only. It does not support HTTP, HTTPS, or HTTP/2 forwarding rules, TLS termination, or the PROXY protocol. Existing load balancers keep their current type, because the controller records the type on the Service before it updates the load balancer. To keep the earlier behavior for a Service, set the annotation to `REGIONAL`.
 
 * On Hetzner, the cloud controller manager and CSI driver versions that kOps deploys support Kubernetes 1.33 and newer. Hetzner removed Kubernetes 1.32 from its support matrix in CSI driver v2.21.0. A Kubernetes 1.32 cluster on Hetzner runs untested component versions. Support for Kubernetes 1.32 is deprecated in kOps 1.37.
 

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kops/pkg/systemd"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure/azuremetadata"
+	"k8s.io/kops/upup/pkg/fi/cloudup/do/dometadata"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/util/pkg/distributions"
 	kubeletv1 "k8s.io/kubelet/config/v1"
@@ -131,6 +132,14 @@ func (b *KubeletBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 				return fmt.Errorf("error querying Azure instance metadata: %v", err)
 			}
 			providerID = "azure://" + metadata.ResourceID
+		} else if b.CloudProvider() == kops.CloudProviderDO {
+			// The DO CCM resolves nodes by provider ID; its name-based fallback does not match
+			// our IP-based node names.
+			dropletID, err := dometadata.GetDropletID()
+			if err != nil {
+				return fmt.Errorf("error querying DigitalOcean droplet ID: %w", err)
+			}
+			providerID = "digitalocean://" + dropletID
 		}
 
 		t, err := b.buildKubeletComponentConfig(kubeletConfig, providerID)

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -117,6 +117,9 @@ func (t *Tester) setSkipRegexFlag() error {
 
 	if cluster.Spec.LegacyCloudProvider == "digitalocean" {
 		skipRegex += "|Services.should.respect.internalTrafficPolicy=Local.Pod.and.Node,.to.Pod"
+		// The metrics grabber scrapes one kube-controller-manager pod picked by name, so with
+		// several control planes it usually misses the leader and reads an empty metric set.
+		skipRegex += "|\\[sig-storage\\].Volume.metrics"
 	}
 
 	if cluster.Spec.LegacyCloudProvider == "azure" {

--- a/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
@@ -41,14 +41,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-      # Do not upgrade past v0.1.45 until kOps sets a providerID on DigitalOcean nodes.
-      # kOps names these nodes after their private IP and leaves providerID empty, so the
-      # cloud-node-controller has to resolve them by name. v0.1.45 matches a droplet by name
-      # or by any of its addresses. Later releases moved to InstancesV2, which needs a
-      # providerID, and the name fallback that v0.1.62 restored asks the DigitalOcean API for
-      # droplets named after the node, so an IP-named node matches nothing. Nodes then keep the
-      # node.cloudprovider.kubernetes.io/uninitialized taint and the cluster never validates.
-      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.45
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.69
         name: digitalocean-cloud-controller-manager
         command:
           - "/bin/digitalocean-cloud-controller-manager"

--- a/upup/pkg/fi/cloudup/do/dometadata/authenticator.go
+++ b/upup/pkg/fi/cloudup/do/dometadata/authenticator.go
@@ -39,7 +39,7 @@ func NewAuthenticator() (bootstrap.Authenticator, error) {
 }
 
 func (o *doAuthenticator) CreateToken(body []byte) (string, error) {
-	dropletID, err := getMetadataDropletID()
+	dropletID, err := GetDropletID()
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch droplet id: %w", err)
 	}
@@ -50,7 +50,8 @@ const (
 	dropletIDMetadataURL = "http://169.254.169.254/metadata/v1/id"
 )
 
-func getMetadataDropletID() (string, error) {
+// GetDropletID returns the droplet ID from the metadata service.
+func GetDropletID() (string, error) {
 	return getMetadata(dropletIDMetadataURL)
 }
 


### PR DESCRIPTION
The DigitalOcean CCM is pinned to v0.1.45 because newer versions resolve nodes by `spec.providerID`. The name-based fallback restored in v0.1.62 calls `Droplets.ListByName`, which filters server-side, so it never matches the private-IP names kOps gives DigitalOcean nodes. Bumping the CCM alone leaves every node stuck with the `uninitialized` taint (#18775).

The kubelet must be registered with `providerID digitalocean://<droplet-id>` from the metadata service. `dometadata` already fetches the droplet ID for the bootstrap authenticator, so that helper can be exported instead of adding another one.

/cc @rifelpet @ameukam 