### PR TITLE
Graduate SELinuxMount to GA

### DIFF
--- a/docs/advanced/experimental.md
+++ b/docs/advanced/experimental.md
@@ -18,3 +18,4 @@ The following experimental features are currently available:
 * `+EtcdEventsHTTP` - Enables HTTP (non-TLS) for the events etcd cluster, matching GCE scale test patterns
 * `+APIServerNodes` - Enables support for dedicated API server nodes
 * `+ExperimentalRoles` - Not fully implemented. Enable support for dedicated Etcd, Scheduler, CloudControllerManager and KubeControllerManager nodes. 
+* `-SELinuxMount` - Disables CSI driver SELinux mount support (`CSIDriver.spec.seLinuxMount` and its host mounts) for clusters that set `spec.containerd.selinuxEnabled: true`. Enabled by default.

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -1317,6 +1317,20 @@ spec:
     configOverride: ""
 ```
 
+### SELinux
+
+Setting `spec.containerd.selinuxEnabled: true` enables SELinux support in containerd (`enable_selinux` in its config) and applies the `spc_t` SELinux context to kOps-managed system pods that need it (via the channels manifest decoration and `kubemanifest.AddHostPathSELinuxContext`).
+
+It also enables `CSIDriver.spec.seLinuxMount: true`, and the extra host mounts it needs (`/etc/selinux`, and on some drivers `/sys/fs/selinux`), on the AWS EBS and GCP PD CSI driver addons. This lets the kubelet mount eligible volumes with `-o context` instead of recursively relabeling every file on the volume, which speeds up pod startup for large volumes on SELinux-enforcing nodes. This is additionally gated by the `SELinuxMount` feature flag (on by default; set `KOPS_FEATURE_FLAGS=-SELinuxMount` to disable it as an escape hatch).
+
+```yaml
+spec:
+  containerd:
+    selinuxEnabled: true
+```
+
+Note: `selinuxEnabled` can also be set per-InstanceGroup, but the CSI driver addons are cluster-scoped, so only the cluster-level `spec.containerd.selinuxEnabled` value affects them.
+
 ### Custom Packages
 
 kOps uses the `.tar.gz` packages for installing containerd on any supported OS. This makes it easy to use a custom build or pre-release packages, by specifying its URL and sha256:

--- a/docs/releases/1.38-NOTES.md
+++ b/docs/releases/1.38-NOTES.md
@@ -1,0 +1,17 @@
+## Release notes for kOps 1.38 series
+
+**&#9888; kOps 1.38 has not been released yet! &#9888;**
+
+This document collects release notes before the final kOps 1.38 release.
+
+# Significant changes
+
+# Breaking changes
+
+# Deprecations
+
+# Other changes of note
+
+## CSI
+
+* On AWS and GCP, kOps now configures the EBS and PD CSI drivers for SELinux mount support (`CSIDriver.spec.seLinuxMount: true`, plus the host mounts it needs) whenever `spec.containerd.selinuxEnabled` is set on the cluster. On a node with SELinux in enforcing mode, this lets the kubelet label eligible volumes with `-o context` at mount time instead of recursively relabeling every file, which speeds up pod startup for large volumes. The behavior is controlled by the `SELinuxMount` feature flag, which now defaults to on; set `KOPS_FEATURE_FLAGS=-SELinuxMount` to disable it as an escape hatch. Clusters that previously set `+SELinuxMount` without `spec.containerd.selinuxEnabled: true` will no longer get the SELinux mount bits — set `spec.containerd.selinuxEnabled: true` to keep them.

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -93,13 +93,14 @@ var (
 	ImageDigest = new("ImageDigest", Bool(true))
 	// Scaleway toggles the Scaleway Cloud support.
 	Scaleway = new("Scaleway", Bool(false))
-	// SELinuxMount configures AWS EBS and GCE PD CSI drivers for SELinuxMount support.
-	// It expects than Kubernetes feature gate SELinuxMountReadWriteOncePod is
-	// enabled or GA in the API server, KCM and kubelet.
-	// OS with SELinux support on all nodes is recommended, but not required
-	// - the feature won't do anything when the node OS does not support SELinux.
-	// TODO(jsafrane): add to all CSI drivers installed by kops.
-	SELinuxMount = new("SELinuxMount", Bool(false))
+	// SELinuxMount is an escape-hatch flag for CSI driver SELinux mount support
+	// (CSIDriver.spec.seLinuxMount and the host mounts it requires) in the AWS EBS
+	// and GCP PD CSI drivers. The feature is enabled per-cluster via
+	// spec.containerd.selinuxEnabled; this flag is a plain kill switch on top of
+	// that (set -SELinuxMount to disable the feature unconditionally, e.g. if it
+	// causes trouble in the field). See
+	// upup/pkg/fi/cloudup.TemplateFunctions.UseSELinuxMount.
+	SELinuxMount = new("SELinuxMount", Bool(true))
 	// DO Terraform toggles the DO terraform support.
 	DOTerraform = new("DOTerraform", Bool(false))
 	// Metal enables the experimental bare-metal support.

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -123,7 +123,7 @@ ClusterName: complex.example.com
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: w3eAJv93W2O4H+z/Dur38TamAzurkddwe52P9skzHYY=
+NodeupConfigHash: 6ITCJWj+JWc5VF3MllZdZhw+ikPRwacgAcexIE0iCIs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
@@ -146,7 +146,7 @@ ConfigServer:
   - https://kops-controller.internal.complex.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: /XIinxiPfLumPG/TYVuuseF4iYZsftfQ05eGC+PWYrw=
+NodeupConfigHash: 1J6VL3LBS/jlgwUm+NWqcl4aBsowysBrTsMVB7NiapQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -58,6 +58,7 @@ spec:
     runc:
       version: 1.4.3
     sandboxImage: registry.k8s.io/pause:3.10.1
+    selinuxEnabled: true
     version: 2.3.4
   dnsZone: Z1AFAKE1ZON3YO
   etcdClusters:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
@@ -189,6 +189,10 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-node-critical
+      securityContext:
+        seLinuxOptions:
+          level: s0
+          type: spc_t
       serviceAccountName: aws-iam-authenticator
       tolerations:
       - effect: NoSchedule

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -53,6 +53,10 @@ spec:
       hostNetwork: true
       nodeSelector: null
       priorityClassName: system-cluster-critical
+      securityContext:
+        seLinuxOptions:
+          level: s0
+          type: spc_t
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
       - operator: Exists

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -812,6 +812,10 @@ spec:
           name: plugin-dir
         - mountPath: /dev
           name: device-dir
+        - mountPath: /etc/selinux
+          name: etc-selinux
+        - mountPath: /sys/fs
+          name: sys-fs
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -900,6 +904,14 @@ spec:
           path: /dev
           type: Directory
         name: device-dir
+      - hostPath:
+          path: /etc/selinux
+          type: DirectoryOrCreate
+        name: etc-selinux
+      - hostPath:
+          path: /sys/fs
+          type: Directory
+        name: sys-fs
       - emptyDir: {}
         name: probe-dir
   updateStrategy:
@@ -1258,3 +1270,4 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  seLinuxMount: true

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -5,14 +5,14 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: aaeab8038dc73abc02cb0da1abf9f575e9ab86790b6d3da12b114243976cbeee
+    manifestHash: dade103d1b92f45bdfcd5e8683bc193f4bc79dbec3af23554ae47f80e2d5766d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 0b180b32473059784ae4bc805d19bc5596a25a86a84041755b792a4766501627
+    manifestHash: 05a3f0ee0b1b2b98145feb19232a5b0567eb0fd0419f0f401accca648a20d0a1
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
@@ -91,19 +91,19 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 22e33f833fccae05f3e7060ea11f4eca26c2a480d8beff874ffda473b6dd0140
+    manifestHash: 1ddc3410db78e729aff21cbeddd84fe2a8526c968cd2d1f9b654c711143c0212
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 095af875ca0994ca5e3b7711a86c5d2707762e16a8b32e61a4059a4a8f48d687
+    manifestHash: b19dba853c99bc11d5f91518826a27b0fec9d36b6fe95a6f3b29951f54b61efb
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 5ec195fdf7bf08b42bee6e25a21fbecf305143c739627721c6255ebf0e239182
+    manifestHash: 3c5873ef67d9ffec0584219cbfc6ba510e72d0cdd75d96a5320f88a42a39b84f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -173,6 +173,9 @@ spec:
             drop:
             - all
           readOnlyRootFilesystem: true
+          seLinuxOptions:
+            level: s0
+            type: spc_t
         volumeMounts:
         - mountPath: /etc/coredns
           name: config-volume

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,6 +68,9 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 10011
+          seLinuxOptions:
+            level: s0
+            type: spc_t
         volumeMounts:
         - mountPath: /etc/kubernetes/kops-controller/config/
           name: kops-controller-config

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -327,6 +327,7 @@ containerdConfig:
   runc:
     version: 1.4.3
   sandboxImage: registry.k8s.io/pause:3.10.1
+  selinuxEnabled: true
   version: 2.3.4
 etcdManifests:
 - memfs://clusters.example.com/complex.example.com/manifests/etcd/main-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
@@ -55,6 +55,7 @@ containerdConfig:
   runc:
     version: 1.4.3
   sandboxImage: registry.k8s.io/pause:3.10.1
+  selinuxEnabled: true
   version: 2.3.4
 packages:
 - nfs-common

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -39,6 +39,8 @@ spec:
     Owner: John Doe
     foo/bar: fib+baz
   configBase: memfs://clusters.example.com/complex.example.com
+  containerd:
+    selinuxEnabled: true
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -46,6 +46,8 @@ spec:
     Owner: John Doe
     foo/bar: fib+baz
   configBase: memfs://clusters.example.com/complex.example.com
+  containerd:
+    selinuxEnabled: true
   etcdClusters:
   - etcdMembers:
     - instanceGroup: master-us-test-1a

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -594,7 +594,7 @@ spec:
               mountPath: /csi
             - name: device-dir
               mountPath: /dev
-{{ if KopsFeatureEnabled "SELinuxMount" }}
+{{ if UseSELinuxMount }}
             - name: etc-selinux
               mountPath: /etc/selinux
             - name: sys-fs
@@ -708,7 +708,7 @@ spec:
           hostPath:
             path: /dev
             type: Directory
-{{ if KopsFeatureEnabled "SELinuxMount" }}
+{{ if UseSELinuxMount }}
         - name: etc-selinux
           hostPath:
             path: /etc/selinux
@@ -1133,7 +1133,7 @@ spec:
 {{ end }}
   # Disabled because the field is immutable and kOps doesn't have a way to delete and recreate the resource
   # fsGroupPolicy: File
-{{ if KopsFeatureEnabled "SELinuxMount" }}
+{{ if UseSELinuxMount }}
   seLinuxMount: true
 {{ end }}
 {{ end }}

--- a/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
@@ -704,7 +704,7 @@ spec:
           name: udev-socket
         - mountPath: /sys
           name: sys
-{{ if KopsFeatureEnabled "SELinuxMount" }}
+{{ if UseSELinuxMount }}
         - name: etc-selinux
           mountPath: /etc/selinux
 {{ end }}
@@ -751,7 +751,7 @@ spec:
           path: /sys
           type: Directory
         name: sys
-{{ if KopsFeatureEnabled "SELinuxMount" }}
+{{ if UseSELinuxMount }}
       - name: etc-selinux
         hostPath:
           path: /etc/selinux
@@ -765,6 +765,6 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
-{{ if KopsFeatureEnabled "SELinuxMount" }}
+{{ if UseSELinuxMount }}
   seLinuxMount: true
 {{ end }}

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -477,6 +477,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["IsKubernetesLT"] = tf.IsKubernetesLT
 
 	dest["KopsFeatureEnabled"] = tf.kopsFeatureEnabled
+	dest["UseSELinuxMount"] = tf.UseSELinuxMount
 	dest["KopsVersion"] = func() string { return kopsroot.Version }
 	dest["KopsVersionImageTag"] = kopsroot.KopsVersionImageTag
 	dest["KopsVersionForLabel"] = func() string {
@@ -1328,4 +1329,25 @@ func (tf *TemplateFunctions) kopsFeatureEnabled(featureName string) (bool, error
 		return false, err
 	}
 	return f.Enabled(), nil
+}
+
+// UseSELinuxMount reports whether CSI drivers should be configured with SELinux mount
+// support (CSIDriver.spec.seLinuxMount and the host mounts it requires). This requires
+// both the SELinuxMount feature flag (a plain kill switch, defaulting to true) and the
+// cluster explicitly enabling SELinux via spec.containerd.selinuxEnabled - without the
+// latter, adding the extra hostPath volumes would just pollute driver pods on clusters
+// that don't use SELinux. Note that this only looks at the cluster-level containerd
+// config; a per-InstanceGroup override cannot drive these cluster-scoped addon
+// manifests.
+//
+// This is safe to enable regardless of Kubernetes version: on clusters where
+// CSIDriver.spec.seLinuxMount isn't recognized or is still pre-GA, volumes just keep
+// being relabeled the old (recursive) way instead of mounted with the SELinux
+// context, so there's no functional regression either way.
+func (tf *TemplateFunctions) UseSELinuxMount() bool {
+	if !featureflag.SELinuxMount.Enabled() {
+		return false
+	}
+	containerd := tf.Cluster.Spec.Containerd
+	return containerd != nil && containerd.SeLinuxEnabled
 }

--- a/upup/pkg/fi/cloudup/template_functions_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_test.go
@@ -351,6 +351,63 @@ func TestKopsFeatureEnabled(t *testing.T) {
 	}
 }
 
+func TestUseSELinuxMount(t *testing.T) {
+	// Restore the default (enabled) once done; the flag state is process-global.
+	defer featureflag.ParseFlags("+SELinuxMount")
+
+	tests := []struct {
+		name           string
+		featureFlags   string
+		selinuxEnabled bool
+		expected       bool
+	}{
+		{
+			name:           "flag enabled, containerd selinux disabled",
+			featureFlags:   "+SELinuxMount",
+			selinuxEnabled: false,
+			expected:       false,
+		},
+		{
+			name:           "flag enabled, containerd selinux enabled",
+			featureFlags:   "+SELinuxMount",
+			selinuxEnabled: true,
+			expected:       true,
+		},
+		{
+			name:           "flag disabled, containerd selinux enabled",
+			featureFlags:   "-SELinuxMount",
+			selinuxEnabled: true,
+			expected:       false,
+		},
+		{
+			name:           "flag disabled, containerd selinux disabled",
+			featureFlags:   "-SELinuxMount",
+			selinuxEnabled: false,
+			expected:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featureflag.ParseFlags(tc.featureFlags)
+
+			tf := &TemplateFunctions{}
+			tf.Cluster = &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					KubernetesVersion: "1.32.0",
+					Containerd: &kops.ContainerdConfig{
+						SeLinuxEnabled: tc.selinuxEnabled,
+					},
+				},
+			}
+
+			if actual := tf.UseSELinuxMount(); actual != tc.expected {
+				t.Errorf("UseSELinuxMount() = %t, want %t", actual, tc.expected)
+			}
+		})
+	}
+}
+
 func TestHasHighlyAvailableControlPlane(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
Promote the SELinuxMount feature flag from opt-in to enabled-by-default. Instead of being gated only by the flag, SELinux mount support in the AWS EBS and GCP PD CSI drivers is now rendered when the cluster sets spec.containerd.selinuxEnabled: true.

This avoids polluting CSI driver pods with SELinux hostPath mounts on clusters that don't use SELinux, while making the feature work out of the box on clusters that do. On SELinux-enforcing nodes, eligible volumes are then mounted with -o context instead of recursively relabeled, speeding up pod startup for large volumes.

The SELinuxMount flag is kept as an escape hatch: set KOPS_FEATURE_FLAGS=-SELinuxMount to disable the feature unconditionally.

Fixes: #18778