### PR TITLE
cert-manager: add feature gate options for webhook and cainjector

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -208,6 +208,27 @@ spec:
     useServiceAccountExternalPermissions: true
 ```
 
+##### Feature gates
+
+{{ kops_feature_table(kops_added_default='1.37') }}
+
+The cert-manager controller, webhook and cainjector each accept their own set of feature gates, so they are configured
+per component: `featureGates` applies to the controller, `webhookFeatureGates` to the webhook and `cainjectorFeatureGates`
+to the cainjector. Some features, such as `AdditionalCertificateOutputFormats` and `NameConstraints`, must be enabled on
+both the controller and the webhook to take effect.
+
+```yaml
+spec:
+  certManager:
+    enabled: true
+    featureGates:
+      AdditionalCertificateOutputFormats: true
+    webhookFeatureGates:
+      AdditionalCertificateOutputFormats: true
+```
+
+See the [cert-manager feature gates documentation](https://cert-manager.io/docs/installation/configuring-components/#feature-gates) for the gates each component supports.
+
 Read more about cert-manager in the [official documentation](https://cert-manager.io/docs/)
 
 #### Karpenter

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -325,6 +325,12 @@ spec:
               certManager:
                 description: CertManager determines the metrics server configuration.
                 properties:
+                  cainjectorFeatureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: CAInjectorFeatureGates is a list of experimental
+                      features that can be enabled or disabled for the cainjector.
+                    type: object
                   defaultIssuer:
                     description: |-
                       defaultIssuer sets a default clusterIssuer
@@ -364,6 +370,12 @@ spec:
                     items:
                       type: string
                     type: array
+                  webhookFeatureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: WebhookFeatureGates is a list of experimental features
+                      that can be enabled or disabled for the webhook.
+                    type: object
                 type: object
               channel:
                 description: The Channel we are following

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -1250,6 +1250,12 @@ type CertManagerConfig struct {
 
 	// FeatureGates is a list of experimental features that can be enabled or disabled.
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
+
+	// WebhookFeatureGates is a list of experimental features that can be enabled or disabled for the webhook.
+	WebhookFeatureGates map[string]bool `json:"webhookFeatureGates,omitempty"`
+
+	// CAInjectorFeatureGates is a list of experimental features that can be enabled or disabled for the cainjector.
+	CAInjectorFeatureGates map[string]bool `json:"cainjectorFeatureGates,omitempty"`
 }
 
 // LoadBalancerControllerSpec determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -1321,6 +1321,12 @@ type CertManagerConfig struct {
 
 	// FeatureGates is a list of experimental features that can be enabled or disabled.
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
+
+	// WebhookFeatureGates is a list of experimental features that can be enabled or disabled for the webhook.
+	WebhookFeatureGates map[string]bool `json:"webhookFeatureGates,omitempty"`
+
+	// CAInjectorFeatureGates is a list of experimental features that can be enabled or disabled for the cainjector.
+	CAInjectorFeatureGates map[string]bool `json:"cainjectorFeatureGates,omitempty"`
 }
 
 // LoadBalancerControllerSpec determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1991,6 +1991,8 @@ func autoConvert_v1alpha2_CertManagerConfig_To_kops_CertManagerConfig(in *CertMa
 	out.Nameservers = in.Nameservers
 	out.HostedZoneIDs = in.HostedZoneIDs
 	out.FeatureGates = in.FeatureGates
+	out.WebhookFeatureGates = in.WebhookFeatureGates
+	out.CAInjectorFeatureGates = in.CAInjectorFeatureGates
 	return nil
 }
 
@@ -2007,6 +2009,8 @@ func autoConvert_kops_CertManagerConfig_To_v1alpha2_CertManagerConfig(in *kops.C
 	out.Nameservers = in.Nameservers
 	out.HostedZoneIDs = in.HostedZoneIDs
 	out.FeatureGates = in.FeatureGates
+	out.WebhookFeatureGates = in.WebhookFeatureGates
+	out.CAInjectorFeatureGates = in.CAInjectorFeatureGates
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -519,6 +519,20 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.WebhookFeatureGates != nil {
+		in, out := &in.WebhookFeatureGates, &out.WebhookFeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.CAInjectorFeatureGates != nil {
+		in, out := &in.CAInjectorFeatureGates, &out.CAInjectorFeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -1233,6 +1233,12 @@ type CertManagerConfig struct {
 
 	// FeatureGates is a list of experimental features that can be enabled or disabled.
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
+
+	// WebhookFeatureGates is a list of experimental features that can be enabled or disabled for the webhook.
+	WebhookFeatureGates map[string]bool `json:"webhookFeatureGates,omitempty"`
+
+	// CAInjectorFeatureGates is a list of experimental features that can be enabled or disabled for the cainjector.
+	CAInjectorFeatureGates map[string]bool `json:"cainjectorFeatureGates,omitempty"`
 }
 
 // LoadBalancerControllerSpec determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2187,6 +2187,8 @@ func autoConvert_v1alpha3_CertManagerConfig_To_kops_CertManagerConfig(in *CertMa
 	out.Nameservers = in.Nameservers
 	out.HostedZoneIDs = in.HostedZoneIDs
 	out.FeatureGates = in.FeatureGates
+	out.WebhookFeatureGates = in.WebhookFeatureGates
+	out.CAInjectorFeatureGates = in.CAInjectorFeatureGates
 	return nil
 }
 
@@ -2203,6 +2205,8 @@ func autoConvert_kops_CertManagerConfig_To_v1alpha3_CertManagerConfig(in *kops.C
 	out.Nameservers = in.Nameservers
 	out.HostedZoneIDs = in.HostedZoneIDs
 	out.FeatureGates = in.FeatureGates
+	out.WebhookFeatureGates = in.WebhookFeatureGates
+	out.CAInjectorFeatureGates = in.CAInjectorFeatureGates
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -595,6 +595,20 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.WebhookFeatureGates != nil {
+		in, out := &in.WebhookFeatureGates, &out.WebhookFeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.CAInjectorFeatureGates != nil {
+		in, out := &in.CAInjectorFeatureGates, &out.CAInjectorFeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -594,6 +594,20 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.WebhookFeatureGates != nil {
+		in, out := &in.WebhookFeatureGates, &out.WebhookFeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.CAInjectorFeatureGates != nil {
+		in, out := &in.CAInjectorFeatureGates, &out.CAInjectorFeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -11,8 +11,12 @@ spec:
   awsLoadBalancerController:
     enabled: true
   certManager:
+    cainjectorFeatureGates:
+      ServerSideApply: true
     enabled: true
     featureGates:
+      AdditionalCertificateOutputFormats: true
+    webhookFeatureGates:
       AdditionalCertificateOutputFormats: true
   channel: stable
   cloudConfig:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
       k8s-app: metrics-server
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 17db9ccb408cc6e020ba494e0fbfb5a25e773a836799dd28f46852d0bb6234d9
+    manifestHash: 5a9e96bc8f86441558134f498eb30fca8d3568efe33e7a941a1dfc722e111599
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-certmanager.io-k8s-1.16_content
@@ -14414,6 +14414,7 @@ spec:
       - args:
         - --v=2
         - --leader-election-namespace=kube-system
+        - --feature-gates=ServerSideApply=true
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -14605,6 +14606,7 @@ spec:
         - --dynamic-serving-dns-names=cert-manager-webhook
         - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE)
         - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE).svc
+        - --feature-gates=AdditionalCertificateOutputFormats=true
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/tests/integration/update_cluster/many-addons/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/many-addons/in-v1alpha2.yaml
@@ -7,8 +7,12 @@ spec:
   awsLoadBalancerController:
     enabled: true
   certManager:
+    cainjectorFeatureGates:
+      ServerSideApply: true
     enabled: true
     featureGates:
+      AdditionalCertificateOutputFormats: true
+    webhookFeatureGates:
       AdditionalCertificateOutputFormats: true
   clusterAutoscaler:
     enabled: true

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -13248,6 +13248,9 @@ spec:
           args:
           - --v=2
           - --leader-election-namespace=kube-system
+          {{ range $key, $value := .CertManager.CAInjectorFeatureGates }}
+          - --feature-gates={{ $key }}={{ $value }}
+          {{ end }}
           ports:
           - containerPort: 9402
             name: http-metrics
@@ -13453,6 +13456,9 @@ spec:
           - --dynamic-serving-dns-names=cert-manager-webhook
           - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE)
           - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE).svc
+          {{ range $key, $value := .CertManager.WebhookFeatureGates }}
+          - --feature-gates={{ $key }}={{ $value }}
+          {{ end }}
           ports:
           - name: https
             protocol: TCP


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `webhookFeatureGates` and `cainjectorFeatureGates` to `spec.certManager`, so cert-manager feature gates can be set per component instead of only on the controller.

## Problem

`spec.certManager.featureGates` is only rendered into the args of the `cert-manager-controller` container. The webhook and cainjector Deployments never receive `--feature-gates`, so gates that cert-manager documents as needing both the controller and the webhook (for example `AdditionalCertificateOutputFormats` or `NameConstraints`) are only half-applied: the controller supports the feature while the webhook refuses the resources that use it.

## Root cause

`upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template`:

- line 13347: `{{ range $key, $value := .CertManager.FeatureGates }}` emits `--feature-gates` for the controller only
- line 13448: the `cert-manager-webhook` container args have no feature gate handling
- line 13248: the `cert-manager-cainjector` container args have no feature gate handling

The three cert-manager components accept different sets of gates (see the cert-manager feature-gates documentation, linked from docs/addons.md in this PR), so blindly copying `featureGates` to every container would not be correct either. The cert-manager Helm chart solves this with per-component values (`featureGates`, `webhook.featureGates`, `cainjector.featureGates`), which is the approach suggested in the issue discussion.

## Fix

- `CertManagerConfig` gains `WebhookFeatureGates` and `CAInjectorFeatureGates` (`map[string]bool`) in `pkg/apis/kops`, `v1alpha2` and `v1alpha3`; conversion and deepcopy regenerated with `make apimachinery-codegen`, CRD regenerated with `make crds`.
- The addon template renders the new maps into the webhook and cainjector container args, using the same `range` pattern as the controller. `featureGates` keeps applying to the controller only, so existing clusters are unchanged.
- `docs/addons.md` documents the per-component gates.
- The `many-addons` integration fixture sets both new fields and the golden output was regenerated with `hack/update-expected.sh`.

## How tested

Golden update-cluster test (`TestManyAddons`), no cloud account needed.

Before the template change, with the fixture setting `webhookFeatureGates` / `cainjectorFeatureGates` and the expected webhook and cainjector args written into the golden file:

```
--- FAIL: TestManyAddons (0.49s)
    compare.go:81: diff:
        ...
                  - --v=2
                  - --leader-election-namespace=kube-system
        -         - --feature-gates=ServerSideApply=true
                  env:
                  - name: POD_NAMESPACE
        ...
                  - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE)
                  - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE).svc
        -         - --feature-gates=AdditionalCertificateOutputFormats=true
                  env:
        ...
    compare.go:85: output did not match expected for ".../many-addons/data/aws_s3_object_many-addons.example.com-addons-certmanager.io-k8s-1.16_content"
FAIL
```

After the template change:

```
=== RUN   TestManyAddons
--- PASS: TestManyAddons (0.46s)
PASS
ok  	k8s.io/kops/cmd/kops	0.519s
```

`hack/update-expected.sh ./cmd/kops/` afterwards produced no further changes beyond the `many-addons` fixture (certmanager.io manifest, its `manifestHash` in the bootstrap addon list, and `cluster-completed.spec`). Also ran `make apimachinery-codegen` (no diff), `go test ./pkg/apis/kops/...`, `go vet` and `go build ./cmd/kops/`.

## Links

- https://github.com/kubernetes/kops/issues/17797

**Which issue(s) this PR fixes**:

Fixes #17797

**Special notes for your reviewer**:

The `kops_feature_table` entry in the docs says `1.37`; adjust if this lands in a different release. Gate names in the fixture (`AdditionalCertificateOutputFormats` for the webhook, `ServerSideApply` for the cainjector) are taken from cert-manager's webhook and cainjector feature lists.

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
