### PR TITLE
build kubetest2 binaries and publish them to the staging bucket

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,21 +36,15 @@ steps:
       - LATEST_FILE=markers/${_PULL_BASE_REF}/latest-ci.txt
     args:
       - gcs-upload-and-tag
-  # Build cloudbuild artifacts (for attestation)
+  # Build the kubetest2 e2e binaries
   - name: "mirror.gcr.io/library/golang:1.27.1-trixie"
-    id: cloudbuild-artifacts
+    id: e2e-binaries
     entrypoint: make
     env:
-      # _GIT_TAG is not a valid semver, we use CI=1 instead
-      # - VERSION=$_GIT_TAG
       - CI=$_CI
-      - PULL_BASE_REF=$_PULL_BASE_REF
-      - DOCKER_REGISTRY=$_DOCKER_REGISTRY
-      - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
-      - GCS_LOCATION=$_GCS_LOCATION
-      - LATEST_FILE=markers/${_PULL_BASE_REF}/latest-ci.txt
+      - GCS_LOCATION=${_GCS_LOCATION}branches/${_PULL_BASE_REF}/
     args:
-      - cloudbuild-artifacts
+      - upload-e2e-binaries
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
@@ -60,7 +54,3 @@ substitutions:
   _DOCKER_REGISTRY: "gcr.io"
   _DOCKER_IMAGE_PREFIX: "k8s-staging-kops/"
   _GCS_LOCATION: "gs://k8s-staging-kops/kops/releases/"
-artifacts:
-  objects:
-    location: "$_GCS_LOCATION/$_GIT_TAG/cloudbuild/"
-    paths: ["cloudbuild/*"]

--- a/tests/e2e/e2e.mk
+++ b/tests/e2e/e2e.mk
@@ -20,3 +20,23 @@ test-e2e-install:
 	cd $(KOPS_ROOT)/tests/e2e && \
 		go install ./kubetest2-tester-kops && \
 		go install ./kubetest2-kops
+
+.PHONY: build-e2e-binaries
+build-e2e-binaries: build-e2e-binaries-amd64 build-e2e-binaries-arm64 build-e2e-binaries-s390x build-e2e-binaries-ppc64le build-e2e-binaries-riscv64 build-e2e-binaries-darwin-arm64
+
+.PHONY: build-e2e-binaries-amd64 build-e2e-binaries-arm64 build-e2e-binaries-s390x build-e2e-binaries-ppc64le build-e2e-binaries-riscv64
+build-e2e-binaries-amd64 build-e2e-binaries-arm64 build-e2e-binaries-s390x build-e2e-binaries-ppc64le build-e2e-binaries-riscv64: build-e2e-binaries-%:
+	mkdir -p "$(KOPS_ROOT)/.build/dist/kubetest2/linux/$*"
+	cd "$(KOPS_ROOT)/tests/e2e" && \
+		CGO_ENABLED=0 GOOS=linux GOARCH=$* go build -o "$(KOPS_ROOT)/.build/dist/kubetest2/linux/$*/" ./kubetest2-kops ./kubetest2-tester-kops
+
+.PHONY: build-e2e-binaries-darwin-arm64
+build-e2e-binaries-darwin-arm64:
+	mkdir -p "$(KOPS_ROOT)/.build/dist/kubetest2/darwin/arm64"
+	cd "$(KOPS_ROOT)/tests/e2e" && \
+		CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o "$(KOPS_ROOT)/.build/dist/kubetest2/darwin/arm64/" ./kubetest2-kops ./kubetest2-tester-kops
+
+.PHONY: upload-e2e-binaries
+upload-e2e-binaries: gcloud build-e2e-binaries
+	gcloud storage cp --custom-metadata="Surrogate-Key=kops-kubetest2" --cache-control="private, max-age=0, no-transform" \
+		--recursive "$(KOPS_ROOT)/.build/dist/kubetest2/"* "$(GCS_LOCATION)kubetest2/"


### PR DESCRIPTION
I want to add the kops kubetest2 binaries directly into our e2e images so we don't need to clone kops to use kubetest2.

I already verified the job and published an initial set of kubetest2 binaries to `gs://k8s-staging-kops/kops/releases/kubetest2`