### PR TITLE
Fix SSH skip regex after upstream provider tag rename

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -160,7 +160,12 @@ func (t *Tester) setSkipRegexFlag() error {
 
 	for _, subnet := range cluster.Spec.Subnets {
 		if subnet.Type == v1alpha2.SubnetTypePrivate || subnet.Type == v1alpha2.SubnetTypeDualStack {
-			skipRegex += "|SSH.should.SSH.to.all.nodes.and.run.commands"
+			// The test SSHes from the pod running the test binary to every node address reported
+			// by the API. Nodes in private subnets are only reachable through the bastion, and
+			// nodes in dual-stack/IPv6 clusters only report IPv6 addresses, which the IPv4-only
+			// Prow pod cannot reach at all. The framework then finds zero SSH-able hosts and the
+			// test fails with `dial tcp: missing address`.
+			skipRegex += "|should.SSH.to.all.nodes.and.run.commands"
 			break
 		}
 	}


### PR DESCRIPTION
 All jobs on the [kops-ipv6 testgrid dashboard](https://testgrid.k8s.io/kops-ipv6), plus private-topology jobs elsewhere, are failing on:

 ```
 [It] [sig-node] SSH [Provider:gce,aws,local,azure] should SSH to all nodes and run commands
 [FAILED] Ran echo "foo" | grep "bar" on , got error error getting SSH client to ubuntu@:
     dial tcp: missing address
 ```

 **Root cause**

 We already skip this test for clusters with private or dual-stack subnets, but the pattern stopped matching. kubernetes/kubernetes#140532 replaced the runtime `SkipUnlessProviderIs` call in `test/e2e/node/ssh.go` with a declarative `framework.WithProvider(...)` tag, renaming the test from:

 ```
 [sig-node] SSH should SSH to all nodes and run commands
 ```

 to:

 ```
 [sig-node] SSH [Provider:gce,aws,local,azure] should SSH to all nodes and run commands
 ```

 Our pattern `SSH.should.SSH.to.all.nodes.and.run.commands` requires exactly one character between `SSH` and `should`, so the inserted tag broke it and the test resumed running where it cannot pass.

 It fails because the framework SSHes from the pod running the test binary to every node address reported by the API. Private-topology nodes are only reachable through the bastion, and IPv6 clusters report only IPv6 node addresses, which the IPv4-only Prow pod cannot reach. From a failing build log:

 ```
 ssh.go:135] No external IP address on nodes, falling back to internal IPs
 ssh.go:160] Skipping host 2600:1f14:1f84:d500:a079:ec4f:cf52:3504 because it does not run anything on port 22
 ... (all nodes rejected within microseconds)
 ```

 `NodeSSHHosts()` then returns zero hosts and the test SSHes to an empty host.

 **Fix**

 Drop the leading `SSH.` anchor so the pattern is not coupled to the container node's tag list.

 **Jobs this should fix**

 - `e2e-kops-aws-cni-calico-ipv6`
 - `e2e-kops-aws-cni-calico-ipv6-flatcar`
 - `e2e-kops-aws-cni-cilium-ipv6`
 - `e2e-kops-aws-cni-kindnet-ipv6`
 - `e2e-kops-aws-ipv6-external-dns`
 - `e2e-kops-aws-ipv6-flatcar`
 - `e2e-kops-scenario-ipv6-terraform`

 plus any private-topology job hitting the same test.

 Not addressed here: `e2e-kops-gce-cni-kindnet-ipv6` fails earlier at cluster `Up` (tracked by #17840), and `e2e-kops-aws-ipv6-karpenter` does not run this test.
