### PR TITLE
fix(pki): drop legacy keyset aliases

### DIFF
--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -3,7 +3,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -12,7 +11,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -21,7 +19,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -30,7 +27,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -39,7 +35,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -3,7 +3,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -12,7 +11,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -21,7 +19,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -30,7 +27,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -39,7 +35,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -3,7 +3,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -12,7 +11,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -21,7 +19,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -30,7 +27,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -39,7 +35,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -3,7 +3,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -12,7 +11,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -21,7 +19,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -30,7 +27,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -39,7 +35,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -82,7 +82,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -91,7 +90,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -100,7 +98,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -109,7 +106,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -118,7 +114,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -127,7 +122,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -136,7 +130,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -145,7 +138,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -157,12 +149,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -174,12 +164,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -188,7 +176,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -197,7 +184,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -81,7 +81,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -90,7 +89,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -99,7 +97,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -108,7 +105,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -117,7 +113,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -126,7 +121,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -135,7 +129,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -144,7 +137,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -156,12 +148,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -173,12 +163,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -187,7 +175,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -196,7 +183,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -81,7 +81,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -90,7 +89,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -99,7 +97,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -108,7 +105,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -117,7 +113,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -126,7 +121,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -135,7 +129,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -144,7 +137,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -156,12 +148,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -173,12 +163,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -187,7 +175,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -196,7 +183,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/configures-allowed-address-pairs-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-allowed-address-pairs-with-annotations.yaml
@@ -83,7 +83,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -92,7 +91,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -101,7 +99,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -110,7 +107,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -119,7 +115,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -128,7 +123,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -137,7 +131,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -146,7 +139,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -158,12 +150,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -175,12 +165,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -189,7 +177,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -198,7 +185,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
@@ -80,7 +80,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -89,7 +88,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -98,7 +96,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -107,7 +104,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -116,7 +112,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -125,7 +120,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -134,7 +128,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -143,7 +136,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -155,12 +147,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -172,12 +162,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -186,7 +174,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -195,7 +182,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -570,7 +570,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -579,7 +578,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -588,7 +586,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -597,7 +594,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -606,7 +602,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -615,7 +610,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -624,7 +618,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -633,7 +626,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -645,12 +637,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -662,12 +652,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -676,7 +664,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -685,7 +672,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -500,7 +500,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -509,7 +508,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -518,7 +516,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -527,7 +524,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -536,7 +532,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -545,7 +540,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -554,7 +548,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -563,7 +556,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -575,12 +567,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -592,12 +582,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -606,7 +594,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -615,7 +602,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -497,7 +497,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -506,7 +505,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -515,7 +513,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -524,7 +521,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -533,7 +529,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -542,7 +537,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -551,7 +545,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -560,7 +553,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -572,12 +564,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -589,12 +579,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -603,7 +591,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -612,7 +599,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -582,7 +582,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -591,7 +590,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -600,7 +598,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -609,7 +606,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -618,7 +614,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -627,7 +622,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -636,7 +630,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -645,7 +638,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -657,12 +649,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -674,12 +664,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -688,7 +676,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -697,7 +684,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -492,7 +492,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -501,7 +500,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -510,7 +508,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -519,7 +516,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -528,7 +524,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -537,7 +532,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -546,7 +540,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -555,7 +548,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -567,12 +559,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -584,12 +574,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -598,7 +586,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -607,7 +594,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -241,7 +241,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -250,7 +249,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -259,7 +257,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -268,7 +265,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -277,7 +273,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -286,7 +281,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -295,7 +289,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -304,7 +297,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -316,12 +308,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -333,12 +323,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -347,7 +335,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -356,7 +343,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -254,7 +254,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -263,7 +262,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -272,7 +270,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -281,7 +278,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -290,7 +286,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -299,7 +294,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -308,7 +302,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -317,7 +310,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -329,12 +321,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -346,12 +336,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -360,7 +348,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -369,7 +356,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -166,7 +166,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -175,7 +174,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -184,7 +182,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -193,7 +190,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -202,7 +198,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -211,7 +206,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -220,7 +214,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -229,7 +222,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -241,12 +233,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -258,12 +248,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -272,7 +260,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -281,7 +268,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -196,7 +196,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -205,7 +204,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -214,7 +212,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -223,7 +220,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -232,7 +228,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -241,7 +236,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -250,7 +244,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -259,7 +252,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -271,12 +263,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -288,12 +278,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -302,7 +290,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -311,7 +298,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/single-zone-setup-3-masters-1-node-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/single-zone-setup-3-masters-1-node-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -352,7 +352,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -361,7 +360,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -370,7 +368,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -379,7 +376,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -388,7 +384,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -397,7 +392,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -406,7 +400,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -415,7 +408,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -427,12 +419,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -444,12 +434,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -458,7 +446,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -467,7 +454,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
@@ -196,7 +196,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -205,7 +204,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -214,7 +212,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -223,7 +220,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -232,7 +228,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -241,7 +236,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -250,7 +244,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -259,7 +252,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -271,12 +263,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -288,12 +278,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -302,7 +290,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -311,7 +298,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -82,7 +82,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -91,7 +90,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -100,7 +98,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -109,7 +106,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -118,7 +114,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -127,7 +122,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -136,7 +130,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -145,7 +138,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -157,12 +149,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -174,12 +164,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -188,7 +176,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -197,7 +184,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -82,7 +82,6 @@ Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
 ---
@@ -91,7 +90,6 @@ Name: etcd-clients-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
 ---
@@ -100,7 +98,6 @@ Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
 ---
@@ -109,7 +106,6 @@ Name: etcd-manager-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-leases
 type: ca
 ---
@@ -118,7 +114,6 @@ Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
 ---
@@ -127,7 +122,6 @@ Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
 ---
@@ -136,7 +130,6 @@ Name: etcd-peers-ca-leases
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-leases
 type: ca
 ---
@@ -145,7 +138,6 @@ Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
 ---
@@ -157,12 +149,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kube-proxy
 type: client
 ---
@@ -174,12 +164,10 @@ Signer:
   Signer: null
   alternateNames: null
   issuer: ""
-  oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubelet
 type: client
 ---
@@ -188,7 +176,6 @@ Name: kubernetes-ca
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=kubernetes
 type: ca
 ---
@@ -197,7 +184,6 @@ Name: service-account
 Signer: null
 alternateNames: null
 issuer: ""
-oldFormat: false
 subject: cn=service-account
 type: ca
 ---

--- a/upup/pkg/fi/ca.go
+++ b/upup/pkg/fi/ca.go
@@ -43,15 +43,9 @@ const (
 	SecretNameSSHPrimary = "admin"
 )
 
-const (
-	keysetFormatLatest = "v1alpha2"
-)
-
 // Keyset is a parsed api.Keyset.
 type Keyset struct {
-	// LegacyFormat instructs a keypair task to convert a Legacy Keyset to the new Keyset API format.
-	LegacyFormat bool
-	Items        map[string]*KeysetItem
+	Items map[string]*KeysetItem
 
 	// Primary is the KeysetItem that is considered the "active" key.
 	// It is guaranteed to be non-nil, if there are any keypairs.

--- a/upup/pkg/fi/fitasks/keypair.go
+++ b/upup/pkg/fi/fitasks/keypair.go
@@ -45,8 +45,6 @@ type Keypair struct {
 	Issuer string `json:"issuer"`
 	// Type the type of certificate i.e. CA, server, client etc
 	Type string `json:"type"`
-	// LegacyFormat is whether the keypair is stored in a legacy format.
-	LegacyFormat bool `json:"oldFormat"`
 
 	certificates *fi.CloudupTaskDependentResource
 	keyset       *fi.Keyset
@@ -103,7 +101,6 @@ func (e *Keypair) Find(c *fi.CloudupContext) (*Keypair, error) {
 		Subject:        pki.PkixNameToString(&cert.Subject),
 		Issuer:         pki.PkixNameToString(&cert.Certificate.Issuer),
 		Type:           pki.BuildTypeDescription(cert.Certificate),
-		LegacyFormat:   keyset.LegacyFormat,
 	}
 
 	actual.Signer = &Keypair{Subject: pki.PkixNameToString(&cert.Certificate.Issuer)}
@@ -153,7 +150,7 @@ func (_ *Keypair) CheckChanges(a, e, changes *Keypair) error {
 
 func (_ *Keypair) ShouldCreate(a, e, changes *Keypair) (bool, error) {
 	// Don't reissue a CA just because the Subject or AlternateNames changed
-	if a != nil && e.Type == "ca" && changes.Type == "" && !a.LegacyFormat {
+	if a != nil && e.Type == "ca" && changes.Type == "" {
 		e.Subject = a.Subject
 		return false, nil
 	}
@@ -169,7 +166,6 @@ func (_ *Keypair) Render(c *fi.CloudupContext, a, e, changes *Keypair) error {
 		return fi.RequiredField("Name")
 	}
 
-	changeStoredFormat := false
 	createCertificate := false
 	if a == nil {
 		createCertificate = true
@@ -188,8 +184,6 @@ func (_ *Keypair) Render(c *fi.CloudupContext, a, e, changes *Keypair) error {
 		} else if changes.Type != "" {
 			createCertificate = true
 			klog.Infof("creating certificate %q as Type has changed (actual=%v, expected=%v)", name, a.Type, e.Type)
-		} else if a.LegacyFormat {
-			changeStoredFormat = true
 		} else {
 			klog.Warningf("Ignoring changes in key: %v", fi.DebugAsJsonString(changes))
 		}
@@ -240,26 +234,6 @@ func (_ *Keypair) Render(c *fi.CloudupContext, a, e, changes *Keypair) error {
 
 	// TODO: Check correct subject / flags
 
-	if changeStoredFormat {
-		// We fetch and reinsert the same keypair, forcing an update to our preferred format
-		// TODO: We're assuming that we want to save in the preferred format
-		keyset, err := c.T.Keystore.FindKeyset(ctx, name)
-		if err != nil {
-			return err
-		}
-		if keyset == nil {
-			return fmt.Errorf("keyset %q not found", name)
-		}
-
-		keyset.LegacyFormat = false
-		err = c.T.Keystore.StoreKeyset(ctx, name, keyset)
-		if err != nil {
-			return err
-		}
-
-		klog.Infof("updated Keypair %q to new format", name)
-	}
-
 	return nil
 
 }
@@ -307,7 +281,6 @@ func CreateKeyset(ctx context.Context, keystore fi.Keystore, name string, req pk
 		PrivateKey:  privateKey,
 	}
 
-	keyset.LegacyFormat = false
 	keyset.Items[ki.Id] = ki
 	keyset.Primary = ki
 

--- a/upup/pkg/fi/vfs_castore_test.go
+++ b/upup/pkg/fi/vfs_castore_test.go
@@ -157,3 +157,52 @@ spec:
 		}
 	}
 }
+
+func TestVFSKeystoreReaderFindKeyset(t *testing.T) {
+	ctx := context.Background()
+
+	for _, test := range []struct {
+		name       string
+		keysetID   string
+		legacyName string
+	}{
+		{name: "kubernetes CA", keysetID: CertificateIDCA, legacyName: "ca"},
+		{name: "service account", keysetID: "service-account", legacyName: "master"},
+	} {
+		t.Run("does not fall back to the legacy "+test.name+" keyset name", func(t *testing.T) {
+			vfs.Context.ResetMemfsContext(true)
+			basePath, err := vfs.Context.BuildVfsPath("memfs://tests")
+			if err != nil {
+				t.Fatalf("building VFS path: %v", err)
+			}
+			if err := basePath.Join("private", test.legacyName, "keyset.yaml").WriteFile(ctx, strings.NewReader("invalid"), nil); err != nil {
+				t.Fatalf("writing legacy keyset: %v", err)
+			}
+
+			keyStore := NewVFSKeystoreReader(basePath)
+			keyset, err := keyStore.FindKeyset(ctx, test.keysetID)
+			if err != nil {
+				t.Fatalf("finding keyset: %v", err)
+			}
+			if keyset != nil {
+				t.Fatalf("expected no keyset, got %v", keyset)
+			}
+		})
+	}
+
+	t.Run("does not swallow a keyset read error", func(t *testing.T) {
+		vfs.Context.ResetMemfsContext(true)
+		basePath, err := vfs.Context.BuildVfsPath("memfs://tests")
+		if err != nil {
+			t.Fatalf("building VFS path: %v", err)
+		}
+		if err := basePath.Join("private", CertificateIDCA, "keyset.yaml").WriteFile(ctx, strings.NewReader("invalid"), nil); err != nil {
+			t.Fatalf("writing invalid keyset: %v", err)
+		}
+
+		keyStore := NewVFSKeystoreReader(basePath)
+		if _, err := keyStore.FindKeyset(ctx, CertificateIDCA); err == nil {
+			t.Fatal("expected keyset read error, got nil")
+		}
+	})
+}

--- a/upup/pkg/fi/vfs_keystorereader.go
+++ b/upup/pkg/fi/vfs_keystorereader.go
@@ -102,13 +102,6 @@ func (c *VFSKeystoreReader) loadKeyset(ctx context.Context, p vfs.Path) (*Keyset
 	return keyset, nil
 }
 
-var legacyKeysetMappings = map[string]string{
-	// The strange name is because kOps prior to 1.19 used the api-server TLS key for this.
-	"service-account": "master",
-	// Renamed in kOps 1.22
-	"kubernetes-ca": "ca",
-}
-
 // FindPrimaryKeypair implements pki.Keystore
 func (c *VFSKeystoreReader) FindPrimaryKeypair(ctx context.Context, name string) (*pki.Certificate, *pki.PrivateKey, error) {
 	keyset, err := c.FindKeyset(ctx, name)
@@ -129,20 +122,6 @@ func (c *VFSKeystoreReader) FindPrimaryKeypair(ctx context.Context, name string)
 }
 
 func (c *VFSKeystoreReader) FindKeyset(ctx context.Context, id string) (*Keyset, error) {
-	keys, err := c.findPrivateKeyset(ctx, id)
-	if keys == nil || os.IsNotExist(err) {
-		if legacyId := legacyKeysetMappings[id]; legacyId != "" {
-			keys, err = c.findPrivateKeyset(ctx, legacyId)
-			if keys != nil {
-				keys.LegacyFormat = true
-			}
-		}
-	}
-
-	return keys, err
-}
-
-func (c *VFSKeystoreReader) findPrivateKeyset(ctx context.Context, id string) (*Keyset, error) {
 	var keys *Keyset
 	var err error
 	if id == CertificateIDCA {

--- a/upup/pkg/fi/vfs_keystorereader.go
+++ b/upup/pkg/fi/vfs_keystorereader.go
@@ -55,24 +55,20 @@ func (c *VFSKeystoreReader) buildPrivateKeyPoolPath(name string) vfs.Path {
 	return c.basedir.Join("private", name)
 }
 
-func (c *VFSKeystoreReader) parseKeysetYaml(data []byte) (*kops.Keyset, bool, error) {
+func (c *VFSKeystoreReader) parseKeysetYaml(data []byte) (*kops.Keyset, error) {
 	defaultReadVersion := v1alpha2.SchemeGroupVersion.WithKind("Keyset")
 
-	object, gvk, err := kopscodecs.Decode(data, &defaultReadVersion)
+	object, _, err := kopscodecs.Decode(data, &defaultReadVersion)
 	if err != nil {
-		return nil, false, fmt.Errorf("error parsing keyset: %v", err)
+		return nil, fmt.Errorf("error parsing keyset: %v", err)
 	}
 
 	keyset, ok := object.(*kops.Keyset)
 	if !ok {
-		return nil, false, fmt.Errorf("object was not a keyset, was a %T", object)
+		return nil, fmt.Errorf("object was not a keyset, was a %T", object)
 	}
 
-	if gvk == nil {
-		return nil, false, fmt.Errorf("object did not have GroupVersionKind: %q", keyset.Name)
-	}
-
-	return keyset, gvk.Version != keysetFormatLatest, nil
+	return keyset, nil
 }
 
 // loadKeyset loads a Keyset from the path.
@@ -88,7 +84,7 @@ func (c *VFSKeystoreReader) loadKeyset(ctx context.Context, p vfs.Path) (*Keyset
 		return nil, fmt.Errorf("unable to read bundle %q: %v", p, err)
 	}
 
-	o, legacyFormat, err := c.parseKeysetYaml(data)
+	o, err := c.parseKeysetYaml(data)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing bundle %q: %v", p, err)
 	}
@@ -98,7 +94,6 @@ func (c *VFSKeystoreReader) loadKeyset(ctx context.Context, p vfs.Path) (*Keyset
 		return nil, fmt.Errorf("error mapping bundle %q: %v", p, err)
 	}
 
-	keyset.LegacyFormat = legacyFormat
 	return keyset, nil
 }
 


### PR DESCRIPTION
Remove legacy keyset fallbacks that could mask transient read errors and cause kOps to propose recreating an existing CA. Also remove obsolete LegacyFormat migration code.

Fixes https://github.com/kubernetes/kops/issues/18680

/cc @rifelpet @justinsb 